### PR TITLE
Moved SpansMultipleLines to new Utilities folder

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11RefactorDebugTest.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11RefactorDebugTest.kt
@@ -17,6 +17,7 @@ package org.openrewrite.java
 
 import org.junit.jupiter.api.extension.ExtendWith
 import org.openrewrite.DebugOnly
+import org.openrewrite.java.utilities.SpansMultipleLinesTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
@@ -117,6 +118,10 @@ class Java11RenameVariableTest: Java11Test(), RenameVariableTest
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
 class JavaReorderMethodArgumentsTest: Java11Test(), ReorderMethodArgumentsTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
+class Java11SpansMultipleLinesTest: Java11Test(), SpansMultipleLinesTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)

--- a/rewrite-java/src/main/java/org/openrewrite/java/utilities/SpansMultipleLines.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/utilities/SpansMultipleLines.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.utilities;
+
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AbstractJavaSourceVisitor;
+import org.openrewrite.java.tree.J;
+
+import java.util.Spliterators;
+
+import static java.util.stream.StreamSupport.stream;
+
+class SpansMultipleLines extends AbstractJavaSourceVisitor<Boolean> {
+    private final J scope;
+
+    @Nullable
+    private final J skip;
+
+    SpansMultipleLines(J scope, @Nullable J skip) {
+        this.scope = scope;
+        this.skip = skip;
+        setCursoringOn();
+    }
+
+    @Override
+    public Boolean defaultTo(Tree t) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitTree(Tree tree) {
+        if (scope.isScope(tree)) {
+            if (tree instanceof J.Block && ((J.Block<?>) tree).getEnd().getPrefix().contains("\n")) {
+                return true;
+            }
+
+            // don't look at the prefix of the scope that we are testing, we are interested in its contents
+            return super.visitTree(tree);
+        } else if (getCursor().isScopeInPath(scope) && !isSkipInCursorPath()) {
+            if (tree instanceof J.Block && ((J.Block<?>) tree).getEnd().getPrefix().contains("\n")) {
+                return true;
+            }
+
+            return tree != null && tree.getFormatting().getPrefix().contains("\n") || super.visitTree(tree);
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isSkipInCursorPath() {
+        Tree t = getCursor().getTree();
+        return skip != null && ((t != null && t.getId().equals(skip.getId())) ||
+                stream(Spliterators.spliteratorUnknownSize(getCursor().getPath(), 0), false)
+                        .anyMatch(p -> p.getId().equals(skip.getId())));
+    }
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRefactorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRefactorCompatibilityKit.kt
@@ -17,6 +17,7 @@ package org.openrewrite.java
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.extension.ExtendWith
+import org.openrewrite.java.utilities.SpansMultipleLinesTest
 
 @ExtendWith(JavaParserResolver::class)
 abstract class JavaRefactorCompatibilityKit {
@@ -90,6 +91,9 @@ abstract class JavaRefactorCompatibilityKit {
 
     @Nested
     inner class ReorderMethodArgumentsTck : ReorderMethodArgumentsTest
+
+    @Nested
+    inner class SpansMultipleLinesTck : SpansMultipleLinesTest
 
     @Nested
     inner class UnwrapParenthesesTck : UnwrapParenthesesTest

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/utilities/SpansMultipleLinesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/utilities/SpansMultipleLinesTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.utilities
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.tree.J
+
+interface SpansMultipleLinesTest {
+
+    @Test
+    fun spansMultipleLines(jp: JavaParser) {
+        val a = jp.parse("""
+            public class A {
+                int m, n;
+                {
+                    { int n = 1; }
+                    { int n = 2;
+                    }
+
+                    if(n == 1) {
+                    }
+
+                    if(n == 1 &&
+                        m == 2) {
+                    }
+                }
+            }
+        """.trimIndent())
+
+        val init = a[0].classes[0].body.statements[1] as J.Block<*>
+
+        assertFalse(SpansMultipleLines(init.statements[0], null).visit(init.statements[0]))
+        assertTrue(SpansMultipleLines(init.statements[1], null).visit(init.statements[1]))
+
+        val iff = init.statements[2] as J.If
+        assertFalse(SpansMultipleLines(iff, iff.thenPart).visit(iff))
+
+        val iff2 = init.statements[3] as J.If
+        assertTrue(SpansMultipleLines(iff2, iff2.thenPart).visit(iff2))
+    }
+
+    @Test
+    fun classDecl(jp: JavaParser) {
+        val a = jp.parse("""
+            public class A {
+                {
+                }
+            }
+        """.trimIndent())
+
+        val aClass = a[0].classes[0]
+        assertFalse(SpansMultipleLines(aClass, aClass.body).visit(aClass))
+    }
+}


### PR DESCRIPTION
Created new Utilities folder because SpansMultipleLines because it didn't fit particularly well anywhere else since:
- You don't use it to find or search for things the way the stuff in org.openrewrite.java.search does
- It doesn't transform java code itself and it isn't a refactoring visitor like the visitors in org.openrewrite.java