### PR TITLE
Change type of J.NewClass.encl to Expression

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11ParserVisitor.java
@@ -901,7 +901,7 @@ public class Java11ParserVisitor extends TreePathScanner<J, Formatting> {
 
     @Override
     public J visitNewClass(NewClassTree node, Formatting fmt) {
-        J.Ident encl = node.getEnclosingExpression() == null ? null : convert(node.getEnclosingExpression());
+        Expression encl = node.getEnclosingExpression() == null ? null : convert(node.getEnclosingExpression());
 
         if(encl != null) {
             encl = encl.withSuffix(sourceBefore("."));

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2571,7 +2571,7 @@ public interface J extends Serializable, Tree {
 
         @Nullable
         @With
-        J.Ident encl;
+        Expression encl;
 
         New nooh;
 


### PR DESCRIPTION
In some case, J.NewClass.encl can be Expression, not J.Ident. For
example,

getSomeInstance().new InnerClass();
MyClass.this.new InnerClass();
myClass.myField.new InnerClass();