### PR TITLE
CU getSourceSet() includes a token of the package name

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1155,7 +1155,8 @@ public interface J extends Serializable, Tree {
         public Path getSourceSet() {
             int packageLevelsUp = getPackageDecl() == null ? 0 :
                     (int) getPackageDecl().printTrimmed().chars().filter(c -> c == '.').count();
-            return Paths.get(sourcePath).resolve(IntStream.range(0, packageLevelsUp + 1)
+            // Skip over java file name
+            return Paths.get(sourcePath).getParent().resolve(IntStream.range(0, packageLevelsUp + 1)
                 .mapToObj(n -> "../")
                 .collect(joining(""))).normalize();
         }


### PR DESCRIPTION
CU source path includes Java file name. Need to call getParent() to look at the parent folder.
(Trivial change - not tested)