### PR TITLE
CU getSourceSet() should skip over java file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ gradle.properties
 out/
 rewrite-java/src/main/gen/
 .idea/
+bin/
+.project
+.classpath
+.settings/
+.DS_Store

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1155,7 +1155,8 @@ public interface J extends Serializable, Tree {
         public Path getSourceSet() {
             int packageLevelsUp = getPackageDecl() == null ? 0 :
                     (int) getPackageDecl().printTrimmed().chars().filter(c -> c == '.').count();
-            return Paths.get(sourcePath).resolve(IntStream.range(0, packageLevelsUp + 1)
+            // Jump over Java file name
+            return Paths.get(sourcePath).getParent().resolve(IntStream.range(0, packageLevelsUp + 1)
                 .mapToObj(n -> "../")
                 .collect(joining(""))).normalize();
         }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/CompilationUnitTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/CompilationUnitTest.kt
@@ -36,6 +36,12 @@ interface CompilationUnitTest {
     }
 
     @Test
+    fun sourceSet(jp: JavaParser) {
+        val a = J.CompilationUnit.buildEmptyClass(Paths.get("sourceSet"), "my.org", "MyClass")
+        assertThat(a.getSourceSet()).isEqualTo(Paths.get("sourceSet"))
+    }
+    
+    @Test
     fun imports(jp: JavaParser) {
         val a = jp.parse("""
             import java.util.List;


### PR DESCRIPTION
getSourceSet() includes first token of the package name since not jumping over the java source file name.

(Includes .gitignore changes for project imported into Eclipse)