### PR TITLE
Fix AddImport to handle static method imports better

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -36,10 +36,16 @@ import static org.openrewrite.Validated.required;
 
 /**
  * A Java refactoring visitor that can be used to add either an import or static import to a given compilation unit.
- *
+ * This visitor can also be configured to only add the import if the imported class/method are referenced within the
+ * compilation unit.
+ * <P><P>
  * The {@link AddImport#type} must be supplied and represents a fully qualified class name.
+ * <P><P>
  * The {@link AddImport#staticMethod} is an optional method within the imported type. The staticMethod can be set to "*"
  * to represent a static wildcard import.
+ * <P><P>
+ * The {@link AddImport#onlyIfReferenced} is a flag (defaulted to true) to indicate if the import should only be added
+ * if there is a reference to the imported class/method.
  */
 @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public class AddImport extends JavaIsoRefactorVisitor {
@@ -172,7 +178,10 @@ public class AddImport extends JavaIsoRefactorVisitor {
 
         //For static imports, we are either looking for a specific method or a wildcard.
         return compilationUnit.findMethodCalls(type + " *(..)").stream()
-                .filter(invocation -> staticMethod.equals("*") || invocation.getName().getSimpleName().equals(staticMethod))
+                .filter(
+                    invocation -> invocation.getSelect() == null &&
+                            (staticMethod.equals("*") || invocation.getName().getSimpleName().equals(staticMethod))
+                )
                 .findAny()
                 .isPresent();
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -35,7 +35,7 @@ import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.Validated.required;
 
 /**
- * A Java refactoring visitor that can be used to add either an import or static import to a given compilation unit.
+ * A Java refactoring visitor that can be used to add an import (or static import) to a given compilation unit.
  * This visitor can also be configured to only add the import if the imported class/method are referenced within the
  * compilation unit.
  * <P><P>

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -201,6 +201,27 @@ interface AddImportTest: RefactorVisitorTest {
     )
 
     @Test
+    fun dontAddImportWhenClassHasNoPackage(jp: JavaParser) = assertUnchanged(
+            jp,
+            visitors = listOf(
+                    AddImport().apply {
+                        setType("C")
+                        setOnlyIfReferenced(false)
+                    }
+            ),
+            before = "class A {}"
+    )
+
+    @Test
+    fun dontAddImportForPrimitive(jp: JavaParser) = assertUnchanged(
+            jp,
+            visitors = listOf(AddImport().apply {
+                setType("int")
+            }),
+            before = "class A {}"
+    )
+
+    @Test
     fun addNamedImportIfStarStaticImportExists(jp: JavaParser) = assertRefactored(
             jp,
             visitors = listOf(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -377,7 +377,7 @@ interface AddImportTest: RefactorVisitorTest {
 
     /**
      * This visitor is used to set the method type of a statically referenced call to java.util.Collections.emptyList().
-     * This allows us to leave an unqualified "emptyList()" method invocation in our "before" snippets and to insure
+     * This allows us to leave an unqualified "emptyList()" method invocation in our "before" snippets and to ensure
      * the static import is correctly added afterwards.
      */
     private class FixEmptyListMethodType : JavaIsoRefactorVisitor() {


### PR DESCRIPTION
This PR adds logic to correctly find method invocations in a compilation unit that belong to a statically imported class/method.