### PR TITLE
Allow visitors to customize their instance of TreeBuilder

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/GenerateConstructorUsingFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/GenerateConstructorUsingFields.java
@@ -122,7 +122,7 @@ public class GenerateConstructorUsingFields {
             public J.MethodDecl visitMethod(J.MethodDecl method) {
                 if (scope.isScope(method)) {
                     return method.withBody(method.getBody().withStatements(
-                            treeBuilder.buildSnippet(
+                            getTreeBuilder().buildSnippet(
                                     getCursor(),
                                     fields.stream().map(mv -> {
                                         String name = mv.getVars().get(0).getSimpleName();

--- a/rewrite-java/src/main/java/org/openrewrite/java/GenerateGetter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/GenerateGetter.java
@@ -77,7 +77,7 @@ public class GenerateGetter {
                     J.VariableDecls.NamedVar fieldVar = field.getVars().get(0);
                     String fieldName = fieldVar.getSimpleName();
 
-                    J.MethodDecl getMethod = treeBuilder.buildMethodDeclaration(
+                    J.MethodDecl getMethod = getTreeBuilder().buildMethodDeclaration(
                             classDecl,
                             "public " + field.getTypeExpr().print().trim() + " get" + capitalize(fieldName) + "()" + " {\n" +
                                     "    return " + fieldName + ";\n" +

--- a/rewrite-java/src/main/java/org/openrewrite/java/GenerateNewBeanUsingProperties.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/GenerateNewBeanUsingProperties.java
@@ -107,7 +107,7 @@ public class GenerateNewBeanUsingProperties {
                         .append(((J) properties[i + 1]).printTrimmed()).append(");\n");
             }
 
-            List<J> beanStatements = treeBuilder.buildSnippet(getCursor(), snippet.toString());
+            List<J> beanStatements = getTreeBuilder().buildSnippet(getCursor(), snippet.toString());
             andThen(new AutoFormat(beanStatements.toArray(new J[0])));
             return beanStatements;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaRefactorVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaRefactorVisitor.java
@@ -462,6 +462,9 @@ public class JavaRefactorVisitor extends AbstractRefactorVisitor<J> implements J
         if (treeBuilder == null && createTreeBuilderSupplier != null) {
             treeBuilder = createTreeBuilderSupplier.get();
         }
+        if (treeBuilder == null) {
+            throw new IllegalArgumentException("Unable resolve a tree builder reference.");
+        }
         return treeBuilder;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TreeBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TreeBuilder.java
@@ -19,6 +19,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Formatting;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.NonNullApi;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.*;
@@ -26,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,10 +47,10 @@ public class TreeBuilder {
     private static final Pattern whitespacePrefixPattern = Pattern.compile("^\\s*");
     private static final Pattern whitespaceSuffixPattern = Pattern.compile("\\s*[^\\s]+(\\s*)");
 
-    private final J.CompilationUnit cu;
+    private JavaParser parser;
 
-    public TreeBuilder(J.CompilationUnit cu) {
-        this.cu = cu;
+    public TreeBuilder(JavaParser parser) {
+        this.parser = parser;
     }
 
     public static <T extends TypeTree & Expression> T buildName(String fullyQualifiedName) {
@@ -105,7 +107,6 @@ public class TreeBuilder {
      * @param types          specify any
      */
     public J buildDeclaration(J.ClassDecl insertionScope, String snippet, JavaType... types) {
-        JavaParser javaParser = cu.buildParser();
 
         // Turn this on in IntelliJ: Preferences > Editor > Code Style > Formatter Control
         // @formatter:off
@@ -135,7 +136,7 @@ public class TreeBuilder {
             logger.debug(source);
         }
 
-        J.CompilationUnit cu = javaParser.parse(source).get(0);
+        J.CompilationUnit cu = parser.parse(source).get(0);
         List<J> statements = cu.getClasses().get(0).getBody().getStatements();
         return new FillTypeAttributions(imports).visit(statements.get(statements.size() - 1));
     }
@@ -198,13 +199,10 @@ public class TreeBuilder {
      * @return A list of AST elements constructed from the snippet.
      */
     @SuppressWarnings("unchecked")
-    public <T extends J> List<T> buildSnippet(Cursor insertionScope,
-                                              String snippet,
-                                              JavaType... imports) {
-
-        //This uses a parser that has the same classpath as the runtime.
-        JavaParser javaParser = cu.buildRuntimeParser();
-
+    public <T extends J> List<T> buildSnippet(
+                Cursor insertionScope,
+                String snippet,
+                JavaType... imports) {
 
         StringBuilder source = new StringBuilder(512);
 
@@ -221,16 +219,18 @@ public class TreeBuilder {
             }
         }
 
+        J.CompilationUnit compilationUnit = getCompilationUnit(insertionScope);
+
         //Need to collect any method invocation within the insert scope. These either need to be stubbed out
         //or statically imported into the synthetic class.
-        List<JavaType.Method> methodTypesInScope = new GetMethodTypesInScope(insertionScope).visit(cu);
+        List<JavaType.Method> methodTypesInScope = new GetMethodTypesInScope(insertionScope).visit(compilationUnit);
 
         List<JavaType.Method> localMethods = new ArrayList<>();
         for (JavaType.Method method: methodTypesInScope) {
             if (method.getDeclaringType() == null) {
                 continue;
             }
-            if (cu.getClasses().stream().map(J.ClassDecl::getType)
+            if (compilationUnit.getClasses().stream().map(J.ClassDecl::getType)
                     .filter(Objects::nonNull)
                     .anyMatch(t -> t.equals(method.getDeclaringType()))) {
                 localMethods.add(method);
@@ -248,11 +248,11 @@ public class TreeBuilder {
                 .map(TreeBuilder::stubMethod)
                 .collect(joining("\n", "\n", "\n")));
         }
-        List<String> localScopeVariables = new ListScopeVariables(insertionScope).visit(cu);
+        List<String> localScopeVariables = new ListScopeVariables(insertionScope).visit(compilationUnit);
         if (!localScopeVariables.isEmpty()) {
             //Stub out in-scope variables
             source.append("\n// variables visible in the insertion scope\n")
-                    .append(new ListScopeVariables(insertionScope).visit(cu).stream()
+                    .append(new ListScopeVariables(insertionScope).visit(compilationUnit).stream()
                     .collect(joining(";\n", "\n", ";\n")));
         }
         source.append("\n// begin snippet block\n{\n")
@@ -265,11 +265,11 @@ public class TreeBuilder {
             logger.debug(sourceString);
         }
 
-        J.CompilationUnit cu = javaParser.parse(sourceString).get(0);
-        List<J> statements = cu.getClasses().get(0).getBody().getStatements();
+        J.CompilationUnit syntheticCompliationUnit = parser.parse(sourceString).get(0);
+        List<J> statements = syntheticCompliationUnit.getClasses().get(0).getBody().getStatements();
         J.Block<T> block = (J.Block<T>) statements.get(statements.size() - 1);
 
-        JavaFormatter formatter = new JavaFormatter(cu);
+        JavaFormatter formatter = new JavaFormatter(syntheticCompliationUnit);
 
         return block.getStatements().stream()
                 .map(stat -> {
@@ -278,6 +278,22 @@ public class TreeBuilder {
                     return (T) shiftRight.visit(stat);
                 })
                 .collect(toList());
+    }
+
+    /**
+     * Starting at the AST element referenced by the cursor, walk up the tree to find the compilation unit.
+     *
+     * @param cursor The cursor to an element in the AST.
+     * @return The parent compilation unit.
+     * @throws IllegalStateException If the AST element does not have a parent compilation unit
+     */
+    @NonNull
+    private J.CompilationUnit getCompilationUnit(Cursor cursor) {
+        J.CompilationUnit cu = cursor.firstEnclosing(J.CompilationUnit.class);
+        if (cu == null) {
+            throw new IllegalStateException("The AST does does not have a compilation unit.");
+        }
+        return cu;
     }
 
     /**

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/InsertDeclarationTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/InsertDeclarationTest.kt
@@ -26,7 +26,7 @@ interface InsertDeclarationTest : RefactorVisitorTest {
             visitorsMapped = listOf { cu ->
                 InsertDeclaration.Scoped(
                         cu.classes[0],
-                        TreeBuilder(cu).buildDeclaration(
+                        TreeBuilder(cu.buildParser()).buildDeclaration(
                                 cu.classes[0],
                                 "void setSomething() {}"
                         )
@@ -50,7 +50,7 @@ interface InsertDeclarationTest : RefactorVisitorTest {
             visitorsMapped = listOf { cu ->
                 InsertDeclaration.Scoped(
                         cu.classes[0],
-                        TreeBuilder(cu).buildDeclaration(
+                        TreeBuilder(cu.buildParser()).buildDeclaration(
                                 cu.classes[0],
                                 "void setSomething() {}"
                         )
@@ -80,7 +80,7 @@ interface InsertDeclarationTest : RefactorVisitorTest {
             visitorsMapped = listOf { cu ->
                 InsertDeclaration.Scoped(
                         cu.classes[0],
-                        TreeBuilder(cu).buildDeclaration(
+                        TreeBuilder(cu.buildParser()).buildDeclaration(
                                 cu.classes[0],
                                 "void setSomething() {}"
                         )

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TreeBuilderTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TreeBuilderTest.kt
@@ -40,7 +40,7 @@ interface TreeBuilderTest {
         val methodBodyCursor = RetrieveCursor(method.body).visit(a)
         val paramName = (method.params.params[0] as J.VariableDecls).vars[0].name
 
-        val snippets = TreeBuilder(a).buildSnippet<Statement>(
+        val snippets = TreeBuilder(jp).buildSnippet<Statement>(
                 methodBodyCursor,
                 "others.add(${paramName.printTrimmed()});")
 
@@ -64,7 +64,7 @@ interface TreeBuilderTest {
         val methodBodyCursor = RetrieveCursor(method.body).visit(a)
         val paramName = (method.params.params[0] as J.VariableDecls).vars[0].name
 
-        val snippets = TreeBuilder(a).buildSnippet<Statement>(
+        val snippets = TreeBuilder(a.buildParser()).buildSnippet<Statement>(
                 methodBodyCursor,
                 """
                     n++;
@@ -100,7 +100,7 @@ interface TreeBuilderTest {
         val methodBodyCursor = RetrieveCursor(method.body!!.statements[0]).visit(a)
         val paramName = (method.params.params[0] as J.VariableDecls).vars[0].name
 
-        val snippets = TreeBuilder(a).buildSnippet<Statement>(
+        val snippets = TreeBuilder(a.buildParser()).buildSnippet<Statement>(
                 methodBodyCursor,
                 """
                     others.add(${paramName.printTrimmed()});
@@ -137,7 +137,7 @@ interface TreeBuilderTest {
         val methodBodyCursor = RetrieveCursor(method.body!!.statements[0]).visit(a)
         val paramName = (method.params.params[0] as J.VariableDecls).vars[0].name
 
-        val snippets = TreeBuilder(a).buildSnippet<Statement>(
+        val snippets = TreeBuilder(a.buildParser()).buildSnippet<Statement>(
                 methodBodyCursor,
                 """
                     if(bucket == null) {
@@ -175,7 +175,7 @@ interface TreeBuilderTest {
                     val methodBodyCursor = RetrieveCursor(method.body).visit(a)
                     val paramName = (method.params.params[0] as J.VariableDecls).vars[0].name.printTrimmed()
 
-                    val snippets = TreeBuilder(a).buildSnippet<Statement>(methodBodyCursor,
+                    val snippets = TreeBuilder(jp).buildSnippet<Statement>(methodBodyCursor,
                             """
                                 others.add(${paramName});
                                 if(others.contains(${paramName})) {
@@ -215,7 +215,7 @@ interface TreeBuilderTest {
             }
         """.trimIndent())[0]
 
-        @Suppress("UNCHECKED_CAST") val init = TreeBuilder(a)
+        @Suppress("UNCHECKED_CAST") val init = TreeBuilder(jp)
                 .buildDeclaration(a.classes[0],
                         """
                             static {
@@ -244,7 +244,7 @@ interface TreeBuilderTest {
             }
         """.trimIndent())[0]
 
-        val methodDecl = TreeBuilder(a).buildMethodDeclaration(a.classes[0],
+        val methodDecl = TreeBuilder(jp).buildMethodDeclaration(a.classes[0],
                 """
                     B build() {
                         return new B();
@@ -306,7 +306,7 @@ interface TreeBuilderTest {
             }
         """.trimIndent()
 
-        val result = TreeBuilder(a).buildDeclaration(a.classes.first(), innerClassSnippet,
+        val result = TreeBuilder(jp).buildDeclaration(a.classes.first(), innerClassSnippet,
                 JavaType.Class.build("java.util.List"))
         assertThat(result).isExactlyInstanceOf(J.ClassDecl::class.java)
         assertThat(result.printTrimmed()).isEqualTo(innerClassSnippet)


### PR DESCRIPTION
**This is a breaking change for any JavaRefactorVisitor that was using the TreeBuilder.** 

This provides two features: 

- It allows a JavaRefactorVisitor to customize the parser used within its TreeBuilder. This would allow a visitor to construct a tree builder instance with a custom parser where the most common use case would be to customize the classpath of the parser.

- The TreeBuilder is now seeded with a parser and can be used outside the context of a compilation unit.  This allows a tree builder to be used in a singleton that is potentially used by several visitors.

