### PR TITLE
Adding an instance check to reduce the work done in "deepEquals" checks.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -61,8 +61,8 @@ public interface JavaType extends Serializable {
 
         @Override
         public boolean deepEquals(@Nullable JavaType type) {
-            return type instanceof MultiCatch &&
-                    TypeUtils.deepEquals(throwableTypes, ((MultiCatch) type).throwableTypes);
+            return this == type  || (type instanceof MultiCatch &&
+                    TypeUtils.deepEquals(throwableTypes, ((MultiCatch) type).throwableTypes));
         }
 
         @Override
@@ -125,8 +125,8 @@ public interface JavaType extends Serializable {
 
         @Override
         public boolean deepEquals(JavaType type) {
-            return type instanceof ShallowClass &&
-                    fullyQualifiedName.equals(((ShallowClass) type).fullyQualifiedName);
+            return this == type  || (type instanceof ShallowClass &&
+                    fullyQualifiedName.equals(((ShallowClass) type).fullyQualifiedName));
         }
 
         @Override
@@ -291,10 +291,12 @@ public interface JavaType extends Serializable {
             }
 
             Class c = (Class) type;
-            return fullyQualifiedName.equals(c.fullyQualifiedName) &&
+            return
+                    this == c || (
+                    fullyQualifiedName.equals(c.fullyQualifiedName) &&
                     TypeUtils.deepEquals(members, c.members) &&
                     TypeUtils.deepEquals(supertype, c.supertype) &&
-                    TypeUtils.deepEquals(typeParameters, c.typeParameters);
+                    TypeUtils.deepEquals(typeParameters, c.typeParameters));
         }
 
         @Override
@@ -339,8 +341,8 @@ public interface JavaType extends Serializable {
             }
 
             Var v = (Var) type;
-            return name.equals(v.name) && TypeUtils.deepEquals(this.type, v.type) &&
-                    flags.equals(v.flags);
+            return this == v  || (name.equals(v.name) && TypeUtils.deepEquals(this.type, v.type) &&
+                    flags.equals(v.flags));
         }
 
         @Override
@@ -407,9 +409,9 @@ public interface JavaType extends Serializable {
         }
 
         private static boolean signatureDeepEquals(@Nullable Signature s1, @Nullable Signature s2) {
-            return s1 == null ? s2 == null : s2 != null &&
+            return s1 == null ? s2 == null : s1 == s2  || (s2 != null &&
                     TypeUtils.deepEquals(s1.returnType, s2.returnType) &&
-                    TypeUtils.deepEquals(s1.paramTypes, s2.paramTypes);
+                    TypeUtils.deepEquals(s1.paramTypes, s2.paramTypes));
         }
 
         public boolean hasFlags(Flag... test) {
@@ -423,11 +425,12 @@ public interface JavaType extends Serializable {
             }
 
             Method m = (Method) type;
-            return paramNames.equals(m.paramNames) &&
+            return this == m || (
+                    paramNames.equals(m.paramNames) &&
                     flags.equals(m.flags) &&
                     declaringType.deepEquals(m.declaringType) &&
                     signatureDeepEquals(genericSignature, m.genericSignature) &&
-                    signatureDeepEquals(resolvedSignature, m.resolvedSignature);
+                    signatureDeepEquals(resolvedSignature, m.resolvedSignature));
         }
 
         @Override
@@ -451,8 +454,8 @@ public interface JavaType extends Serializable {
             }
 
             GenericTypeVariable generic = (GenericTypeVariable) type;
-            return fullyQualifiedName.equals(generic.fullyQualifiedName) &&
-                    TypeUtils.deepEquals(bound, generic.bound);
+            return this == generic || (fullyQualifiedName.equals(generic.fullyQualifiedName) &&
+                    TypeUtils.deepEquals(bound, generic.bound));
         }
 
         @Override
@@ -467,7 +470,7 @@ public interface JavaType extends Serializable {
 
         @Override
         public boolean deepEquals(JavaType type) {
-            return type instanceof Array && elemType != null && elemType.deepEquals(((Array) type).elemType);
+            return type instanceof Array && (this == type || (elemType != null && elemType.deepEquals(((Array) type).elemType)));
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -134,8 +134,7 @@ public class TypeUtils {
 
         return true;
     }
-
     static boolean deepEquals(@Nullable JavaType t, @Nullable JavaType t2) {
-        return t == null ? t2 == null : t.deepEquals(t2);
+        return t == null ? t2 == null : t == t2 || t.deepEquals(t2);
     }
 }


### PR DESCRIPTION
What do you think? 