### PR TITLE
Add support for Maven repository mirrors in settings.xml

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -150,6 +150,7 @@ public class AddDependency extends MavenRefactorVisitor {
     @Override
     public Maven visitMaven(Maven maven) {
         model = maven.getModel();
+        downloader = maven.getDownloader();
 
         Validated versionValidation = Semver.validate(version, metadataPattern);
         if (versionValidation.isValid()) {
@@ -239,8 +240,7 @@ public class AddDependency extends MavenRefactorVisitor {
             return version;
         }
 
-        MavenMetadata mavenMetadata = new MavenDownloader(new NoopCache())
-                .downloadMetadata(groupId, artifactId, emptyList());
+        MavenMetadata mavenMetadata = downloader.downloadMetadata(groupId, artifactId, emptyList());
 
         LatestRelease latest = new LatestRelease(metadataPattern);
         return mavenMetadata.getVersioning().getVersions().stream()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -150,7 +150,7 @@ public class AddDependency extends MavenRefactorVisitor {
     @Override
     public Maven visitMaven(Maven maven) {
         model = maven.getModel();
-        downloader = maven.getDownloader();
+        settings = maven.getSettings();
 
         Validated versionValidation = Semver.validate(version, metadataPattern);
         if (versionValidation.isValid()) {
@@ -240,7 +240,8 @@ public class AddDependency extends MavenRefactorVisitor {
             return version;
         }
 
-        MavenMetadata mavenMetadata = downloader.downloadMetadata(groupId, artifactId, emptyList());
+        MavenMetadata mavenMetadata = new MavenDownloader(new NoopCache(), emptyMap(), settings)
+                .downloadMetadata(groupId, artifactId, emptyList());
 
         LatestRelease latest = new LatestRelease(metadataPattern);
         return mavenMetadata.getVersioning().getVersions().stream()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -45,11 +45,11 @@ public class MavenParser implements Parser<Maven> {
 
     private final MavenCache mavenCache;
     private final Collection<String> activeProfiles;
-    private final MavenSettings mavenSettings;
+    @Nullable private final MavenSettings mavenSettings;
     private final boolean resolveOptional;
 
     private MavenParser(MavenCache mavenCache, Collection<String> activeProfiles,
-                        MavenSettings mavenSettings, boolean resolveOptional) {
+                        @Nullable MavenSettings mavenSettings, boolean resolveOptional) {
         this.mavenCache = mavenCache;
         this.activeProfiles = activeProfiles;
         this.mavenSettings = mavenSettings;
@@ -63,13 +63,14 @@ public class MavenParser implements Parser<Maven> {
                 .collect(toList());
 
         MavenDownloader downloader = new MavenDownloader(mavenCache,
-                projectPoms.stream().collect(toMap(RawMaven::getSourcePath, Function.identity())));
+                projectPoms.stream().collect(toMap(RawMaven::getSourcePath, Function.identity())),
+                (mavenSettings == null) ? null : mavenSettings.getMirrors());
 
         List<Maven> parsed = projectPoms.stream()
                 .map(raw -> new RawMavenResolver(downloader, false, activeProfiles,
                         mavenSettings, resolveOptional).resolve(raw))
                 .filter(Objects::nonNull)
-                .map(Maven::new)
+                .map(xmlDoc -> new Maven(xmlDoc, downloader))
                 .collect(toCollection(ArrayList::new));
 
         for (int i = 0; i < parsed.size(); i++) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -64,13 +64,13 @@ public class MavenParser implements Parser<Maven> {
 
         MavenDownloader downloader = new MavenDownloader(mavenCache,
                 projectPoms.stream().collect(toMap(RawMaven::getSourcePath, Function.identity())),
-                (mavenSettings == null) ? null : mavenSettings.getMirrors());
+                mavenSettings);
 
         List<Maven> parsed = projectPoms.stream()
                 .map(raw -> new RawMavenResolver(downloader, false, activeProfiles,
                         mavenSettings, resolveOptional).resolve(raw))
                 .filter(Objects::nonNull)
-                .map(xmlDoc -> new Maven(xmlDoc, downloader))
+                .map(xmlDoc -> new Maven(xmlDoc, mavenSettings))
                 .collect(toCollection(ArrayList::new));
 
         for (int i = 0; i < parsed.size(); i++) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenRefactorVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenRefactorVisitor.java
@@ -16,6 +16,7 @@
 package org.openrewrite.maven;
 
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.internal.MavenDownloader;
 import org.openrewrite.maven.tree.Maven;
 import org.openrewrite.maven.tree.Pom;
 import org.openrewrite.xml.XPathMatcher;
@@ -37,11 +38,13 @@ public class MavenRefactorVisitor extends XmlRefactorVisitor
 
     protected Pom model;
     protected Collection<Pom> modules;
+    protected MavenDownloader downloader;
 
     @Override
     public Maven visitMaven(Maven maven) {
         this.model = maven.getModel();
         this.modules = maven.getModules();
+        this.downloader = maven.getDownloader();
         return (Maven) visitDocument(maven);
     }
 
@@ -49,7 +52,7 @@ public class MavenRefactorVisitor extends XmlRefactorVisitor
     public final Xml visitDocument(Xml.Document document) {
         Xml.Document refactored = refactor(document, super::visitDocument);
         if (refactored != document) {
-            return new Maven(refactored);
+            return new Maven(refactored, downloader);
         }
         return refactored;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenRefactorVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenRefactorVisitor.java
@@ -38,13 +38,13 @@ public class MavenRefactorVisitor extends XmlRefactorVisitor
 
     protected Pom model;
     protected Collection<Pom> modules;
-    protected MavenDownloader downloader;
+    protected MavenSettings settings;
 
     @Override
     public Maven visitMaven(Maven maven) {
         this.model = maven.getModel();
         this.modules = maven.getModules();
-        this.downloader = maven.getDownloader();
+        this.settings = maven.getSettings();
         return (Maven) visitDocument(maven);
     }
 
@@ -52,7 +52,7 @@ public class MavenRefactorVisitor extends XmlRefactorVisitor
     public final Xml visitDocument(Xml.Document document) {
         Xml.Document refactored = refactor(document, super::visitDocument);
         if (refactored != document) {
-            return new Maven(refactored, downloader);
+            return new Maven(refactored, settings);
         }
         return refactored;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
 import org.openrewrite.Parser;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.internal.RawRepositories;
@@ -35,9 +36,14 @@ import org.openrewrite.maven.internal.RawRepositories;
 import javax.xml.stream.XMLInputFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 
@@ -65,12 +71,18 @@ public class MavenSettings {
     @Nullable
     ActiveProfiles activeProfiles;
 
+    @Nullable
+    @Getter
+    Mirrors mirrors;
+
     @JsonCreator
     MavenSettings(
             @JsonProperty("profiles") @Nullable Profiles profiles,
-            @JsonProperty("activeProfiles") @Nullable ActiveProfiles activeProfiles) {
+            @JsonProperty("activeProfiles") @Nullable ActiveProfiles activeProfiles,
+            @JsonProperty("mirrors") @Nullable Mirrors mirrors) {
         this.profiles = profiles;
         this.activeProfiles = activeProfiles;
+        this.mirrors = mirrors;
     }
 
     public static MavenSettings parse(Parser.Input source) {
@@ -94,8 +106,27 @@ public class MavenSettings {
                 }
             }
         }
+        return applyMirrors(activeRepositories);
+    }
 
-        return activeRepositories;
+    public List<RawRepositories.Repository> applyMirrors(Collection<RawRepositories.Repository> repositories) {
+        if(mirrors == null) {
+            if(repositories instanceof List) {
+                return (List<RawRepositories.Repository>) repositories;
+            } else {
+                return new ArrayList<>(repositories);
+            }
+        } else {
+            return mirrors.applyMirrors(repositories);
+        }
+    }
+
+    public RawRepositories.Repository applyMirrors(RawRepositories.Repository repository) {
+        if(mirrors == null) {
+            return repository;
+        } else {
+            return mirrors.applyMirrors(repository);
+        }
     }
 
     @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -135,6 +166,163 @@ public class MavenSettings {
                 }
             }
             return false;
+        }
+    }
+
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @Getter
+    @Setter
+    public static class Mirrors {
+        @JacksonXmlProperty(localName = "mirror")
+        @JacksonXmlElementWrapper(useWrapping = false)
+        List<Mirror> mirrors = emptyList();
+
+        public List<RawRepositories.Repository> applyMirrors(Collection<RawRepositories.Repository> repositories) {
+                return repositories.stream()
+                        .map(this::applyMirrors)
+                        .distinct()
+                        .collect(Collectors.toList());
+        }
+
+        public RawRepositories.Repository applyMirrors(RawRepositories.Repository repository) {
+            RawRepositories.Repository result = repository;
+            for(Mirror mirror : mirrors) {
+                result = mirror.apply(result);
+            }
+            return result;
+        }
+    }
+
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Data
+    public static class Mirror {
+
+        /**
+         * The id of this mirror.
+         */
+        @Nullable
+        String id;
+
+        /**
+         * The optional name that describes the mirror.
+         */
+        @Nullable
+        String name;
+
+        @Nullable
+        URI url;
+
+        /**
+         * The server ID of the repository being mirrored, e.g., "central".
+         * This can be a literal id, but it can also take a few other patterns:
+         *     * = everything
+         *     external:* = everything not on the localhost and not file based.
+         *     repo,repo1 = repo or repo1
+         *     !repo1 = everything except repo1
+         *
+         * See: https://maven.apache.org/guides/mini/guide-mirror-settings.html#advanced-mirror-specification
+         *
+         */
+        @Nullable
+        String mirrorOf;
+
+        @NonFinal
+        private ApplicabilitySpec applicabilitySpec = null;
+
+        private ApplicabilitySpec buildApplicabilitySpec() {
+            if(mirrorOf == null) {
+                return APPLICABLE_TO_NOTHING;
+            }
+            if(mirrorOf.equals("*")) {
+                return APPLICABLE_TO_EVERYTHING;
+            }
+            int colonIndex = mirrorOf.indexOf(':');
+            String mirrorOfWithoutExternal = mirrorOf;
+            boolean externalOnly = false;
+            if(colonIndex != -1) {
+                externalOnly = true;
+                mirrorOfWithoutExternal = mirrorOf.substring(colonIndex + 1);
+            }
+            List<String> mirrorsOf = Arrays.stream(mirrorOfWithoutExternal.split(",")).collect(Collectors.toList());
+            Set<String> excludedRepos = new HashSet<>();
+            Set<String> includedRepos = new HashSet<>();
+            for(String mirror : mirrorsOf) {
+                if(mirror.startsWith("!")) {
+                    excludedRepos.add(mirror.substring(1));
+                } else {
+                    includedRepos.add(mirror);
+                }
+            }
+
+            return new DefaultApplicabilitySpec(externalOnly, excludedRepos, includedRepos);
+        }
+
+        private interface ApplicabilitySpec {
+            boolean isApplicable(RawRepositories.Repository repo);
+        }
+
+        private static ApplicabilitySpec APPLICABLE_TO_EVERYTHING = repo -> true;
+        private static ApplicabilitySpec APPLICABLE_TO_NOTHING = repo -> false;
+        private static class DefaultApplicabilitySpec implements ApplicabilitySpec {
+            final boolean isExternalOnly;
+            final Set<String> excludedRepos;
+            final Set<String> includedRepos;
+
+            DefaultApplicabilitySpec(boolean isExternalOnly, Set<String> excludedRepos, Set<String> includedRepos) {
+                this.isExternalOnly = isExternalOnly;
+                this.excludedRepos = excludedRepos;
+                this.includedRepos = includedRepos;
+            }
+
+            @Override
+            public boolean isApplicable(RawRepositories.Repository repo) {
+                if(isExternalOnly && isInternal(repo)) {
+                    return false;
+                }
+                // Named inclusion/exclusion beats wildcard inclusion/exclusion
+                if(excludedRepos.stream().anyMatch(it -> it.equals("*"))) {
+                    return includedRepos.contains(repo.getId());
+                }
+                if(includedRepos.stream().anyMatch(it -> it.equals("*"))) {
+                    return !excludedRepos.contains(repo.getId());
+                }
+                return !excludedRepos.contains(repo.getId()) && includedRepos.contains(repo.getId());
+            }
+
+            private boolean isInternal(RawRepositories.Repository repo) {
+                URI repoUri = URI.create(repo.getUrl());
+                if(repoUri.getScheme().startsWith("file")) {
+                    return true;
+                }
+                // Best-effort basis, by no means a full guarantee of detecting all possible local URIs
+                if(repoUri.getHost().equals("localhost") || repoUri.getHost().equals("127.0.0.1")) {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        /**
+         * Apply this mirror to the supplied Repository.
+         * If this mirror is applicable, a Repository with the URL specified in this mirror will be returned.
+         * If this mirror is inapplicable, the supplied repository will be returned unmodified.
+         */
+        public RawRepositories.Repository apply(RawRepositories.Repository repo) {
+            if(isApplicable(repo) && url != null) {
+                return new RawRepositories.Repository(id, url.toString(), repo.getReleases(), repo.getSnapshots());
+            } else {
+                return repo;
+            }
+        }
+
+        /**
+         * Returns true if this mirror is applicable to the supplied repository, otherwise false.
+         */
+        public boolean isApplicable(RawRepositories.Repository repo) {
+            if(applicabilitySpec == null) {
+                applicabilitySpec = buildApplicabilitySpec();
+            }
+            return applicabilitySpec.isApplicable(repo);
         }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -101,6 +101,7 @@ public class UpgradeDependencyVersion extends MavenRefactorVisitor {
     @Override
     public Maven visitMaven(Maven maven) {
         versionComparator = Semver.validate(toVersion, metadataPattern).getValue();
+        downloader = maven.getDownloader();
 
         maybeChangeDependencyVersion(maven.getModel());
 
@@ -139,8 +140,7 @@ public class UpgradeDependencyVersion extends MavenRefactorVisitor {
 
     private Optional<String> findNewerDependencyVersion(String groupId, String artifactId, String currentVersion) {
         if (availableVersions == null) {
-            MavenMetadata mavenMetadata = new MavenDownloader(new NoopCache())
-                    .downloadMetadata(groupId, artifactId, emptyList());
+            MavenMetadata mavenMetadata = downloader.downloadMetadata(groupId, artifactId, emptyList());
             availableVersions = mavenMetadata.getVersioning().getVersions().stream()
                     .filter(versionComparator::isValid)
                     .collect(Collectors.toList());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -102,8 +102,7 @@ public class UpgradeParentVersion extends MavenRefactorVisitor {
 
     private Optional<String> findNewerDependencyVersion(String groupId, String artifactId, String currentVersion) {
         if (availableVersions == null) {
-            MavenMetadata mavenMetadata = new MavenDownloader(new NoopCache())
-                    .downloadMetadata(groupId, artifactId, emptyList());
+            MavenMetadata mavenMetadata = downloader.downloadMetadata(groupId, artifactId, emptyList());
             availableVersions = mavenMetadata.getVersioning().getVersions().stream()
                     .filter(versionComparator::isValid)
                     .collect(Collectors.toList());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.openrewrite.Validated.required;
 
 public class UpgradeParentVersion extends MavenRefactorVisitor {
@@ -102,7 +103,8 @@ public class UpgradeParentVersion extends MavenRefactorVisitor {
 
     private Optional<String> findNewerDependencyVersion(String groupId, String artifactId, String currentVersion) {
         if (availableVersions == null) {
-            MavenMetadata mavenMetadata = downloader.downloadMetadata(groupId, artifactId, emptyList());
+            MavenMetadata mavenMetadata = new MavenDownloader(new NoopCache(), emptyMap(), settings)
+                    .downloadMetadata(groupId, artifactId, emptyList());
             availableVersions = mavenMetadata.getVersioning().getVersions().stream()
                     .filter(versionComparator::isValid)
                     .collect(Collectors.toList());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenDownloader.java
@@ -55,16 +55,16 @@ public class MavenDownloader {
     private final MavenCache mavenCache;
     private final Map<Path, RawMaven> projectPoms;
     @Nullable
-    private final MavenSettings.Mirrors mirrors;
+    private final MavenSettings settings;
 
     public MavenDownloader(MavenCache mavenCache) {
         this(mavenCache, emptyMap(), null);
     }
 
-    public MavenDownloader(MavenCache mavenCache, Map<Path, RawMaven> projectPoms, @Nullable MavenSettings.Mirrors mirrors) {
+    public MavenDownloader(MavenCache mavenCache, Map<Path, RawMaven> projectPoms, @Nullable MavenSettings settings) {
         this.mavenCache = mavenCache;
         this.projectPoms = projectPoms;
-        this.mirrors = mirrors;
+        this.settings = settings;
     }
 
     public MavenMetadata downloadMetadata(String groupId, String artifactId,
@@ -317,10 +317,10 @@ public class MavenDownloader {
     }
 
     private RawRepositories.Repository applyMirrors(RawRepositories.Repository repository) {
-        if(mirrors == null) {
+        if(settings == null) {
             return repository;
         } else {
-            return mirrors.applyMirrors(repository);
+            return settings.applyMirrors(repository);
         }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.tree.GroupArtifact;
 
 import java.util.*;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.tree.GroupArtifact;
 
 import java.util.*;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
@@ -16,6 +16,7 @@
 package org.openrewrite.maven.internal;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -38,6 +39,10 @@ public class RawRepositories {
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @Data
     public static class Repository {
+
+        @Nullable
+        String id;
+
         @With
         String url;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Maven.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Maven.java
@@ -20,6 +20,7 @@ import org.openrewrite.Formatting;
 import org.openrewrite.Metadata;
 import org.openrewrite.SourceVisitor;
 import org.openrewrite.maven.MavenSourceVisitor;
+import org.openrewrite.maven.internal.MavenDownloader;
 import org.openrewrite.xml.XmlSourceVisitor;
 import org.openrewrite.xml.tree.Xml;
 
@@ -32,8 +33,9 @@ import static java.util.Collections.emptyList;
 public class Maven extends Xml.Document {
     private final transient Pom model;
     private final transient Collection<Pom> modules;
+    private final transient MavenDownloader downloader;
 
-    public Maven(Xml.Document document) {
+    public Maven(Xml.Document document, MavenDownloader downloader) {
         super(
                 document.getId(),
                 document.getSourcePath(),
@@ -42,6 +44,8 @@ public class Maven extends Xml.Document {
                 document.getRoot(),
                 document.getFormatting()
         );
+
+        this.downloader = downloader;
 
         model = getMetadata(Pom.class);
         assert model != null;
@@ -61,6 +65,11 @@ public class Maven extends Xml.Document {
         return modules;
     }
 
+    @JsonIgnore
+    public MavenDownloader getDownloader() {
+        return downloader;
+    }
+
     @Override
     public <R> R accept(SourceVisitor<R> v) {
         if (v instanceof MavenSourceVisitor) {
@@ -77,7 +86,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m);
+        return new Maven(m, downloader);
     }
 
     @Override
@@ -86,7 +95,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m);
+        return new Maven(m, downloader);
     }
 
     @Override
@@ -95,7 +104,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m);
+        return new Maven(m, downloader);
     }
 
     @Override
@@ -104,7 +113,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m);
+        return new Maven(m, downloader);
     }
 
     public Maven withModel(Pom model) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Maven.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Maven.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.openrewrite.Formatting;
 import org.openrewrite.Metadata;
 import org.openrewrite.SourceVisitor;
+import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.MavenSourceVisitor;
 import org.openrewrite.maven.internal.MavenDownloader;
 import org.openrewrite.xml.XmlSourceVisitor;
@@ -33,9 +34,9 @@ import static java.util.Collections.emptyList;
 public class Maven extends Xml.Document {
     private final transient Pom model;
     private final transient Collection<Pom> modules;
-    private final transient MavenDownloader downloader;
+    private final transient MavenSettings settings;
 
-    public Maven(Xml.Document document, MavenDownloader downloader) {
+    public Maven(Xml.Document document, MavenSettings settings) {
         super(
                 document.getId(),
                 document.getSourcePath(),
@@ -45,7 +46,7 @@ public class Maven extends Xml.Document {
                 document.getFormatting()
         );
 
-        this.downloader = downloader;
+        this.settings = settings;
 
         model = getMetadata(Pom.class);
         assert model != null;
@@ -66,8 +67,8 @@ public class Maven extends Xml.Document {
     }
 
     @JsonIgnore
-    public MavenDownloader getDownloader() {
-        return downloader;
+    public MavenSettings getSettings() {
+        return settings;
     }
 
     @Override
@@ -86,7 +87,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m, downloader);
+        return new Maven(m, settings);
     }
 
     @Override
@@ -95,7 +96,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m, downloader);
+        return new Maven(m, settings);
     }
 
     @Override
@@ -104,7 +105,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m, downloader);
+        return new Maven(m, settings);
     }
 
     @Override
@@ -113,7 +114,7 @@ public class Maven extends Xml.Document {
         if (m instanceof Maven) {
             return (Maven) m;
         }
-        return new Maven(m, downloader);
+        return new Maven(m, settings);
     }
 
     public Maven withModel(Pom model) {

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/MavenSettingsTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/MavenSettingsTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.maven
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Condition
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
@@ -143,5 +144,90 @@ class MavenSettingsTest {
         assertThat(settings.getActiveRepositories(emptyList()))
             .hasSize(1)
             .allMatch { it.url == "https://actviebyactivationlist.com" }
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/130")
+    @Test
+    fun mirrorReplacesRepository() {
+        val settings = MavenSettings.parse(Parser.Input(Paths.get("settings.xml")) {
+            """
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+                <activeProfiles>
+                    <activeProfile>
+                        repo
+                    </activeProfile>
+                </activeProfiles>
+                <profiles>
+                    <profile>
+                        <id>repo</id>
+                        <repositories>
+                            <repository>
+                                <id>spring-milestones</id>
+                                <url>https://externalrepository.com</url>
+                            </repository>
+                        </repositories>
+                    </profile>
+                </profiles>
+                <mirrors>
+                    <mirror>
+                        <mirrorOf>*</mirrorOf>
+                        <name>repo</name>
+                        <url>https://internalartifactrepository.yourorg.com</url>
+                        <id>repo</id>
+                    </mirror>
+                </mirrors>
+            </settings>
+            """.trimIndent().byteInputStream()
+        })
+
+        assertThat(settings.getActiveRepositories(emptyList()))
+            .hasSize(1)
+            .allMatch { it.url == "https://internalartifactrepository.yourorg.com" }
+    }
+
+    @Test
+    fun starredMirrorWithExclusion() {
+        val settings = MavenSettings.parse(Parser.Input(Paths.get("settings.xml")) {
+            """
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+                <activeProfiles>
+                    <activeProfile>
+                        repo
+                    </activeProfile>
+                </activeProfiles>
+                <profiles>
+                    <profile>
+                        <id>repo</id>
+                        <repositories>
+                            <repository>
+                                <id>should-be-mirrored</id>
+                                <url>https://externalrepository.com</url>
+                            </repository>
+                            <repository>
+                                <id>should-not-be-mirrored</id>
+                                <url>https://externalrepository.com</url>
+                            </repository>
+                        </repositories>
+                    </profile>
+                </profiles>
+                <mirrors>
+                    <mirror>
+                        <mirrorOf>*,!should-not-be-mirrored</mirrorOf>
+                        <name>repo</name>
+                        <url>https://internalartifactrepository.yourorg.com</url>
+                        <id>repo</id>
+                    </mirror>
+                </mirrors>
+            </settings>
+            """.trimIndent().byteInputStream()
+        })
+        assertThat(settings.getActiveRepositories(emptyList()))
+            .hasSize(2)
+            .haveAtLeastOne(Condition({repo -> repo.url == "https://internalartifactrepository.yourorg.com"}, "Repository should-be-mirrored should have had its URL changed to https://internalartifactrepository.yourorg.com"))
+            .haveAtLeastOne(Condition({repo -> repo.url == "https://externalrepository.com" && repo.id == "should-not-be-mirrored"}, "Repository should-not-be-mirrored should have had its URL left unchanged"))
     }
 }

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/internal/RawPomTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/internal/RawPomTest.kt
@@ -74,7 +74,7 @@ class RawPomTest {
 
     @Test
     fun repositorySerializationAndDeserialization() {
-        val repo = RawRepositories.Repository("https://repo.maven.apache.org/maven2",
+        val repo = RawRepositories.Repository("central","https://repo.maven.apache.org/maven2",
                 ArtifactPolicy(true), ArtifactPolicy(false))
 
         val mapper = ObjectMapper()

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/internal/RawPomTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/internal/RawPomTest.kt
@@ -74,7 +74,7 @@ class RawPomTest {
 
     @Test
     fun repositorySerializationAndDeserialization() {
-        val repo = RawRepositories.Repository("central","https://repo.maven.apache.org/maven2",
+        val repo = RawRepositories.Repository("central", "https://repo.maven.apache.org/maven2",
                 ArtifactPolicy(true), ArtifactPolicy(false))
 
         val mapper = ObjectMapper()


### PR DESCRIPTION
I'm going to do some more testing, but I thought I'd get feedback on the basic approach. 
Essentially the mirrors information from settings.xml has to end up in `MavenDownloader` for it to matter, but `MavenDownloader`s can be freely instantiated anywhere, including places where settings.xml information isn't available. So I added a `MavenDownloader` field to `Maven` so that any visitors which might want to download something can access that per-constructed downloader rather than creating a new one. 
