### PR TITLE
Tidy YamlPrinter comments

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -79,7 +79,6 @@ public class YamlPrinter<P> implements YamlVisitor<String, P> {
 
     @Override
     public String visitSequence(Yaml.Sequence sequence, P p) {
-        // todo, something isn't right with just not accessing the element prefix
         return visit(sequence.getEntries(), p);
     }
 
@@ -90,7 +89,6 @@ public class YamlPrinter<P> implements YamlVisitor<String, P> {
 
     @Override
     public String visitMapping(Yaml.Mapping mapping, P p) {
-        // todo, something isn't right with just not accessing the element prefix
         return visit(mapping.getEntries(), p);
     }
 


### PR DESCRIPTION
part of: https://github.com/openrewrite/rewrite/issues/153

see: https://github.com/openrewrite/rewrite/blob/a1cbc9b257b669d3251b61fd80457095194aa932/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/PrintYaml.java#L24

Note that in 6.x in PrintYaml we haven't overridden the implementation of visitSequence and visitMapping leaving them to default, preventing the printing of their prefix and post in the same fashion. We've done the same thing here as in 6.x. So, at least for the time being, removing the comments from source and instead leaving out the assessment through issue-tracking. If anything this means there's something off about how prefixing is assigned to a mapping vs. mappingEntry. But, again, pulling the comments for the time being.