### PR TITLE
Yaml.Document.End document separators

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -18,6 +18,7 @@ package org.openrewrite.yaml;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.yaml.tree.Yaml;
+import org.yaml.snakeyaml.events.DocumentEndEvent;
 import org.yaml.snakeyaml.events.Event;
 import org.yaml.snakeyaml.events.ScalarEvent;
 import org.yaml.snakeyaml.parser.Parser;
@@ -73,7 +74,13 @@ public class YamlParser implements org.openrewrite.Parser<Yaml.Documents> {
                     case Alias:
                         break;
                     case DocumentEnd:
-                        documents.add(document);
+                        documents.add(document.withEnd(new Yaml.Document.End(
+                                randomId(),
+                                ((DocumentEndEvent) event).getExplicit(),
+                                fmt,
+                                Markers.EMPTY
+                        )));
+                        lastEnd = event.getEndMark().getIndex();
                         break;
                     case DocumentStart:
                         document = new Yaml.Document(

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -64,7 +64,9 @@ public class YamlPrinter<P> implements YamlVisitor<String, P> {
 
     @Override
     public String visitDocument(Yaml.Document document, P p) {
-        return fmt(document, (document.isExplicit() ? "---" : "") + visit(document.getBlocks(), p));
+        return fmt(document, (document.isExplicit() ? "---" : "") + visit(document.getBlocks(), p) +
+                document.getEnd().getPrefix() +
+                (document.getEnd().isExplicit() ? "..." : ""));
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
@@ -161,6 +161,9 @@ public interface Yaml extends Serializable, Tree {
             UUID id;
 
             @With
+            boolean explicit;
+
+            @With
             String prefix;
 
             @With
@@ -168,7 +171,7 @@ public interface Yaml extends Serializable, Tree {
 
             @Override
             public End copyPaste() {
-                return new End(randomId(), prefix, Markers.EMPTY);
+                return new End(randomId(), explicit, prefix, Markers.EMPTY);
             }
         }
     }

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DocumentTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DocumentTest.kt
@@ -18,13 +18,14 @@ package org.openrewrite.yaml
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class DocumentTest: YamlParser() {
+class DocumentTest : YamlParser() {
     @Test
-    fun explicit() {
+    fun explicitStart() {
         val yText = """
             ---
             type: specs.openrewrite.org/v1beta/visitor
             ---
+            
             type: specs.openrewrite.org/v1beta/recipe
         """.trimIndent()
 
@@ -36,12 +37,40 @@ class DocumentTest: YamlParser() {
     }
 
     @Test
-    fun implicit() {
+    fun explicitEnd() {
+        val yText = """
+            type: specs.openrewrite.org/v1beta/visitor
+            ...
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            
+            ...
+        """.trimIndent()
+
+        val y = parse(yText)[0]
+
+        assertThat(y.documents).hasSize(2)
+        assertThat(y.documents[0].end.isExplicit).isTrue()
+        assertThat(y.printTrimmed()).isEqualTo(yText)
+    }
+
+    @Test
+    fun implicitStart() {
         val yText = "type: specs.openrewrite.org/v1beta/visitor"
         val y = parse(yText)[0]
 
         assertThat(y.documents).hasSize(1)
         assertThat(y.documents[0].isExplicit).isFalse()
+        assertThat(y.printTrimmed()).isEqualTo(yText)
+    }
+
+    @Test
+    fun implicitEnd() {
+        val yText = "type: specs.openrewrite.org/v1beta/visitor"
+        val y = parse(yText)[0]
+
+        assertThat(y.documents).hasSize(1)
+        assertThat(y.documents[0].end.isExplicit).isFalse()
         assertThat(y.printTrimmed()).isEqualTo(yText)
     }
 }


### PR DESCRIPTION
Adds parsing and rendering logic to the Yaml.Document.End token, as described by the yaml spec (https://yaml.org/spec/1.1/#c-document-end). Is it rare to see? Yeah, it's a bit rare to see it in the wild, but it's out there.

example:

```yml
---
some: document
# explicit example:
...


---
more: 
  - documents
  - go
  - here
# implicit example:
...
```

This additionally functions as the equivalent of a whitespace `suffix' for the end of documents.