### PR TITLE
un-comment-out rewrite-yaml test and move to ignored

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlProcessor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlProcessor.java
@@ -57,7 +57,6 @@ public class YamlProcessor<P> extends TreeProcessor<Yaml, P> implements YamlVisi
         return entry.withBlock(call(entry.getBlock(), p));
     }
 
-    // TODO proper usage here? Feels like a matter of execution context?
     public void maybeCoalesceProperties() {
         if (getAfterVisit().stream().noneMatch(CoalesceProperties.CoalescePropertiesProcessor.class::isInstance)) {
             doAfterVisit(new CoalesceProperties());

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/CoalescePropertiesTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/CoalescePropertiesTest.kt
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.RecipeTest
 
@@ -23,7 +24,7 @@ class CoalescePropertiesTest : RecipeTest {
 
     @Test
     fun fold() = assertChanged(
-            recipe = CoalesceProperties().apply { },
+            recipe = CoalesceProperties(),
             before = """
                 management:
                     metrics:
@@ -42,19 +43,19 @@ class CoalescePropertiesTest : RecipeTest {
             """
     )
 
-//    @Test
-//    fun group() {
-//        val y = parse("""
-//            management.metrics.enable.process.files: true
-//            management.metrics.enable.jvm: true
-//        """.trimIndent())
-//
-//        val fixed = y.refactor().visit(CoalesceProperties()).fix().fixed
-//
-//        assertRefactored(fixed, """
-//            management.metrics.enable:
-//                process.files: true
-//                jvm: true
-//        """.trimIndent())
-//    }
+    @Test
+    @Disabled
+    fun group() = assertChanged(
+            recipe = CoalesceProperties(),
+            before = """
+                management.metrics.enable.process.files: true
+                management.metrics.enable.jvm: true
+            """,
+            after = """
+                management.metrics.enable:
+                    process.files: true
+                    jvm: true
+            """
+    )
+
 }


### PR DESCRIPTION
Small detail; the `group` test for CoalesceProperties in rewrite-yaml has always been commented out, but for the sake of keeping things up-to-date, just placing an `ignored` annotation on it