### PR TITLE
Small optimization for OrderImports recipe

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
@@ -61,11 +61,12 @@ public class OrderImports extends Recipe {
 
             if (orderedImports.size() != cu.getImports().size()) {
                 cu = cu.withImports(orderedImports);
-            }
-
-            for (int i = 0; i < orderedImports.size(); i++) {
-                if (orderedImports.get(i) != cu.getImports().get(i)) {
-                    cu = cu.withImports(orderedImports);
+            } else {
+                for (int i = 0; i < orderedImports.size(); i++) {
+                    if (orderedImports.get(i) != cu.getImports().get(i)) {
+                        cu = cu.withImports(orderedImports);
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
While the Lombok `@With`-generated method should be smart enough to always return the same object when the given list of imports is the same object, there is no need to loop over all imports.