### PR TITLE
hasModifier("...") only evaluates true when "Modifier"

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -30,8 +30,8 @@ import java.util.Objects;
 
 public class JavaVisitor<P> extends TreeVisitor<J, P> {
 
-    @Incubating(since="7.0.0")
-    public <J2 extends J> J2 generate(JavaTemplate template, JavaCoordinates coordinates, Object... parameters ) {
+    @Incubating(since = "7.0.0")
+    public <J2 extends J> J2 generate(JavaTemplate template, JavaCoordinates coordinates, Object... parameters) {
         //TODO Not Implemented.
         return null;
     }
@@ -43,7 +43,6 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      * @param parameters Template parameters
      * @param <J2>       Expected type returned from the template.
      * @return A list of generated elements
-     *
      * @deprecated This method is deprecated and will be removed in 7.0.
      */
     @Deprecated
@@ -847,7 +846,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             if (childScope instanceof J.ClassDecl) {
                 J.ClassDecl childClass = (J.ClassDecl) childScope;
                 if (!(childClass.getKind().equals(J.ClassDecl.Kind.Class)) ||
-                        childClass.hasModifier("static")) {
+                        childClass.hasModifier(J.Modifier.Type.Static)) {
                     //Short circuit the search if a terminating element is encountered.
                     return false;
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2881,8 +2881,7 @@ public interface J extends Serializable, Tree {
     @Data
     final class Modifier implements J {
         public static boolean hasModifier(Collection<Modifier> modifiers, String modifier) {
-            return modifiers.stream().anyMatch(m -> m.getClass().getSimpleName()
-                    .toLowerCase().equals(modifier));
+            return modifiers.stream().anyMatch(m -> m.getType().toString().toLowerCase().equals(modifier));
         }
 
         @EqualsAndHashCode.Include

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -877,7 +877,7 @@ public interface J extends Serializable, Tree {
             Annotation
         }
 
-        public boolean hasModifier(String modifier) {
+        public boolean hasModifier(Modifier.Type modifier) {
             return Modifier.hasModifier(getModifiers(), modifier);
         }
 
@@ -2652,7 +2652,7 @@ public interface J extends Serializable, Tree {
             return name.getSimpleName();
         }
 
-        public boolean hasModifier(String modifier) {
+        public boolean hasModifier(Modifier.Type modifier) {
             return Modifier.hasModifier(getModifiers(), modifier);
         }
 
@@ -2880,8 +2880,8 @@ public interface J extends Serializable, Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @Data
     final class Modifier implements J {
-        public static boolean hasModifier(Collection<Modifier> modifiers, String modifier) {
-            return modifiers.stream().anyMatch(m -> m.getType().toString().toLowerCase().equals(modifier));
+        public static boolean hasModifier(Collection<Modifier> modifiers, Modifier.Type modifier) {
+            return modifiers.stream().anyMatch(m -> m.getType() == modifier);
         }
 
         @EqualsAndHashCode.Include
@@ -4289,7 +4289,7 @@ public interface J extends Serializable, Tree {
             }
         }
 
-        public boolean hasModifier(String modifier) {
+        public boolean hasModifier(Modifier.Type modifier) {
             return Modifier.hasModifier(getModifiers(), modifier);
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/ClassDeclTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/ClassDeclTest.kt
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.tree
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
 import org.openrewrite.java.JavaParser
@@ -95,4 +97,19 @@ interface ClassDeclTest : JavaTreeTest {
             public strictfp class A {}
         """
     )
+
+    @Test
+    fun hasModifier(jp: JavaParser) {
+        val a = jp.parse(
+            """
+            public strictfp class A {}
+        """
+        )[0]
+
+        val inv = a.classes[0]
+        assertThat(inv.modifiers).hasSize(2)
+        assertTrue(inv.hasModifier(J.Modifier.Type.Public))
+        assertTrue(inv.hasModifier(J.Modifier.Type.Strictfp))
+    }
+
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/MethodDeclTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/MethodDeclTest.kt
@@ -15,7 +15,7 @@
  */
 package org.openrewrite.java.tree
 
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.openrewrite.java.JavaParser
@@ -76,6 +76,13 @@ interface MethodDeclTest : JavaTreeTest {
     )
 
     @Test
+    fun methodWithSuffixMultiComment(jp: JavaParser) = assertParsePrintAndProcess(
+        jp, Class, """
+            public void foo() { }/*Comments*/
+        """
+    )
+
+    @Test
     fun hasModifier(jp: JavaParser) {
         val a = jp.parse(
             """
@@ -86,16 +93,8 @@ interface MethodDeclTest : JavaTreeTest {
         )[0]
 
         val inv = a.classes[0].body.statements.filterIsInstance<J.MethodDecl>().first()
+        assertThat(inv.modifiers).hasSize(2)
         assertTrue(inv.hasModifier(J.Modifier.Type.Private))
         assertTrue(inv.hasModifier(J.Modifier.Type.Static))
-        assertFalse(inv.hasModifier(J.Modifier.Type.Default))
     }
-
-    @Test
-    fun methodWithSuffixMultiComment(jp: JavaParser) = assertParsePrintAndProcess(
-        jp, Class, """
-            public void foo() { }/*Comments*/
-        """
-    )
-
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/MethodDeclTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/MethodDeclTest.kt
@@ -20,6 +20,7 @@ import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaTreeTest
 import org.openrewrite.java.JavaTreeTest.NestingLevel.Class
 import org.openrewrite.java.JavaTreeTest.NestingLevel.CompilationUnit
+import org.junit.jupiter.api.Assertions.*
 
 interface MethodDeclTest : JavaTreeTest {
 
@@ -72,6 +73,21 @@ interface MethodDeclTest : JavaTreeTest {
             public native void foo();
         """
     )
+
+    @Test
+    fun hasModifier(jp: JavaParser) {
+        val a = jp.parse("""
+            public class A {
+                private static boolean foo() { return true; };
+            }
+        """)[0]
+
+        val inv = a.classes[0].body.statements.filterIsInstance<J.MethodDecl>().first()
+        assertTrue(inv.hasModifier("private"))
+        assertTrue(inv.hasModifier("static"))
+        assertFalse(inv.hasModifier("sTaTiC"))
+        assertFalse(inv.hasModifier("fake"))
+    }
 
     @Test
     fun methodWithSuffixMultiComment(jp: JavaParser) = assertParsePrintAndProcess(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/MethodDeclTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/MethodDeclTest.kt
@@ -15,12 +15,13 @@
  */
 package org.openrewrite.java.tree
 
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaTreeTest
 import org.openrewrite.java.JavaTreeTest.NestingLevel.Class
 import org.openrewrite.java.JavaTreeTest.NestingLevel.CompilationUnit
-import org.junit.jupiter.api.Assertions.*
 
 interface MethodDeclTest : JavaTreeTest {
 
@@ -76,17 +77,18 @@ interface MethodDeclTest : JavaTreeTest {
 
     @Test
     fun hasModifier(jp: JavaParser) {
-        val a = jp.parse("""
+        val a = jp.parse(
+            """
             public class A {
                 private static boolean foo() { return true; };
             }
-        """)[0]
+        """
+        )[0]
 
         val inv = a.classes[0].body.statements.filterIsInstance<J.MethodDecl>().first()
-        assertTrue(inv.hasModifier("private"))
-        assertTrue(inv.hasModifier("static"))
-        assertFalse(inv.hasModifier("sTaTiC"))
-        assertFalse(inv.hasModifier("fake"))
+        assertTrue(inv.hasModifier(J.Modifier.Type.Private))
+        assertTrue(inv.hasModifier(J.Modifier.Type.Static))
+        assertFalse(inv.hasModifier(J.Modifier.Type.Default))
     }
 
     @Test

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/VariableDeclsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/VariableDeclsTest.kt
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.tree
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaTreeTest
@@ -77,4 +79,21 @@ interface VariableDeclsTest : JavaTreeTest {
             public /* static */ final static Integer n = 0;
         """
     )
+
+    @Test
+    fun hasModifier(jp: JavaParser) {
+        val a = jp.parse(
+            """
+            class A {
+                protected static final Integer n = 0;
+            }
+        """
+        )[0]
+
+        val inv = a.classes[0].body.statements.filterIsInstance<J.VariableDecls>().first()
+        assertThat(inv.modifiers).hasSize(3)
+        assertTrue(inv.hasModifier(J.Modifier.Type.Protected))
+        assertTrue(inv.hasModifier(J.Modifier.Type.Static))
+        assertTrue(inv.hasModifier(J.Modifier.Type.Final))
+    }
 }


### PR DESCRIPTION
In 6.x, modifiers were extensions of Modifier, so [having the stream -> anyMatch -> getClass -> simpleName worked](https://github.com/openrewrite/rewrite/blob/292b9fc4fab400aaddfc85d8b4840a2dd03b5ead/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java#L2247); now in 7.x that Modifier Type is an enum, this same logic causes the `getClass -> getSimpleName` to evaluate to just `Modifier`.

No obligation to merge this / keep the tests / keep the implementation, etc., as they're just included to show what I mean.

**As a sidenote**, it may be better to either replace `hasModifier` with a typesafe implementation (`hasModifier(Collection<J.Modifier>, J.Modifier)`, or just... removing it? As in, having to pass an actual `J.Modifier.Type.{Private,Public,etc.}`, etc., since in most other cases where we're checking `Kind`, `Type`, etc., we don't use `hasModifier("string")`-- we use `getKind() == ThingToCheck` -- such as here in `spring-rewrite` https://github.com/openrewrite/rewrite-spring/blob/92a023ee9ceabea911036bbc61134c40f35ca264/src/main/java/org/openrewrite/java/spring/BeanMethodsNotPublic.java#L50 where we're using getType 