### PR TITLE
SimplifyBooleanReturn

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -133,6 +133,10 @@ class Java11ReorderMethodArgumentsTest : Java11Test, ReorderMethodArgumentsTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11SimplifyBooleanReturnTest : Java11Test, SimplifyBooleanReturnTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11SpacesTest : Java11Test, SpacesTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -68,10 +68,15 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
     }
 
-    @SuppressWarnings({"unchecked", "ConstantConditions"})
+
     public <J2 extends J> J2 maybeAutoFormat(J2 before, J2 after, P p) {
+        return maybeAutoFormat(before, after, p, getCursor());
+    }
+
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
+    public <J2 extends J> J2 maybeAutoFormat(J2 before, J2 after, P p, Cursor cursor) {
         if(before != after) {
-            return (J2) new AutoFormatVisitor<>().visit(after, p, getCursor());
+            return (J2) new AutoFormatVisitor<>().visit(after, p, cursor);
         }
         return after;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanReturn.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanReturn.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@Incubating(since = "7.0.0")
+public class SimplifyBooleanReturn extends Recipe {
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new SimplifyBooleanReturnVisitor();
+    }
+}
+
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanReturn.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanReturn.java
@@ -27,5 +27,3 @@ public class SimplifyBooleanReturn extends Recipe {
         return new SimplifyBooleanReturnVisitor();
     }
 }
-
-

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanReturnVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanReturnVisitor.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
+import org.openrewrite.java.DeleteStatement;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.openrewrite.Tree.randomId;
+
+@Incubating(since = "7.0.0")
+public class SimplifyBooleanReturnVisitor<P> extends JavaVisitor<P> {
+
+    public SimplifyBooleanReturnVisitor() {
+        setCursoringOn();
+    }
+
+    @Override
+    public J visitIf(J.If iff, P p) {
+        J.If i = visitAndCast(iff, p, super::visitIf);
+
+        Cursor parent = getCursor().dropParentUntil(J.class::isInstance);
+
+        if (parent.getValue() instanceof J.Block &&
+                parent.getParentOrThrow().getValue() instanceof J.MethodDecl &&
+                thenHasOnlyReturnStatement(iff) &&
+                elseWithOnlyReturn(i)) {
+            List<Statement> followingStatements = followingStatements();
+            Optional<Expression> singleFollowingStatement = Optional.ofNullable(followingStatements.isEmpty() ? null : followingStatements.get(0))
+                    .flatMap(stat -> Optional.ofNullable(stat instanceof J.Return ? (J.Return) stat : null))
+                    .map(J.Return::getExpr);
+
+            if (followingStatements.isEmpty() || singleFollowingStatement.map(r -> isLiteralFalse(r) || isLiteralTrue(r)).orElse(false)) {
+                J.Return retrn = getReturnIfOnlyStatementInThen(iff).orElse(null);
+                if (retrn == null) {
+                    throw new NoSuchElementException("No return statement");
+                }
+
+                Expression ifCondition = i.getIfCondition().getTree();
+
+                if (isLiteralTrue(retrn.getExpr())) {
+                    if (singleFollowingStatement.map(this::isLiteralFalse).orElse(false) && i.getElsePart() == null) {
+                        doAfterVisit(new DeleteStatement<>(followingStatements.get(0)));
+                        return retrn
+                                .withExpr(ifCondition.withPrefix(Space.format(" ")))
+                                .withPrefix(i.getPrefix());
+                    } else if (!singleFollowingStatement.isPresent() &&
+                            getReturnExprIfOnlyStatementInElseThen(i).map(this::isLiteralFalse).orElse(false)) {
+                        if (i.getElsePart() != null) {
+                            doAfterVisit(new DeleteStatement<>(i.getElsePart().getBody()));
+                        }
+
+                        return retrn
+                                .withExpr(ifCondition.withPrefix(Space.format(" ")))
+                                .withPrefix(i.getPrefix());
+                    }
+                } else if (isLiteralFalse(retrn.getExpr())) {
+                    boolean returnThenPart = false;
+
+                    if (singleFollowingStatement.map(this::isLiteralTrue).orElse(false) && i.getElsePart() == null) {
+                        doAfterVisit(new DeleteStatement<>(followingStatements.get(0)));
+                        returnThenPart = true;
+                    } else if (!singleFollowingStatement.isPresent() && getReturnExprIfOnlyStatementInElseThen(i)
+                            .map(this::isLiteralTrue).orElse(false)) {
+                        if (i.getElsePart() != null) {
+                            doAfterVisit(new DeleteStatement<>(i.getElsePart().getBody()));
+                        }
+                        returnThenPart = true;
+                    }
+
+                    if (returnThenPart) {
+                        // we need to NOT the expression inside the if condition
+                        Expression maybeParenthesizedCondition = ifCondition instanceof J.Binary || ifCondition instanceof J.Ternary ?
+                                new J.Parentheses<>(
+                                        randomId(),
+                                        Space.EMPTY,
+                                        Markers.EMPTY,
+                                        new JRightPadded<>(ifCondition, Space.EMPTY, Markers.EMPTY)
+                                ) :
+                                ifCondition;
+
+                        return retrn
+                                .withExpr(new J.Unary(
+                                        randomId(),
+                                        Space.format(" "),
+                                        Markers.EMPTY,
+                                        new JLeftPadded<>(Space.EMPTY, J.Unary.Type.Not, Markers.EMPTY),
+                                        maybeParenthesizedCondition,
+                                        JavaType.Primitive.Boolean)
+                                )
+                                .withPrefix(i.getPrefix());
+                    }
+                }
+            }
+        }
+
+        return i;
+    }
+
+    private boolean elseWithOnlyReturn(J.If i) {
+        return i.getElsePart() == null || !(i.getElsePart().getBody() instanceof J.If);
+    }
+
+    private boolean thenHasOnlyReturnStatement(J.If iff) {
+        return getReturnIfOnlyStatementInThen(iff)
+                .map(retrn -> isLiteralFalse(retrn.getExpr()) || isLiteralTrue(retrn.getExpr()))
+                .orElse(false);
+    }
+
+    private List<Statement> followingStatements() {
+        J.Block block = getCursor().dropParentUntil(J.class::isInstance).getValue();
+        AtomicBoolean dropWhile = new AtomicBoolean(false);
+        return block.getStatements().stream()
+                .filter(s -> {
+                    dropWhile.set(dropWhile.get() || s == getCursor().getValue());
+                    return dropWhile.get();
+                })
+                .skip(1)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isLiteralTrue(J tree) {
+        return tree instanceof J.Literal && ((J.Literal) tree).getValue() == Boolean.valueOf(true);
+    }
+
+    private boolean isLiteralFalse(J tree) {
+        return tree instanceof J.Literal && ((J.Literal) tree).getValue() == Boolean.valueOf(false);
+    }
+
+    private Optional<J.Return> getReturnIfOnlyStatementInThen(J.If iff) {
+        if (iff.getThenPart() instanceof J.Return) {
+            return Optional.of((J.Return) iff.getThenPart());
+        }
+        if (iff.getThenPart() instanceof J.Block) {
+            J.Block then = (J.Block) iff.getThenPart();
+            if (then.getStatements().size() == 1 && then.getStatements().get(0) instanceof J.Return) {
+                return Optional.of((J.Return) then.getStatements().get(0));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Expression> getReturnExprIfOnlyStatementInElseThen(J.If iff2) {
+        if (iff2.getElsePart() == null) {
+            return Optional.empty();
+        }
+
+        Statement elze = iff2.getElsePart().getBody();
+        if (elze instanceof J.Return) {
+            return Optional.ofNullable(((J.Return) elze).getExpr());
+        }
+
+        if (elze instanceof J.Block) {
+            List<Statement> statements = ((J.Block) elze).getStatements();
+            if (statements.size() == 1) {
+                J statement = statements.get(0);
+                if (statement instanceof J.Return) {
+                    return Optional.ofNullable(((J.Return) statement).getExpr());
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+}
+
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -31,6 +31,8 @@ public class AutoFormatVisitor<P> extends JavaVisitor<P> {
 
         J t = new NormalizeFormatVisitor<>().visit(tree, p, cursor);
 
+        t = new MinimumViableSpacingVisitor<>().visit(t, p, cursor);
+
         t = new RemoveTrailingWhitespaceVisitor<>().visit(t, p, cursor);
 
         t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
@@ -84,4 +84,13 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
 
         return m;
     }
+
+    @Override
+    public J.Return visitReturn(J.Return retrn, P p) {
+        J.Return r = super.visitReturn(retrn, p);
+        if (r.getExpr() != null && r.getExpr().getPrefix().getWhitespace().isEmpty()) {
+            r = r.withExpr(r.getExpr().withPrefix(r.getExpr().getPrefix().withWhitespace(" ")));
+        }
+        return r;
+    }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -105,6 +105,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class SemanticallyEqualTck : SemanticallyEqualTest
 
     @Nested
+    inner class SimplifyBooleanReturnTck : SimplifyBooleanReturnTest
+
+    @Nested
     inner class SpacesTck : SpacesTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanReturnTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanReturnTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.RecipeTest
+import org.openrewrite.java.JavaParser
+
+interface SimplifyBooleanReturnTest : RecipeTest {
+
+    override val recipe: Recipe?
+        get() = SimplifyBooleanReturn()
+
+    @Test
+    fun simplifyBooleanReturn(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+                public class A {
+                    boolean ifNoElse() {
+                        if (isOddMillis()) {
+                            return true;
+                        }
+                        return false;
+                    }
+                    
+                    static boolean isOddMillis() {
+                        boolean even = System.currentTimeMillis() % 2 == 0;
+                        if (even == true) {
+                            return false;
+                        }
+                        else {
+                            return true;
+                        }
+                    }
+                }
+            """,
+        after = """
+                public class A {
+                    boolean ifNoElse() {
+                        return isOddMillis();
+                    }
+                    
+                    static boolean isOddMillis() {
+                        boolean even = System.currentTimeMillis() % 2 == 0;
+                        return !(even == true);
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun dontSimplifyToReturnUnlessLastStatement(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+                public class A {
+                    public boolean absurdEquals(Object o) {
+                        if(this == o) {
+                            return true;
+                        }
+                        if(this == o) {
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+            """,
+        after = """
+                public class A {
+                    public boolean absurdEquals(Object o) {
+                        if(this == o) {
+                            return true;
+                        }
+                        return this == o;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun nestedIfsWithNoBlock(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+                public class A {
+                    public boolean absurdEquals(Object o) {
+                        if(this == o)
+                            if(this == 0) 
+                                return true;
+                        return false;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun dontAlterWhenElseIfPresent(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+                public class A {
+                    public boolean foo(int n) {
+                        if (n == 1) {
+                            return false;
+                        } 
+                        else if (n == 2) {
+                            return true;
+                        } 
+                        else {
+                            return false;
+                        }
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun dontAlterWhenElseContainsSomethingOtherThanReturn(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+                public class A {
+                    public boolean foo(int n) {
+                        if (n == 1) {
+                            return true;
+                        } 
+                        else {
+                            System.out.println("side effect");
+                            return false;
+                        } 
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun onlySimplifyToReturnWhenLastStatement(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+                import java.util.*;
+                public class A {
+                    public static boolean deepEquals(List<byte[]> l, List<byte[]> r) {
+                        for (int i = 0; i < l.size(); ++i) {
+                            if (!Arrays.equals(l.get(i), r.get(i))) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun wrapNotReturnsOfTernaryIfConditionsInParentheses(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+                public class A {
+                    Object failure;
+                    public boolean equals(Object o) {
+                        if (failure != null ? !failure.equals(this.failure) : this.failure != null) {
+                            return false;
+                        }
+                        return true;
+                    }
+                }
+            """,
+        after = """
+                public class A {
+                    Object failure;
+                    public boolean equals(Object o) {
+                        return !(failure != null ? !failure.equals(this.failure) : this.failure != null);
+                    }
+                }
+            """
+    )
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanReturnTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanReturnTest.kt
@@ -29,160 +29,160 @@ interface SimplifyBooleanReturnTest : RecipeTest {
     fun simplifyBooleanReturn(jp: JavaParser) = assertChanged(
         jp,
         before = """
-                public class A {
-                    boolean ifNoElse() {
-                        if (isOddMillis()) {
-                            return true;
-                        }
+            public class A {
+                boolean ifNoElse() {
+                    if (isOddMillis()) {
+                        return true;
+                    }
+                    return false;
+                }
+                
+                static boolean isOddMillis() {
+                    boolean even = System.currentTimeMillis() % 2 == 0;
+                    if (even == true) {
                         return false;
                     }
-                    
-                    static boolean isOddMillis() {
-                        boolean even = System.currentTimeMillis() % 2 == 0;
-                        if (even == true) {
-                            return false;
-                        }
-                        else {
-                            return true;
-                        }
+                    else {
+                        return true;
                     }
                 }
-            """,
+            }
+        """,
         after = """
-                public class A {
-                    boolean ifNoElse() {
-                        return isOddMillis();
-                    }
-                    
-                    static boolean isOddMillis() {
-                        boolean even = System.currentTimeMillis() % 2 == 0;
-                        return !(even == true);
-                    }
+            public class A {
+                boolean ifNoElse() {
+                    return isOddMillis();
                 }
-            """
+                
+                static boolean isOddMillis() {
+                    boolean even = System.currentTimeMillis() % 2 == 0;
+                    return !(even == true);
+                }
+            }
+        """
     )
 
     @Test
     fun dontSimplifyToReturnUnlessLastStatement(jp: JavaParser) = assertChanged(
         jp,
         before = """
-                public class A {
-                    public boolean absurdEquals(Object o) {
-                        if(this == o) {
-                            return true;
-                        }
-                        if(this == o) {
-                            return true;
-                        }
-                        return false;
+            public class A {
+                public boolean absurdEquals(Object o) {
+                    if(this == o) {
+                        return true;
                     }
+                    if(this == o) {
+                        return true;
+                    }
+                    return false;
                 }
-            """,
+            }
+        """,
         after = """
-                public class A {
-                    public boolean absurdEquals(Object o) {
-                        if(this == o) {
-                            return true;
-                        }
-                        return this == o;
+            public class A {
+                public boolean absurdEquals(Object o) {
+                    if(this == o) {
+                        return true;
                     }
+                    return this == o;
                 }
-            """
+            }
+        """
     )
 
     @Test
     fun nestedIfsWithNoBlock(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
-                public class A {
-                    public boolean absurdEquals(Object o) {
-                        if(this == o)
-                            if(this == 0) 
-                                return true;
-                        return false;
-                    }
+            public class A {
+                public boolean absurdEquals(Object o) {
+                    if(this == o)
+                        if(this == 0) 
+                            return true;
+                    return false;
                 }
-            """
+            }
+        """
     )
 
     @Test
     fun dontAlterWhenElseIfPresent(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
-                public class A {
-                    public boolean foo(int n) {
-                        if (n == 1) {
-                            return false;
-                        } 
-                        else if (n == 2) {
-                            return true;
-                        } 
-                        else {
-                            return false;
-                        }
+            public class A {
+                public boolean foo(int n) {
+                    if (n == 1) {
+                        return false;
+                    } 
+                    else if (n == 2) {
+                        return true;
+                    } 
+                    else {
+                        return false;
                     }
                 }
-            """
+            }
+        """
     )
 
     @Test
     fun dontAlterWhenElseContainsSomethingOtherThanReturn(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
-                public class A {
-                    public boolean foo(int n) {
-                        if (n == 1) {
-                            return true;
-                        } 
-                        else {
-                            System.out.println("side effect");
-                            return false;
-                        } 
-                    }
+            public class A {
+                public boolean foo(int n) {
+                    if (n == 1) {
+                        return true;
+                    } 
+                    else {
+                        System.out.println("side effect");
+                        return false;
+                    } 
                 }
-            """
+            }
+        """
     )
 
     @Test
     fun onlySimplifyToReturnWhenLastStatement(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
-                import java.util.*;
-                public class A {
-                    public static boolean deepEquals(List<byte[]> l, List<byte[]> r) {
-                        for (int i = 0; i < l.size(); ++i) {
-                            if (!Arrays.equals(l.get(i), r.get(i))) {
-                                return false;
-                            }
+            import java.util.*;
+            public class A {
+                public static boolean deepEquals(List<byte[]> l, List<byte[]> r) {
+                    for (int i = 0; i < l.size(); ++i) {
+                        if (!Arrays.equals(l.get(i), r.get(i))) {
+                            return false;
                         }
-                        return true;
                     }
+                    return true;
                 }
-            """
+            }
+        """
     )
 
     @Test
     fun wrapNotReturnsOfTernaryIfConditionsInParentheses(jp: JavaParser) = assertChanged(
         jp,
         before = """
-                public class A {
-                    Object failure;
-                    public boolean equals(Object o) {
-                        if (failure != null ? !failure.equals(this.failure) : this.failure != null) {
-                            return false;
-                        }
-                        return true;
+            public class A {
+                Object failure;
+                public boolean equals(Object o) {
+                    if (failure != null ? !failure.equals(this.failure) : this.failure != null) {
+                        return false;
                     }
+                    return true;
                 }
-            """,
+            }
+        """,
         after = """
-                public class A {
-                    Object failure;
-                    public boolean equals(Object o) {
-                        return !(failure != null ? !failure.equals(this.failure) : this.failure != null);
-                    }
+            public class A {
+                Object failure;
+                public boolean equals(Object o) {
+                    return !(failure != null ? !failure.equals(this.failure) : this.failure != null);
                 }
-            """
+            }
+        """
     )
 
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanReturnTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanReturnTest.kt
@@ -97,7 +97,7 @@ interface SimplifyBooleanReturnTest : RecipeTest {
             public class A {
                 public boolean absurdEquals(Object o) {
                     if(this == o)
-                        if(this == 0) 
+                        if(this == null) 
                             return true;
                     return false;
                 }


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite/issues/197

- Adapted `SimplifyBooleanReturn` recipe for 7.x. 
- Includes `visitReturn` for `MinimumViableSpacingVisitor` for autoformat calls
- adds `MinimumViableSpacingVisitor` to autoformat; appears it hasn't been part of the autoformat chain before?