### PR TITLE
Cleaner parent cursoring on UnnecessaryParentheses

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
@@ -48,7 +48,7 @@ public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
     @Override
     public J visitIdentifier(J.Ident ident, P p) {
         J.Ident i = visitAndCast(ident, p, super::visitIdentifier);
-        if (style.isIdent() && getCursor().getParent().getParent().getValue() instanceof J.Parentheses) {
+        if (style.isIdent() && getCursor().dropParentUntil(J.class::isInstance).getValue() instanceof J.Parentheses) {
             getCursor().putMessageOnFirstEnclosing(J.Parentheses.class, UNNECESSARY_PARENTHESES_MARKER, getCursor());
         }
         return i;
@@ -66,7 +66,7 @@ public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
                 (style.isLiteralNull() && type == JavaType.Primitive.Null) ||
                 (style.isLiteralFalse() && type == JavaType.Primitive.Boolean && l.getValue() == Boolean.valueOf(false)) ||
                 (style.isLiteralTrue() && type == JavaType.Primitive.Boolean && l.getValue() == Boolean.valueOf(true))) {
-            if (getCursor().getParent().getParent().getValue() instanceof J.Parentheses) {
+            if (getCursor().dropParentUntil(J.class::isInstance).getValue() instanceof J.Parentheses) {
                 getCursor().putMessageOnFirstEnclosing(J.Parentheses.class, UNNECESSARY_PARENTHESES_MARKER, getCursor());
             }
         }


### PR DESCRIPTION
see https://github.com/openrewrite/rewrite/pull/204

It feels like this is a more appropriate means of traversing to check if immediately enclosed by parentheses, rather than using `getParent(2)` to cut through Container types?