### PR TITLE
SimplifyBooleanExpression

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -133,6 +133,10 @@ class Java11ReorderMethodArgumentsTest : Java11Test, ReorderMethodArgumentsTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11SimplifyBooleanExpressionTest : Java11Test, SimplifyBooleanExpressionTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11SimplifyBooleanReturnTest : Java11Test, SimplifyBooleanReturnTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpression.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpression.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@Incubating(since = "7.0.0")
+public class SimplifyBooleanExpression extends Recipe {
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new SimplifyBooleanExpressionVisitor();
+    }
+}
+
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.UnwrapParentheses;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+@Incubating(since = "7.0.0")
+public class SimplifyBooleanExpressionVisitor<P> extends JavaVisitor<P> {
+    public SimplifyBooleanExpressionVisitor() {
+        setCursoringOn();
+    }
+
+    @Override
+    public J visitCompilationUnit(J.CompilationUnit cu, P p) {
+        J.CompilationUnit c = visitAndCast(cu, p, super::visitCompilationUnit);
+        if (c != cu) {
+            doAfterVisit(new SimplifyBooleanExpressionVisitor());
+        }
+        return maybeAutoFormat(cu, c, p);
+    }
+
+    @Override
+    public J visitBinary(J.Binary binary, P p) {
+        J j = super.visitBinary(binary, p);
+        J.Binary asBinary = (J.Binary) j;
+
+        if (asBinary.getOperator() == J.Binary.Type.And) {
+            if (isLiteralFalse(asBinary.getLeft())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getLeft();
+            } else if (isLiteralFalse(asBinary.getRight())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getRight();
+            } else if (asBinary.getLeft().printTrimmed().replaceAll("\\s", "").equals(asBinary.getRight().printTrimmed().replaceAll("\\s", ""))) {
+                maybeUnwrapParentheses();
+                j = asBinary.getLeft();
+            }
+        } else if (asBinary.getOperator() == J.Binary.Type.Or) {
+            if (isLiteralTrue(asBinary.getLeft())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getLeft();
+            } else if (isLiteralTrue(asBinary.getRight())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getRight();
+            } else if (asBinary.getLeft().printTrimmed().replaceAll("\\s", "").equals(asBinary.getRight().printTrimmed().replaceAll("\\s", ""))) {
+                maybeUnwrapParentheses();
+                j = asBinary.getLeft();
+            }
+        } else if (asBinary.getOperator() == J.Binary.Type.Equal) {
+            if (isLiteralTrue(asBinary.getLeft())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getRight();
+            } else if (isLiteralTrue(asBinary.getRight())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getLeft();
+            }
+        } else if (asBinary.getOperator() == J.Binary.Type.NotEqual) {
+            if (isLiteralFalse(asBinary.getLeft())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getRight();
+            } else if (isLiteralFalse(asBinary.getRight())) {
+                maybeUnwrapParentheses();
+                j = asBinary.getLeft();
+            }
+        }
+
+        return j;
+    }
+
+    @Override
+    public J visitUnary(J.Unary unary, P p) {
+        J j = super.visitUnary(unary, p);
+        J.Unary asUnary = (J.Unary) j;
+
+        if (asUnary.getOperator() == J.Unary.Type.Not) {
+            if (isLiteralTrue(asUnary.getExpr())) {
+                maybeUnwrapParentheses();
+                j = ((J.Literal) asUnary.getExpr()).withValue(false).withValueSource("false");
+            } else if (isLiteralFalse(asUnary.getExpr())) {
+                maybeUnwrapParentheses();
+                j = ((J.Literal) asUnary.getExpr()).withValue(true).withValueSource("true");
+            } else if (asUnary.getExpr() instanceof J.Unary && ((J.Unary) asUnary.getExpr()).getOperator() == J.Unary.Type.Not) {
+                maybeUnwrapParentheses();
+                j = ((J.Unary) asUnary.getExpr()).getExpr();
+            }
+        }
+
+        return j;
+    }
+
+    /**
+     * Specifically for removing immediately-enclosing parentheses on Identifiers and Literals.
+     * This queues a potential unwrap operation for the next visit. After unwrapping something, it's possible
+     * there are more Simplifications this recipe can identify and perform, which is why visitCompilationUnit
+     * checks for any changes to the entire Compilation Unit, and if so, queues up another SimplifyBooleanExpression
+     * recipe call. This convergence loop eventually reconciles any remaining Boolean Expression Simplifications
+     * the recipe can perform.
+     */
+    private void maybeUnwrapParentheses() {
+        Cursor c = getCursor().getParentOrThrow().dropParentUntil(J.class::isInstance);
+        if (c.getValue() instanceof J.Parentheses) {
+            doAfterVisit(new UnwrapParentheses<>(c.getValue()));
+        }
+    }
+
+    private boolean isLiteralTrue(@Nullable Expression expression) {
+        return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(true);
+    }
+
+    private boolean isLiteralFalse(@Nullable Expression expression) {
+        return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(false);
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -35,7 +35,7 @@ public class SimplifyBooleanExpressionVisitor<P> extends JavaVisitor<P> {
         if (c != cu) {
             doAfterVisit(new SimplifyBooleanExpressionVisitor());
         }
-        return maybeAutoFormat(cu, c, p);
+        return maybeAutoFormat(cu, c, p); // TODO, don't want to require autoformatting the entire CU
     }
 
     @Override

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -105,6 +105,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class SemanticallyEqualTck : SemanticallyEqualTest
 
     @Nested
+    inner class SimplifyBooleanExpressionTck : SimplifyBooleanExpressionTest
+
+    @Nested
     inner class SimplifyBooleanReturnTck : SimplifyBooleanReturnTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanExpressionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyBooleanExpressionTest.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.RecipeTest
+import org.openrewrite.java.JavaParser
+
+interface SimplifyBooleanExpressionTest : RecipeTest {
+    override val recipe: Recipe?
+        get() = SimplifyBooleanExpression()
+
+    @Test
+    fun simplifyBooleanExpressionComprehensive(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean a = !false;
+                    boolean b = (a == true);
+                    boolean c = b || true;
+                    boolean d = c || c;
+                    boolean e = d && d;
+                    boolean f = (e == true) || e;
+                    boolean g = f && false;
+                    boolean h = !!g;
+                    boolean i = (a != false);
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean a = true;
+                    boolean b = a;
+                    boolean c = true;
+                    boolean d = c;
+                    boolean e = d;
+                    boolean f = e;
+                    boolean g = false;
+                    boolean h = g;
+                    boolean i = a;
+                }
+            }
+        """
+    )
+
+
+    @Test
+    fun simplifyInvertedBooleanLiteral(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean a = !false;
+                    boolean b = !true;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean a = true;
+                    boolean b = false;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyEqualsLiteralTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean a = true;
+                    boolean b = (a == true);
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean a = true;
+                    boolean b = a;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyOrLiteralTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean b = true;
+                    boolean c = b || true;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean b = true;
+                    boolean c = true;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyOrAlwaysTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean c = true;
+                    boolean d = c || c;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean c = true;
+                    boolean d = c;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyAndAlwaysTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean d = true;
+                    boolean e = d && d;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean d = true;
+                    boolean e = d;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyEqualsLiteralTrueAlwaysTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean e = true;
+                    boolean f = (e == true) || e;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean e = true;
+                    boolean f = e;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyLiteralFalseAlwaysFalse(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean f = true;
+                    boolean g = f && false;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean f = true;
+                    boolean g = false;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyDoubleNegation(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void doubleNegation(boolean g) {
+                    boolean h = !!g;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void doubleNegation(boolean g) {
+                    boolean h = g;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyNotEqualsFalse(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    boolean a = true;
+                    boolean i = (a != false);
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    boolean a = true;
+                    boolean i = a;
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite/issues/197

- Tried writing this in such a way that there was a single return on each `visitX` rather than multiple returns within the body.
  - Doesn't have to be this way, though I do personally think it's easier to debug and follow the logic on.
  - It's a bit harder to do with non-iso visitors, since the eventual return type will be different and may need to be cast around
- Performs a `maybeAutoFormat` on the compilation unit, due formatting being removed when we replace the entire `unary` or `binary`-- in lieu of being able to perform autoformat on the subtree being replaced, it's being formatted on the compilation unit. 
  - Note, I feel like there's probably a better way of doing this than running autoformat on the entire CU.