### PR TITLE
Remove import visitor deletes static named import

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -21,10 +21,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Set;
+import java.util.*;
 
 import static org.openrewrite.Tree.randomId;
 
@@ -96,7 +93,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
     @Override
     public J.Import visitImport(J.Import impoort, P p) {
         if (impoort.isStatic()) {
-            if (impoort.getQualid().getTarget().printTrimmed().equals(type)) {
+            if (impoort.getQualid().getTarget().printTrimmed().equals(type) || impoort.getQualid().printTrimmed().equals(type)) {
                 if ("*".equals(impoort.getQualid().getSimpleName())) {
                     staticStarImport = impoort;
                 } else {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
@@ -24,6 +24,32 @@ interface RemoveImportTest : RecipeTest {
         RemoveImport<ExecutionContext>(type).toRecipe()
 
     @Test
+    fun removeStaticFieldImport(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = removeImport("java.time.DayOfWeek.MONDAY"),
+        before = """
+            import java.time.DayOfWeek;
+            import static java.time.DayOfWeek.MONDAY;
+            import static java.time.DayOfWeek.TUESDAY;
+            
+            class WorkWeek {
+                DayOfWeek shortWeekStarts(){
+                    return TUESDAY;
+                }
+            }
+        """,
+        after = """
+            import java.time.DayOfWeek;
+            import static java.time.DayOfWeek.TUESDAY;
+            
+            class WorkWeek {
+                DayOfWeek shortWeekStarts(){
+                    return TUESDAY;
+                }
+            }
+        """
+    )
+    @Test
     fun removeNamedImport(jp: JavaParser) = assertChanged(
         jp,
         recipe = removeImport("java.util.List"),

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
@@ -24,32 +24,6 @@ interface RemoveImportTest : RecipeTest {
         RemoveImport<ExecutionContext>(type).toRecipe()
 
     @Test
-    fun removeStaticFieldImport(jp: JavaParser) = assertChanged(
-        jp,
-        recipe = removeImport("java.time.DayOfWeek.MONDAY"),
-        before = """
-            import java.time.DayOfWeek;
-            import static java.time.DayOfWeek.MONDAY;
-            import static java.time.DayOfWeek.TUESDAY;
-            
-            class WorkWeek {
-                DayOfWeek shortWeekStarts(){
-                    return TUESDAY;
-                }
-            }
-        """,
-        after = """
-            import java.time.DayOfWeek;
-            import static java.time.DayOfWeek.TUESDAY;
-            
-            class WorkWeek {
-                DayOfWeek shortWeekStarts(){
-                    return TUESDAY;
-                }
-            }
-        """
-    )
-    @Test
     fun removeNamedImport(jp: JavaParser) = assertChanged(
         jp,
         recipe = removeImport("java.util.List"),
@@ -133,6 +107,33 @@ interface RemoveImportTest : RecipeTest {
             import static java.util.Collections.*;
             class A {
                Object o = emptyList();
+            }
+        """
+    )
+
+    @Test
+    fun removeStaticImportIfNotReferenced(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = removeImport("java.time.DayOfWeek.MONDAY"),
+        before = """
+            import java.time.DayOfWeek;
+            import static java.time.DayOfWeek.MONDAY;
+            import static java.time.DayOfWeek.TUESDAY;
+            
+            class WorkWeek {
+                DayOfWeek shortWeekStarts(){
+                    return TUESDAY;
+                }
+            }
+        """,
+        after = """
+            import java.time.DayOfWeek;
+            import static java.time.DayOfWeek.TUESDAY;
+            
+            class WorkWeek {
+                DayOfWeek shortWeekStarts(){
+                    return TUESDAY;
+                }
             }
         """
     )


### PR DESCRIPTION
This is to resolve an issue with the `RemoveImport` where it does not remove a non-referenced static import.