### PR TITLE
 Add missing Maven model elements: Add type to Pom.Dependency, add packaging to Pom 

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -59,6 +59,9 @@ public class AddDependency extends Recipe {
     @Nullable
     private String scope;
 
+    @Nullable
+    private String type;
+
     private boolean skipIfPresent = true;
 
     /**
@@ -122,6 +125,7 @@ public class AddDependency extends Recipe {
                 releasesOnly,
                 classifier,
                 scope,
+                type,
                 skipIfPresent,
                 familyPattern == null ? null : Pattern.compile(familyPattern.replace("*", ".*"))
         );

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -67,6 +67,9 @@ public class AddDependencyVisitor<P> extends MavenVisitor<P> {
     @Nullable
     private final String scope;
 
+    @Nullable
+    private final String type;
+
     private final boolean skipIfPresent;
 
     @Nullable
@@ -82,6 +85,7 @@ public class AddDependencyVisitor<P> extends MavenVisitor<P> {
                                 boolean releasesOnly,
                                 @Nullable String classifier,
                                 @Nullable String scope,
+                                @Nullable String type,
                                 boolean skipIfPresent,
                                 @Nullable Pattern familyPattern) {
         this.groupId = groupId;
@@ -91,6 +95,7 @@ public class AddDependencyVisitor<P> extends MavenVisitor<P> {
         this.releasesOnly = releasesOnly;
         this.classifier = classifier;
         this.scope = scope;
+        this.type = type;
         this.skipIfPresent = skipIfPresent;
         this.familyPattern = familyPattern;
     }
@@ -120,12 +125,14 @@ public class AddDependencyVisitor<P> extends MavenVisitor<P> {
         doAfterVisit(new InsertDependencyInOrder());
 
         Collection<Pom.Dependency> dependencies = new ArrayList<>(model.getDependencies());
+        String packaging = (type == null) ? "jar" : type;
         dependencies.add(
                 new Pom.Dependency(
                         Scope.fromName(scope),
                         classifier,
+                        packaging,
                         false,
-                        new Pom(null, groupId, artifactId, version, null, "jar", classifier, null,
+                        new Pom(null, groupId, artifactId, version, null, packaging, classifier, null,
                                 emptyList(), new Pom.DependencyManagement(emptyList()), emptyList(), emptyList(), emptyMap()),
                         version,
                         emptySet()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -121,7 +121,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     }
 
     public void maybeAddDependency(String groupId, String artifactId, String version,
-                                   @Nullable String classifier, @Nullable String scope) {
+                                   @Nullable String classifier, @Nullable String scope, @Nullable String type) {
         AddDependencyVisitor<P> op = new AddDependencyVisitor<>(
                 groupId,
                 artifactId,
@@ -130,6 +130,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 true,
                 classifier,
                 scope,
+                type,
                 true,
                 null);
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -174,13 +174,6 @@ public class RawPom {
         @Nullable
         @JacksonXmlElementWrapper(useWrapping = true)
         Set<GroupArtifact> exclusions;
-
-        /**
-         * @return the groupId, artifactId, and version concatenated with ":" as the delimiter between them.
-         */
-        public String gavCoordinates() {
-            return groupId + ":" + artifactId + ":" + version;
-        }
     }
 
     @Getter

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -53,7 +53,7 @@ public class Pom implements Marker {
     String snapshotVersion;
 
     @Nullable
-    String type;
+    String packaging;
 
     @Nullable
     String classifier;
@@ -77,7 +77,7 @@ public class Pom implements Marker {
                String artifactId,
                @Nullable String version,
                @Nullable String snapshotVersion,
-               @Nullable String type,
+               @Nullable String packaging,
                @Nullable String classifier,
                @Nullable Pom parent,
                Collection<Dependency> dependencies,
@@ -90,7 +90,7 @@ public class Pom implements Marker {
         this.artifactId = artifactId;
         this.version = version;
         this.snapshotVersion = snapshotVersion;
-        this.type = type;
+        this.packaging = packaging;
         this.classifier = classifier;
         this.parent = parent;
         this.dependencies = dependencies;
@@ -187,8 +187,8 @@ public class Pom implements Marker {
     }
 
     @Nullable
-    public String getType() {
-        return type;
+    public String getPackaging() {
+        return packaging;
     }
 
     @Nullable
@@ -280,6 +280,9 @@ public class Pom implements Marker {
 
         @Nullable
         String classifier;
+
+        @Nullable
+        String type;
 
         boolean optional;
         Pom model;

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/MavenParserTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/MavenParserTest.kt
@@ -33,7 +33,7 @@ class MavenParserTest {
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-
+                <packaging>pom</packaging>
                 <developers>
                     <developer>
                         <name>Trygve Laugst&oslash;l</name>
@@ -45,6 +45,7 @@ class MavenParserTest {
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter-api</artifactId>
                     <version>5.7.0</version>
+                    <type>jar</type>
                     <scope>test</scope>
                   </dependency>
                 </dependencies>
@@ -57,6 +58,10 @@ class MavenParserTest {
 
         assertThat(maven.model.dependencies.first().model.licenses.first()?.type)
                 .isEqualTo(Pom.LicenseType.Eclipse)
+        assertThat(maven.model.dependencies.first().type)
+            .isEqualTo("jar")
+        assertThat(maven.model.packaging)
+            .isEqualTo("pom")
     }
 
     @Test
@@ -155,7 +160,7 @@ class MavenParserTest {
     }
 
     val parserStrict = MavenParser.builder().resolveOptional(false).build()
-    val parserLenient = MavenParser.builder().continueOnError(true).resolveOptional(false).build()
+    val parserLenient = MavenParser.builder().onError{  }.resolveOptional(false).build()
 
     @Issue("https://github.com/openrewrite/rewrite/issues/199")
     @Test

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/MavenParserTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/MavenParserTest.kt
@@ -45,7 +45,7 @@ class MavenParserTest {
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter-api</artifactId>
                     <version>5.7.0</version>
-                    <type>jar</type>
+                    <type>pom</type>
                     <scope>test</scope>
                   </dependency>
                 </dependencies>
@@ -59,7 +59,7 @@ class MavenParserTest {
         assertThat(maven.model.dependencies.first().model.licenses.first()?.type)
                 .isEqualTo(Pom.LicenseType.Eclipse)
         assertThat(maven.model.dependencies.first().type)
-            .isEqualTo("jar")
+            .isEqualTo("pom")
         assertThat(maven.model.packaging)
             .isEqualTo("pom")
     }

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/internal/RawPomTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/internal/RawPomTest.kt
@@ -110,7 +110,8 @@ class RawPomTest {
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-            
+                <packaging>jar</packaging>
+                
                 <dependencyManagement>
                     <dependencies>
                         <dependency>
@@ -191,6 +192,8 @@ class RawPomTest {
         val model = MavenXmlMapper.readMapper().readValue(pom, RawPom::class.java)
 
         assertThat(model.parent!!.groupId).isEqualTo("org.springframework.boot")
+
+        assertThat(model.packaging).isEqualTo("jar")
 
         assertThat(model.getActiveDependencies(emptyList())[0].groupId)
             .isEqualTo("org.junit.jupiter")


### PR DESCRIPTION
This doesn't include any behavioral changes to dependency resolution in the presence of pom-type dependencies. Maybe it should? At worst I expect the lack of special behavior for pom-type dependencies would result in an extra jar in the final list of dependencies.

Also remove unneeded continueOnError functionality which has been supplanted by onError.

Closes #227