### PR TITLE
CovariantEquals

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -65,6 +65,10 @@ class Java11ChangeTypeTest : Java11Test, ChangeTypeTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11CovariantEqualsTest : Java11Test, CovariantEqualsTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11DeleteMethodArgumentTest : Java11Test, DeleteMethodArgumentTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CovariantEquals.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CovariantEquals.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@Incubating(since = "7.0.0")
+public class CovariantEquals extends Recipe {
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new CovariantEqualsVisitor<>();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CovariantEqualsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CovariantEqualsVisitor.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Incubating(since = "7.0.0")
+public class CovariantEqualsVisitor<P> extends JavaIsoVisitor<P> {
+
+    private static final MethodMatcher OBJECT_EQUALS_SIGNATURE = new MethodMatcher("* equals(java.lang.Object)");
+
+    public CovariantEqualsVisitor() {
+        setCursoringOn();
+    }
+
+    @Override
+    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, P p) {
+        J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, p);
+        Stream<J.MethodDeclaration> mds = cd.getBody().getStatements().stream().filter(J.MethodDeclaration.class::isInstance).map(J.MethodDeclaration.class::cast);
+        if (mds.noneMatch(m -> OBJECT_EQUALS_SIGNATURE.matches(m, classDecl))) {
+            cd = (J.ClassDeclaration) new ChangeCovariantEqualsMethodVisitor<>(cd).visit(cd, p, getCursor());
+        }
+        return cd;
+    }
+
+    private static class ChangeCovariantEqualsMethodVisitor<P> extends JavaIsoVisitor<P> {
+
+        private static final AnnotationMatcher OVERRIDE_ANNOTATION_SIGNATURE = new AnnotationMatcher("@java.lang.Override");
+        private static final String EQUALS_BODY_PREFIX_TEMPLATE = "{\n" +
+                "if (#{} == this) return true;\n" +
+                "if (#{} == null || getClass() != #{}.getClass()) return false;\n" +
+                "#{} #{} = (#{}) #{};\n" +
+                "#{}\n" +
+                "}";
+
+        private final J.ClassDeclaration enclosingClass;
+
+        public ChangeCovariantEqualsMethodVisitor(J.ClassDeclaration enclosingClass) {
+            this.enclosingClass = enclosingClass;
+            setCursoringOn();
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, P p) {
+            J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
+
+            /**
+             * Looking for "public boolean equals(EnclosingClassType)" as the method signature match.
+             * We'll replace it with "public boolean equals(Object)"
+             */
+            String ecfqn = enclosingClass.getType().getFullyQualifiedName();
+            if (new MethodMatcher(String.format("%s equals(%s)", ecfqn, ecfqn)).matches(m, enclosingClass) &&
+                    m.hasModifier(J.Modifier.Type.Public) &&
+                    m.getReturnTypeExpression() != null &&
+                    JavaType.Primitive.Boolean.equals(m.getReturnTypeExpression().getType())) {
+
+                if (m.getAnnotations().stream().noneMatch(OVERRIDE_ANNOTATION_SIGNATURE::matches)) {
+                    m = maybeAutoFormat(m,
+                            m.withTemplate(
+                                    template("@Override").build(),
+                                    m.getAnnotations().isEmpty() ? m.getCoordinates().replaceAnnotations() : m.getAnnotations().get(0).getCoordinates().before()
+                            ), p, getCursor().getParentOrThrow());
+                }
+
+                /**
+                 * Change parameter type to Object, and maybe change input parameter name representing the other object.
+                 * This is because we prepend these type-checking replacement statements to the existing "equals(..)" body.
+                 * Therefore we don't want to collide with any existing variable names.
+                 */
+                J.VariableDeclarations.NamedVariable oldParamName = ((J.VariableDeclarations) m.getParameters().iterator().next()).getVariables().iterator().next();
+                String paramName = "obj".equals(oldParamName.getSimpleName()) ? "other" : "obj";
+                m = maybeAutoFormat(m,
+                        m.withTemplate(
+                                template("(Object #{})").build(),
+                                m.getCoordinates().replaceParameters(),
+                                paramName
+                        ), p, getCursor().getParentOrThrow());
+
+                /**
+                 * We'll prepend this type-check and type-cast to the beginning of the existing
+                 * equals(..) method body statements, and let the existing equals(..) method definition continue
+                 * with the logic doing what it was doing.
+                 */
+                JavaTemplate equalsBodySnippet = template(EQUALS_BODY_PREFIX_TEMPLATE).build();
+                Object[] params = new Object[]{
+                        paramName,
+                        paramName,
+                        paramName,
+                        enclosingClass.getSimpleName(),
+                        oldParamName.printTrimmed(),
+                        enclosingClass.getSimpleName(),
+                        paramName,
+                        m.getBody().getStatements().stream().map(J::printTrimmed).collect(Collectors.joining(";"))
+                };
+
+                m = maybeAutoFormat(m,
+                        m.withTemplate(
+                                equalsBodySnippet,
+                                m.getCoordinates().replaceBody(),
+                                params
+                        ), p, getCursor().getParentOrThrow());
+            }
+
+            return m;
+        }
+    }
+
+}
+
+

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -57,6 +57,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class ChangeTypeTck : ChangeTypeTest
 
     @Nested
+    inner class CovariantEqualsTck : CovariantEqualsTest
+
+    @Nested
     inner class DeleteMethodArgumentTck : DeleteMethodArgumentTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/CovariantEqualsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/CovariantEqualsTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.RecipeTest
+import org.openrewrite.java.JavaParser
+
+interface CovariantEqualsTest : RecipeTest {
+    override val recipe: Recipe?
+        get() = CovariantEquals()
+
+    @Test
+    fun replaceWithNonCovariantEquals(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                int n;
+
+                public boolean equals(Test tee) {
+                    return n == tee.n;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                int n;
+
+                @Override
+                public boolean equals(Object obj) {
+                    if (obj == this) return true;
+                    if (obj == null || getClass() != obj.getClass()) return false;
+                    Test tee = (Test) obj;
+                    return n == tee.n;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun replaceMultiStatementReturnBody(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                String id;
+
+                public boolean equals(A other) {
+                    boolean isEqual = id.equals(other.id);
+                    return isEqual;
+                }
+            }
+        """,
+        after = """
+            class A {
+                String id;
+
+                @Override
+                public boolean equals(Object obj) {
+                    if (obj == this) return true;
+                    if (obj == null || getClass() != obj.getClass()) return false;
+                    A other = (A) obj;
+                    boolean isEqual = id.equals(other.id);
+                    return isEqual;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun replaceEqualsBasedOnTypeSignature(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                int n;
+                public void placeholder(Test test) {}
+                public void placeholder(Object test) {}
+
+                public boolean equals(Number test) {
+                    return false;
+                }
+
+                public boolean equals(Test test) {
+                    return n == test.n;
+                }
+
+                public boolean equals() {
+                    return false;
+                }
+
+                public boolean equals(String test) {
+                    return false;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                int n;
+                public void placeholder(Test test) {}
+                public void placeholder(Object test) {}
+
+                public boolean equals(Number test) {
+                    return false;
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                    if (obj == this) return true;
+                    if (obj == null || getClass() != obj.getClass()) return false;
+                    Test test = (Test) obj;
+                    return n == test.n;
+                }
+
+                public boolean equals() {
+                    return false;
+                }
+
+                public boolean equals(String test) {
+                    return false;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun replaceEqualsMaintainsExistingAnnotations(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                String id;
+
+                @SuppressWarnings("all")
+                public boolean equals(A other) {
+                    boolean isEqual = id.equals(other.id);
+                    return isEqual;
+                }
+            }
+        """,
+        after = """
+            class A {
+                String id;
+
+                @Override
+                @SuppressWarnings("all")
+                public boolean equals(Object obj) {
+                    if (obj == this) return true;
+                    if (obj == null || getClass() != obj.getClass()) return false;
+                    A other = (A) obj;
+                    boolean isEqual = id.equals(other.id);
+                    return isEqual;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun replaceWithNonCovariantEqualsWhenNested(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                class B {
+                    int n;
+
+                    public boolean equals(B bee) {
+                        return n == bee.n;
+                    }
+                }
+            }
+        """,
+        after = """
+            class A {
+                class B {
+                    int n;
+
+                    @Override
+                    public boolean equals(Object obj) {
+                        if (obj == this) return true;
+                        if (obj == null || getClass() != obj.getClass()) return false;
+                        B bee = (B) obj;
+                        return n == bee.n;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun renameExistingParameterNameWhenParameterNameIsDefaultTemplateName(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                int n;
+
+                public boolean equals(Test obj) {
+                    return n == obj.n;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                int n;
+
+                @Override
+                public boolean equals(Object other) {
+                    if (other == this) return true;
+                    if (other == null || getClass() != other.getClass()) return false;
+                    Test obj = (Test) other;
+                    return n == obj.n;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun ignoreIfAtLeastOneExistingNonCovariantEqualsMethod(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                public boolean equals(Test t) {
+                    return false;
+                }
+
+                public boolean equals(Object i) {
+                    return false;
+                }
+                
+                public boolean equals(Object i, Test t) {
+                    return false;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun ignoreIfNoExistingEqualsMethod(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class A {}
+            
+            class B {
+                B() {}
+                public void placeholder(B t) {}
+                public void placeholder(Object t) {}
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite/issues/197
replaces https://github.com/openrewrite/rewrite-checkstyle/blob/master/src/main/java/org/openrewrite/checkstyle/CovariantEquals.java

This enables replacing `equals(EnclosingClass)` method declarations with `equals(Object)` by prepending the matching existing `equals(..)` method body with type-checking and type-casting.

Also, note, fixing `CovariantEquals` can also apply to `Records` which were introduced in Java14, though not handled in this PR