### PR TITLE
MinimumViableSpacing unit test on return expressions

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/MinimumViableSpacingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/MinimumViableSpacingTest.kt
@@ -34,7 +34,7 @@ interface MinimumViableSpacingTest : RecipeTest {
     @Test
     fun method(jp: JavaParser) = assertChanged(
         jp,
-        before = """,
+        before = """
             class A {
                 public <T> void foo() {
                 }
@@ -42,6 +42,21 @@ interface MinimumViableSpacingTest : RecipeTest {
         """,
         after = """
             class A {public <T> void foo() {}}
+        """
+    )
+
+    @Test
+    fun returnExpression(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                public String foo() {
+                    return"foo";
+                }
+            }
+        """,
+        after = """
+            class A {public String foo() {return "foo";}}
         """
     )
 }


### PR DESCRIPTION
unit test for minimum viable spacing on return expressions which was introduced in https://github.com/openrewrite/rewrite/pull/217

minor, but, noticed a test for this was never introduced while doing other work with minimal viable spacing
also minor, but, this removes an unnecessary `,` in these unit tests which was causing minor warning