### PR TITLE
FinalizeLocalVariables recipe

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -76,6 +76,10 @@ class Java11DeleteStatementTest : Java11Test, DeleteStatementTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11FinalizeLocalVariablesTest : Java11Test, FinalizeLocalVariablesTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11FindAnnotationsTest : Java11Test, FindAnnotationsTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@Incubating(since = "7.0.0")
+public class FinalizeLocalVariables extends Recipe {
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new FinalizeLocalVariablesVisitor<>();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariablesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariablesVisitor.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * FinalizeLocalVariables will add the "final" modifier keyword to local variables which are not being reassigned.
+ * A local variable is defined as being declared between the opening and closing braces of a method.
+ * <p>
+ * (Note, this is not related to the "finalize" method provided by the root Object class. The "Finalize" in the name
+ * just refers to making a local variable "final".)
+ * <p>
+ * For the time being, we keep the definition of "local variable" strictly to the technical definition of a variable
+ * declared between the opening and closing braces of a method. This means a method parameter variable will not be
+ * considered as a target for adding the "final" modifier; nor instance variables (non-static fields) nor class variables (static fields).
+ * <p>
+ * {@see <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html">https://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html</a>}
+ * <p>
+ * There are specific situations which count as a "local variable". In fact, "local variable" has a specific
+ * technical definition, even though it is occasionally referred to when discussing other things (such as method parameter variables, or
+ * class variables ("static fields"), or instance variables ("non-static fields"), etc.).
+ * By the technical definition, a "local variable" is defined by the location it is declared.
+ */
+@Incubating(since = "7.0.0")
+public class FinalizeLocalVariablesVisitor<P> extends JavaIsoVisitor<P> {
+
+    @Override
+    public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, P p) {
+        J.VariableDeclarations mv = visitAndCast(multiVariable, p, super::visitVariableDeclarations);
+
+        // first off, if this already has "final", we don't need to bother going any further; we're done
+        if (mv.hasModifier(J.Modifier.Type.Final)) {
+            return mv;
+        }
+
+        // we don't try to finalize method parameter variables
+        if (isMethodParameterVariable()) {
+            return mv;
+        }
+
+        // we don't want to add a "final" keyword to a lambda parameter variable declaration
+        if (isDeclaredInLambda()) {
+            return mv;
+        }
+
+        // ignore fields (aka "instance variable" or "class variable")
+        if (mv.getVariables().stream().anyMatch(v -> v.isField(getCursor()) || isField(getCursor()))) {
+            return mv;
+        }
+
+        Predicate<J.VariableDeclarations.NamedVariable> hasReassignment;
+        if (isDeclaredInForEachLoop()) {
+            // ForEach loops (aka "enhanced for-loop") will always have the variable initialized
+            hasReassignment = (v) -> !FindAssignmentReferencesToVariable.find(getCursor().firstEnclosingOrThrow(J.ForEachLoop.class), v).isEmpty();
+        } else {
+            // off-sets number of acceptable "reassignments" depending on whether there's an initializer at declaration
+            hasReassignment = (v) -> FindAssignmentReferencesToVariable.find(getCursor().dropParentUntil(J.class::isInstance).getValue(), v).size() + (v.getInitializer() == null ? -1 : 0) > 0;
+        }
+
+        if (mv.getVariables().stream().noneMatch(hasReassignment)) {
+            mv = maybeAutoFormat(mv,
+                    mv.withModifiers(
+                            ListUtils.concat(mv.getModifiers(), new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, J.Modifier.Type.Final))
+                    ), p, getCursor().dropParentUntil(J.class::isInstance));
+        }
+
+        return mv;
+    }
+
+    private boolean isMethodParameterVariable() {
+        return getCursor()
+                .dropParentUntil(J.class::isInstance) // maybe J.MethodDeclaration
+                .getValue() instanceof J.MethodDeclaration;
+    }
+
+    private boolean isDeclaredInForEachLoop() {
+        return getCursor()
+                .dropParentUntil(J.class::isInstance) // maybe J.ForEachLoop.Control
+                .dropParentUntil(J.class::isInstance) // maybe J.ForEachLoop
+                .getValue() instanceof J.ForEachLoop;
+    }
+
+    private boolean isDeclaredInLambda() {
+        return getCursor()
+                .dropParentUntil(J.class::isInstance) // maybe J.Lambda
+                .getValue() instanceof J.Lambda;
+    }
+
+    private boolean isField(Cursor cursor) {
+        return cursor
+                // .getParentOrThrow() // JRightPadded
+                // .getParentOrThrow() // J.VariableDeclarations
+                .getParentOrThrow() // JRightPadded
+                .getParentOrThrow() // J.Block
+                .getParentOrThrow() // maybe J.ClassDeclaration
+                .getValue() instanceof J.ClassDeclaration;
+    }
+
+
+    private static class FindAssignmentReferencesToVariable {
+        private FindAssignmentReferencesToVariable() {
+        }
+
+        /**
+         * @param j        The subtree to search.
+         * @param variable A {@link J.VariableDeclarations.NamedVariable} to check for any reassignment calls.
+         * @return A set of {@link NameTree} locations of reassignment calls to this variable.
+         */
+        private static Set<NameTree> find(J j, J.VariableDeclarations.NamedVariable variable) {
+            JavaIsoVisitor<Set<NameTree>> findVisitor = new JavaIsoVisitor<Set<NameTree>>() {
+                @Override
+                public J.Assignment visitAssignment(J.Assignment assignment, Set<NameTree> ctx) {
+                    J.Assignment a = super.visitAssignment(assignment, ctx);
+                    if (a.getVariable() instanceof J.Identifier) {
+                        J.Identifier i = ((J.Identifier) a.getVariable());
+                        if (i.getSimpleName().equals(variable.getSimpleName())) {
+                            ctx.add(i);
+                        }
+                    }
+                    return a;
+                }
+
+                @Override
+                public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, Set<NameTree> ctx) {
+                    J.AssignmentOperation a = super.visitAssignmentOperation(assignOp, ctx);
+                    if (a.getVariable() instanceof J.Identifier) {
+                        J.Identifier i = ((J.Identifier) a.getVariable());
+                        if (i.getSimpleName().equals(variable.getSimpleName())) {
+                            ctx.add(i);
+                        }
+                    }
+                    return a;
+                }
+
+                @Override
+                public J.Unary visitUnary(J.Unary unary, Set<NameTree> ctx) {
+                    J.Unary u = super.visitUnary(unary, ctx);
+                    if (u.getExpression() instanceof J.Identifier) {
+                        J.Identifier i = ((J.Identifier) u.getExpression());
+                        if (i.getSimpleName().equals(variable.getSimpleName())) {
+                            ctx.add(i);
+                        }
+                    }
+                    return u;
+                }
+
+            };
+
+            Set<NameTree> refs = new HashSet<>();
+            findVisitor.visit(j, refs);
+            return refs;
+        }
+
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -66,6 +66,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class DeleteStatementTck : DeleteStatementTest
 
     @Nested
+    inner class FinalizeLocalVariablesTck : FinalizeLocalVariablesTest
+
+    @Nested
     inner class FindAnnotationsTck : FindAnnotationsTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/FinalizeLocalVariablesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/FinalizeLocalVariablesTest.kt
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+interface FinalizeLocalVariablesTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = FinalizeLocalVariables()
+
+    @Test
+    fun localVariablesAreMadeFinal(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                public void test() {
+                    int n = 1;
+                    for(int i = 0; i < n; i++) {
+                    }
+                }
+            }
+        """,
+        after = """
+            class A {
+                public void test() {
+                    final int n = 1;
+                    for(int i = 0; i < n; i++) {
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun identifyReassignedLocalVariables(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                public void test() {
+                    int a = 0;
+                    int b = 0;
+                    int c = 10;
+                    for(int i = 0; i < c; i++) {
+                        a = i + c;
+                        b++;
+                    }
+                }
+            }
+        """,
+        after = """
+            class A {
+                public void test() {
+                    int a = 0;
+                    int b = 0;
+                    final int c = 10;
+                    for(int i = 0; i < c; i++) {
+                        a = i + c;
+                        b++;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun multipleVariablesDeclarationOnSingleLine(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                public void multiVariables() {
+                    int a, b = 1;
+                    a = 0;
+                }
+            }
+        """,
+        // the final only applies to any initialized variables (b in this case)
+        after = """
+            class A {
+                public void multiVariables() {
+                    final int a, b = 1;
+                    a = 0;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun calculateLocalVariablesInitializerOffset(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                public void testOne() {
+                    int a;
+                    a = 0;
+                    System.out.println(a);
+                }
+
+                public void testTwo() {
+                    int a;
+                    a = 0;
+                    a = 0;
+                    System.out.println(a);
+                }
+
+                public void testThree() {
+                    int a;
+                    a = 0;
+                    a++;
+                    System.out.println(a);
+                }
+            }
+        """,
+        after = """
+            class A {
+                public void testOne() {
+                    final int a;
+                    a = 0;
+                    System.out.println(a);
+                }
+
+                public void testTwo() {
+                    int a;
+                    a = 0;
+                    a = 0;
+                    System.out.println(a);
+                }
+
+                public void testThree() {
+                    int a;
+                    a = 0;
+                    a++;
+                    System.out.println(a);
+                }
+            }
+        """
+    )
+
+    @Test
+    @Disabled
+    fun calculateLocalVariablesInitializerBranching(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class A {
+                public void test(boolean hasThing) {
+                    int a;
+                    if (hasThing) {
+                        a = 0;
+                    } else {
+                        a = 1;
+                    }
+                    System.out.println(a);
+                }
+            }
+        """,
+        after = """
+            class A {
+                public void test(boolean hasThing) {
+                    final int a;
+                    if (hasThing) {
+                        a = 0;
+                    } else {
+                        a = 1;
+                    }
+                    System.out.println(a);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun forEachLoopAssignmentMadeFinal(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                public static void testForEach(String[] args) {
+                    for (String a : args) {
+                        System.out.println(a);
+                    }
+
+                    for (String b : args) {
+                        b = b.toUpperCase();
+                        System.out.println(b);
+                    }
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public static void testForEach(String[] args) {
+                    for (final String a : args) {
+                        System.out.println(a);
+                    }
+
+                    for (String b : args) {
+                        b = b.toUpperCase();
+                        System.out.println(b);
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableScopeAwareness(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                public static void testA() {
+                    int a = 0;
+                    a = 1;
+                }
+
+                public static void testB() {
+                    int a = 0;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public static void testA() {
+                    int a = 0;
+                    a = 1;
+                }
+
+                public static void testB() {
+                    final int a = 0;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun forEachLoopScopeAwareness(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                public static void testForEach(String[] args) {
+                    for (String i : args) {
+                        System.out.println(i);
+                    }
+
+                    for (String i : args) {
+                        i = i.toUpperCase();
+                        System.out.println(i);
+                    }
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public static void testForEach(String[] args) {
+                    for (final String i : args) {
+                        System.out.println(i);
+                    }
+
+                    for (String i : args) {
+                        i = i.toUpperCase();
+                        System.out.println(i);
+                    }
+                }
+            }
+        """
+    )
+
+    @Test // aka "non-static-fields"
+    fun instanceVariablesIgnored(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                int instanceVariableUninitialized;
+                int instanceVariableInitialized = 0;
+            }
+        """
+    )
+
+    @Test // aka "static fields"
+    fun classVariablesIgnored(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                static int classVariableInitialized = 0;
+            }
+        """
+    )
+
+    @Test
+    fun classInitializersIgnored(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                {
+                    int n = 1;
+                    for(int i = 0; i < n; i++) {
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun methodParameterVariablesIgnored(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                private static int testMath(int x, int y) {
+                    y = y + y;
+                    return x + y;
+                }
+
+                public static void main(String[] args) {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun lambdaVariablesIgnored(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            import java.util.stream.Stream;
+            class A {
+                public boolean hasFoo(Stream<String> input) {
+                    return input.anyMatch(word -> word.equalsIgnoreCase("foo"));
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite/issues/197

drafting issue body

- Tested with `RewriteJavaProjectOnDisk`
- Does NOT add `final` to MethodDeclarationParameterVariables, since those are not the same as a "true" `LocalVariable` (https://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html)
- Does NOT add `final` for a Class `Field`s, since a `Field` != `LocalVariable`. That's not the technical term for it, dangit.
- ~~I feel like this may be more appropriate to rename to something besides `FinalLocalVariables`, since I feel like it may add confusion.~~ Renamed to `FinalizeLocalVariables`