### PR TITLE
Declaritive and Active Recipe validation

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -16,6 +16,7 @@
 package org.openrewrite.config;
 
 import org.openrewrite.Recipe;
+import org.openrewrite.RecipeException;
 import org.openrewrite.style.NamedStyles;
 
 import java.io.File;
@@ -44,12 +45,23 @@ public class Environment {
 
     public Recipe activateRecipes(Iterable<String> activeRecipes) {
         Recipe root = new Recipe();
-        for (Recipe recipe : listRecipes()) {
-            for (String activeRecipe : activeRecipes) {
-                if (activeRecipe.equals(recipe.getName())) {
+        Collection<Recipe> recipes = listRecipes();
+        List<String> recipesNotFound = new ArrayList<>();
+        for (String activeRecipe : activeRecipes) {
+            boolean foundRecipe = false;
+            for (Recipe recipe : recipes) {
+                if (activeRecipe.equals(recipe.getName())){
                     root.doNext(recipe);
+                    foundRecipe = true;
+                    break;
                 }
             }
+            if (!foundRecipe) {
+                recipesNotFound.add(activeRecipe);
+            }
+        }
+        if (!recipesNotFound.isEmpty()) {
+            throw new RecipeException("Recipes not found: " + String.join(", ",recipesNotFound));
         }
         return root;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.openrewrite.Recipe;
+import org.openrewrite.RecipeException;
 import org.openrewrite.Validated;
 import org.openrewrite.internal.PropertyPlaceholderHelper;
 import org.openrewrite.internal.lang.Nullable;
@@ -119,6 +120,9 @@ public class YamlResourceLoader implements ResourceLoader {
                     String name = (String) r.get("name");
                     DeclarativeRecipe recipe = new DeclarativeRecipe(name, source);
                     List<Object> recipeList = (List<Object>) r.get("recipeList");
+                    if (recipeList == null) {
+                        throw new RecipeException("Invalid Recipe [" + name + "] recipeList is null");
+                    }
                     for (int i = 0; i < recipeList.size(); i++) {
                         Object next = recipeList.get(i);
                         if (next instanceof String) {


### PR DESCRIPTION
This fix will:
- Identify by name Recipes having a null 'recipeList'.  Before the `YamlResourceLoader` would throw a Null Pointer Exception with out any context.
- Identify `activeRecipes` which are not associated with any loaded Recipes.  Before the invalid `activeRecipe` would be silently ignored.
