### PR TITLE
SemanticallyEqual-No-Args-BugFix

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -62,9 +62,7 @@ public class SemanticallyEqual {
             J.Annotation secondAnnotation = (J.Annotation) second;
 
             if (firstAnnotation.getArguments() != null && secondAnnotation.getArguments() != null) {
-                if (firstAnnotation.getArguments() != null &&
-                        secondAnnotation.getArguments() != null &&
-                        firstAnnotation.getArguments().size() == secondAnnotation.getArguments().size()) {
+                if (firstAnnotation.getArguments().size() == secondAnnotation.getArguments().size()) {
 
                     List<Expression> firstArgs = firstAnnotation.getArguments();
                     List<Expression> secondArgs = secondAnnotation.getArguments();
@@ -76,9 +74,8 @@ public class SemanticallyEqual {
                     isEqual = false;
                     return null;
                 }
-
-                this.visitTypeName(firstAnnotation.getAnnotationType(), secondAnnotation.getAnnotationType());
             }
+            this.visitTypeName(firstAnnotation.getAnnotationType(), secondAnnotation.getAnnotationType());
             return null;
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
@@ -33,7 +33,45 @@ interface SemanticallyEqualTest {
                 boolean value();
                 String srcValue(); 
             }
+            @interface NoArgAnnotation1{}
+            @interface NoArgAnnotation2{}
         """
+    }
+
+    @Test
+    fun noArgumentsTest(jp: JavaParser) {
+        val cu = jp.parse(
+            """
+                @NoArgAnnotation1
+                class A {}
+            """,
+            annotInterface
+        )
+
+        val firstAnnot = cu[0].classes[0].annotations[0]
+
+        jp.reset()
+
+        val secondAnnot = jp.parse(
+            """
+                @NoArgAnnotation2
+                class B {}
+            """,
+            annotInterface
+        )[0].classes[0].annotations[0]
+
+        jp.reset()
+
+        val thirdAnnot = jp.parse(
+            """
+                @NoArgAnnotation2
+                class B {}
+            """,
+            annotInterface
+        )[0].classes[0].annotations[0]
+
+        assertThat(SemanticallyEqual.areEqual(firstAnnot, secondAnnot)).isFalse()
+        assertThat(SemanticallyEqual.areEqual(secondAnnot,thirdAnnot)).isTrue()
     }
 
     @Test


### PR DESCRIPTION
SemanticallyEqual would always be false when arguments are null