### PR TITLE
issue #254: annotation locations

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CovariantEqualsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CovariantEqualsVisitor.java
@@ -75,7 +75,7 @@ public class CovariantEqualsVisitor<P> extends JavaIsoVisitor<P> {
                     m.getReturnTypeExpression() != null &&
                     JavaType.Primitive.Boolean.equals(m.getReturnTypeExpression().getType())) {
 
-                if (m.getAnnotations().stream().noneMatch(OVERRIDE_ANNOTATION_SIGNATURE::matches)) {
+                if (m.getAllAnnotations().stream().noneMatch(OVERRIDE_ANNOTATION_SIGNATURE::matches)) {
                     m = maybeAutoFormat(m,
                             m.withTemplate(
                                     template("@Override").build(),

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariablesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariablesVisitor.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.NameTree;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -86,7 +87,7 @@ public class FinalizeLocalVariablesVisitor<P> extends JavaIsoVisitor<P> {
         if (mv.getVariables().stream().noneMatch(hasReassignment)) {
             mv = maybeAutoFormat(mv,
                     mv.withModifiers(
-                            ListUtils.concat(mv.getModifiers(), new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, J.Modifier.Type.Final))
+                            ListUtils.concat(mv.getModifiers(), new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, J.Modifier.Type.Final, Collections.emptyList()))
                     ), p, getCursor().dropParentUntil(J.class::isInstance));
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
@@ -33,6 +33,7 @@ import org.openrewrite.marker.Markers;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -72,7 +73,7 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, P p) {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
         if (UtilityClassUtilities.isRefactorableUtilityClass(c, style)) {
-            /**
+            /*
              * Note, it's a deliberate choice to have these be their own respective visitors rather than putting
              * all the logic in one visitor. It's conceptually easier to distinguish what each are doing.
              * And some linters which deal with "utility classes", such as IntelliJ, Checkstyle, etc., treat
@@ -128,7 +129,7 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
                 );
                 // If visibility is Package-Private (no access modifier keyword), replace it with Private
                 if (!md.hasModifier(J.Modifier.Type.Private)) {
-                    J.Modifier mod = new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, J.Modifier.Type.Private);
+                    J.Modifier mod = new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, J.Modifier.Type.Private, Collections.emptyList());
                     md = md.withModifiers(
                             ListUtils.concat(md.getModifiers(), mod)
                     );
@@ -166,7 +167,7 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
          * @return true if the Class Declaration is annotated with at least one matching ignorableAnnotation
          */
         static boolean hasIgnorableAnnotation(J.ClassDeclaration c, Collection<String> ignorableAnnotations) {
-            return c.getAnnotations().stream().anyMatch(
+            return c.getAllAnnotations().stream().anyMatch(
                     classAnn -> ignorableAnnotations.stream().anyMatch(
                             ignorableAnn -> new AnnotationMatcher(ignorableAnn).matches(classAnn)
                     )

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
@@ -162,13 +162,13 @@ class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
                 // don't adjust the first statement in a block
                 if (!block.getStatements().isEmpty() && block.getStatements().iterator().next() != j) {
                     if (j instanceof J.VariableDeclarations) {
-                        if (classDecl.getKind() == J.ClassDeclaration.Kind.Interface) {
+                        if (classDecl.getKind() == J.ClassDeclaration.Kind.Type.Interface) {
                             j = minimumLines(j, style.getMinimum().getAroundFieldInInterface());
                         } else {
                             j = minimumLines(j, style.getMinimum().getAroundField());
                         }
                     } else if (j instanceof J.MethodDeclaration) {
-                        if (classDecl.getKind() == J.ClassDeclaration.Kind.Interface) {
+                        if (classDecl.getKind() == J.ClassDeclaration.Kind.Type.Interface) {
                             j = minimumLines(j, style.getMinimum().getAroundMethodInInterface());
                         } else {
                             j = minimumLines(j, style.getMinimum().getAroundMethod());

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
@@ -28,7 +28,7 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
 
         boolean first = true;
-        if (!c.getAnnotations().isEmpty()) {
+        if (!c.getLeadingAnnotations().isEmpty()) {
             first = false;
         }
         if (!c.getModifiers().isEmpty()) {
@@ -82,7 +82,7 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
 
         boolean first = true;
-        if (!m.getAnnotations().isEmpty()) {
+        if (!m.getLeadingAnnotations().isEmpty()) {
             first = false;
         }
         if (!m.getModifiers().isEmpty()) {
@@ -92,13 +92,16 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
             }
             first = false;
         }
-        J.MethodDeclaration.Padding padding = m.getPadding();
-        JContainer<J.TypeParameter> typeParameters = padding.getTypeParameters();
-        if (typeParameters != null && !typeParameters.getElements().isEmpty()) {
-            if (!first && typeParameters.getBefore().getWhitespace().isEmpty()) {
-                m = padding.withTypeParameters(typeParameters.withBefore(typeParameters.getBefore().withWhitespace(" ")));
+        J.TypeParameters typeParameters = m.getAnnotations().getTypeParameters();
+        if (typeParameters != null && !typeParameters.getTypeParameters().isEmpty()) {
+            if (!first && typeParameters.getPrefix().getWhitespace().isEmpty()) {
+                m = m.getAnnotations().withTypeParameters(
+                        typeParameters.withPrefix(
+                                typeParameters.getPrefix().withWhitespace(" ")
+                        )
+                );
+                first = false;
             }
-            first = false;
         }
         if (m.getReturnTypeExpression() != null && m.getReturnTypeExpression().getPrefix().getWhitespace().isEmpty()) {
             if (!first) {
@@ -142,7 +145,7 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
             }
         }
 
-        /**
+        /*
          * We need at least one space between multiple modifiers, otherwise we could get a run-on like "publicstaticfinal".
          * Note, this is applicable anywhere that modifiers can exist, such as class declarations, etc.
          */
@@ -150,7 +153,7 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
             v = v.withModifiers(
                     ListUtils.map(v.getModifiers(), (index, modifier) -> {
                         if (index == 0) {
-                            /**
+                            /*
                              * Skip the first modifier in the modifier list (if any). We only
                              * care about ensuring there is at least one space between multiple modifiers.
                              */

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeFormatVisitor.java
@@ -28,9 +28,9 @@ public class NormalizeFormatVisitor<P> extends JavaIsoVisitor<P> {
     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, P p) {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
 
-        if (!c.getAnnotations().isEmpty()) {
-            c = concatenatePrefix(c, Space.firstPrefix(c.getAnnotations()));
-            c = c.withAnnotations(Space.formatFirstPrefix(c.getAnnotations(), Space.EMPTY));
+        if (!c.getLeadingAnnotations().isEmpty()) {
+            c = concatenatePrefix(c, Space.firstPrefix(c.getLeadingAnnotations()));
+            c = c.withLeadingAnnotations(Space.formatFirstPrefix(c.getLeadingAnnotations(), Space.EMPTY));
             return c;
         }
 
@@ -40,9 +40,9 @@ public class NormalizeFormatVisitor<P> extends JavaIsoVisitor<P> {
             return c;
         }
 
-        if(!c.getPadding().getKind().getBefore().isEmpty()) {
-            c = concatenatePrefix(c, c.getPadding().getKind().getBefore());
-            c = c.getPadding().withKind(c.getPadding().getKind().withBefore(Space.EMPTY));
+        if(!c.getAnnotations().getKind().getPrefix().isEmpty()) {
+            c = concatenatePrefix(c, c.getAnnotations().getKind().getPrefix());
+            c = c.getAnnotations().withKind(c.getAnnotations().getKind().withPrefix(Space.EMPTY));
             return c;
         }
 
@@ -61,9 +61,9 @@ public class NormalizeFormatVisitor<P> extends JavaIsoVisitor<P> {
     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, P p) {
         J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
 
-        if (!m.getAnnotations().isEmpty()) {
-            m = concatenatePrefix(m, Space.firstPrefix(m.getAnnotations()));
-            m = m.withAnnotations(Space.formatFirstPrefix(m.getAnnotations(), Space.EMPTY));
+        if (!m.getLeadingAnnotations().isEmpty()) {
+            m = concatenatePrefix(m, Space.firstPrefix(m.getLeadingAnnotations()));
+            m = m.withLeadingAnnotations(Space.formatFirstPrefix(m.getLeadingAnnotations(), Space.EMPTY));
             return m;
         }
 
@@ -73,9 +73,9 @@ public class NormalizeFormatVisitor<P> extends JavaIsoVisitor<P> {
             return m;
         }
 
-        if (m.getPadding().getTypeParameters() != null && !m.getPadding().getTypeParameters().getElements().isEmpty()) {
-            m = concatenatePrefix(m, m.getPadding().getTypeParameters().getBefore());
-            m = m.getPadding().withTypeParameters(m.getPadding().getTypeParameters().withBefore(Space.EMPTY));
+        if (m.getAnnotations().getTypeParameters() != null && !m.getAnnotations().getTypeParameters().getTypeParameters().isEmpty()) {
+            m = concatenatePrefix(m, m.getAnnotations().getTypeParameters().getPrefix());
+            m = m.getAnnotations().withTypeParameters(m.getAnnotations().getTypeParameters().withPrefix(Space.EMPTY));
             return m;
         }
 
@@ -95,9 +95,9 @@ public class NormalizeFormatVisitor<P> extends JavaIsoVisitor<P> {
     public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, P p) {
         J.VariableDeclarations v = super.visitVariableDeclarations(multiVariable, p);
 
-        if (!v.getAnnotations().isEmpty()) {
-            v = concatenatePrefix(v, Space.firstPrefix(v.getAnnotations()));
-            v = v.withAnnotations(Space.formatFirstPrefix(v.getAnnotations(), Space.EMPTY));
+        if (!v.getLeadingAnnotations().isEmpty()) {
+            v = concatenatePrefix(v, Space.firstPrefix(v.getLeadingAnnotations()));
+            v = v.withLeadingAnnotations(Space.formatFirstPrefix(v.getLeadingAnnotations(), Space.EMPTY));
             return v;
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -86,7 +86,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
         c = c.withBody(spaceBefore(c.getBody(), style.getBeforeLeftBrace().isClassLeftBrace()));
         if (c.getBody().getStatements().isEmpty()) {
-            if (c.getKind() != J.ClassDeclaration.Kind.Enum) {
+            if (c.getKind() != J.ClassDeclaration.Kind.Type.Enum) {
                 boolean withinCodeBraces = style.getWithin().isCodeBraces();
                 if (withinCodeBraces && StringUtils.isNullOrEmpty(c.getBody().getEnd().getWhitespace())) {
                     c = c.withBody(
@@ -188,12 +188,12 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
                     )
             );
         }
-        if (m.getPadding().getTypeParameters() != null) {
+        if (m.getAnnotations().getTypeParameters() != null) {
             boolean spaceWithinAngleBrackets = style.getWithin().isAngleBrackets();
-            int typeParametersSize = m.getPadding().getTypeParameters().getElements().size();
-            m = m.getPadding().withTypeParameters(
-                    m.getPadding().getTypeParameters().getPadding().withElements(
-                            ListUtils.map(m.getPadding().getTypeParameters().getPadding().getElements(),
+            int typeParametersSize = m.getAnnotations().getTypeParameters().getTypeParameters().size();
+            m = m.getAnnotations().withTypeParameters(
+                    m.getAnnotations().getTypeParameters().getPadding().withTypeParameters(
+                            ListUtils.map(m.getAnnotations().getTypeParameters().getPadding().getTypeParameters(),
                                     (index, elemContainer) -> {
                                         if (index == 0) {
                                             elemContainer = elemContainer.withElement(
@@ -209,8 +209,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
                                             elemContainer = spaceAfter(elemContainer, spaceWithinAngleBrackets);
                                         }
                                         return elemContainer;
-                                    }
-                            )
+                                    })
                     )
             );
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
@@ -19,7 +19,6 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.WrappingAndBracesStyle;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JLeftPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 
@@ -50,15 +49,15 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
     @Override public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, P p) {
         J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
         // TODO make annotation wrapping configurable
-        m = m.withAnnotations(withNewlines(m.getAnnotations()));
-        if (!m.getAnnotations().isEmpty()) {
+        m = m.withLeadingAnnotations(withNewlines(m.getLeadingAnnotations()));
+        if (!m.getLeadingAnnotations().isEmpty()) {
             if (!m.getModifiers().isEmpty()) {
                 m = m.withModifiers(withNewline(m.getModifiers()));
-            } else if (m.getPadding().getTypeParameters() != null) {
-                if (!m.getPadding().getTypeParameters().getBefore().getWhitespace().contains("\n")) {
-                    m = m.getPadding().withTypeParameters(
-                            m.getPadding().getTypeParameters().withBefore(
-                                    withNewline(m.getPadding().getTypeParameters().getBefore())
+            } else if (m.getAnnotations().getTypeParameters() != null) {
+                if (!m.getAnnotations().getTypeParameters().getPrefix().getWhitespace().contains("\n")) {
+                    m = m.getAnnotations().withTypeParameters(
+                            m.getAnnotations().getTypeParameters().withPrefix(
+                                    withNewline(m.getAnnotations().getTypeParameters().getPrefix())
                             )
                     );
                 }
@@ -86,21 +85,16 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
     @Override public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, P p) {
         J.ClassDeclaration j = super.visitClassDeclaration(classDecl, p);
         // TODO make annotation wrapping configurable
-        j = j.withAnnotations(withNewlines(j.getAnnotations()));
-        if (!j.getAnnotations().isEmpty()) {
+        j = j.withLeadingAnnotations(withNewlines(j.getLeadingAnnotations()));
+        if (!j.getLeadingAnnotations().isEmpty()) {
             if (!j.getModifiers().isEmpty()) {
                 j = j.withModifiers(withNewline(j.getModifiers()));
             } else {
-                J.ClassDeclaration.Padding padding = j.getPadding();
-                JLeftPadded<J.ClassDeclaration.Kind> kind = padding.getKind();
-                if (!kind.getBefore().getWhitespace().contains("\n")) {
-                    j = padding.withKind(
-                            kind.withBefore(
-                                    kind.getBefore().withWhitespace(
-                                            "\n" + kind.getBefore().getWhitespace()
-                                    )
-                            )
-                    );
+                J.ClassDeclaration.Kind kind = j.getAnnotations().getKind();
+                if (!kind.getPrefix().getWhitespace().contains("\n")) {
+                    j = j.getAnnotations().withKind(kind.withPrefix(
+                            kind.getPrefix().withWhitespace("\n" + kind.getPrefix().getWhitespace())
+                    ));
                 }
             }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassDeclarationToString.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassDeclarationToString.java
@@ -57,7 +57,7 @@ public class ClassDeclarationToString {
             }
             visitLeftPadded("extends", classDecl.getPadding().getExtends(), JLeftPadded.Location.EXTENDS, unused);
             if (classDecl.getImplements() != null) {
-                if (J.ClassDeclaration.Kind.Interface.equals(classDecl.getKind())) {
+                if (J.ClassDeclaration.Kind.Type.Interface.equals(classDecl.getKind())) {
                     acc.append("extends");
                 } else {
                     acc.append("implements");

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/MethodDeclarationToString.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/MethodDeclarationToString.java
@@ -19,6 +19,7 @@ import org.openrewrite.TreePrinter;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 
 public class MethodDeclarationToString {
@@ -35,7 +36,13 @@ public class MethodDeclarationToString {
             if (!method.getModifiers().isEmpty()) {
                 acc.append(' ');
             }
-            visitContainer("<", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", unused);
+            J.TypeParameters typeParameters = method.getAnnotations().getTypeParameters();
+            if (typeParameters != null) {
+                visitSpace(typeParameters.getPrefix(), Space.Location.TYPE_PARAMETERS, unused);
+                acc.append("<");
+                visitRightPadded(typeParameters.getPadding().getTypeParameters(), JRightPadded.Location.TYPE_PARAMETER, ",", unused);
+                acc.append(">");
+            }
             if (method.getReturnTypeExpression() != null) {
                 acc.append(method.getReturnTypeExpression().printTrimmed()).append(' ');
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/InsertAtCoordinates.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/InsertAtCoordinates.java
@@ -98,10 +98,10 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
                 case ANNOTATIONS: {
                     J.ClassDeclaration temp;
                     if (INSERTION.equals(coordinates.getMode())) {
-                        temp = c.withAnnotations(ListUtils.insertInOrder(c.getAnnotations(), (J.Annotation) generated.get(0),
+                        temp = c.withLeadingAnnotations(ListUtils.insertInOrder(c.getLeadingAnnotations(), (J.Annotation) generated.get(0),
                                 coordinates.getComparator()));
                     } else {
-                        temp = c.withAnnotations((List<J.Annotation>) generated);
+                        temp = c.withLeadingAnnotations((List<J.Annotation>) generated);
                     }
                     //If the annotations have changed, reformat the class declaration (so we can get properly formatted
                     //annotations). The class declaration is reformatted (minus the body) and we must format
@@ -137,7 +137,7 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
                     break;
             }
         } else {
-            J.ClassDeclaration temp = c.withAnnotations(maybeMergeList(c.getAnnotations(), generated));
+            J.ClassDeclaration temp = c.withLeadingAnnotations(maybeMergeList(c.getLeadingAnnotations(), generated));
             if (temp != c) {
                 //If the annotations have changed, reformat the class declaration (so we can get properly formatted
                 //annotations). The class declaration is reformatted (minus the body) and we must format
@@ -175,10 +175,10 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
                 case ANNOTATIONS: {
                     J.MethodDeclaration temp;
                     if (INSERTION.equals(coordinates.getMode())) {
-                        temp = m.withAnnotations(ListUtils.insertInOrder(m.getAnnotations(), (J.Annotation) generated.get(0),
+                        temp = m.withLeadingAnnotations(ListUtils.insertInOrder(m.getLeadingAnnotations(), (J.Annotation) generated.get(0),
                                 coordinates.getComparator()));
                     } else {
-                        temp = m.withAnnotations((List<J.Annotation>) generated);
+                        temp = m.withLeadingAnnotations((List<J.Annotation>) generated);
                     }
                     //If the annotations have changed, reformat the method declaration (so we can get properly formatted
                     //annotations). The entire method declaration is reformatted (minus the body) and we must format
@@ -193,7 +193,7 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
                     J.MethodDeclaration temp = m.withTypeParameters((List<J.TypeParameter>) generated);
                     temp = (J.MethodDeclaration) autoFormat.visit(temp.withBody(EMPTY_BLOCK), 0, getCursor());
                     assert temp != null;
-                    m = m.getPadding().withTypeParameters(temp.getPadding().getTypeParameters());
+                    m = m.withTypeParameters(temp.getTypeParameters());
                     break;
                 }
                 case METHOD_DECLARATION_PARAMETERS: {
@@ -215,7 +215,7 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
                     break;
             }
         } else {
-            J.MethodDeclaration temp = m.withAnnotations(maybeMergeList(m.getAnnotations(), generated));
+            J.MethodDeclaration temp = m.withLeadingAnnotations(maybeMergeList(m.getLeadingAnnotations(), generated));
             if (temp != m) {
                 //If the annotations have changed, reformat the method declaration (so we can get properly formatted
                 //annotations). The entire method declaration is reformatted (minus the body) and we must format
@@ -232,7 +232,7 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
                 //Auto-format the type parameters if they have been changed.
                 temp = (J.MethodDeclaration) autoFormat.visit(temp.withBody(EMPTY_BLOCK), 0, getCursor());
                 assert temp != null;
-                return m.getPadding().withTypeParameters(temp.getPadding().getTypeParameters());
+                return m.getAnnotations().withTypeParameters(temp.getAnnotations().getTypeParameters());
             }
 
             temp = m.withParameters(maybeMergeList(m.getParameters(), generated));
@@ -262,17 +262,17 @@ public class InsertAtCoordinates extends JavaVisitor<List<? extends J>> {
         if (insertId.equals(m.getId())) {
             if (location == Space.Location.ANNOTATIONS) {
                 if (INSERTION.equals(coordinates.getMode())) {
-                    m = m.withAnnotations(ListUtils.insertInOrder(m.getAnnotations(), (J.Annotation) generated.get(0),
+                    m = m.withLeadingAnnotations(ListUtils.insertInOrder(m.getLeadingAnnotations(), (J.Annotation) generated.get(0),
                             coordinates.getComparator()));
                 } else {
-                    m = m.withAnnotations((List<J.Annotation>) generated);
+                    m = m.withLeadingAnnotations((List<J.Annotation>) generated);
                 }
                 //If the annotations have changed, reformat the variable declaration (so we can get properly formatted
                 //annotations). We must format relative to the first enclosing J.Block.
                 m = (J.VariableDeclarations) autoFormat.visit(m, 0, getFormattingParent(getCursor()));
             }
         } else {
-            J.VariableDeclarations temp = m.withAnnotations(maybeMergeList(m.getAnnotations(), generated));
+            J.VariableDeclarations temp = m.withLeadingAnnotations(maybeMergeList(m.getLeadingAnnotations(), generated));
             if (temp != m) {
                 //If the annotations have changed, reformat the variable declaration (so we can get properly formatted
                 //annotations). We must format relative to the first enclosing J.Block.

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplatePrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplatePrinter.java
@@ -130,7 +130,7 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
     @Override
     public J visitClassDeclaration(J.ClassDeclaration classDecl, Cursor insertionScope) {
         if (!insertionScope.isScopeInPath(classDecl) || !classDecl.getId().equals(coordinates.getTree().getId())) {
-            return super.visitClassDeclaration(classDecl.withAnnotations(emptyList()), insertionScope);
+            return super.visitClassDeclaration(classDecl.withLeadingAnnotations(emptyList()), insertionScope);
         }
 
         String kind = "";
@@ -157,14 +157,14 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
             }
             else {
                 printTemplate();
-                visit(classDecl.getAnnotations(), insertionScope);
+                visit(classDecl.getLeadingAnnotations(), insertionScope);
             }
         } else {
-            visit(classDecl.getAnnotations(), insertionScope);
+            visit(classDecl.getLeadingAnnotations(), insertionScope);
         }
 
         visitModifiers(classDecl.getModifiers(), insertionScope);
-        visitSpace(classDecl.getPadding().getKind().getBefore(), Space.Location.CLASS_KIND, insertionScope);
+        visitSpace(classDecl.getAnnotations().getKind().getPrefix(), Space.Location.CLASS_KIND, insertionScope);
         StringBuilder acc = getPrinter();
         acc.append(kind);
         visit(classDecl.getName(), insertionScope);
@@ -184,7 +184,7 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
         if (coordinates.isReplacement() && Space.Location.IMPLEMENTS.equals(coordinates.getSpaceLocation())) {
             printTemplate();
         } else {
-            visitContainer(classDecl.getKind().equals(J.ClassDeclaration.Kind.Interface) ? "extends" : "implements",
+            visitContainer(classDecl.getKind().equals(J.ClassDeclaration.Kind.Type.Interface) ? "extends" : "implements",
                     classDecl.getPadding().getImplements(), JContainer.Location.IMPLEMENTS, ",", null, insertionScope);
         }
 
@@ -200,7 +200,7 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
     @Override
     public J visitMethodDeclaration(J.MethodDeclaration method, Cursor insertionScope) {
         if (!insertionScope.isScopeInPath(method)) {
-            return super.visitMethodDeclaration(method.withAnnotations(emptyList()).withBody(EMPTY_BLOCK), insertionScope);
+            return super.visitMethodDeclaration(method.withLeadingAnnotations(emptyList()).withBody(EMPTY_BLOCK), insertionScope);
         }
 
         visitSpace(method.getPrefix(), Space.Location.METHOD_DECLARATION_PREFIX, insertionScope);
@@ -211,10 +211,10 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
             }
             else {
                 printTemplate();
-                visit(method.getAnnotations(), insertionScope);
+                visit(method.getLeadingAnnotations(), insertionScope);
             }
         } else {
-            visit(method.getAnnotations(), insertionScope);
+            visit(method.getLeadingAnnotations(), insertionScope);
         }
 
         visitModifiers(method.getModifiers(), insertionScope);
@@ -222,7 +222,15 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
         if (coordinates.isReplacement() && Space.Location.TYPE_PARAMETERS.equals(coordinates.getSpaceLocation())) {
             printTemplate();
         } else {
-            visitContainer("<", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", insertionScope);
+            J.TypeParameters typeParameters = method.getAnnotations().getTypeParameters();
+            if (typeParameters != null) {
+                visit(typeParameters.getAnnotations(), insertionScope);
+                visitSpace(typeParameters.getPrefix(), Space.Location.TYPE_PARAMETERS, insertionScope);
+                StringBuilder acc = getPrinter();
+                acc.append("<");
+                visitRightPadded(typeParameters.getPadding().getTypeParameters(), JRightPadded.Location.TYPE_PARAMETER, ",", insertionScope);
+                acc.append(">");
+            }
         }
 
         visit(method.getReturnTypeExpression(), insertionScope);
@@ -278,9 +286,9 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
     @Override
     public J visitVariableDeclarations(J.VariableDeclarations multiVariable, Cursor insertionScope) {
         if (!insertionScope.isScopeInPath(multiVariable)) {
-            return super.visitVariableDeclarations(multiVariable.withAnnotations(emptyList()), insertionScope);
+            return super.visitVariableDeclarations(multiVariable.withLeadingAnnotations(emptyList()), insertionScope);
         } else if (!multiVariable.getId().equals(coordinates.getTree().getId())) {
-            return super.visitVariableDeclarations(multiVariable.withAnnotations(emptyList()), insertionScope);
+            return super.visitVariableDeclarations(multiVariable.withLeadingAnnotations(emptyList()), insertionScope);
         }
 
         StringBuilder acc = getPrinter();
@@ -292,10 +300,10 @@ public class JavaTemplatePrinter extends JavaPrinter<Cursor> {
             }
             else {
                 printTemplate();
-                visit(multiVariable.getAnnotations(), insertionScope);
+                visit(multiVariable.getLeadingAnnotations(), insertionScope);
             }
         } else {
-            visit(multiVariable.getAnnotations(), insertionScope);
+            visit(multiVariable.getLeadingAnnotations(), insertionScope);
         }
 
         visitModifiers(multiVariable.getModifiers(), insertionScope);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Coordinates.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Coordinates.java
@@ -215,6 +215,17 @@ public abstract class Coordinates {
         public JavaCoordinates replaceBody() {
             return replace(Space.Location.BLOCK_PREFIX);
         }
+
+        public static class Kind extends Coordinates {
+            Kind(J.ClassDeclaration.Kind tree) {
+                super(tree);
+            }
+
+            @Override
+            public JavaCoordinates before() {
+                return insert(Space.Location.CLASS_KIND);
+            }
+        }
     }
 
     public static class CompilationUnit extends Coordinates {
@@ -719,6 +730,17 @@ public abstract class Coordinates {
 
         public JavaCoordinates bounds() {
             return insert(Space.Location.TYPE_BOUNDS);
+        }
+    }
+
+    public static class TypeParameters extends Coordinates {
+        TypeParameters(J.TypeParameters tree) {
+            super(tree);
+        }
+
+        @Override
+        public JavaCoordinates before() {
+            return insert(Space.Location.TYPE_PARAMETERS_PREFIX);
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2946,6 +2946,7 @@ public interface J extends Serializable, Tree {
             if (returnTypeExpression instanceof AnnotatedType) {
                 allAnnotations.addAll(((AnnotatedType) returnTypeExpression).getAnnotations());
             }
+            allAnnotations.addAll(name.getAnnotations());
             return allAnnotations;
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
@@ -48,7 +48,7 @@ interface SemanticallyEqualTest {
             annotInterface
         )
 
-        val firstAnnot = cu[0].classes[0].annotations[0]
+        val firstAnnot = cu[0].classes[0].leadingAnnotations[0]
 
         jp.reset()
 
@@ -58,7 +58,7 @@ interface SemanticallyEqualTest {
                 class B {}
             """,
             annotInterface
-        )[0].classes[0].annotations[0]
+        )[0].classes[0].leadingAnnotations[0]
 
         jp.reset()
 
@@ -68,7 +68,7 @@ interface SemanticallyEqualTest {
                 class B {}
             """,
             annotInterface
-        )[0].classes[0].annotations[0]
+        )[0].classes[0].leadingAnnotations[0]
 
         assertThat(SemanticallyEqual.areEqual(firstAnnot, secondAnnot)).isFalse()
         assertThat(SemanticallyEqual.areEqual(secondAnnot,thirdAnnot)).isTrue()
@@ -98,9 +98,9 @@ interface SemanticallyEqualTest {
             "public interface SlowTests {}"
         )
 
-        val fastTest = cu[0].classes[0].annotations[0]
-        val fastTest2 = cu[0].classes[0].annotations[1]
-        val slowTest = cu[0].classes[0].annotations[2]
+        val fastTest = cu[0].classes[0].leadingAnnotations[0]
+        val fastTest2 = cu[0].classes[0].leadingAnnotations[1]
+        val slowTest = cu[0].classes[0].leadingAnnotations[2]
 
         assertThat(SemanticallyEqual.areEqual(fastTest, fastTest2)).isTrue()
         assertThat(SemanticallyEqual.areEqual(fastTest, slowTest)).isFalse()
@@ -116,7 +116,7 @@ interface SemanticallyEqualTest {
             annotInterface
         )
 
-        val firstAnnot = cu[0].classes[0].annotations[0]
+        val firstAnnot = cu[0].classes[0].leadingAnnotations[0]
 
         jp.reset()
 
@@ -126,7 +126,7 @@ interface SemanticallyEqualTest {
                 class B {}
             """,
             annotInterface
-        )[0].classes[0].annotations[0]
+        )[0].classes[0].leadingAnnotations[0]
 
         assertThat(SemanticallyEqual.areEqual(firstAnnot, secondAnnot)).isTrue()
     }
@@ -141,7 +141,7 @@ interface SemanticallyEqualTest {
             "@interface MyAnnotation { boolean value(); }"
         )
 
-        val firstIdent = cu[0].classes[0].annotations[0].annotationType
+        val firstIdent = cu[0].classes[0].leadingAnnotations[0].annotationType
         val secondIdent = J.Identifier.build(
             randomId(),
             Space.EMPTY,
@@ -186,7 +186,7 @@ interface SemanticallyEqualTest {
             "class SlowTest {}"
         )
 
-        val firstFieldAccess = cu[0].classes[0].annotations[0].arguments!!.first()
+        val firstFieldAccess = cu[0].classes[0].leadingAnnotations[0].arguments!!.first()
         val secondFieldAccess = J.FieldAccess(
             randomId(),
             Space.EMPTY,
@@ -211,7 +211,7 @@ interface SemanticallyEqualTest {
             ),
             JavaType.Class.build("java.lang.Class")
         )
-        val thirdFieldAccess = cu[0].classes[0].annotations[1].arguments!!.first()
+        val thirdFieldAccess = cu[0].classes[0].leadingAnnotations[1].arguments!!.first()
 
         assertThat(
             SemanticallyEqual
@@ -240,7 +240,7 @@ interface SemanticallyEqualTest {
             "@interface MyAnnotation { boolean value(); }"
         )
 
-        val firstAssign = cu[0].classes[0].annotations[0].arguments!!.first()
+        val firstAssign = cu[0].classes[0].leadingAnnotations[0].arguments!!.first()
         val secondAssign = J.Assignment(
             randomId(),
             Space.EMPTY,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/AnnotationTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/AnnotationTest.kt
@@ -60,23 +60,28 @@ interface AnnotationTest : JavaTreeTest {
     )
 
     @Test
-    @Issue("#254")
-    @Disabled
-    fun annotationAfterTypeParameters(jp: JavaParser) = assertParsePrintAndProcess(
-        jp, CompilationUnit, """
-           import java.util.List;
-           import java.lang.annotation.*;
-
-            @Target({ElementType.TYPE_USE})
-            @Retention(RetentionPolicy.RUNTIME)
-            public @interface Yo {}
-
-            public class A {
-                <T> @Yo T method(List<T> list, int element) {
-                    return list.get(element);
+    fun annotationsInManyLocations(jp: JavaParser) = assertParsePrintAndProcess(
+            jp, CompilationUnit, """
+                import java.lang.annotation.*;
+                @Ho
+                public @Ho final @Ho class Test {
+                    @Ho private @Ho transient @Ho String s;
+                    @Ho
+                    public @Ho final @Ho <T> @Ho T merryChristmas() {
+                        return null;
+                    }
+                    @Ho
+                    public @Ho Test() {
+                    }
                 }
-            }
-        """
+                @Target({ElementType.TYPE_USE, ElementType.TYPE, ElementType.FIELD})
+                @interface Hos {
+                    Ho[] value();
+                }
+                @Target({ElementType.TYPE_USE, ElementType.TYPE, ElementType.FIELD})
+                @Repeatable(Hos.class)
+                @interface Ho {
+                }
+            """
     )
-
 }


### PR DESCRIPTION
Annotations may occur mixed with modifiers and between type parameters and return type
in method declarations. Support this in rewrite's java parser and AST with a minimum
of incompatible change.