### PR TITLE
github actions scaffolding precursor to direct releasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+---
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - "*"
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+env:
+  GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+  GRADLE_SWITCHES: "-s --console=plain --info --stacktrace"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: set-up-jdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+      - name: setup-cache
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: build
+        run: ./gradlew ${GRADLE_SWITCHES} build test
+
+      # - name: publish-snapshots
+      #   if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      #   timeout-minutes: 30
+      #   run: ./gradlew ${GRADLE_SWITCHES} snapshot publish
+      #   env:
+      #     OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      #     OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      #     SIGNING_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      #     SIGNING_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,3 +1,4 @@
+---
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 

--- a/.github/workflows/publish.yml.disabled
+++ b/.github/workflows/publish.yml.disabled
@@ -1,0 +1,56 @@
+---
+name: publish
+
+on:
+  push:
+    tags:
+      - v*.*.*
+      - v*.*.*-rc.*
+
+env:
+  GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+  GRADLE_SWITCHES: "-s --console=plain --info --stacktrace"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: set-up-jdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+      - name: setup-cache
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: build
+        run: ./gradlew ${GRADLE_SWITCHES} build test
+
+      - name: publish-candidate
+        if: contains(github.ref, '-rc.')
+        timeout-minutes: 30
+        run: ./gradlew ${GRADLE_SWITCHES} -Prelease.disableGitChecks=true -Prelease.useLastTag=true candidate publishToSonatype closeSonatypeStagingRepository # closeAndReleaseSonatypeStagingRepository
+        env:
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          SIGNING_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          SIGNING_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+
+      - name: publish-release
+        if: (!contains(github.ref, '-rc.'))
+        timeout-minutes: 30
+        run: ./gradlew ${GRADLE_SWITCHES} -Prelease.disableGitChecks=true -Prelease.useLastTag=true final publishToSonatype closeSonatypeStagingRepository # closeAndReleaseSonatypeStagingRepository
+        env:
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          SIGNING_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          SIGNING_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
see: https://github.com/openrewrite/rewrite/issues/324

Tested this on these two repositories:
- https://github.com/slugstack/slugstack-rewrite-java-definitions
- https://github.com/slugstack/slugstack-publishing-test

Will come back to activate the rest, e.g. pushing snapshots and actual build content, will need to do that after the `build.gradle.kts` has been updated, credentials added, and told circle-ci to not try to take command on publishing.

For now this is simply performs `build` and `test` in conjunction with circle-ci. You could release using normal practices and it'd be fine.