### PR TITLE
multiline comment handles double slash comment on first line

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
@@ -160,7 +160,7 @@ public class Space implements Markable {
                     if (last == '/' && !inSingleLineComment && !inMultiLineComment && !inJavadoc) {
                         inSingleLineComment = true;
                         comment = new StringBuilder();
-                    } else if (last == '*' && inMultiLineComment) {
+                    } else if (last == '*' && inMultiLineComment && comment.length() > 0) {
                         inMultiLineComment = false;
                         comment.setLength(comment.length() - 1); // trim the last '*'
                         comments.add(new Comment(Comment.Style.BLOCK, comment.toString(), prefix.toString()));

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/SpaceTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/SpaceTest.kt
@@ -91,6 +91,17 @@ class SpaceTest {
     }
 
     @Test
+    fun multilineCommentWithDoubleSlashCommentOnFirstLine() {
+        val cf = Space.format("""
+        /*// debugging
+        * bla
+        */
+        """.trimIndent())
+        assertThat(cf.comments).hasSize(1)
+        assertThat(cf.comments.first().text).isEqualTo("// debugging\n* bla\n")
+    }
+
+    @Test
     fun stringify() {
         assertThat(Space.format("\n  \n\t \t").toString())
             .isEqualTo("Space(comments=<0 comments>, whitespace='\\n·₁·₂\\n-₁·₂-₃')")


### PR DESCRIPTION
fixing index out of bounds exception when double slash comment on first line