### PR TITLE
Remove reflective check in `TypeUtils.isAssignableTo`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -61,15 +61,7 @@ public class TypeUtils {
             return true;
         }
 
-        try {
-            Class<?> classFromReflect = Class.forName(classFrom.getFullyQualifiedName(), false, TypeUtils.class.getClassLoader());
-            if (classFromReflect.getSuperclass() != null && isAssignableTo(to, JavaType.Class.build(classFromReflect.getSuperclass().getName()))) {
-                return true;
-            }
-            return Arrays.stream(classFromReflect.getInterfaces()).anyMatch(i -> isAssignableTo(to, JavaType.Class.build(i.getName())));
-        } catch (ClassNotFoundException ignored) {
-            return false;
-        }
+        return false;
     }
 
     @Nullable


### PR DESCRIPTION
Instantiating the classes via reflection is unnecessary given that their fully qualified names are compared. 