### PR TITLE
Add RemoveRedundantDependencyVersions as a do-next to the upgrade version recipes

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -195,6 +195,7 @@ public class UpgradeDependencyVersion extends Recipe {
                     for (Pom.Dependency dependency : module.getDependencies()) {
                         if (propertyKeyRef.equals(dependency.getRequestedVersion())) {
                             doAfterVisit(new ChangeTagValueVisitor<>(tag, newVersion));
+                            doAfterVisit(new RemoveRedundantDependencyVersions());
                             break OUTER;
                         }
                     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -156,6 +156,7 @@ public class UpgradeParentVersion extends Recipe {
                         artifactId.equals(parent.getChildValue("artifactId").orElse(null)) &&
                         !toVersion.equals(tag.getValue().orElse(null))) {
                     doAfterVisit(new ChangeTagValueVisitor<>(tag, toVersion));
+                    doAfterVisit(new RemoveRedundantDependencyVersions());
                 }
             }
             return super.visitTag(tag, ctx);


### PR DESCRIPTION
After `UpgradeDependencyVersion` or `UpgradeParentVersion`, we want to delete any redundant versions specified further down by using `RemoveRedundantDependencyVersions`.

Fixes #344 