### PR TITLE
Removing dependencies with a specific scope considers the dependencies effective scope

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -102,20 +102,6 @@ public class MavenVisitor extends XmlVisitor<ExecutionContext> {
                 .orElse(null);
     }
 
-    @Incubating(since = "7.2.0")
-    @Nullable
-    public Scope findDependencyScope(Xml.Tag tag) {
-        Scope dependencyScope = tag.getChildValue("scope")
-                .map(Scope::fromName).orElse(null);
-        if (dependencyScope == null) {
-            Pom.Dependency dependency = findDependency(tag);
-            if (dependency != null) {
-                dependencyScope = dependency.getScope();
-            }
-        }
-        return dependencyScope;
-    }
-
     /**
      * Finds dependencies in the model that match the provided group and artifact ids.
      *

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
@@ -76,9 +76,15 @@ public class RemoveDependency extends Recipe {
 
         @Override
         public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
-            if (isDependencyTag(groupId, artifactId) && (scope == null ||
-                    Scope.fromName(scope).equals(findDependencyScope(tag)))) {
-                doAfterVisit(new RemoveContentVisitor<>(tag, true));
+            if (isDependencyTag(groupId, artifactId)) {
+                Pom.Dependency dependency = findDependency(tag);
+                if (dependency != null) {
+                    Scope checkScope = scope != null ? Scope.fromName(scope) : null;
+                    if (checkScope == null || checkScope == dependency.getScope() ||
+                            (dependency.getScope() != null && dependency.getScope().isInClasspathOf(checkScope))) {
+                        doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                    }
+                }
             }
 
             return super.visitTag(tag, ctx);

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/RemoveDependencyTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/RemoveDependencyTest.kt
@@ -177,7 +177,6 @@ class RemoveDependencyTest : MavenRecipeTest {
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/422")
-    @Disabled
     @Test
     fun removeDependencyByEffectiveScope() = assertChanged(
         recipe = RemoveDependency("junit","junit", "runtime"),


### PR DESCRIPTION
When removing dependencies with a specific scope, the effective scope of the dependency related to the scope constraint is also evaluated. Fixes #422