### PR TITLE
Java parser byte classpath

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
     implementation("io.micrometer:micrometer-core:latest.release")
     implementation("io.github.classgraph:classgraph:latest.release")
+    implementation("org.ow2.asm:asm:latest.release")
 
     testImplementation(project(":rewrite-test"))
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -139,6 +139,8 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
         @Nullable
         protected Collection<Path> classpath = runtimeClasspath;
 
+        protected Collection<byte[]> classBytesClasspath = Collections.emptyList();
+
         @Nullable
         protected Collection<Input> dependsOn;
 
@@ -174,6 +176,11 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
 
         public B classpath(String... classpath) {
             this.classpath = dependenciesFromClasspath(classpath);
+            return (B) this;
+        }
+
+        public B classpath(byte[]... classpath) {
+            this.classBytesClasspath = Arrays.asList(classpath);
             return (B) this;
         }
 


### PR DESCRIPTION
- Jonathan added byte aware classes.
- Adjusted the Stream concatenation to prioritize the byte array classes when provided.
- Overrode JavacFileManager#inferBinaryName so that type attributions work correctly.
- Explicitly tested only using the byte array classes for the test to ensure types were attributed in the tree without existing on the class path.