### PR TITLE
Management enhancements to the rocksdb maven cache

### DIFF
--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     integTestImplementation("org.apache.maven:maven-aether-provider:latest.release")
     integTestImplementation("org.apache.maven:maven-core:latest.release")
     integTestImplementation("io.micrometer:micrometer-registry-prometheus:latest.release")
+    integTestImplementation("org.rocksdb:rocksdbjni:latest.release")
 
     integTestImplementation(project(":rewrite-java-11"))
     integTestImplementation(project(":rewrite-properties"))

--- a/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/cache/RocksdbMavenPomCacheTest.kt
+++ b/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/cache/RocksdbMavenPomCacheTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.cache
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.ExecutionContext
+import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.maven.MavenParser
+import java.io.File
+import java.nio.file.Path
+
+class RocksdbMavenPomCacheTest {
+
+    companion object {
+        private val executionContext: ExecutionContext
+            get() = InMemoryExecutionContext { t ->
+                    t.printStackTrace()
+                }
+    }
+
+    @Test
+    fun rocksCache(@TempDir tempDir: Path) {
+
+
+        val pom = """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>2.2.11.RELEASE</version>
+                        <relativePath/> 
+                    </parent>
+                    <groupId>com.foo</groupId>
+                    <artifactId>test</artifactId>
+                    <version>${"$"}{revision}</version>
+                    <name>test</name>
+                
+                    <properties>
+                        <java.version>1.8</java.version>
+                        <spring-cloud-service.version>2.2.6.RELEASE</spring-cloud-service.version>
+                        <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+                        <jackson-bom.version>2.12.1</jackson-bom.version>
+                        <guava-bom.version>30.1-jre</guava-bom.version>
+                        <revision>1.0.0</revision>
+                        <owaspDb>${"$"}{maven.repo.local}/org/owasp/dependency-check-data/3.0</owaspDb>
+                        <argLine></argLine>
+                        <org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
+                        <tomcat.version>9.0.43</tomcat.version>
+                    </properties>
+                
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.yaml</groupId>
+                            <artifactId>snakeyaml</artifactId>
+                            <version>1.27</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-web</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-actuator</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.cloud</groupId>
+                            <artifactId>spring-cloud-starter-sleuth</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-data-jpa</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-devtools</artifactId>
+                            <scope>runtime</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-test</artifactId>
+                            <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <scope>provided</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct</artifactId>
+                            <version>${"$"}{org.mapstruct.version}</version>
+                            <scope>provided</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.h2database</groupId>
+                            <artifactId>h2</artifactId>
+                            <scope>provided</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.flywaydb</groupId>
+                            <artifactId>flyway-core</artifactId>
+                            <version>6.0.8</version>
+                            <scope>provided</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.postgresql</groupId>
+                            <artifactId>postgresql</artifactId>
+                            <scope>provided</scope>
+                            <version>42.2.18.jre7</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.bouncycastle</groupId>
+                            <artifactId>bcprov-jdk15on</artifactId>
+                            <version>1.68</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.bouncycastle</groupId>
+                            <artifactId>bcpkix-jdk15on</artifactId>
+                            <version>1.68</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.hibernate.validator</groupId>
+                            <artifactId>hibernate-validator</artifactId>
+                            <version>7.0.1.Final</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.hibernate</groupId> 
+                            <artifactId>hibernate-core</artifactId>
+                            <version>5.4.28.Final</version>
+                        </dependency>
+                    </dependencies>
+                
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.pivotal.spring.cloud</groupId>
+                                <artifactId>spring-cloud-services-dependencies</artifactId>
+                                <version>${"$"}{spring-cloud-service.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>${"$"}{spring-cloud.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>com.fasterxml.jackson</groupId>
+                                <artifactId>jackson-bom</artifactId>
+                                <version>${"$"}{jackson-bom.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>com.google.guava</groupId>
+                                <artifactId>guava-bom</artifactId>
+                                <version>${"$"}{guava-bom.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+                """
+        //This is not much of a test, it just ensures the maven parser works correctly with the rocksdb caching
+        //implementation. This does work as a good place to experiment with the various configuration settings.
+        val workspace = File(System.getProperty("user.home") + "/.rewrite/cache/pom")
+
+        val mavenCache = RocksdbMavenPomCache(workspace)
+        val pomAst = MavenParser.builder()
+            .cache(mavenCache)
+            .build()
+            .parse(executionContext, pom)
+            .first()
+
+        Assertions.assertThat(pomAst.model).isNotNull
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/RocksdbMavenPomCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/RocksdbMavenPomCache.java
@@ -50,14 +50,32 @@ import org.openrewrite.maven.tree.MavenRepository;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteOptions;
 
 /**
  * Implementation of the maven cache that leverages Rocksdb. The keys and values are serialized to/from byte arrays
- * using jackson.
+ * using jackson. Things to know about this cache implementation:
+ * <P>
+ * <li> It will create a rocks db in the workspace directory passed to it.</li>
+ * <li> If two caches are pointed to the same workspace folder, they will "share" the same underlying rocks database,
+ *      it is thread-safe.</li>
+ * <li> Because multiple caches can share the same database, the close on this cache implementation does nothing.</li>
+ * <li> The database is closed via a system shutdown hook registered by this class. Any unexpected process termination
+ *      is non-fatal, any non-flushed data is lost, but the database will not be corrupted.</li>
+ * <li> The database is configured to auto-flush when the in-memory size reaches 1MB.</li>
+ * <li> Rocksdb's write ahead log has been disabled because we are using this as a cache and do not need to recover any
+ *      "lost" data.</li>
+ * <li> Rocksdb computes checksums for all of its files, normally it checks those on startup, this has been disabled as
+ *      well.</li>
  */
 public class RocksdbMavenPomCache implements MavenPomCache {
 
     static ObjectMapper mapper;
+
+    //The RocksDB instance is thread safe, the first call to create a database for a workspace will open the database
+    //subsequent calls will get the same instances back. This cache also registers a shutdown hook to close the
+    //databases on shutdown.
+    private static final Map<String, RocksCache> cacheMap = new HashMap<>();
 
     static {
         SmileFactory f = new SmileFactory();
@@ -76,25 +94,16 @@ public class RocksdbMavenPomCache implements MavenPomCache {
 
         //Init the rockdb native jni library
         RocksDB.loadLibrary();
+
+        //Register a shutdown hook to close things down on exit.
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> cacheMap.values().forEach(RocksCache::close)));
     }
 
-    //While the RocksDB instance is thread-safe, attempts to create two instances of the database to the same
-    //folder will fail.
-    private static final Map<String, RocksDB> cacheMap = new HashMap<>();
-    static synchronized RocksDB getCache(String workspace) {
-        return cacheMap.computeIfAbsent(workspace, k -> {
-            final Options options = new Options();
-            options.setCreateIfMissing(true);
-            try {
-                return RocksDB.open(options, k);
-            } catch (RocksDBException exception) {
-                throw new IllegalStateException(("Unable to create cache database." + exception.getMessage()));
-            }
-        });
+    static synchronized RocksCache getCache(String workspace) {
+        return cacheMap.computeIfAbsent(workspace, RocksCache::new);
     }
 
-
-    private final RocksDB cache;
+    private final RocksCache cache;
     private final Set<String> unresolvablePoms = new HashSet<>();
 
     CacheResult<RawMaven> UNAVAILABLE_POM = new CacheResult<>(CacheResult.State.Unavailable, null);
@@ -200,11 +209,6 @@ public class RocksdbMavenPomCache implements MavenPomCache {
                 .orElse(UNAVAILABLE_REPOSITORY);
     }
 
-    @Override
-    public void close() {
-        cache.close();
-    }
-
     private void fillUnresolvablePoms() {
         new BufferedReader(new InputStreamReader(MavenPomDownloader.class.getResourceAsStream("/unresolvable.txt"), StandardCharsets.UTF_8))
                 .lines()
@@ -265,4 +269,57 @@ public class RocksdbMavenPomCache implements MavenPomCache {
             throw new IllegalArgumentException("IO exception while deserializing object to byte array.");
         }
     }
+
+    /**
+     * Wrapper class around the rocksdb. The database and options are all backed by C++ data structures that
+     * must be explicitly closed to ensure proper memory management. Note, if the same database is being used
+     * by multiple threads, close should only be executed once all threads are done using the database. This class
+     * registers a shutdown hook to close all open databases, so there should be no need to explicitly close the
+     * databases.
+     */
+    static class RocksCache {
+
+        private final RocksDB database;
+        private final Options options;
+        private final WriteOptions writeOptions;
+
+        RocksCache(String workspace) {
+            try {
+                options = new Options();
+                options.setCreateIfMissing(true);
+                //Default memtable buffer size is 64MB, changing this to 1MB because we are only caching pom.xml files
+                //When the memtable exceeds 1MB, rocks will write the contents to disk. Note, closing the database
+                //also forces a flush to occur.
+                options.setWriteBufferSize(1_000_000);
+                //since we are only using rocks db as a cache, turning off checksum verification when opening.
+                options.setParanoidChecks(false);
+                options.setParanoidFileChecks(false);
+
+                //Turn off write ahead log, there is no needs to record the data in both memory and in a log (from which
+                //rocks can recover in the case of a system failure).
+                writeOptions = new WriteOptions();
+                writeOptions.setDisableWAL(true);
+                database = RocksDB.open(options, workspace);
+            } catch (RocksDBException exception) {
+                throw new IllegalStateException("Unable to create cache database." + exception.getMessage(), exception);
+            }
+        }
+
+        private void put(byte[] key, byte[] value) throws RocksDBException {
+            database.put(writeOptions, key, value);
+        }
+
+        private byte[] get(byte[] key) throws RocksDBException {
+            return database.get(key);
+        }
+        private void close() {
+            //Called by a shutdown hook, this will flush any in-memory memtables to disk and free up resources held
+            //by the underlying C++ code. The worse case scenario is that this is not called because the system exits
+            //abnormally, in which case, the data in-memory is simply not saved to the cache.
+            database.close();
+            writeOptions.close();
+            options.close();
+        }
+    }
+
 }


### PR DESCRIPTION
Enhancements RocksdbMavenPomCache to better manage the underlying rocksdb file cache:

Resource Cleanup:

- The Rocksdb library uses JNI to interact with the underlying file system and only one instance of the database may be pointed to the same workspace directory. To accommodate multiple cache instances using the same folder, the first cache will create the underlying RocksDB instance and any subsequent caches will use the same, thread-safe instance. However, closing the database can be a bit tricky because multiple caches may be using it. This PR adds a system shutdown hook to correctly close the underlying database when the process completes normally. It will also gracefully release any resources managed by the native (JNI) RocksDB library.  Killing the process in mid-operation does not appear to have an adverse impact on the database other than not flushing any uncommitted, in-memory data to the cache. An alternative to this would be to use a reference-counting scheme but it is unclear when the cache's close method is called. 

- Rocksdb records each write to an in-memory `memtable` and, by default, also records the write in a write-ahead log. The write-ahead log is used to recover writes in the case of a system failure and is not necessary for this caching implementation. The write-ahead log has been disabled.
- The in-memory data must be flushed from the `memtable` to disk and this is either done explicitly, by calling `database.flush()` or when the `memtable` grows to a certain size. The default size is 64MB, which is quite large for our use case (saving pom.xml files). This PR changes the flush size to 1MB.
- Finally, Rocksdb computes checksums for all of its files and normally it checks those on startup to ensure consistency.  This too has been disabled for our caching use case.