### PR TITLE
Add Recipe - XML parsers should not be vulnerable to XXE attacks

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -209,3 +209,7 @@ class Java11UseStaticImportTest : Java11Test, UseStaticImportTest
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
 class Java11WrappingAndBracesTest : Java11Test, WrappingAndBracesTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
+class Java11XmlParserXXEVulnerabilityFixTest: Java11Test, XmlParserXXEVulnerabilityFixTest

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/XmlParserXXEVulnerabilityFix.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/XmlParserXXEVulnerabilityFix.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.HasTypes;
+import org.openrewrite.java.tree.*;
+
+import java.util.Collections;
+
+public class XmlParserXXEVulnerabilityFix extends Recipe {
+    private static final MethodMatcher XML_PARSER_FACTORY_INSTANCE_METHOD_MATCHER = new MethodMatcher("javax.xml.stream.XMLInputFactory new*()");
+    private static final MethodMatcher XML_PARSER_FACTORY_SET_PROPERTY_METHOD_MATCHER = new MethodMatcher("javax.xml.stream.XMLInputFactory setProperty(java.lang.String, ..)");
+
+    private static final String XML_FACTORY_FQN = "javax.xml.stream.XMLInputFactory";
+    private static final String SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME = "IS_SUPPORTING_EXTERNAL_ENTITIES";
+    private static final String SUPPORT_DTD_PROPERTY_NAME = "SUPPORT_DTD";
+    private static final String XML_PARSER_INITIALIZATION_METHOD = "xml-parser-initialization-method";
+    private static final String XML_FACTORY_VARIABLE_NAME = "xml-factory-variable-name";
+
+    private static final ThreadLocal<JavaParser> JAVA_PARSER_THREAD_LOCAL = ThreadLocal.withInitial(() -> JavaParser.fromJavaVersion().build());
+
+    @Override
+    public String getDisplayName() {
+        return "XML Parser XXE Vulnerability Fix.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Avoid exposing dangerous features of the XML parser by setting XMLInputFactory IS_SUPPORTING_EXTERNAL_ENTITIES and SUPPORT_DTD properties to false.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new HasTypes(Collections.singletonList(XML_FACTORY_FQN)).getVisitor();
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+                Cursor supportsExternalCursor = getCursor().getMessage(SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME);
+                Cursor supportsDTDCursor = getCursor().getMessage(SUPPORT_DTD_PROPERTY_NAME);
+                Cursor initializationCursor = getCursor().getMessage(XML_PARSER_INITIALIZATION_METHOD);
+                String xmlFactoryVariableName = getCursor().getMessage(XML_FACTORY_VARIABLE_NAME);
+
+                Cursor setPropertyBlockCursor = null;
+                if (supportsExternalCursor == null && supportsDTDCursor == null) {
+                    setPropertyBlockCursor = initializationCursor;
+                } else if (supportsExternalCursor == null ^ supportsDTDCursor == null) {
+                    setPropertyBlockCursor = supportsExternalCursor == null ? supportsDTDCursor : supportsExternalCursor;
+                }
+                if (setPropertyBlockCursor != null && xmlFactoryVariableName != null) {
+                    doAfterVisit(new XmlFactoryInsertPropertyStatementVisitor(setPropertyBlockCursor.getValue(), xmlFactoryVariableName,supportsExternalCursor == null, supportsDTDCursor == null));
+                }
+                return cd;
+            }
+
+            @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext executionContext) {
+                J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, executionContext);
+                if (v.getType() != null && v.getType() instanceof JavaType.Class
+                        && XML_FACTORY_FQN.equals(((JavaType.Class) v.getType()).getFullyQualifiedName())) {
+                    getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, XML_FACTORY_VARIABLE_NAME, v.getSimpleName());
+                }
+                return v;
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+                if (XML_PARSER_FACTORY_INSTANCE_METHOD_MATCHER.matches(mi)) {
+                    getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, XML_PARSER_INITIALIZATION_METHOD, getCursor().dropParentUntil(J.Block.class::isInstance));
+                } else if (XML_PARSER_FACTORY_SET_PROPERTY_METHOD_MATCHER.matches(mi) && mi.getArguments().get(0) instanceof J.FieldAccess) {
+                    J.FieldAccess fa = ((J.FieldAccess)mi.getArguments().get(0));
+                    if (SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME.equals(fa.getSimpleName())) {
+                        getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORTING_EXTERNAL_ENTITIES_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                    } else if (SUPPORT_DTD_PROPERTY_NAME.equals(fa.getSimpleName())) {
+                        getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, SUPPORT_DTD_PROPERTY_NAME, getCursor().dropParentUntil(J.Block.class::isInstance));
+                    }
+                }
+                return mi;
+            }
+        };
+    }
+
+    private static class XmlFactoryInsertPropertyStatementVisitor extends JavaIsoVisitor<ExecutionContext> {
+        J.Block scope;
+        StringBuilder propertyTemplate = new  StringBuilder();
+
+        public XmlFactoryInsertPropertyStatementVisitor(J.Block scope, String factoryVariableName, boolean needsExternalEntitiesDisabled, boolean needsSupportsDtdDisabled) {
+            this.scope = scope;
+            if (needsExternalEntitiesDisabled) {
+                propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);");
+            }
+            if (needsSupportsDtdDisabled) {
+                propertyTemplate.append(factoryVariableName).append(".setProperty(XMLInputFactory.SUPPORT_DTD, false);");
+            }
+        }
+
+        @Override
+        public J.Block visitBlock(J.Block block, ExecutionContext executionContext) {
+            J.Block bl = super.visitBlock(block, executionContext);
+            Statement beforeStatement = null;
+            if (bl == scope) {
+                for (int i = bl.getStatements().size() -2; i>-1; i--) {
+                    Statement st = bl.getStatements().get(i);
+                    Statement stBefore = bl.getStatements().get(i+1);
+                    if (st instanceof J.MethodInvocation) {
+                        J.MethodInvocation mi = (J.MethodInvocation) st;
+                        if (XML_PARSER_FACTORY_INSTANCE_METHOD_MATCHER.matches(mi) || XML_PARSER_FACTORY_SET_PROPERTY_METHOD_MATCHER.matches(mi)) {
+                            beforeStatement = stBefore;
+                        }
+                    } else if (st instanceof J.VariableDeclarations) {
+                        J.VariableDeclarations vd = (J.VariableDeclarations) st;
+                        if (vd.getVariables().get(0).getInitializer() instanceof J.MethodInvocation) {
+                            J.MethodInvocation mi = (J.MethodInvocation)vd.getVariables().get(0).getInitializer();
+                            if (mi != null && XML_PARSER_FACTORY_INSTANCE_METHOD_MATCHER.matches(mi)) {
+                                beforeStatement = stBefore;
+                            }
+                        }
+                    }
+                }
+
+                if (getCursor().getParent() != null && getCursor().getParent().getValue() instanceof J.ClassDeclaration) {
+                    propertyTemplate.insert(0, "{\n").append("}");
+                }
+                JavaCoordinates insertCoordinates = beforeStatement != null ? beforeStatement.getCoordinates().before() : bl.getCoordinates().lastStatement();
+                bl = bl.withTemplate(template(propertyTemplate.toString()).javaParser(JAVA_PARSER_THREAD_LOCAL.get()).build(), insertCoordinates);
+            }
+            return bl;
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/XmlParserXXEVulnerabilityFix.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/XmlParserXXEVulnerabilityFix.java
@@ -78,8 +78,8 @@ public class XmlParserXXEVulnerabilityFix extends Recipe {
             @Override
             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext executionContext) {
                 J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, executionContext);
-                if (v.getType() != null && v.getType() instanceof JavaType.Class
-                        && XML_FACTORY_FQN.equals(((JavaType.Class) v.getType()).getFullyQualifiedName())) {
+                if (v.getType() != null && v.getType() instanceof JavaType.FullyQualified
+                        && XML_FACTORY_FQN.equals(((JavaType.FullyQualified) v.getType()).getFullyQualifiedName())) {
                     getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, XML_FACTORY_VARIABLE_NAME, v.getSimpleName());
                 }
                 return v;
@@ -121,7 +121,7 @@ public class XmlParserXXEVulnerabilityFix extends Recipe {
         public J.Block visitBlock(J.Block block, ExecutionContext executionContext) {
             J.Block bl = super.visitBlock(block, executionContext);
             Statement beforeStatement = null;
-            if (bl == scope) {
+            if (bl.isScope(scope)) {
                 for (int i = bl.getStatements().size() -2; i>-1; i--) {
                     Statement st = bl.getStatements().get(i);
                     Statement stBefore = bl.getStatements().get(i+1);

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -163,4 +163,7 @@ abstract class JavaVisitorCompatibilityKit {
 
     @Nested
     inner class WrappingAndBracesTck : WrappingAndBracesTest
+
+    @Nested
+    inner class XmlParserXXEVulnerabilityFixTck : XmlParserXXEVulnerabilityFixTest
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/XmlParserXXEVulnerabilityFixTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/XmlParserXXEVulnerabilityFixTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+interface XmlParserXXEVulnerabilityFixTest : JavaRecipeTest {
+
+    override val recipe: Recipe?
+        get() = XmlParserXXEVulnerabilityFix()
+
+    @Test
+    fun factoryIsNotVulnerable(jp: JavaParser) = assertUnchanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                public void parseXML(InputStream input) {
+                    XMLInputFactory factory = XMLInputFactory.newFactory();
+                    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun factoryIsNotVulnerableClassBlockInitialization(jp: JavaParser) = assertUnchanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory fact = XMLInputFactory.newFactory();
+                {
+                    fact.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                    fact.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                }
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun factoryIsVulnerableWithMethodInitialization() = assertChanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                public void parseXML(InputStream input) {
+                    XMLInputFactory f = XMLInputFactory.newFactory();
+                    XMLStreamReader reader = f.createXMLStreamReader(input);
+                }
+            }
+        """,
+        after = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                public void parseXML(InputStream input) {
+                    XMLInputFactory f = XMLInputFactory.newFactory();
+                    f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                    f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                    XMLStreamReader reader = f.createXMLStreamReader(input);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun factoryConstructorInitialization() = assertChanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            public class MyXmlReader {
+                private XMLInputFactory f;
+                public MyXmlReader() {
+                    f = XMLInputFactory.newFactory();
+                    f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                }
+            }
+        """,
+        after = """
+            import javax.xml.stream.XMLInputFactory;
+            public class MyXmlReader {
+                private XMLInputFactory f;
+                public MyXmlReader() {
+                    f = XMLInputFactory.newFactory();
+                    f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                    f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun factoryIsVulnerableWithClassBlockInitialization() = assertChanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory factory = XMLInputFactory.newFactory();
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """,
+        after = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory factory = XMLInputFactory.newFactory();
+            
+                {
+                    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                }
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun factoryNeedsDtdWithClassBlockInitialization() = assertChanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory factory = XMLInputFactory.newFactory();
+                
+                {
+                    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                }
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """,
+        after = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory factory = XMLInputFactory.newFactory();
+                
+                {
+                    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                }
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun factoryExternalWithClassBlockInitialization() = assertChanged(
+        before = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory factory = XMLInputFactory.newFactory();
+                
+                {
+                    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                }
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """,
+        after = """
+            import javax.xml.stream.XMLInputFactory;
+            import javax.xml.stream.XMLStreamReader;
+            import java.io.InputStream;
+            public class MyXmlReader {
+                XMLInputFactory factory = XMLInputFactory.newFactory();
+                
+                {
+                    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+                }
+                public void parseXML(InputStream input) {
+                    XMLStreamReader reader = factory.createXMLStreamReader(input);
+                }
+            }
+        """
+    )
+}


### PR DESCRIPTION
Add Recipe for Sonar RSPEC-2755 - XML parsers should not be vulnerable to XXE attacks. Fixes #453