### PR TITLE
Fix issue where parser fails when symbol is not on the class path

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11ParserVisitor.java
@@ -1585,6 +1585,9 @@ public class Java11ParserVisitor extends TreePathScanner<J, Space> {
 
     @Nullable
     private JavaType type(@Nullable com.sun.tools.javac.code.Type type, List<Symbol> stack, boolean shallow) {
+        //Word of caution, during attribution, we will likely encounter symbols that have been parsed but are not
+        //on the parser's classpath. Calling a method on the symbol that calls complete() will result in an exception
+        // being thrown. That is why this method uses the symbol's underlying fields directly vs the accessor methods.
         if (type instanceof ClassType) {
             if (type instanceof com.sun.tools.javac.code.Type.ErrorType) {
                 return null;


### PR DESCRIPTION
When mapping javac's ASTs to rewrite's ASTs, care must be taken to ensure we do not invoke `complete()` on the symbol.  Most of the accessor methods on the ClassSymbol will implicitly call `complete()` and therefore, we must make sure to use the underlying fields of the symbol directly. 
