### PR TITLE
Handle unwritable directory in MavenArtifactHelper by allowing client to specify maven local path

### DIFF
--- a/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/MavenDependencyDownloadIntegTest.kt
+++ b/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/MavenDependencyDownloadIntegTest.kt
@@ -32,13 +32,12 @@ import org.openrewrite.maven.tree.Maven
 import org.openrewrite.maven.tree.Scope
 import org.openrewrite.maven.utilities.MavenArtifactDownloader
 import java.nio.file.Path
-import java.nio.file.Paths
 
 class MavenDependencyDownloadIntegTest {
     private val ctx = InMemoryExecutionContext { t -> t.printStackTrace() }
 
     private fun downloader(path: Path) = MavenArtifactDownloader(
-        ReadOnlyLocalMavenArtifactCache.MAVEN_LOCAL.orElse(
+        ReadOnlyLocalMavenArtifactCache.mavenLocal().orElse(
             LocalMavenArtifactCache(path)
         ),
         null

--- a/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/ParseMavenProjectOnDisk.kt
+++ b/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/ParseMavenProjectOnDisk.kt
@@ -40,7 +40,7 @@ object ParseMavenProjectOnDisk {
         }
 
         val downloader = MavenArtifactDownloader(
-            ReadOnlyLocalMavenArtifactCache.MAVEN_LOCAL.orElse(
+            ReadOnlyLocalMavenArtifactCache.mavenLocal().orElse(
                 LocalMavenArtifactCache(Paths.get(System.getProperty("user.home"), ".rewrite", "cache", "artifacts"))
             ),
             null,

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/ReadOnlyLocalMavenArtifactCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/ReadOnlyLocalMavenArtifactCache.java
@@ -24,11 +24,13 @@ import java.nio.file.Paths;
 import java.util.function.Consumer;
 
 public class ReadOnlyLocalMavenArtifactCache extends LocalMavenArtifactCache {
-    public static ReadOnlyLocalMavenArtifactCache MAVEN_LOCAL = new ReadOnlyLocalMavenArtifactCache(
-            Paths.get(System.getProperty("user.home"), ".m2", "repository"));
-
     public ReadOnlyLocalMavenArtifactCache(Path cache) {
         super(cache);
+    }
+
+    public static ReadOnlyLocalMavenArtifactCache mavenLocal() {
+        return new ReadOnlyLocalMavenArtifactCache(
+                Paths.get(System.getProperty("user.home"), ".m2", "repository"));
     }
 
     @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactHelper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactHelper.java
@@ -60,7 +60,7 @@ public class MavenArtifactHelper {
      * @return List of paths to downloaded artifacts
      */
     public static List<Path> downloadArtifactAndDependencies(String groupId, String artifactId, String version, ExecutionContext ctx, MavenPomCache mavenPomCache, List<MavenRepository> repositories) {
-        return downloadArtifactAndDependenciesInternal(groupId, artifactId, version, ctx, mavenPomCache, repositories, ReadOnlyLocalMavenArtifactCache.MAVEN_LOCAL.orElse(
+        return downloadArtifactAndDependenciesInternal(groupId, artifactId, version, ctx, mavenPomCache, repositories, ReadOnlyLocalMavenArtifactCache.mavenLocal().orElse(
                 new LocalMavenArtifactCache(Paths.get(System.getProperty("user.home"), ".rewrite", "cache", "artifacts"))
         ));
     }


### PR DESCRIPTION
If the `$USER_HOME/.m2/repository` directory is unwritable, it prevents `ReadOnlyLocalMavenArtifactCache` from initializing. To circumvent this, allow clients to pass a Path.