### PR TITLE
Added a couple referential equality checks and test

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JContainer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JContainer.java
@@ -71,12 +71,11 @@ public class JContainer<T> {
     }
 
     public JContainer<T> withBefore(Space before) {
-        return build(before, elements, markers);
+        return this.before == before ? this : build(before, elements, markers);
     }
 
-    @SuppressWarnings("unchecked")
     public JContainer<T> withMarkers(Markers markers) {
-        return build(getBefore(), elements, markers);
+        return this.markers == markers ? this : build(getBefore(), elements, markers);
     }
 
     public Markers getMarkers() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JRightPadded.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JRightPadded.java
@@ -134,7 +134,7 @@ public class JRightPadded<T> {
                 // Check if the order of elements is different than the original list.
                 if (i != before.indexOf(found) ||
                         // Check if the element has been modified.
-                        System.identityHashCode(found) != System.identityHashCode(found.withElement(j))) {
+                        found != found.withElement(j)) {
                     hasChanged = true;
                 }
                 after.add(found.withElement(j));

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JContainerTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JContainerTest.kt
@@ -23,6 +23,20 @@ import org.openrewrite.marker.Markers
 class JContainerTest {
 
     @Test
+    fun withBeforeThatDoesntChangeReference() {
+        val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
+        val trees = JContainer.build(listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY)))
+        assertThat(trees.withBefore(Space.EMPTY)).isSameAs(trees)
+    }
+
+    @Test
+    fun withMarkerThatDoesntChangeReference() {
+        val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
+        val trees = JContainer.build(listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY)))
+        assertThat(trees.withMarkers(Markers.EMPTY)).isSameAs(trees)
+    }
+
+    @Test
     fun withElementsThatDoesntChangeReference() {
         val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
         val trees = JContainer.build(listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY)))

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JRightPaddedTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JRightPaddedTest.kt
@@ -23,6 +23,13 @@ import org.openrewrite.marker.Markers
 class JRightPaddedTest {
 
     @Test
+    fun withElementThatDoesntChangeReference() {
+        val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
+        val trees = JRightPadded(t, Space.EMPTY, Markers.EMPTY)
+        assertThat(JRightPadded.withElement(trees, t)).isSameAs(trees)
+    }
+
+    @Test
     fun withElementsThatDoesntChangeReference() {
         val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
         val trees = listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY))

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.tree
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.Tree.randomId
+import org.openrewrite.marker.Markers
+import java.util.*
+
+class JTest {
+
+    @Test
+    fun blockWithStatements() {
+        val statements: List<Statement> = Collections.emptyList()
+        val tree = J.Block(randomId(), Space.EMPTY, Markers.EMPTY,
+            JRightPadded(false, Space.EMPTY, Markers.EMPTY), Collections.emptyList(), Space.EMPTY)
+        assertThat(tree.withStatements(statements)).isSameAs(tree)
+    }
+}


### PR DESCRIPTION
Refactored J.Container withBefore and withMarker to do referential equality check before building new container.