### PR TITLE
Check for referential equality in JContainer #withBefore and #withMar…

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JContainer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JContainer.java
@@ -71,12 +71,11 @@ public class JContainer<T> {
     }
 
     public JContainer<T> withBefore(Space before) {
-        return build(before, elements, markers);
+        return getBefore() == before ? this : build(before, elements, markers);
     }
 
-    @SuppressWarnings("unchecked")
     public JContainer<T> withMarkers(Markers markers) {
-        return build(getBefore(), elements, markers);
+        return getMarkers() == markers ? this : build(before, elements, markers);
     }
 
     public Markers getMarkers() {

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JContainerTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/tree/JContainerTest.kt
@@ -23,6 +23,20 @@ import org.openrewrite.marker.Markers
 class JContainerTest {
 
     @Test
+    fun withBeforeThatDoesntChangeReference() {
+        val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
+        val trees = JContainer.build(listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY)))
+        assertThat(trees.withBefore(Space.EMPTY)).isSameAs(trees)
+    }
+
+    @Test
+    fun withMarkerThatDoesntChangeReference() {
+        val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
+        val trees = JContainer.build(listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY)))
+        assertThat(trees.withMarkers(Markers.EMPTY)).isSameAs(trees)
+    }
+
+    @Test
     fun withElementsThatDoesntChangeReference() {
         val t = J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)
         val trees = JContainer.build(listOf(JRightPadded(t, Space.EMPTY, Markers.EMPTY)))


### PR DESCRIPTION
bugFix: prevent withBefore and withMarkers from creating a new container if the object is referentially equal.