### PR TITLE
Add condition to check if the type is already J.Empty.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
@@ -47,7 +47,9 @@ public class UseDiamondOperator extends Recipe {
                 if (n.getClazz() instanceof J.ParameterizedType && n.getBody() == null) {
                     J.ParameterizedType parameterizedType = (J.ParameterizedType) n.getClazz();
                     if (parameterizedType.getTypeParameters() != null && !parameterizedType.getTypeParameters().isEmpty()) {
-                        n = n.withClazz(parameterizedType.withTypeParameters(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY))));
+                        if (parameterizedType.getTypeParameters().size() == 1 && !(parameterizedType.getTypeParameters().get(0) instanceof J.Empty)) {
+                            n = n.withClazz(parameterizedType.withTypeParameters(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY))));
+                        }
                     }
                 }
                 return n;


### PR DESCRIPTION
bugFix: prevents a new J.Empty with a different it from being created if J.Empty already exists.