### PR TITLE
Fixes #530 Fix Try-With-Resource Navigation

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaIsoVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaIsoVisitor.java
@@ -286,6 +286,11 @@ public class JavaIsoVisitor<P> extends JavaVisitor<P> {
     }
 
     @Override
+    public J.Try.Resource visitTryResource(J.Try.Resource tryResource, P p) {
+        return (J.Try.Resource) super.visitTryResource(tryResource, p);
+    }
+
+    @Override
     public J.TypeCast visitTypeCast(J.TypeCast typeCast, P p) {
         return (J.TypeCast) super.visitTypeCast(typeCast, p);
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -1000,6 +1000,8 @@ public class JavaPrinter<P> extends JavaVisitor<P> {
         visitMarkers(tryable.getMarkers(), p);
         acc.append("try");
         if (tryable.getPadding().getResources() != null) {
+            //Note: we do not call visitContainer here because the last resource may or may not be semicolon terminated.
+            //      Doing this means that visitTryResource is not called, therefore this logic must visit the resources.
             visitSpace(tryable.getPadding().getResources().getBefore(), Space.Location.TRY_RESOURCES, p);
             acc.append('(');
             List<JRightPadded<Try.Resource>> resources = tryable.getPadding().getResources().getPadding().getElements();
@@ -1007,6 +1009,7 @@ public class JavaPrinter<P> extends JavaVisitor<P> {
                 JRightPadded<Try.Resource> resource = resources.get(i);
 
                 visitSpace(resource.getElement().getPrefix(), Space.Location.TRY_RESOURCE, p);
+                visitMarkers(resource.getElement().getMarkers(), p);
                 visit(resource.getElement().getVariableDeclarations(), p);
 
                 if (i < resources.size() - 1 || resource.getElement().isTerminatedWithSemicolon()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -793,17 +793,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         t = t.withPrefix(visitSpace(t.getPrefix(), Space.Location.TRY_PREFIX, p));
         t = visitAndCast(t, p, this::visitStatement);
         if (t.getPadding().getResources() != null) {
-            t = t.getPadding().withResources(visitContainer(
-                    t.getPadding().getResources().getPadding().withElements(
-                            ListUtils.map(t.getPadding().getResources().getPadding().getElements(),
-                                    res -> res.withElement(
-                                            res.getElement().withPrefix(
-                                                    visitSpace(res.getElement().getPrefix(), Space.Location.TRY_RESOURCE, p)
-                                            )
-                                    )
-                            )
-                    ),
-                    JContainer.Location.TRY_RESOURCES, p));
+            t = t.getPadding().withResources(visitContainer(t.getPadding().getResources(), JContainer.Location.TRY_RESOURCES, p));
         }
         t = t.withBody(visitAndCast(t.getBody(), p));
         t = t.withCatches(ListUtils.map(t.getCatches(), c -> visitAndCast(c, p)));
@@ -812,6 +802,14 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
         t = t.withMarkers(visitMarkers(t.getMarkers(), p));
         return t;
+    }
+
+    public J visitTryResource(J.Try.Resource tryResource, P p) {
+        J.Try.Resource r = tryResource;
+        r = tryResource.withPrefix(visitSpace(r.getPrefix(), Space.Location.TRY_RESOURCE, p));
+        r = tryResource.withVariableDeclarations(visitAndCast(r.getVariableDeclarations(), p, this::visitVariableDeclarations));
+        r = r.withMarkers(visitMarkers(r.getMarkers(), p));
+        return r;
     }
 
     public J visitTypeCast(J.TypeCast typeCast, P p) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -4299,6 +4299,11 @@ public interface J extends Serializable, Tree {
             boolean terminatedWithSemicolon;
 
             @Override
+            public <P> J acceptJava(JavaVisitor<P> v, P p) {
+                return v.visitTryResource(this, p);
+            }
+
+            @Override
             public Coordinates.Try.Resource getCoordinates() {
                 return new Coordinates.Try.Resource(this);
             }


### PR DESCRIPTION
This PR fixes the navigation for resources in a try-with-resource code block. This has been resolved by overriding the `accept()` method in `J.Try.Resource` and adding a `visitTryResource` to JavaVisitor.