### PR TITLE
Fix hide-utility-cleanup visitor to identify main methods

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
@@ -174,10 +174,10 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
         }
 
         /**
-         * @return true if this class has a {@code public static void main(String[] args)} method signature in it
+         * @return true if this class has a {@code public static void main(String[] args)} method signature in it.
          */
         static boolean hasMainMethod(J.ClassDeclaration c) {
-            return c.getBody().getStatements().stream()
+            return c.getType() != null && c.getBody().getStatements().stream()
                     .filter(J.MethodDeclaration.class::isInstance)
                     .map(J.MethodDeclaration.class::cast)
                     .filter(md -> !md.isConstructor())
@@ -185,7 +185,8 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
                     .filter(md -> md.hasModifier(J.Modifier.Type.Static))
                     .filter(md -> md.getReturnTypeExpression() != null)
                     .filter(md -> JavaType.Primitive.Void.equals(md.getReturnTypeExpression().getType()))
-                    .anyMatch(md -> new MethodMatcher("* main(String)").matches(md, c));
+                    // note that, as of writing this, the matcher for "main(String)" will match on "main(String[]) as expected.
+                    .anyMatch(md -> new MethodMatcher(c.getType().getFullyQualifiedName() + " main(String)").matches(md, c));
         }
 
         /**

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HideUtilityClassConstructorTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HideUtilityClassConstructorTest.kt
@@ -16,8 +16,8 @@
 package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
 import org.openrewrite.Recipe
-import org.openrewrite.Tree
 import org.openrewrite.Tree.randomId
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
@@ -162,15 +162,13 @@ interface HideUtilityClassConstructorTest : JavaRecipeTest {
     )
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/538")
     fun ignoreClassesWithMainMethod(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
+            package a;
+
             public class A {
-                public static final int SOME_NUMBER = 0;
-
-                public static void utility() {
-                }
-
                 public static void main(String[] args) {
                     // SpringApplication.run(A.class, args);
                 }
@@ -420,7 +418,7 @@ interface HideUtilityClassConstructorTest : JavaRecipeTest {
         jp.styles(
             listOf(
                 NamedStyles(
-                        randomId(), "test", "test", "test", emptySet(), listOf(
+                    randomId(), "test", "test", "test", emptySet(), listOf(
                         HideUtilityClassConstructorStyle(
                             listOf(
                                 "@lombok.experimental.UtilityClass",


### PR DESCRIPTION
see: https://github.com/openrewrite/rewrite/issues/538
see also: https://github.com/openrewrite/rewrite/issues/383

The unit test for identifying a main method was passing because the test was not labeled as being within a `package` (see: https://github.com/openrewrite/rewrite/issues/383). The test was updated to have a package declaration, and the method matcher was updated to use the fully-qualified enclosing class name directly.
