### PR TITLE
JavaVisitor handles JRightPadded and JLeftPadded having null element.

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -144,6 +144,10 @@ class Java11JavaTemplateTest : Java11Test, JavaTemplateTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11JavaVisitorTest : Java11Test, JavaVisitorTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11MaybeUsesImportTest : Java11Test, MaybeUsesImportTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -144,6 +144,10 @@ class Java8JavaTemplateTest : Java8Test, JavaTemplateTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8JavaVisitorTest : Java8Test, JavaVisitorTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8MaybeUsesImportTest : Java8Test, MaybeUsesImportTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -907,12 +907,11 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
             t = visitAndCast((J) right.getElement(), p);
         }
 
-        Space after = visitSpace(right.getAfter(), loc.getAfterLocation(), p);
-
         setCursor(getCursor().getParent());
         if (t == null) {
             return null;
         }
+        Space after = visitSpace(right.getAfter(), loc.getAfterLocation(), p);
         return (after == right.getAfter() && t == right.getElement()) ? right : new JRightPadded<>(t, after, right.getMarkers());
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -910,7 +910,9 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         Space after = visitSpace(right.getAfter(), loc.getAfterLocation(), p);
 
         setCursor(getCursor().getParent());
-
+        if (t == null) {
+            return null;
+        }
         return (after == right.getAfter() && t == right.getElement()) ? right : new JRightPadded<>(t, after, right.getMarkers());
     }
 
@@ -926,6 +928,9 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
 
         setCursor(getCursor().getParent());
+        if (t == null) {
+            return null;
+        }
 
         return (before == left.getBefore() && t == left.getElement()) ? left : new JLeftPadded<>(before, t, left.getMarkers());
     }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -119,6 +119,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class JavaTemplateTck : JavaTemplateTest
 
     @Nested
+    inner class JavaVisitorTestTck : JavaVisitorTest
+
+    @Nested
     inner class MaybeUsesImportTck : MaybeUsesImportTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.java.tree.J
+
+interface JavaVisitorTest : JavaRecipeTest {
+
+    @Test
+    fun javaVisitorHandlesPaddedWithNullElem() = assertChanged(
+        recipe = object : JavaIsoVisitor<ExecutionContext>() {
+            override fun visitMethodInvocation(method: J.MethodInvocation, p: ExecutionContext): J.MethodInvocation? {
+                val mi = super.visitMethodInvocation(method, p)
+                if ("removeMethod".equals(mi.simpleName)) {
+                    return null
+                }
+                return mi
+            }
+        }.toRecipe().doNext(
+            object : JavaIsoVisitor<ExecutionContext>() {
+                override fun visitMethodDeclaration(method: J.MethodDeclaration, p: ExecutionContext): J.MethodDeclaration {
+                    var md = super.visitMethodDeclaration(method, p)
+                    if (md.simpleName.equals("allTheThings")) {
+                        md = md.withTemplate(template("throws Exception").build(), md.coordinates.replaceThrows())
+                    }
+                    return md
+                }
+            }.toRecipe()
+        ),
+        before = """
+            class A {
+                void allTheThings() {
+                    doSomething();
+                    removeMethod();
+                }
+                void doSomething() {}
+                void removeMethod() {}
+            }
+        """,
+        after = """
+            class A {
+                void allTheThings() throws Exception {
+                    doSomething();
+                }
+                void doSomething() {}
+                void removeMethod() {}
+            }
+        """,
+        cycles = 2,
+        expectedCyclesToComplete = 2
+    )
+}


### PR DESCRIPTION
This is to fix a null pointer exception thrown by the `JavaVisitor` when visiting a JLeftPadded or JRightPadded element having a null element.
