### PR TITLE
Test that parser can handle two classes with the same name and different packages

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -265,3 +265,8 @@ class Java11WrappingAndBracesTest : Java11Test, WrappingAndBracesTest
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
 class Java11XmlParserXXEVulnerabilityTest : Java11Test, XmlParserXXEVulnerabilityTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
+class Java11SameClassNameTest : Java11Test, SameClassNameTest
+

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -265,3 +265,7 @@ class Java8WrappingAndBracesTest : Java8Test, WrappingAndBracesTest
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
 class Java8XmlParserXXEVulnerabilityTest : Java8Test, XmlParserXXEVulnerabilityTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
+class Java8SameClassNameTest : Java8Test, SameClassNameTest

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/SameClassNameTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/SameClassNameTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java
 
 import org.junit.jupiter.api.Disabled

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/SameClassNameTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/SameClassNameTest.kt
@@ -1,0 +1,43 @@
+package org.openrewrite.java
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.Recipe
+import org.openrewrite.SourceFile
+
+interface SameClassNameTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = ExampleRecipe()
+
+    @Disabled
+    @Test
+    fun canParseTheSameJavaClass(jp: JavaParser) =
+        assertUnchanged(
+            jp,
+            before = """
+                package com.foo;
+                class A {}
+            """,
+            dependsOn = arrayOf("""
+                package a.b.c;
+                class Bar {}
+            """, """
+                package d.e.f;
+                class Bar {}
+            """
+            )
+        )
+
+    class ExampleRecipe : Recipe() {
+        override fun getDisplayName(): String {
+            return "Do nothing"
+        }
+
+        override fun visit(before: MutableList<SourceFile>, ctx: ExecutionContext): MutableList<SourceFile> {
+            return super.visit(before, ctx)
+        }
+    }
+
+
+}


### PR DESCRIPTION
In the `assert(Unc|C)hanged` test harness's `dependsOn`, if you have two files with the same simple name, the Java parser errors out with the below exception. This PR adds a disabled unit test that demonstrates the behavior.

```
java.lang.IllegalStateException: Call reset() on JavaParser before parsing anotherset of source files that have some of the same fully qualified names

	at org.openrewrite.java.Java11Parser.lambda$parseInputs$0(Java11Parser.java:179)
	at io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:57)
	at org.openrewrite.java.Java11Parser.parseInputs(Java11Parser.java:174)
	at org.openrewrite.java.JavaParser.parse(JavaParser.java:98)
	at org.openrewrite.RecipeTest$DefaultImpls.assertChanged(RecipeTest.kt:66)
	at org.openrewrite.java.JavaRecipeTest$DefaultImpls.assertChanged(JavaRecipeTest.kt:122)
	at org.openrewrite.java.cleanup.UnnecessaryQualificationTest$DefaultImpls.assertChanged(UnnecessaryQualificationTest.kt:8)
	at org.openrewrite.java.Java11UnnecessaryQualificationTest.assertChanged(Java11VisitorDebugTests.kt)
	at org.openrewrite.RecipeTest$DefaultImpls.assertChanged$default(RecipeTest.kt:34)
	at org.openrewrite.java.cleanup.UnnecessaryQualificationTest$DefaultImpls.keepsTheMostUsedClass(UnnecessaryQualificationTest.kt:112)
	at org.openrewrite.java.Java11UnnecessaryQualificationTest.keepsTheMostUsedClass(Java11VisitorDebugTests.kt)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:210)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:206)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:131)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:65)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:71)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
Caused by: java.lang.IllegalStateException: endPosTable already set
	at jdk.compiler/com.sun.tools.javac.util.DiagnosticSource.setEndPosTable(DiagnosticSource.java:136)
	at jdk.compiler/com.sun.tools.javac.util.Log.setEndPosTable(Log.java:438)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.parse(JavaCompiler.java:678)
	at org.openrewrite.java.Java11Parser.lambda$parseInputs$0(Java11Parser.java:176)
	... 77 more
```