### PR TITLE
FallThrough cleanup

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -106,6 +106,10 @@ class Java11ExplicitInitializationTest : Java11Test, ExplicitInitializationTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11FallThroughTest : Java11Test, FallThroughTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11FinalizeLocalVariablesTest : Java11Test, FinalizeLocalVariablesTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -106,6 +106,10 @@ class Java8ExplicitInitializationTest : Java8Test, ExplicitInitializationTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8FallThroughTest : Java8Test, FallThroughTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8FinalizeLocalVariablesTest : Java8Test, FinalizeLocalVariablesTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThrough.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThrough.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+public class FallThrough extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Fall through";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks for fall-through in switch statements, adding `break` statements in locations where a case contains Java code but does not have a `break`, `return`, `throw`, or `continue` statement.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new FallThroughFromCompilationUnitStyle();
+    }
+
+    private static class FallThroughFromCompilationUnitStyle extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+            FallThroughStyle style = cu.getStyle(FallThroughStyle.class);
+            if (style == null) {
+                style = FallThroughStyle.fallThroughStyle();
+            }
+            doAfterVisit(new FallThroughVisitor<>(style));
+            return cu;
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThroughStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThroughStyle.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.java.style.StyleHelper;
+import org.openrewrite.style.Style;
+
+import java.util.regex.Pattern;
+
+@Value
+@With
+public class FallThroughStyle implements Style {
+    /**
+     * Control whether the last case group should be checked.
+     */
+    Boolean checkLastCaseGroup;
+
+    /**
+     * Ignores any fall-through commented with a text matching the regex pattern.
+     * This is currently non-user-configurable, though held within {@link FallThroughStyle}.
+     */
+    static final Pattern RELIEF_PATTERN = Pattern.compile("falls?[ -]?thr(u|ough)");
+
+    @Override
+    public Style applyDefaults() {
+        return StyleHelper.merge(fallThroughStyle(), this);
+    }
+
+    /**
+     * The default of what would be part of {@link org.openrewrite.java.style.IntelliJ} (as of the time of writing) is to not
+     * include this at all. Therefore, it is not included as a default there.
+     *
+     * @return instantiation of {@link FallThroughStyle} with default settings.
+     */
+    public static FallThroughStyle fallThroughStyle() {
+        return new FallThroughStyle(false);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThroughVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThroughVisitor.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
+    FallThroughStyle style;
+
+    private static boolean isLastCase(J.Case caze, J.Switch switzh) {
+        J.Block switchBlock = switzh.getCases();
+        return caze == switchBlock.getStatements().get(switchBlock.getStatements().size() - 1);
+    }
+
+    @Override
+    public J.Case visitCase(J.Case caze, P p) {
+        J.Case c = super.visitCase(caze, p);
+        J.Switch switzh = getCursor().dropParentUntil(J.Switch.class::isInstance).getValue();
+        if ((Boolean.TRUE.equals(style.getCheckLastCaseGroup()) || !isLastCase(c, switzh))) {
+            if (FindLastLineBreaksOrFallsThroughComments.find(switzh, c).isEmpty()) {
+                doAfterVisit(new AddBreak<>(c));
+            }
+        }
+        return c;
+    }
+
+    private static class AddBreak<P> extends JavaIsoVisitor<P> {
+        private final J.Case scope;
+
+        public AddBreak(J.Case scope) {
+            this.scope = scope;
+        }
+
+        @Override
+        public J.Case visitCase(J.Case caze, P p) {
+            J.Case c = super.visitCase(caze, p);
+            if (scope.isScope(c) &&
+                    c.getStatements().stream().noneMatch(J.Break.class::isInstance) &&
+                    c.getStatements().stream()
+                            .reduce((s1, s2) -> s2)
+                            .map(s -> !(s instanceof J.Block))
+                            .orElse(true)) {
+                List<Statement> statements = new ArrayList<>(c.getStatements());
+                J.Break breakToAdd = autoFormat(
+                        new J.Break(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null),
+                        p, getCursor().getParentOrThrow()
+                );
+                statements.add(breakToAdd);
+                c = c.withStatements(ListUtils.map(statements, stmt -> autoFormat(stmt, p)));
+            }
+            return c;
+        }
+
+        @Override
+        public J.Block visitBlock(J.Block block, P p) {
+            J.Block b = super.visitBlock(block, p);
+            if (getCursor().isScopeInPath(scope) &&
+                    b.getStatements().stream().noneMatch(J.Break.class::isInstance) &&
+                    b.getStatements().stream()
+                            .reduce((s1, s2) -> s2)
+                            .map(s -> !(s instanceof J.Block))
+                            .orElse(true)) {
+                List<Statement> statements = b.getStatements();
+                J.Break breakToAdd = autoFormat(
+                        new J.Break(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null),
+                        p, getCursor().getParentOrThrow()
+                );
+                statements.add(breakToAdd);
+                b = b.withStatements(ListUtils.map(statements, stmt -> autoFormat(stmt, p)));
+            }
+            return b;
+        }
+    }
+
+    private static class FindLastLineBreaksOrFallsThroughComments {
+        private FindLastLineBreaksOrFallsThroughComments() {
+        }
+
+        /**
+         * If no results are found, it means we should append a {@link J.Break} to the provided {@link J.Case}.
+         * A result is added to the set when the last line of the provided {@link J.Case} scope is either an acceptable "break"-able type,
+         * specifically {@link J.Return}, {@link J.Break}, {@link J.Continue}, or {@link J.Throw}, or a "fallthrough" {@link Comment} matching the {@link FallThroughStyle#RELIEF_PATTERN} regular expression.
+         *
+         * @param enclosingSwitch The enclosing {@link J.Switch} subtree to search.
+         * @param scope           the {@link J.Case} to use as a target.
+         * @return A set representing whether the last {@link Statement} is an acceptable "break"-able type or has a "fallthrough" comment.
+         */
+        private static Set<J> find(J.Switch enclosingSwitch, J.Case scope) {
+            Set<J> references = new HashSet<>();
+            new FindLastLineBreaksOrFallsThroughCommentsVisitor(scope).visit(enclosingSwitch, references);
+            return references;
+        }
+
+        private static class FindLastLineBreaksOrFallsThroughCommentsVisitor extends JavaIsoVisitor<Set<J>> {
+            private static final Predicate<Comment> HAS_RELIEF_PATTERN_COMMENT = stmt -> FallThroughStyle.RELIEF_PATTERN.matcher(stmt.getText()).find();
+            private final J.Case scope;
+
+            public FindLastLineBreaksOrFallsThroughCommentsVisitor(J.Case scope) {
+                this.scope = scope;
+            }
+
+            private static boolean lastLineBreaksOrFallsThrough(List<? extends Tree> trees) {
+                return trees.stream()
+                        .reduce((s1, s2) -> s2) // last statement
+                        .map(s -> s instanceof J.Return ||
+                                s instanceof J.Break ||
+                                s instanceof J.Continue ||
+                                s instanceof J.Throw ||
+                                ((J) s).getComments().stream().anyMatch(HAS_RELIEF_PATTERN_COMMENT)
+                        ).orElse(false);
+            }
+
+            @Override
+            public J.Switch visitSwitch(J.Switch switzh, Set<J> ctx) {
+                J.Switch s = super.visitSwitch(switzh, ctx);
+                List<Statement> statements = s.getCases().getStatements();
+                for (int i = 0; i < statements.size() - 1; i++) {
+                    J.Case caze = (J.Case) statements.get(i);
+                    /**
+                     * {@code i + 1} because a last-line comment for a J.Case gets attached as a prefix comment in the next case
+                     *
+                     * <pre>
+                     * SWITCH(..) {
+                     *  CASE 1:
+                     *      someStatement1; // fallthrough
+                     *  CASE 2:
+                     *      someStatement2;
+                     * }
+                     * </pre>
+                     * <p>
+                     * In order to know whether or not "CASE 1" ended with the comment "fallthrough", we have to check
+                     * the "prefix" of CASE 2, because the CASE 2 prefix is what has the comments associated for CASE 1.
+                     **/
+                    if (caze == scope && statements.get(i + 1).getPrefix().getComments().stream().anyMatch(HAS_RELIEF_PATTERN_COMMENT)) {
+                        ctx.add(s);
+                    }
+                }
+                return s;
+            }
+
+            @Override
+            public J.Case visitCase(J.Case caze, Set<J> ctx) {
+                J.Case c = super.visitCase(caze, ctx);
+                if (c == scope) {
+                    if (c.getStatements().isEmpty() || lastLineBreaksOrFallsThrough(c.getStatements())) {
+                        ctx.add(c);
+                    }
+                }
+                return c;
+            }
+
+            @Override
+            public J.Block visitBlock(J.Block block, Set<J> ctx) {
+                J.Block b = super.visitBlock(block, ctx);
+                if (getCursor().isScopeInPath(scope)) {
+                    if (lastLineBreaksOrFallsThrough(b.getStatements()) || b.getEnd().getComments().stream().anyMatch(HAS_RELIEF_PATTERN_COMMENT)) {
+                        ctx.add(b);
+                    }
+                }
+                return b;
+            }
+
+        }
+
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -91,6 +91,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class ExplicitInitializationTck : ExplicitInitializationTest
 
     @Nested
+    inner class FallThroughTck : FallThroughTest
+
+    @Nested
     inner class FinalizeLocalVariablesTck : FinalizeLocalVariablesTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/FallThroughTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/FallThroughTest.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.Tree
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.style.NamedStyles
+
+interface FallThroughTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = FallThrough()
+
+    @Test
+    fun addBreakWhenPreviousCaseHasCodeButLacksBreak(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                        i++;
+                    case 99:
+                        i++;
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                        i++;
+                        break;
+                    case 99:
+                        i++;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotAddBreakWhenPreviousCaseDoesNotContainCode(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                    case 99:
+                        i++;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun checkLastCaseGroupAddsBreakToLastCase(jp: JavaParser.Builder<*, *>) = assertChanged(
+        jp.styles(
+            listOf(
+                NamedStyles(
+                    Tree.randomId(), "test", "test", "test", emptySet(),
+                    listOf(FallThroughStyle(true))
+                )
+            )
+        ).build(),
+        before = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                    case 99:
+                        i++;
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                    case 99:
+                        i++;
+                        break;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun acceptableStatementsAreBreakOrReturnOrThrowOrContinue(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                        i++;
+                        break;
+                    case 1:
+                        i++;
+                        return;
+                    case 2:
+                        i++;
+                        throw new Exception();
+                    case 3:
+                        i++;
+                        continue;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun reliefPatternExpectedMatchesVariations(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                        i++; // fall through
+                    case 1:
+                        i++; // falls through
+                    case 2:
+                        i++; // fallthrough
+                    case 3:
+                        i++; // fallthru
+                    case 4:
+                        i++; // fall-through
+                    case 5:
+                        i++; // fallthrough
+                    case 99:
+                        i++;
+                        break;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun handlesSwitchesWithOneOrNoneCases(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                public void noCase(int i) {
+                    switch (i) {
+                    }
+                }
+                
+                public void oneCase(int i) {
+                    switch (i) {
+                        case 0:
+                            i++;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun addBreaksFallthroughCasesComprehensive(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                        i++; // fall through
+
+                    case 1:
+                        i++;
+                        // falls through
+                    case 2:
+                    case 3: {{
+                    }}
+                    case 4: {
+                        i++;
+                    }
+                    // fallthrough
+                    case 5:
+                        i++;
+                    /* fallthru */case 6:
+                        i++;
+                        // fall-through
+                    case 7:
+                        i++;
+                        break;
+                    case 8: {
+                        // fallthrough
+                    }
+                    case 9:
+                        i++;
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                int i;
+                {
+                    switch (i) {
+                    case 0:
+                        i++; // fall through
+
+                    case 1:
+                        i++;
+                        // falls through
+                    case 2:
+                    case 3: {{
+                        break;
+                    }}
+                    case 4: {
+                        i++;
+                    }
+                    // fallthrough
+                    case 5:
+                        i++;
+                    /* fallthru */case 6:
+                        i++;
+                        // fall-through
+                    case 7:
+                        i++;
+                        break;
+                    case 8: {
+                        // fallthrough
+                    }
+                    case 9:
+                        i++;
+                    }
+                }
+            }
+        """
+    )
+
+
+}


### PR DESCRIPTION
https://github.com/openrewrite/rewrite/issues/197

Checks for fall-through in switch statements. Finds locations where a case contains Java code but lacks a break, return, throw or continue statement.