### PR TITLE
`isPluginTag` convenience for MavenVisitor

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -36,6 +36,7 @@ public class MavenVisitor extends XmlVisitor<ExecutionContext> {
     private static final XPathMatcher DEPENDENCY_MATCHER = new XPathMatcher("/project/dependencies/dependency");
     private static final XPathMatcher MANAGED_DEPENDENCY_MATCHER = new XPathMatcher("/project/dependencyManagement/dependencies/dependency");
     private static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
+    private static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/*/plugins/plugin");
     private static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
 
     protected Pom model;
@@ -79,6 +80,14 @@ public class MavenVisitor extends XmlVisitor<ExecutionContext> {
 
     public boolean isManagedDependencyTag(String groupId, @Nullable String artifactId) {
         return isManagedDependencyTag() && hasGroupAndArtifact(groupId, artifactId);
+    }
+
+    public boolean isPluginTag() {
+        return PLUGIN_MATCHER.matches(getCursor());
+    }
+
+    public boolean isPluginTag(String groupId, @Nullable String artifactId) {
+        return isPluginTag() && hasGroupAndArtifact(groupId, artifactId);
     }
 
     public boolean isParentTag() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePlugin.java
@@ -19,15 +19,12 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.xml.RemoveContentVisitor;
-import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 @Incubating(since = "7.7.0")
 public class RemovePlugin extends Recipe {
-
-    private static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/*/plugins/plugin");
 
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'.",
@@ -58,13 +55,8 @@ public class RemovePlugin extends Recipe {
 
         @Override
         public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
-            if (PLUGIN_MATCHER.matches(getCursor())) {
-                if (groupId.equals(tag.getChildValue("groupId").orElse(model.getGroupId())) &&
-                        tag.getChildValue("artifactId")
-                                .map(a -> a.equals(artifactId))
-                                .orElse(artifactId == null)) {
-                    doAfterVisit(new RemoveContentVisitor<>(tag, true));
-                }
+            if (isPluginTag(groupId, artifactId)) {
+                doAfterVisit(new RemoveContentVisitor<>(tag, true));
             }
 
             return super.visitTag(tag, ctx);


### PR DESCRIPTION
As the title implies-- same functional logic as `isDependencyTag`, etc., but matching on `plugin` tags within a pom.xml