### PR TITLE
feat: Allow usage of latest.release and integration

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public interface VersionComparator extends Comparator<String> {
     Pattern RELEASE_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?([-+].*)?");
-    Pattern PRE_RELEASE_ENDING = Pattern.compile("[.-](RC|rc|M|m)\\d+$");
+    Pattern PRE_RELEASE_ENDING = Pattern.compile("[.-](SNAPSHOT|RC|rc|M|m)\\d*$");
 
     boolean isValid(String version);
 }

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
@@ -17,16 +17,20 @@ package org.openrewrite.semver
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 
 class LatestReleaseTest {
     private val latestRelease = LatestRelease(null)
 
     @Test
     fun onlyNumericPartsValid() {
-        assertThat(latestRelease.isValid("1.1.1")).isTrue()
-        assertThat(latestRelease.isValid("1.1")).isTrue()
-        assertThat(latestRelease.isValid("1")).isTrue()
-        assertThat(latestRelease.isValid("1.1.a")).isFalse()
+        assertAll(
+            { assertThat(latestRelease.isValid("1.1.1")).isTrue },
+            { assertThat(latestRelease.isValid("1.1")).isTrue },
+            { assertThat(latestRelease.isValid("1")).isTrue },
+            { assertThat(latestRelease.isValid("1.1.a")).isFalse },
+            { assertThat(latestRelease.isValid("1.1.0-SNAPSHOT")).isFalse }
+        )
     }
 
     @Test


### PR DESCRIPTION
Allow MavenArtifactHelper to coalesce latest.integration and
latest.release to an actual version from all repositories passed into
it.