### PR TITLE
Make a best-effort attempt to update the type of method invocations when updating their argument list with JavaTemplate

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -347,6 +347,7 @@ public class JavaTemplate {
                 if (loc.equals(METHOD_INVOCATION_ARGUMENTS) && method.isScope(insertionPoint)) {
                     List<Expression> args = substitutions.unsubstitute(templateParser.parseMethodArguments(getCursor(), substitutedTemplate, loc));
                     J.MethodInvocation m = method.withArguments(args);
+                    // Make a best-effort attempt to find type information for the newly modified method signature
                     if(method.getType() != null && method.getType().getGenericSignature().getReturnType() != null) {
                         JavaType.Method mtype = JavaType.Method.lookupExistingType(method.getType().getDeclaringType(),
                                 method.getSimpleName(),

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -687,6 +687,42 @@ public interface JavaType extends Serializable {
             }
         }
 
+        @Nullable
+        public static JavaType.Method lookupExistingType(
+                JavaType.FullyQualified declaringClassType,
+                String methodName,
+                JavaType returnType,
+                List<JavaType> paramTypes
+        ) {
+            synchronized (flyweights) {
+                Map<String, Set<Method>> methodsByClass = flyweights.get(declaringClassType);
+                if(methodsByClass == null) {
+                    return null;
+                }
+                Set<Method> methods = methodsByClass.get(methodName);
+                if(methods == null) {
+                    return null;
+                }
+                nextMethod:
+                for(Method method : methods) {
+                    Signature genericSignature = method.getGenericSignature();
+                    if(!TypeUtils.isOfType(returnType, genericSignature.getReturnType())) {
+                        continue;
+                    }
+                    if(paramTypes.size() != genericSignature.paramTypes.size()) {
+                        continue;
+                    }
+                    for(int i = 0; i < paramTypes.size(); i++) {
+                        if(!TypeUtils.isOfType(paramTypes.get(i), genericSignature.paramTypes.get(i))) {
+                            continue nextMethod;
+                        }
+                    }
+                    return method;
+                }
+                return null;
+            }
+        }
+
         @Data
         public static class Signature implements Serializable {
             @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.tree;
 
 import org.openrewrite.internal.lang.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -36,6 +35,23 @@ public class TypeUtils {
                 ( type instanceof JavaType.Class &&
                         "java.lang.String".equals(((JavaType.Class) type).getFullyQualifiedName())
                 );
+    }
+
+    public static boolean isOfType(@Nullable JavaType type1, @Nullable JavaType type2) {
+        if(type1 == null || type2 == null) {
+            return false;
+        }
+        if(type1 instanceof JavaType.Primitive && type2 instanceof JavaType.Primitive) {
+            return ((JavaType.Primitive) type1).getKeyword().equals(((JavaType.Primitive)type2).getKeyword());
+        }
+        if(type1 instanceof JavaType.FullyQualified && type2 instanceof JavaType.FullyQualified) {
+            return ((JavaType.FullyQualified) type1).getFullyQualifiedName().equals(((JavaType.FullyQualified) type2).getFullyQualifiedName());
+        }
+        if(type1 instanceof JavaType.Array && type2 instanceof JavaType.Array) {
+            return isOfType(((JavaType.Array)type1).getElemType(), ((JavaType.Array)type2).getElemType());
+        }
+
+        return type1.deepEquals(type2);
     }
 
     public static boolean isOfClassType(@Nullable JavaType type, String fqn) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -32,14 +32,18 @@ public class TypeUtils {
 
     public static boolean isString(@Nullable JavaType type) {
         return type == JavaType.Primitive.String ||
-                ( type instanceof JavaType.Class &&
-                        "java.lang.String".equals(((JavaType.Class) type).getFullyQualifiedName())
+                ( type instanceof JavaType.FullyQualified &&
+                        "java.lang.String".equals(((JavaType.FullyQualified) type).getFullyQualifiedName())
                 );
     }
 
     public static boolean isOfType(@Nullable JavaType type1, @Nullable JavaType type2) {
         if(type1 == null || type2 == null) {
             return false;
+        }
+        // Strings, uniquely amongst all other types, can be either primitives or classes depending on the context
+        if(TypeUtils.isString(type1) && TypeUtils.isString(type2)) {
+            return true;
         }
         if(type1 instanceof JavaType.Primitive && type2 instanceof JavaType.Primitive) {
             return ((JavaType.Primitive) type1).getKeyword().equals(((JavaType.Primitive)type2).getKeyword());

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
@@ -613,7 +613,14 @@ interface JavaTemplateTest : JavaRecipeTest {
                     test(m, n);
                 }
             }
-        """
+        """,
+        afterConditions = { cu ->
+            val m = (cu.classes[0].body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.MethodInvocation
+            val type = m.type!!
+            assertThat(type.paramNames).containsExactly("m", "n")
+            assertThat(type.resolvedSignature.paramTypes)
+                    .containsExactly(JavaType.Primitive.Int, JavaType.Primitive.Int)
+        }
     )
 
     @Test


### PR DESCRIPTION
When looking at a method invocation alone you don't have enough information to construct a complete `JavaType.Method`. So attempt to lookup the type from the `JavaType.Method` flyweights map. This approach fails if there's a recipe which is creating new methods, or altering existing method signatures, and attempts to update invocations _before_ the new entry has ended up in the flyweights map. So this is on a best-effort basis, but it is at least _more_ correct than what we currently have. 

An approach would surmount this limitation would probably require users of this sort of template having to specify the full & exact method signature they're updating the invocation to have. 

I know we've shied away from providing a lookup into the contents of the JavaType.Method flyweights before and for good reason, but I believe this scenario is a compelling argument for this functionality to exist despite the tradeoffs.

This fixes the problem @aegershman is having with [this PR](https://github.com/openrewrite/rewrite-migrate-java/pull/22/files#diff-19626282f9371cc94732167d084ecec5e951a96a495b599511b98e9f3a00d7deR54-R60).