### PR TITLE
Fixing AddDependency when using partial version selector

### DIFF
--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/AddDependencyTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/AddDependencyTest.kt
@@ -21,6 +21,8 @@ import org.openrewrite.InMemoryExecutionContext
 import org.openrewrite.Parser
 import org.openrewrite.SourceFile
 import org.openrewrite.java.JavaParser
+import org.openrewrite.maven.tree.Maven
+
 import java.util.*
 
 class AddDependencyTest : MavenRecipeTest {
@@ -289,7 +291,10 @@ class AddDependencyTest : MavenRecipeTest {
                 </dependency>
               </dependencies>
             </project>
-        """
+        """,
+        afterConditions = { m : Maven ->
+            assertThat(m.model.dependencies.first().version).isEqualTo("1.4.7.RELEASE")
+        }
     )
 
     @Test


### PR DESCRIPTION
If `AddDependency` is used in combination with a version selector, the visitor was incorrectly updating the pom model with the selector `2.3.x` instead of resolving the version to `2.3.3`. This can manifest later as an exception when other recipes expect the pom model to only contain fully-formed semantic versions. A specific example of where this fails is if you attempt to use both `AddDependency` and `UpgradeDependency` over the same artifact. 

![image](https://user-images.githubusercontent.com/1878529/121101517-d5cbb200-c7b0-11eb-85e0-f88df18c9f5e.png)

