### PR TITLE
Prevent index out of bound in TabsAndIndentsVisitor#shift(). fixes #521

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -434,10 +434,14 @@ class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                 text.append(' ');
             }
         } else {
+            int len;
             if (style.getUseTabCharacter()) {
-                text.delete(text.length() + (shift / tabIndent), text.length());
+                len = text.length() + (shift / tabIndent);
             } else {
-                text.delete(text.length() + shift, text.length());
+                len = text.length() + shift;
+            }
+            if (len > 0) {
+                text.delete(len, text.length());
             }
         }
     }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -460,6 +460,47 @@ interface TabsAndIndentsTest : JavaRecipeTest {
     )
 
     @Test
+    fun noIndexOutOfBoundsUsingSpaces(jp: JavaParser.Builder<*, *>) = assertChanged(
+        jp.styles(tabsAndIndents()).build(),
+        before = """
+            public class A {
+            // length = 1 from new line.
+                  int valA = 10; // text.length = 1 + shift -2 == -1.
+            }
+        """.trimIndent(),
+        after = """
+            public class A {
+            // length = 1 from new line.
+                int valA = 10; // text.length = 1 + shift -2 == -1.
+            }
+        """.trimIndent()
+    )
+
+    @Test
+    fun noIndexOutOfBoundsUsingTabs(jp: JavaParser.Builder<*, *>) = assertChanged(
+        jp.styles(tabsAndIndents {
+            withUseTabCharacter(true)
+                .withTabSize(1)
+                .withIndentSize(1)
+        }).build(),
+        before = """
+            class Test {
+            	void test() {
+            		System.out.println(); // comment
+            	}
+            }
+        """.trimIndent(),
+        after = """
+            class Test {
+            	void test() {
+            		System.out.println();// comment
+            	}
+            }
+        """.trimIndent(),
+        expectedCyclesThatMakeChanges = 2
+    )
+
+    @Test
     fun blockComment(jp: JavaParser.Builder<*, *>) = assertChanged(
         jp.styles(tabsAndIndents()).build(),
         before = """


### PR DESCRIPTION
fixes #521