### PR TITLE
Add validation to JavaRecipeTest that method invocations are type attributed

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -641,7 +641,7 @@ public interface JavaType extends Serializable {
         private final FullyQualified declaringType;
 
         private final String name;
-        private final Signature genericSignature;
+        @Nullable private final Signature genericSignature;
         private final Signature resolvedSignature;
         private final List<String> paramNames;
         private final List<FullyQualified> thrownExceptions;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
@@ -35,9 +35,18 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
         @Language("java") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
+        skipEnhancedTypeValidation: Boolean = false,
         afterConditions: (J.CompilationUnit) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        val typeValidatingAfterConditions: (J.CompilationUnit) -> Unit = if(skipEnhancedTypeValidation) {
+            afterConditions
+        } else {
+            {
+                TypeValidator.assertTypesValid(it)
+                afterConditions(it)
+            }
+        }
+        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, typeValidatingAfterConditions)
     }
 
     fun assertChanged(
@@ -48,9 +57,18 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
         @Language("java") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
+        skipEnhancedTypeValidation: Boolean = false,
         afterConditions: (J.CompilationUnit) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        val typeValidatingAfterConditions: (J.CompilationUnit) -> Unit = if(skipEnhancedTypeValidation) {
+            afterConditions
+        } else {
+            {
+                TypeValidator.assertTypesValid(it)
+                afterConditions(it)
+            }
+        }
+        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, typeValidatingAfterConditions)
     }
 
     fun assertUnchanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/TypeValidator.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/TypeValidator.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java
+
+import org.junit.jupiter.api.fail
+import org.openrewrite.Cursor
+import org.openrewrite.TreeVisitor
+import org.openrewrite.java.TypeValidator.InvalidTypeResult
+import org.openrewrite.java.tree.J
+import org.openrewrite.java.tree.JavaType
+
+/**
+ * Produces a report about missing type attributions within a CompilationUnit.
+ */
+class TypeValidator : JavaIsoVisitor<MutableList<InvalidTypeResult>>() {
+    data class InvalidTypeResult(val cursor: Cursor, val astElement: J, val message: String)
+    companion object {
+        @JvmStatic
+        fun analyzeTypes(cu: J.CompilationUnit): List<InvalidTypeResult> {
+            val report = mutableListOf<InvalidTypeResult>()
+            TypeValidator().visit(cu, report)
+            return report
+        }
+
+        @JvmStatic
+        fun assertTypesValid(cu: J.CompilationUnit) {
+            val report = analyzeTypes(cu)
+            if(report.isNotEmpty()) {
+
+                val reportText = report.asSequence()
+                        .map { """
+                             |  ${it.message}
+                             |    At : ${it.cursor}
+                             |    AST:
+                             ${it.astElement.printTrimmed().prependIndent("|      ")}
+                             |
+                        """.trimMargin() }
+                        .joinToString("\n")
+                fail("Found missing or invalid types: \n$reportText")
+            }
+        }
+
+        /**
+         * Convenience method for creating an InvalidType result without having to manually specify anything except the message.
+         * And a convenient place to put a breakpoint if you want to catch an invalid type in the debugger.
+         */
+        private fun JavaVisitor<*>.invalidTypeResult(message: String) = InvalidTypeResult(cursor, cursor.getValue(), message)
+    }
+
+    override fun visitMethodInvocation(method: J.MethodInvocation, p: MutableList<InvalidTypeResult>): J.MethodInvocation {
+        val m = super.visitMethodInvocation(method, p)
+        val mt = method.type
+        if(mt == null) {
+            p.add(invalidTypeResult("J.MethodInvocation type is null"))
+            return m
+        }
+        if(mt.genericSignature == null) {
+            p.add(invalidTypeResult("J.MethodInvocation is missing a genericSignature"))
+        }
+
+        return m
+    }
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/CovariantEqualsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/CovariantEqualsTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
 import org.openrewrite.Recipe
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
@@ -166,9 +167,11 @@ interface CovariantEqualsTest : JavaRecipeTest {
         """
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/653")
     @Test
     fun replaceWithNonCovariantEqualsWhenNested(jp: JavaParser) = assertChanged(
         jp,
+        skipEnhancedTypeValidation = true,
         before = """
             class A {
                 class B {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
@@ -251,6 +251,9 @@ interface HiddenFieldTest : JavaRecipeTest {
         jp,
         before = """
             package org.openrewrite;
+            
+            import java.util.List;
+            import java.util.Arrays;
 
             public class A {
                 List<Integer> numbers = Arrays.asList(1, 2, 3);
@@ -262,6 +265,9 @@ interface HiddenFieldTest : JavaRecipeTest {
         """,
         after = """
             package org.openrewrite;
+
+            import java.util.List;
+            import java.util.Arrays;
 
             public class A {
                 List<Integer> numbers = Arrays.asList(1, 2, 3);

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/PrimitiveWrapperClassConstructorToValueOfTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/PrimitiveWrapperClassConstructorToValueOfTest.kt
@@ -43,7 +43,7 @@ interface PrimitiveWrapperClassConstructorToValueOfTest : JavaRecipeTest {
                 Byte b = new Byte("1");
                 Character c = new Character('c');
                 Double d = new Double(1.0);
-                Float f = new Float(1.1);
+                Float f = new Float(1.1f);
                 Long l = new Long(1);
                 Short sh = new Short("12");
                 short s3 = 3;
@@ -57,7 +57,7 @@ interface PrimitiveWrapperClassConstructorToValueOfTest : JavaRecipeTest {
                 Byte b = Byte.valueOf("1");
                 Character c = Character.valueOf('c');
                 Double d = Double.valueOf(1.0);
-                Float f = Float.valueOf(1.1);
+                Float f = Float.valueOf(1.1f);
                 Long l = Long.valueOf(1);
                 Short sh = Short.valueOf("12");
                 short s3 = 3;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -195,7 +195,11 @@ interface TabsAndIndentsTest : JavaRecipeTest {
         before = """
             public class Test {
             public int[] X = new int[]{1, 3, 5, 7, 9, 11};
-
+            public void doSomething(int i) {}
+            public void doCase0() {}
+            public void doDefault() {}
+            public void processException(Object a, Object b, Object c, Object d) {}
+            public void processFinally() {}
             public void test(boolean a, int x, int y, int z) {
             label1:
             do {
@@ -244,7 +248,11 @@ interface TabsAndIndentsTest : JavaRecipeTest {
         after = """
             public class Test {
                 public int[] X = new int[]{1, 3, 5, 7, 9, 11};
-
+                public void doSomething(int i) {}
+                public void doCase0() {}
+                public void doDefault() {}
+                public void processException(Object a, Object b, Object c, Object d) {}
+                public void processFinally() {}
                 public void test(boolean a, int x, int y, int z) {
                     label1:
                     do {


### PR DESCRIPTION
There are a lot more invariants we can enforce with this approach. This is just the start. 