### PR TITLE
Set continuation indent when lambda body is a block with closing bracket is on a newline

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -219,6 +219,12 @@ class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                         break;
                     }
                     case METHOD_INVOCATION_ARGUMENT:
+                        if (elem instanceof J.Lambda) {
+                            J.Lambda lambda = ((J.Lambda) elem);
+                            if (lambda.getBody() instanceof J.Block) {
+                                getCursor().getParentOrThrow().putMessage("lastIndent", indent + style.getContinuationIndent());
+                            }
+                        }
                         elem = visitAndCast(elem, p);
                         after = indentTo(right.getAfter(), indent, loc.getAfterLocation());
                         break;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -188,7 +188,7 @@ interface TabsAndIndentsTest : JavaRecipeTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/660")
-    fun methodInvocationArgumentLambdaWithClosingBracketOnSameLineHasContinuationIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
+    fun methodInvocationLambdaBlockWithClosingBracketOnSameLineIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
         jp.styles(tabsAndIndents { withContinuationIndent(8) }).build(),
         before = """
             class Test {
@@ -209,8 +209,8 @@ interface TabsAndIndentsTest : JavaRecipeTest {
     )
 
     @Test
-    @Disabled("https://github.com/openrewrite/rewrite/issues/660")
-    fun methodInvocationArgumentLambdaWithClosingBracketOnNewLineHasContinuationIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
+    @Issue("https://github.com/openrewrite/rewrite/issues/660")
+    fun methodInvocationLambdaBlockWithClosingBracketOnNewLineIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
         jp.styles(tabsAndIndents { withContinuationIndent(8) }).build(),
         before = """
             class Test {


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite/issues/660