### PR TITLE
feat: Refactor MavenArtifactHelper to include necessary data

### DIFF
--- a/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/MavenArtifactHelperIntegTest.kt
+++ b/rewrite-maven/src/integTest/kotlin/org/openrewrite/maven/MavenArtifactHelperIntegTest.kt
@@ -25,13 +25,14 @@ class MavenArtifactHelperIntegTest {
 
     @Test
     fun downloadArtifactAndDependencies() {
-        val artifactPaths = MavenArtifactHelper.downloadArtifactAndDependencies(
+        val dependencyData = MavenArtifactHelper.downloadArtifactAndDependencies(
                 "org.openrewrite.recipe",
                 "rewrite-spring",
                 "4.0.0",
                 InMemoryExecutionContext { t -> t.printStackTrace() },
                 InMemoryMavenPomCache()
         )
+        val artifactPaths = dependencyData.artifactClasspath
         assertThat(artifactPaths).hasSizeGreaterThan(0)
         val firstArtifact = artifactPaths[0]
         assertThat(firstArtifact.fileName.toString()).contains("rewrite-spring")

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenMetadata.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenMetadata.java
@@ -40,7 +40,7 @@ public class MavenMetadata {
         }
     };
 
-    public static final MavenMetadata EMPTY = new MavenMetadata(new MavenMetadata.Versioning(emptyList(), null));
+    public static final MavenMetadata EMPTY = new MavenMetadata(new MavenMetadata.Versioning(emptyList(), emptyList(), null));
 
     Versioning versioning;
 
@@ -51,15 +51,21 @@ public class MavenMetadata {
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @Getter
     public static class Versioning {
+
         List<String> versions;
+
+        @Nullable
+        List<SnapshotVersion> snapshotVersions;
 
         @Nullable
         Snapshot snapshot;
 
         public Versioning(
                 @JacksonXmlElementWrapper(localName = "versions") List<String> versions,
+                @Nullable List<SnapshotVersion> snapshotVersions,
                 @Nullable Snapshot snapshot) {
             this.versions = versions;
+            this.snapshotVersions = snapshotVersions;
             this.snapshot = snapshot;
         }
     }
@@ -77,5 +83,13 @@ public class MavenMetadata {
     public static class Snapshot {
         String timestamp;
         String buildNumber;
+    }
+
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Data
+    public static class SnapshotVersion {
+        String extension;
+        String value;
+        String updated;
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -118,6 +118,8 @@ public class MavenPomDownloader {
                         return new MavenMetadata(new MavenMetadata.Versioning(
                                 Stream.concat(m1.getVersioning().getVersions().stream(),
                                         m2.getVersioning().getVersions().stream()).collect(toList()),
+                                Stream.concat(m1.getVersioning().getSnapshotVersions() == null ? Stream.empty() : m1.getVersioning().getSnapshotVersions().stream(),
+                                        m2.getVersioning().getSnapshotVersions() == null ? Stream.empty() : m2.getVersioning().getSnapshotVersions().stream()).collect(toList()),
                                 null
                         ));
                     }
@@ -172,7 +174,7 @@ public class MavenPomDownloader {
                              ExecutionContext ctx) {
         Map<MavenRepository, Exception> errors = new HashMap<>();
 
-        String versionMaybeDatedSnapshot = findDatedSnapshotVersionIfNecessary(groupId, artifactId, version, repositories);
+        String versionMaybeDatedSnapshot = datedSnapshotVersion(groupId, artifactId, version, repositories);
         if (versionMaybeDatedSnapshot == null) {
             return null;
         }
@@ -283,7 +285,7 @@ public class MavenPomDownloader {
     }
 
     @Nullable
-    private String findDatedSnapshotVersionIfNecessary(String groupId, String artifactId, String version, Collection<MavenRepository> repositories) {
+    public String datedSnapshotVersion(String groupId, String artifactId, String version, Collection<MavenRepository> repositories) {
         if (version.endsWith("-SNAPSHOT")) {
             MavenMetadata mavenMetadata = repositories.stream()
                     .map(this::normalizeRepository)


### PR DESCRIPTION
Allow MavenArtifactHelper to pull all information, not just the list of paths.

Also, allow MavenPomDownloader to return the latest dated version (snapshot or otherwise).