### PR TITLE
handle indents on lambdas when bodies are more invocations [#679]

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -219,10 +219,14 @@ class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                         break;
                     }
                     case METHOD_INVOCATION_ARGUMENT:
-                        if (elem instanceof J.Lambda) {
-                            J.Lambda lambda = ((J.Lambda) elem);
-                            if (lambda.getBody() instanceof J.Block) {
-                                getCursor().getParentOrThrow().putMessage("lastIndent", indent + style.getContinuationIndent());
+                        if (!elem.getPrefix().getLastWhitespace().contains("\n")) {
+                            if (elem instanceof J.Lambda) {
+                                J body = ((J.Lambda) elem).getBody();
+                                if (!(body instanceof J.Binary)) {
+                                    if (!body.getPrefix().getLastWhitespace().contains("\n")) {
+                                        getCursor().getParentOrThrow().putMessage("lastIndent", indent + style.getContinuationIndent());
+                                    }
+                                }
                             }
                         }
                         elem = visitAndCast(elem, p);

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -232,18 +232,53 @@ interface TabsAndIndentsTest : JavaRecipeTest {
     )
 
     @Test
-    @Disabled("https://github.com/openrewrite/rewrite/issues/679")
-    fun methodInvocationStatementLambdaBlockIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
+    @Issue("https://github.com/openrewrite/rewrite/issues/679")
+    fun lambdaBodyWithNestedMethodInvocationLambdaStatementBodyIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
         jp.styles(tabsAndIndents()).build(),
         before = """
             class Test {
                 void method(Collection<List<String>> c) {
-                    c.stream()
-                            .map(x -> x.stream().max((r1, r2) -> {
-                                        return 0;
-                                    })
-                            )
+                    c.stream().map(x -> x.stream().max((r1, r2) -> {
+                                return 0;
+                            })
+                    )
                             .collect(Collectors.toList());
+                }
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/679")
+    fun lambdaBodyWithNestedMethodInvocationLambdaExpressionBodyIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
+        jp.styles(tabsAndIndents()).build(),
+        before = """
+            class Test {
+                void method(Collection<List<String>> c) {
+                    c.stream().map(x -> x.stream().max((r1, r2) ->
+                                    0
+                            )
+                    )
+                            .collect(Collectors.toList());
+                }
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/679")
+    fun methodInvocationLambdaArgumentIndent(jp: JavaParser.Builder<*, *>) = assertUnchanged(
+        jp.styles(tabsAndIndents()).build(),
+        before = """
+            import java.util.function.Function;
+
+            abstract class Test {
+                abstract Test a(Function<String, String> f);
+
+                void method(String s) {
+                    a(
+                            f -> s.toLowerCase()
+                    );
                 }
             }
         """


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite/issues/679
