### PR TITLE
Do not apply diamond operator in a method receiver.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
@@ -48,16 +48,15 @@ public class UseDiamondOperator extends Recipe {
             public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
                 J.NewClass n = super.visitNewClass(newClass, executionContext);
                 if (n.getClazz() instanceof J.ParameterizedType && n.getBody() == null) {
-
                     J.ParameterizedType parameterizedType = (J.ParameterizedType) n.getClazz();
-                    if (useDiamondOperator((J.ParameterizedType) n.getClazz())) {
+                    if (useDiamondOperator(newClass, parameterizedType)) {
                         n = n.withClazz(parameterizedType.withTypeParameters(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY))));
                     }
                 }
                 return n;
             }
 
-            private boolean useDiamondOperator(J.ParameterizedType parameterizedType) {
+            private boolean useDiamondOperator(J.NewClass newClass, J.ParameterizedType parameterizedType) {
                 if (parameterizedType.getTypeParameters() == null || parameterizedType.getTypeParameters().isEmpty()
                         || parameterizedType.getTypeParameters().get(0) instanceof J.Empty) {
                     return false;
@@ -72,6 +71,9 @@ public class UseDiamondOperator extends Recipe {
                     //not using local variable type inference.
                     J.VariableDeclarations variableDeclaration = c.firstEnclosing(J.VariableDeclarations.class);
                     return variableDeclaration != null && !(variableDeclaration.getTypeExpression() instanceof J.VarType);
+                } else if (c.getValue() instanceof J.MethodInvocation) {
+                    J.MethodInvocation invocation = c.getValue();
+                    return invocation.getSelect() != newClass;
                 } else {
                     return !(c.getValue() instanceof J.Block);
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
@@ -64,17 +64,18 @@ public class UseDiamondOperator extends Recipe {
 
                 Cursor c = getCursor().dropParentUntil(J.class::isInstance);
 
-                //If the immediate parent is a block, this new operation is a statement and there is no left side to
-                //infer the type parameters.
                 if (c.getValue() instanceof J.VariableDeclarations.NamedVariable) {
                     //If the immediate parent is named variable, check the variable declaration to make sure it's
                     //not using local variable type inference.
                     J.VariableDeclarations variableDeclaration = c.firstEnclosing(J.VariableDeclarations.class);
                     return variableDeclaration != null && !(variableDeclaration.getTypeExpression() instanceof J.VarType);
                 } else if (c.getValue() instanceof J.MethodInvocation) {
+                    //Do not remove the type parameters if the newClass is the receiver of a method invocation.
                     J.MethodInvocation invocation = c.getValue();
                     return invocation.getSelect() != newClass;
                 } else {
+                    //If the immediate parent is a block, this new operation is a statement and there is no left side to
+                    //infer the type parameters.
                     return !(c.getValue() instanceof J.Block);
                 }
             }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
@@ -66,4 +66,41 @@ interface UseDiamondOperatorTest: JavaRecipeTest {
             }
         """.trimIndent()
     )
+
+    @Test
+    fun notAsAChainedMethodInvocation(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                public static ResponseBuilder<String> bResponse(String entity) {
+                    return new ResponseBuilder<String>().entity(entity);
+                }
+                public static ResponseBuilder<String> bResponse(String entity) {
+                    return new ResponseBuilder<String>();
+                }
+
+                public static class ResponseBuilder<T> {
+                    public ResponseBuilder<T> entity(T entity) {
+                        return this;
+                    }
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public static ResponseBuilder<String> bResponse(String entity) {
+                    return new ResponseBuilder<String>().entity(entity);
+                }
+                public static ResponseBuilder<String> bResponse(String entity) {
+                    return new ResponseBuilder<>();
+                }
+
+                public static class ResponseBuilder<T> {
+                    public ResponseBuilder<T> entity(T entity) {
+                        return this;
+                    }
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
This fix prevents the diamond operator from being applied when the "new" operation is a method invocation's receiver. 

```
    class Test {
        public static void test() {
            ResponseBuilder<String> response = new ResponseBuilder<String>().entity("hello");
        }

        public static class ResponseBuilder<T> {
            public ResponseBuilder<T> entity(T entity) {
                return this;
            }
        }
    }
```
This cannot be converted to : 

```
ResponseBuilder<String> response = new ResponseBuilder<>.entity("hello");
```
This would not compile because the type returned by "entity" would be `ResponseBuilder<Object>`
