### PR TITLE
Add filename into the error message

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -57,7 +57,7 @@ public class PropertiesParser implements Parser<Properties.File> {
                         return file;
                     } catch (Throwable t) {
                         sample.stop(MetricsHelper.errorTags(timer, t).register(Metrics.globalRegistry));
-                        ctx.getOnError().accept(t);
+                        ctx.getOnError().accept(new IllegalStateException(sourceFile.getPath() + " " + t.getMessage(), t));
                         return null;
                     }
                 })

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -60,7 +60,7 @@ public class XmlParser implements Parser<Xml.Document> {
                         return document;
                     } catch (Throwable t) {
                         sample.stop(MetricsHelper.errorTags(timer, t).register(Metrics.globalRegistry));
-                        ctx.getOnError().accept(t);
+                        ctx.getOnError().accept(new IllegalStateException(sourceFile.getPath() + " " + t.getMessage(), t));
                         return null;
                     }
                 })
@@ -91,7 +91,7 @@ public class XmlParser implements Parser<Xml.Document> {
         public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
                                 int line, int charPositionInLine, String msg, RecognitionException e) {
             ctx.getOnError().accept(new XmlParsingException(sourcePath,
-                    String.format("Syntax error at line %d:%d %s.", line, charPositionInLine, msg), e));
+                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath.toString(), line, charPositionInLine, msg), e));
         }
     }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -70,7 +70,7 @@ public class YamlParser implements org.openrewrite.Parser<Yaml.Documents> {
                         return yaml;
                     } catch (Throwable t) {
                         sample.stop(MetricsHelper.errorTags(timer, t).register(Metrics.globalRegistry));
-                        ctx.getOnError().accept(t);
+                        ctx.getOnError().accept(new IllegalStateException(sourceFile.getPath() + " " + t.getMessage(), t));
                         return null;
                     }
                 })


### PR DESCRIPTION
Currently parsing errors in resource parsers like XML, YAML, and Properties files will fail with the message of the error but not give specifics about which file caused the error making troubleshooting difficult.

This change adds the filename being parsed to the error message to aid troubleshooting.