### PR TITLE
Optional fileMatcher option for YAML recipes

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeKey.java
@@ -17,10 +17,8 @@ package org.openrewrite.yaml;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
 @Value
@@ -36,6 +34,14 @@ public class ChangeKey extends Recipe {
             example = "kind")
     String newKey;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Change key";
@@ -44,6 +50,14 @@ public class ChangeKey extends Recipe {
     @Override
     public String getDescription() {
         return "Change a YAML mapping entry key leaving the value intact.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -17,11 +17,9 @@ package org.openrewrite.yaml;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -53,6 +51,14 @@ public class ChangePropertyKey extends Recipe {
             example = "management.metrics.enable.process.files")
     String newPropertyKey;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Change property key";
@@ -63,6 +69,14 @@ public class ChangePropertyKey extends Recipe {
         return "Change a YAML property key leaving the value intact. Nested YAML mappings are " +
                 "interpreted as dot separated property names, i.e. as Spring Boot interprets " +
                 "application.yml files.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeValue.java
@@ -17,10 +17,8 @@ package org.openrewrite.yaml;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -39,6 +37,14 @@ public class ChangeValue extends Recipe {
             example = "Deployment")
     String value;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Change value";
@@ -47,6 +53,14 @@ public class ChangeValue extends Recipe {
     @Override
     public String getDescription() {
         return "Change a YAML mapping entry value leaving the key intact.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
@@ -17,9 +17,8 @@ package org.openrewrite.yaml;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
 @Value
@@ -35,6 +34,14 @@ public class CopyValue extends Recipe {
             example = "dest/kind")
     String newKey;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Copy YAML value";
@@ -43,6 +50,14 @@ public class CopyValue extends Recipe {
     @Override
     public String getDescription() {
         return "Copies a YAML value from one key to another. The existing key/value pair remains unaffected by this change. If either the source or destination key path does not exist, no value will be copied. Furthermore, copies are limited to scalar values, not whole YAML blocks.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +32,14 @@ public class DeleteKey extends Recipe {
             example = "subjects/kind")
     String keyPath;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Delete key";
@@ -39,6 +48,14 @@ public class DeleteKey extends Recipe {
     @Override
     public String getDescription() {
         return "Delete a YAML mapping entry key.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
@@ -17,11 +17,9 @@ package org.openrewrite.yaml;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayDeque;
@@ -46,6 +44,14 @@ public class DeleteProperty extends Recipe {
             example = "true")
     Boolean coalesce;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Delete property";
@@ -55,6 +61,14 @@ public class DeleteProperty extends Recipe {
     public String getDescription() {
         return "Delete a YAML property. Nested YAML mappings are interpreted as dot separated property names, i.e. " +
                 " as Spring Boot interprets application.yml files.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/InsertYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/InsertYaml.java
@@ -18,6 +18,7 @@ package org.openrewrite.yaml;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
 @Value
@@ -34,6 +35,14 @@ public class InsertYaml extends Recipe {
             example = "label-one: \"value-one\"")
     String yaml;
 
+    @Incubating(since = "7.8.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Override
     public String getDisplayName() {
         return "Insert YAML snippet";
@@ -42,6 +51,14 @@ public class InsertYaml extends Recipe {
     @Override
     public String getDescription() {
         return "Insert a YAML snippet at a given key.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
     }
 
     @Override

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
@@ -17,11 +17,14 @@ package org.openrewrite.yaml
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 
 class ChangePropertyKeyTest : YamlRecipeTest {
     private val changeProp = ChangePropertyKey(
         "management.metrics.binders.files.enabled",
-        "management.metrics.enable.process.files"
+        "management.metrics.enable.process.files",
+        null
     )
 
     @Test
@@ -64,30 +67,49 @@ class ChangePropertyKeyTest : YamlRecipeTest {
         """
     )
 
+    @Test
+    fun changeOnlyMatchingFile(@TempDir tempDir: Path) {
+        val matchingFile = tempDir.resolve("a.yml").apply {
+            toFile().parentFile.mkdirs()
+            toFile().writeText("management.metrics.binders.files.enabled: true")
+        }.toFile()
+        val nonMatchingFile = tempDir.resolve("b.yml").apply {
+            toFile().parentFile.mkdirs()
+            toFile().writeText("management.metrics.binders.files.enabled: true")
+        }.toFile()
+        val recipe = ChangePropertyKey(
+                "management.metrics.binders.files.enabled",
+                "management.metrics.enable.process.files",
+                "**/a.yml"
+        )
+        assertChanged(recipe = recipe, before = matchingFile, after = "management.metrics.enable.process.files: true")
+        assertUnchanged(recipe = recipe, before = nonMatchingFile)
+    }
+
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @Test
     fun checkValidation() {
-        var recipe = ChangePropertyKey(null, null)
+        var recipe = ChangePropertyKey(null, null, null)
         var valid = recipe.validate()
         assertThat(valid.isValid).isFalse()
         assertThat(valid.failures()).hasSize(2)
         assertThat(valid.failures()[0].property).isEqualTo("newPropertyKey")
         assertThat(valid.failures()[1].property).isEqualTo("oldPropertyKey")
 
-        recipe = ChangePropertyKey(null, "management.metrics.enable.process.files")
+        recipe = ChangePropertyKey(null, "management.metrics.enable.process.files", null)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse()
         assertThat(valid.failures()).hasSize(1)
         assertThat(valid.failures()[0].property).isEqualTo("oldPropertyKey")
 
-        recipe = ChangePropertyKey("management.metrics.binders.files.enabled", null)
+        recipe = ChangePropertyKey("management.metrics.binders.files.enabled", null, null)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse()
         assertThat(valid.failures()).hasSize(1)
         assertThat(valid.failures()[0].property).isEqualTo("newPropertyKey")
 
         recipe =
-            ChangePropertyKey("management.metrics.binders.files.enabled", "management.metrics.enable.process.files")
+            ChangePropertyKey("management.metrics.binders.files.enabled", "management.metrics.enable.process.files", null)
         valid = recipe.validate()
         assertThat(valid.isValid).isTrue()
     }


### PR DESCRIPTION
See #656

So we have feature parity between properties and yaml. 
I looked at existing XML recipes, but none seems to really need this option.

I think this will cover most needs for changing YAML and properties in projects.