### PR TITLE
fix: Move FQ ref check from J.FieldAccess to MethodMatcher

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
@@ -134,7 +134,7 @@ public class ChangeMethodName extends Recipe {
         @Override
         public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
             J.FieldAccess f = super.visitFieldAccess(fieldAccess, ctx);
-            if (f.isFullyQualifiedClassReference(methodMatcher)) {
+            if (methodMatcher.isFullyQualifiedClassReference(f)) {
                 Expression target = f.getTarget();
                 if (target instanceof J.FieldAccess) {
                     String className = target.printTrimmed();

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -177,6 +177,19 @@ public class MethodMatcher {
                         (matchesTargetType(type.getSupertype() == null ? JavaType.Class.OBJECT : type.getSupertype())));
     }
 
+    /**
+     * Evaluate whether this MethodMatcher and the specified FieldAccess are describing the same type or not.
+     * Known limitation/bug: MethodMatchers can have patterns/wildcards like "com.*.Bar" instead of something
+     * concrete like "com.foo.Bar". This limitation is not desirable or intentional and should be fixed.
+     * If a methodMatcher is passed that includes wildcards the result will always be "false"
+     *
+     * @param fieldAccess A J.FieldAccess that hopefully has the same fully qualified type as this matcher.
+     */
+    public boolean isFullyQualifiedClassReference(J.FieldAccess fieldAccess) {
+        String hopefullyFullyQualifiedMethod = this.getTargetTypePattern().pattern() + "." + this.getMethodNamePattern().pattern();
+        return fieldAccess.isFullyQualifiedClassReference(hopefullyFullyQualifiedMethod);
+    }
+
     @Nullable
     private static String typePattern(JavaType type) {
         if (type instanceof JavaType.Primitive) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1556,19 +1556,6 @@ public interface J extends Serializable, Tree {
             return isFullyQualifiedClassReference(this, className);
         }
 
-        /**
-         * Evaluate whether the specified MethodMatcher and this FieldAccess are describing the same type or not.
-         * Known limitation/bug: MethodMatchers can have patterns/wildcards like "com.*.Bar" instead of something
-         * concrete like "com.foo.Bar". This limitation is not desirable or intentional and should be fixed.
-         * If a methodMatcher is passed that includes wildcards the result will always be "false"
-         *
-         * @param methodMatcher a methodMatcher whose internal pattern is fully concrete (no wildcards)
-         */
-        public boolean isFullyQualifiedClassReference(MethodMatcher methodMatcher) {
-            String hopefullyFullyQualifiedMethod = methodMatcher.getTargetTypePattern().pattern() + "." + methodMatcher.getMethodNamePattern().pattern();
-            return isFullyQualifiedClassReference(this, hopefullyFullyQualifiedMethod);
-        }
-
         private boolean isFullyQualifiedClassReference(J.FieldAccess fieldAccess, String className) {
             if (!className.contains(".")) {
                 return false;


### PR DESCRIPTION
Move J.FieldAccess#isFullyQualifiedReference(MethodMatcher) from J.FieldAccess to MethodMatcher