### PR TITLE
Perform deep merge on YAML with a merge visitor

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -48,7 +48,7 @@ public class MergeYaml extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Merge a YAML snippet with an existing YAML document";
+        return "Merge a YAML snippet with an existing YAML document.";
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -1,0 +1,72 @@
+package org.openrewrite.yaml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.intellij.lang.annotations.Language;
+import org.openrewrite.*;
+import org.openrewrite.yaml.format.AutoFormatVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class MergeYaml extends Recipe {
+
+    @Option(displayName = "Key path",
+            description = "XPath expression used to find matching keys.",
+            example = "/metadata")
+    String key;
+    @Option(displayName = "YAML snippet",
+            description = "The YAML snippet to insert. The snippet will be indented to match the style of its surroundings.",
+            example = "labels: \n\tlabel-one: \"value-one\"")
+    @Language("yml")
+    String yaml;
+
+    @Override
+    public Validated validate() {
+        return super.validate()
+                .and(Validated.test("yaml", "Must be valid YAML",
+                        yaml, y -> {
+                            List<Yaml.Documents> docs = new YamlParser().parse(yaml);
+                            if (docs.size() == 0) {
+                                return false;
+                            }
+                            Yaml.Documents doc = docs.get(0);
+                            if (doc.getDocuments().size() == 0) {
+                                return false;
+                            }
+                            Yaml.Block block = doc.getDocuments().get(0).getBlock();
+                            return block instanceof Yaml.Mapping;
+                        }));
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Merge YAML snippet";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Merge a YAML snippet with an existing YAML document";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        XPathMatcher matcher = new XPathMatcher(key);
+        Yaml.Mapping incoming = (Yaml.Mapping) new YamlParser().parse(yaml).get(0).getDocuments().get(0).getBlock();
+
+        return new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.visitMappingEntry(entry, ctx);
+                if (matcher.matches(getCursor())) {
+                    doAfterVisit(new MergeYamlVisitor(getCursor().getParentOrThrow().getValue(), incoming));
+                    doAfterVisit(new AutoFormatVisitor<>(e));
+                }
+                return e;
+            }
+        };
+    }
+
+}

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -1,0 +1,81 @@
+package org.openrewrite.yaml;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
+
+@RequiredArgsConstructor
+public class MergeYamlVisitor extends YamlVisitor<ExecutionContext> {
+    final Yaml scope;
+    final Yaml incoming;
+
+    @Override
+    public Yaml visitScalar(Yaml.Scalar existingScalar, ExecutionContext executionContext) {
+        if (!scope.isScope(existingScalar)) {
+            return super.visitScalar(existingScalar, executionContext);
+        }
+        return mergeScalar(existingScalar, (Yaml.Scalar) incoming);
+    }
+
+    @Override
+    public Yaml visitSequence(Yaml.Sequence existingSeq, ExecutionContext ctx) {
+        if (!scope.isScope(existingSeq)) {
+            return super.visitSequence(existingSeq, ctx);
+        }
+        return mergeSequence(existingSeq, (Yaml.Sequence) incoming, ctx, getCursor());
+    }
+
+    @Override
+    public Yaml visitMapping(Yaml.Mapping existingMapping, ExecutionContext ctx) {
+        if (!scope.isScope(existingMapping)) {
+            return super.visitMapping(existingMapping, ctx);
+        }
+
+        return mergeMapping(existingMapping, (Yaml.Mapping) incoming, ctx, getCursor());
+    }
+
+    private static boolean keyMatches(Yaml.Mapping.Entry e1, Yaml.Mapping.Entry e2) {
+        return e1.getKey().getValue().equals(e2.getKey().getValue());
+    }
+
+    private static Yaml.Mapping mergeMapping(Yaml.Mapping m1, Yaml.Mapping m2, ExecutionContext ctx, Cursor cursor) {
+        List<Yaml.Mapping.Entry> mutatedEntries = ListUtils.map(m1.getEntries(), existingEntry -> {
+            return m2.getEntries().stream()
+                    .filter(incomingEntry -> keyMatches(existingEntry, incomingEntry))
+                    .findFirst()
+                    .map(incomingEntry -> {
+                        return existingEntry.withValue((Yaml.Block) new MergeYamlVisitor(existingEntry.getValue(), incomingEntry.getValue())
+                                .visit(existingEntry.getValue(), ctx, cursor));
+                    })
+                    .orElse(existingEntry);
+        });
+        return m1.withEntries(mutatedEntries);
+    }
+
+    private static Yaml.Sequence mergeSequence(Yaml.Sequence existingSeq, Yaml.Sequence incomingSeq, ExecutionContext ctx, Cursor cursor) {
+        AtomicInteger idx = new AtomicInteger(0);
+        List<Yaml.Sequence.Entry> incomingEntries = incomingSeq.getEntries();
+        List<Yaml.Sequence.Entry> entries = ListUtils.map(existingSeq.getEntries(), existingSeqEntry -> {
+            Yaml.Sequence.Entry incomingEntry = incomingEntries.get(idx.getAndIncrement());
+            Yaml.Block b = (Yaml.Block) new MergeYamlVisitor(existingSeqEntry.getBlock(), incomingEntry.getBlock())
+                    .visit(existingSeqEntry.getBlock(), ctx, cursor);
+            return existingSeqEntry.withBlock(requireNonNull(b));
+        });
+        return existingSeq.withEntries(entries);
+    }
+
+    private static Yaml.Scalar mergeScalar(Yaml.Scalar y1, Yaml.Scalar y2) {
+        String s1 = y1.getValue();
+        String s2 = y2.getValue();
+        return !s1.equals(s2) ? y1.withValue(s2) : y1;
+
+    }
+
+}

--- a/rewrite-yaml/src/test/kotlin/MergeYamlTest.kt
+++ b/rewrite-yaml/src/test/kotlin/MergeYamlTest.kt
@@ -1,0 +1,97 @@
+import org.junit.jupiter.api.Test
+import org.openrewrite.yaml.MergeYaml
+import org.openrewrite.yaml.YamlRecipeTest
+
+class MergeYamlTest : YamlRecipeTest {
+
+    @Test
+    fun mustMergeYamlWhenBlockExists() = assertChanged(
+        recipe = MergeYaml(
+            "/spec/lifecycleRule",
+            """
+            lifecycleRule:
+                - condition:
+                    age: 7
+            """.trimIndent()
+        ),
+        before = """
+            apiVersion: storage.cnrm.cloud.google.com/v1beta1
+            kind: StorageBucket
+            spec:
+                bucketPolicyOnly: true
+                lifecycleRule:
+                    - action:
+                          type: Delete
+                      condition:
+                          age: 1
+        """,
+        after = """
+            apiVersion: storage.cnrm.cloud.google.com/v1beta1
+            kind: StorageBucket
+            spec:
+                bucketPolicyOnly: true
+                lifecycleRule:
+                    - action:
+                          type: Delete
+                      condition:
+                          age: 7
+        """,
+        cycles = 2
+    )
+
+    @Test
+    fun mustMergeYamlWhenBlockDoesntExist() = assertChanged(
+        recipe = MergeYaml(
+            "/spec/lifecycleRule",
+            """
+              lifecycleRule:
+                  - action:
+                        type: Delete
+                    condition:
+                        age: 7
+            """.trimIndent()
+        ),
+        before = """
+            apiVersion: storage.cnrm.cloud.google.com/v1beta1
+            kind: StorageBucket
+            spec:
+                bucketPolicyOnly: true
+        """,
+        after = """
+            apiVersion: storage.cnrm.cloud.google.com/v1beta1
+            kind: StorageBucket
+            spec:
+                bucketPolicyOnly: true
+                lifecycleRule:
+                    - action:
+                          type: Delete
+                      condition:
+                          age: 7
+        """,
+        cycles = 2
+    )
+
+    @Test
+    fun mustMergeYamlForScalar() = assertChanged(
+        recipe = MergeYaml(
+            "/spec/bucketPolicyOnly",
+            """
+              bucketPolicyOnly: true
+            """.trimIndent()
+        ),
+        before = """
+            apiVersion: storage.cnrm.cloud.google.com/v1beta1
+            kind: StorageBucket
+            spec:
+                bucketPolicyOnly: false
+        """,
+        after = """
+            apiVersion: storage.cnrm.cloud.google.com/v1beta1
+            kind: StorageBucket
+            spec:
+                bucketPolicyOnly: true
+        """,
+        cycles = 2
+    )
+
+}


### PR DESCRIPTION
In order to accommodate use cases where we need to make complex changes to YAML, it is needed to have a `MergeYamlVisitor` that perform a deep merge on an object.