### PR TITLE
fix(camelcase): do not rewrite instance variables of anonymous inner classes

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenameLocalVariablesToCamelCase.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenameLocalVariablesToCamelCase.java
@@ -86,6 +86,8 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
 
             // Does not currently support renaming fields in a J.ClassDeclaration.
             if (!(parentScope.getParent() != null && parentScope.getParent().getValue() instanceof J.ClassDeclaration) &&
+                    // Does not apply for instance variables of anonymous inner classes
+                    !(parentScope.getParent().getValue() instanceof J.NewClass) &&
                     // Does not apply to for loop controls.
                     !(parentScope.getValue() instanceof J.ForLoop.Control) &&
                     // Does not apply to catches with 1 character.

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RenameLocalVariablesToCamelCaseTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RenameLocalVariablesToCamelCaseTest.kt
@@ -142,4 +142,23 @@ interface RenameLocalVariablesToCamelCaseTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun doNotRenameConstantVariable(jp: JavaParser) = assertUnchanged(
+            jp,
+            before = """
+            import java.util.ArrayList;
+            import java.util.List;
+            class Test {
+                public List<String> testFoo() {
+                    return new ArrayList<>() {
+                        private final int DO_NOT_CHANGE = 1;
+                   
+                    };
+                    
+                }
+            }
+
+        """
+    )
 }


### PR DESCRIPTION
### Problem
[While testing rename](https://github.com/openrewrite/rewrite-testing-frameworks/compare/refactor/reformat-local-variable-names-to-camel-case-Un436?w=1) local variables to camel test, discovered that recipe was making changes to instance variables in anonymous inner classes.

### Solution
Exclude rewriting variables if within anon. inner class