### PR TITLE
Append `.` to pkg in longest common prefix in Autodetect#getPattern. …

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -263,7 +263,7 @@ public class Autodetect extends NamedStyles {
                 String longestCommonPrefix = null;
 
                 for (J.Import anImport : imports) {
-                    String pkg = anImport.getPackageName();
+                    String pkg = anImport.getPackageName() + ".";
                     longestCommonPrefix = longestCommonPrefix(pkg, longestCommonPrefix);
                     if (longestCommonPrefix.isEmpty()) {
                         return "all other imports";

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
@@ -721,5 +721,25 @@ interface OrderImportsTest : JavaRecipeTest {
             }
         """.trimIndent()
     )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/733")
+    @Test
+    fun detectBlockPattern(jp: JavaParser) = assertUnchanged(
+        jp,
+        recipe = recipe.withRemoveUnused(false),
+        before = """
+            package org.bar;
+            
+            // org.slf4j should be detected as a block pattern, and not be moved to all other imports.
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+            
+            import java.util.Arrays;
+            import java.util.List;
+            
+            public class C {
+            }
+        """
+    )
 }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/style/AutodetectTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/style/AutodetectTest.kt
@@ -181,14 +181,14 @@ interface AutodetectTest {
         assertThat(importLayout.layout[2])
             .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
             .matches { b -> !(b as ImportLayoutStyle.Block.ImportPackage).isStatic }
-            .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "com\\.fasterxml\\.jackson\\.annotation.+" }
+            .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "com\\.fasterxml\\.jackson\\.annotation\\..+" }
 
         assertThat(importLayout.layout[3]).isInstanceOf(ImportLayoutStyle.Block.BlankLines::class.java)
 
         assertThat(importLayout.layout[4])
             .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
             .matches { b -> !(b as ImportLayoutStyle.Block.ImportPackage).isStatic }
-            .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "org\\.openrewrite\\.internal.+" }
+            .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "org\\.openrewrite\\.internal\\..+" }
 
         assertThat(importLayout.layout[5]).isInstanceOf(ImportLayoutStyle.Block.BlankLines::class.java)
 


### PR DESCRIPTION
Appends a "." to anImport.getPackageName(), so that package patterns are detected. fixes #733