### PR TITLE
Add helper that Kubernetes recipes will use.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeValueVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeValueVisitor.java
@@ -1,0 +1,41 @@
+package org.openrewrite.yaml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class MergeValueVisitor<B extends Yaml, Y extends Yaml> extends YamlIsoVisitor<ExecutionContext> {
+
+    String xpath;
+    BiPredicate<B, ExecutionContext> shouldMergeFunction;
+    BiFunction<B, ExecutionContext, Y> mergeFunction;
+
+    XPathMatcher matcher;
+
+    public MergeValueVisitor(String xpath,
+                             BiPredicate<B, ExecutionContext> shouldMergeFunction,
+                             BiFunction<B, ExecutionContext, Y> mergeFunction) {
+        this.xpath = xpath;
+        this.shouldMergeFunction = shouldMergeFunction;
+        this.mergeFunction = mergeFunction;
+
+        this.matcher = new XPathMatcher(xpath);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext context) {
+        if (matcher.matches(getCursor()) && shouldMergeFunction.test((B) entry.getValue(), context)) {
+            return entry.withValue((Yaml.Block) new MergeYamlVisitor(entry.getValue(), mergeFunction.apply((B) entry.getValue(), context))
+                    .visit(entry.getValue(), context, getCursor()));
+        }
+        return super.visitMappingEntry(entry, context);
+    }
+
+}

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.Marker;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.List;
@@ -89,6 +90,9 @@ public class MergeYamlVisitor extends YamlVisitor<ExecutionContext> {
     private static Yaml.Scalar mergeScalar(Yaml.Scalar y1, Yaml.Scalar y2) {
         String s1 = y1.getValue();
         String s2 = y2.getValue();
+        for (Marker m : y2.getMarkers().entries()) {
+            y1 = y1.withMarkers(y1.getMarkers().addIfAbsent(m));
+        }
         return !s1.equals(s2) ? y1.withValue(s2) : y1;
 
     }


### PR DESCRIPTION
`ChangeValue` currently doesn't include markers, so I needed a helper to merge not only scalar values but the markers as well so it can be used both to find and to search.