### PR TITLE
Add a StringUtils method to match two strings with a glob pattern

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -32,6 +33,8 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
 public class StringUtils {
+    private final static FileSystem FS = FileSystems.getDefault();
+
     private StringUtils() {
     }
 
@@ -369,4 +372,26 @@ public class StringUtils {
         System.arraycopy(multiple, 0, multiple, copied, limit - copied);
         return new String(multiple);
     }
+
+    private static boolean matchesGlob(@Nullable String value, @Nullable String globPattern) {
+        if ("*".equals(globPattern)) {
+            return true;
+        }
+        PathMatcher pm = FS.getPathMatcher("glob:" + globPattern);
+        Path path;
+        if (value != null && value.contains("/")) {
+            String[] parts = value.split("/");
+            if (parts.length > 1) {
+                path = Paths.get(parts[0], Arrays.copyOfRange(parts, 1, parts.length - 1));
+            } else {
+                path = Paths.get(parts[0]);
+            }
+        } else if (value == null) {
+            path = Paths.get("");
+        } else {
+            path = Paths.get(value);
+        }
+        return pm.matches(path);
+    }
+
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -25,10 +25,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static java.util.Arrays.copyOfRange;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
@@ -378,31 +378,26 @@ public class StringUtils {
         if ("*".equals(globPattern)) {
             return true;
         }
-        Function<String, String> normalizeSlashesFn = s -> {
-            if (s.startsWith("//")) {
-                return s.substring(2);
-            } else if (s.startsWith("/")) {
-                return s.substring(1);
-            } else
-                return s;
-        };
-        if (null != value) {
-            value = normalizeSlashesFn.apply(value);
+        if (null == globPattern) {
+            return false;
         }
-        if (null != globPattern) {
-            globPattern = normalizeSlashesFn.apply(globPattern);
+        if (null == value) {
+            value = "";
         }
         PathMatcher pm = FS.getPathMatcher("glob:" + globPattern);
-        Path path;
-        if (value != null && value.contains("/")) {
+        Path path = Paths.get("");
+        if (value.contains("/")) {
             String[] parts = value.split("/");
-            if (parts.length > 0 && StringUtils.isBlank(parts[0])) {
-                path = Paths.get("", Arrays.copyOfRange(parts, 1, parts.length - 1));
+            if (parts.length > 1) {
+                for (int i = 0, len = parts.length; i < len; i++) {
+                    path = Paths.get("", copyOfRange(parts, i, parts.length));
+                    if (!isBlank(parts[i])) {
+                        break;
+                    }
+                }
             } else {
-                path = Paths.get("", parts);
+                path = Paths.get(parts[0]);
             }
-        } else if (value == null) {
-            path = Paths.get("");
         } else {
             path = Paths.get(value);
         }

--- a/rewrite-core/src/test/kotlin/org/openrewrite/internal/StringUtilsTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/internal/StringUtilsTest.kt
@@ -174,8 +174,8 @@ class StringUtilsTest {
     fun globMatching() {
         assertThat(matchesGlob("expression", "expr*")).isTrue()
         assertThat(matchesGlob("some/xpath", "some/*")).isTrue()
-        assertThat(matchesGlob("/some/xpath/expression", "/some/**")).isTrue()
-        assertThat(matchesGlob("//some/xpath/expression", "*/xpath/*")).isTrue()
+        assertThat(matchesGlob("some/xpath/expression", "some/**")).isTrue()
+        assertThat(matchesGlob("//some/xpath/expression", "**/xpath/*")).isTrue()
     }
 
 }

--- a/rewrite-core/src/test/kotlin/org/openrewrite/internal/StringUtilsTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/internal/StringUtilsTest.kt
@@ -169,4 +169,13 @@ class StringUtilsTest {
         assertThat(countOccurrences("nonononono", "yo")).isEqualTo(0)
         assertThat(countOccurrences("", "")).isEqualTo(0)
     }
+
+    @Test
+    fun globMatching() {
+        assertThat(matchesGlob("expression", "expr*")).isTrue()
+        assertThat(matchesGlob("some/xpath", "some/*")).isTrue()
+        assertThat(matchesGlob("/some/xpath/expression", "/some/**")).isTrue()
+        assertThat(matchesGlob("//some/xpath/expression", "*/xpath/*")).isTrue()
+    }
+
 }


### PR DESCRIPTION
In order to do glob matching in recipe options we need to encapsulate the non-trivial task of evaluating two strings to see if they match based on a glob expression. Internally, this uses the JDK's `PathMatcher` and only supports the `glob:` syntax. 

This makes it possible to specify recipe options as:

`somevalue-*` and when you visit the scalar in the recipe, use this check to evaluate if the value matches the pattern.