### PR TITLE
Update EmptyForInitializerPad from rewrite-checkstyle into modern cleanup recipe. Closes #749

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/style/StyleHelper.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/StyleHelper.java
@@ -43,6 +43,11 @@ public class StyleHelper {
         return type.isPrimitive() || primitiveWrapperClasses.contains(type);
     }
 
+    private static boolean isEnum(Object value) {
+        Class<?> type = value.getClass();
+        return type.isEnum();
+    }
+
     /**
      * Copies all non-null properties from right into left, recursively. Assumes use of @With from project lombok.
      *
@@ -68,7 +73,7 @@ public class StyleHelper {
             try {
                 Object rightValue = getter.invoke(right);
                 if (rightValue != null) {
-                    if (!isPrimitiveOrWrapper(rightValue)) {
+                    if (!isPrimitiveOrWrapper(rightValue) && !isEnum(rightValue)) {
                         Object leftValue = getter.invoke(left);
                         rightValue = merge(leftValue, rightValue);
                     }

--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -115,6 +115,10 @@ class Java11EmptyBlockTest : Java11Test, EmptyBlockTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11EmptyForInitializerPadTest : Java11Test, EmptyForInitializerPadTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11EqualsAvoidsNullTest : Java11Test, EqualsAvoidsNullTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -115,6 +115,10 @@ class Java8EmptyBlockTest : Java8Test, EmptyBlockTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8EmptyForInitializerPadTest : Java8Test, EmptyForInitializerPadTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8EqualsAvoidsNullTest : Java8Test, EqualsAvoidsNullTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyForInitializerPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyForInitializerPad.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.style.PadPolicy;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+
+public class EmptyForInitializerPad extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Empty for initializer padding";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fixes the whitespace of an empty for initializer. Adds or removes this whitespace according to `CheckstyleStyle.getEmptyForInitializer()`";
+    }
+
+    @Override
+    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private PadPolicy option = null;
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                EmptyForInitializerStyle style = cu.getStyle(EmptyForInitializerStyle.class);
+                if(style == null) {
+                    return cu;
+                }
+                option = style.getOption();
+                return super.visitCompilationUnit(cu, executionContext);
+            }
+
+            @Override
+            public J.ForLoop visitForLoop(J.ForLoop f, ExecutionContext executionContext) {
+                J.ForLoop.Control control = f.getControl();
+                Statement init = control.getInit();
+                Space prefix = init.getPrefix();
+                String whitespace = prefix.getWhitespace();
+                if(!whitespace.contains("\n") && init instanceof J.Empty) {
+                    if(option == PadPolicy.NOSPACE && !whitespace.isEmpty()) {
+                        f = f.withControl(control.withInit(init.withPrefix(prefix.withWhitespace(""))));
+                    } else if(option == PadPolicy.SPACE && !whitespace.equals(" ")) {
+                        f = f.withControl(control.withInit(init.withPrefix(prefix.withWhitespace(" "))));
+                    }
+                }
+                return f;
+            }
+        };
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyForInitializerStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyForInitializerStyle.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.java.JavaStyle;
+import org.openrewrite.java.style.PadPolicy;
+import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
+
+@Value
+@With
+public class EmptyForInitializerStyle implements JavaStyle {
+    private static final EmptyForInitializerStyle INSTANCE =
+            new EmptyForInitializerStyle(
+                   PadPolicy.NOSPACE
+            );
+
+    @JsonCreator
+    public static EmptyForInitializerStyle defaults() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Style applyDefaults() {
+        return StyleHelper.merge(INSTANCE, this);
+    }
+
+    PadPolicy option;
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/PadPolicy.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/PadPolicy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.style;
+
+public enum PadPolicy {
+    /**
+     * Do not pad. For example, method(a, b);
+     */
+    NOSPACE,
+
+    /**
+     * Ensure padding. For example, method( a, b );
+     */
+    SPACE
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -98,6 +98,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class EmptyBlockTck : EmptyBlockTest
 
     @Nested
+    inner class EmptyForInitializerTck : EmptyForInitializerPadTest
+
+    @Nested
     inner class EqualsAvoidsNullTck : EqualsAvoidsNullTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EmptyForInitializerPadTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EmptyForInitializerPadTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.Tree
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.java.style.PadPolicy
+import org.openrewrite.style.NamedStyles
+
+interface EmptyForInitializerPadTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = EmptyForInitializerPad()
+
+    @Test
+    fun noSpaceInitializerPadding(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    for (; i < j; i++, j--);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun spaceInitializerPadding(jp: JavaParser.Builder<*, *>) = assertChanged(
+        jp.styles(
+            listOf(
+                NamedStyles(
+                    Tree.randomId(), "test", "test", "test", emptySet(),
+                    listOf(EmptyForInitializerStyle(PadPolicy.SPACE))
+                )
+            )
+        ).build(),
+        before = """
+            public class A {
+                {
+                    for (; i < j; i++, j--);
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    for ( ; i < j; i++, j--);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun noCheckIfInitializerStartsWithLineTerminator(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    for (
+                          ; i < j; i++, j--);
+                }
+            }
+        """
+    )
+}


### PR DESCRIPTION
I'm not entirely sure if this is how we want to represent the old checkstyle policies as `JavaStyle`s. Maybe it should just be a `Boolean`, rather than a whole `PadPolicy` enum? 