### PR TITLE
String Literal Equality cleanup

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -291,6 +291,10 @@ class Java11TypeTreeTest : Java11Test, TypeTreeTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11StringLiteralEqualityTest : Java11Test, StringLiteralEqualityTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11UnnecessaryExplicitTypeArgumentsTest : Java11Test, UnnecessaryExplicitTypeArgumentsTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -287,6 +287,10 @@ class Java8TypeTreeTest : Java8Test, TypeTreeTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8StringLiteralEqualityTest : Java8Test, StringLiteralEqualityTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8UnnecessaryExplicitTypeArgumentsTest : Java8Test, UnnecessaryExplicitTypeArgumentsTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/StringLiteralEquality.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/StringLiteralEquality.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+import java.util.Objects;
+
+public class StringLiteralEquality extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Use `String.equals()` on String literals";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`String.equals()` should be used when checking value equality on String literals. " +
+                "Using `==` or `!=` compares object references, not the actual value of the Strings. " +
+                "This only modifies code where at least one side of the binary operation (`==` or `!=`) is a String literal, such as `\"someString\" == someVariable;`. " +
+                "This is to prevent inadvertently changing code where referential equality is the user's intent.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>("java.lang.String");
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new StringLiteralEqualityVisitor();
+    }
+
+    private static class StringLiteralEqualityVisitor extends JavaVisitor<ExecutionContext> {
+        private static final JavaType.FullyQualified TYPE_STRING = TypeUtils.asFullyQualified(JavaType.buildType("java.lang.String"));
+        private static final JavaType TYPE_OBJECT = JavaType.buildType("java.lang.Object");
+        private static final JavaType.Method.Signature INVOCATION_SIGNATURE = new JavaType.Method.Signature(JavaType.Primitive.Boolean, Collections.singletonList(TYPE_OBJECT));
+
+        private static boolean isStringLiteral(Expression expression) {
+            return expression instanceof J.Literal && TypeUtils.isString(((J.Literal) expression).getType());
+        }
+
+        /**
+         * Transform a binary expression into a method invocation on String.equals. For example,
+         * <p>
+         * {@code "foo" == "bar"} into {@code "foo".equals("bar")}
+         */
+        private static J.MethodInvocation asEqualsMethodInvocation(J.Binary binary) {
+            return new J.MethodInvocation(
+                    Tree.randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    new JRightPadded<>(binary.getLeft().withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY),
+                    null,
+                    J.Identifier.build(Tree.randomId(), Space.EMPTY, Markers.EMPTY, "equals", JavaType.Primitive.Boolean),
+                    JContainer.build(Collections.singletonList(new JRightPadded<>(binary.getRight().withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY))),
+                    JavaType.Method.build(
+                            Collections.singleton(Flag.Public),
+                            Objects.requireNonNull(TYPE_STRING),
+                            "equals",
+                            INVOCATION_SIGNATURE,
+                            INVOCATION_SIGNATURE,
+                            Collections.singletonList("o"),
+                            Collections.emptyList()
+                    )
+            );
+        }
+
+        /**
+         * Wrap a method invocation within a negated unary expression. For example,
+         * <p>
+         * {@code "foo".equals("bar")} into {@code !"foo".equals("bar")}
+         */
+        private static J.Unary asNegatedUnary(J.MethodInvocation mi) {
+            return new J.Unary(
+                    Tree.randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    new JLeftPadded<>(Space.EMPTY, J.Unary.Type.Not, Markers.EMPTY),
+                    mi,
+                    JavaType.Primitive.Boolean
+            );
+        }
+
+        @Override
+        public J visitBinary(J.Binary binary, ExecutionContext ctx) {
+            if (isStringLiteral(binary.getLeft()) || isStringLiteral(binary.getRight())) {
+                switch (binary.getOperator()) {
+                    case Equal:
+                        return asEqualsMethodInvocation(binary);
+                    case NotEqual:
+                        J.MethodInvocation mi = asEqualsMethodInvocation(binary);
+                        return asNegatedUnary(mi);
+                }
+            }
+
+            return super.visitBinary(binary, ctx);
+        }
+
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -230,6 +230,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class TypeTreeTck : TypeTreeTest
 
     @Nested
+    inner class StringLiteralEqualityTestTck : StringLiteralEqualityTest
+
+    @Nested
     inner class UnnecessaryExplicitTypeArgumentsTck : UnnecessaryExplicitTypeArgumentsTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/StringLiteralEqualityTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/StringLiteralEqualityTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+@Suppress(
+    "RedundantStringOperation",
+    "ConstantConditions",
+    "NewObjectEquality",
+    "StatementWithEmptyBody",
+    "LoopConditionNotUpdatedInsideLoop",
+    "EqualsWithItself"
+)
+interface StringLiteralEqualityTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = StringLiteralEquality()
+
+    @Test
+    fun stringLiteralEqualityReplacedWithEquals() = assertChanged(
+        before = """
+            class Test {
+                public String getString() {
+                    return "stringy";
+                }
+
+                public void method(String str) {
+                    if (str == "test") ;
+                    if ("test" == str) ;
+                    if ("test" == "test") ;
+                    if ("test" == new String("test")) ;
+                    if ("test" == getString());
+                    boolean flag = (str == "test");
+                    while ("test" == str) {
+                    }
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public String getString() {
+                    return "stringy";
+                }
+
+                public void method(String str) {
+                    if (str.equals("test")) ;
+                    if ("test".equals(str)) ;
+                    if ("test".equals("test")) ;
+                    if ("test".equals(new String("test"))) ;
+                    if ("test".equals(getString()));
+                    boolean flag = (str.equals("test"));
+                    while ("test".equals(str)) {
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun stringLiteralEqualityReplacedWithNotEquals() = assertChanged(
+        before = """
+            class Test {
+                public String getString() {
+                    return "stringy";
+                }
+
+                public void method(String str) {
+                    if (str != "test") ;
+                    if ("test" != str) ;
+                    if ("test" != "test") ;
+                    if ("test" != new String("test")) ;
+                    if ("test" != getString());
+                    boolean flag = (str != "test");
+                    while ("test" != str) {
+                    }
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public String getString() {
+                    return "stringy";
+                }
+
+                public void method(String str) {
+                    if (!str.equals("test")) ;
+                    if (!"test".equals(str)) ;
+                    if (!"test".equals("test")) ;
+                    if (!"test".equals(new String("test"))) ;
+                    if (!"test".equals(getString()));
+                    boolean flag = (!str.equals("test"));
+                    while (!"test".equals(str)) {
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun changeNotNeeded() = assertUnchanged(
+        before = """
+            class Test {
+                public String getString() {
+                    return "stringy";
+                }
+
+                public void method(String str0, String str1) {
+                    if (str0 == new String("str0")) ;
+                    if (str1 != new String("str1")) ;
+                    if (str0 == str1) ;
+                    if (getString() == str0) ;
+                    if (str1 != str0) ;
+                    if (getString() != str1) ;
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Use `String.equals()` for value equality

see: http://cwe.mitre.org/data/definitions/597.html
see: https://rules.sonarsource.com/java/tag/suspicious/RSPEC-1698

<!--
This manually constructs the return of a method invocation, but in lieu of template coordinates (and since the return type is simple (just `java.lang.object`)), we construct the return manually. Not the end of the world. Plus, hey, free example of manually constructing a method invocation return type.

see: https://github.com/openrewrite/rewrite-checkstyle/blob/master/src/main/java/org/openrewrite/checkstyle/StringLiteralEquality.java
see: https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/
https://www.geeksforgeeks.org/difference-equals-method-java/
-->


Note: changing this from the original implementation to have the left-hand and right-hand operators remain in the same position. E.g., `str == "string"` should be `str.equals("string")`, and not change it to `"string".equals(str)`-- that may not necessarily be desired by end-users, and the functionality can be activated using `EqualsAvoidNull`. Additionally, fixing when the operator is notequals. This didn't handle != previously, but now it does, all good