### PR TITLE
No Finalizer cleanup

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -211,6 +211,10 @@ class Java11ModifierOrderTest : Java11Test, ModifierOrderTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11NoFinalizerTest : Java11Test, NoFinalizerTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11NormalizeFormatTest : Java11Test, NormalizeFormatTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -207,6 +207,10 @@ class Java8ModifierOrderTest : Java8Test, ModifierOrderTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8NoFinalizerTest : Java8Test, NoFinalizerTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8NormalizeFormatTest : Java8Test, NormalizeFormatTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoFinalizer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoFinalizer.java
@@ -26,12 +26,12 @@ import org.openrewrite.java.tree.J;
 public class NoFinalizer extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Remove `finalize()` finalizer method.";
+        return "Remove `finalize()` method";
     }
 
     @Override
     public String getDescription() {
-        return "Finalizers are problematic, and their use can lead to performance issues, deadlocks, hangs, and other unnecessary behavior.";
+        return "Finalizers are deprecated. Use of `finalize()` can lead to performance issues, deadlocks, hangs, and other undesirable behavior.";
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoFinalizer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoFinalizer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+
+public class NoFinalizer extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Remove `finalize()` method declarations.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Finalizers are problematic, and their use can lead to performance issues, deadlocks, hangs, and other unnecessary behavior.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new NoFinalizerVisitor();
+    }
+
+    private static class NoFinalizerVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private static final MethodMatcher FINALIZER = new MethodMatcher("java.lang.Object finalize()");
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+            if (FINALIZER.matches(method, getCursor().firstEnclosingOrThrow(J.ClassDeclaration.class))) {
+                return null;
+            }
+            return super.visitMethodDeclaration(method, ctx);
+        }
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -173,6 +173,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class ModifierOrderTck : ModifierOrderTest
 
     @Nested
+    inner class NoFinalizerTck : NoFinalizerTest
+
+    @Nested
     inner class NormalizeFormatTck : NormalizeFormatTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/NoFinalizerTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/NoFinalizerTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+interface NoFinalizerTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = NoFinalizer()
+
+    @Test
+    fun noFinalizer() = assertChanged(
+        before = """
+            class Test {
+                public void method() {
+                }
+
+                @Override
+                protected void finalize() throws Throwable {
+                    super.finalize();
+                }
+
+                protected void finalize(Object param) throws Throwable {
+                    super.finalize();
+                }
+            }
+        """,
+        after = """
+            class Test {
+                public void method() {
+                }
+
+                protected void finalize(Object param) throws Throwable {
+                    super.finalize();
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Removes overridden/implemented method declarations of https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#finalize()