### PR TITLE
Provide a utility for loading checkstyle configuration xml into Rewrite styles. Closes #779 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,7 +206,8 @@ subprojects {
             publications {
                 named("nebula", MavenPublication::class.java) {
                     suppressPomMetadataWarningsFor("runtimeElements")
-
+                    suppressPomMetadataWarningsFor("checkstyleApiElements")
+                    suppressPomMetadataWarningsFor("checkstyleRuntimeElements")
                     pom.withXml {
                         (asElement().getElementsByTagName("dependencies")
                             .item(0) as org.w3c.dom.Element).let { dependencies ->

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -11,6 +11,24 @@ tasks.register<JavaExec>("generateAntlrSources") {
     classpath = sourceSets["main"].runtimeClasspath
 }
 
+// So as to ensure that com.puppycrawl.tools:checkstyle is truly an optional dependency, keep things that depend on it in their own sourceSet
+sourceSets {
+    create("checkstyle") {
+        compileClasspath += sourceSets.getByName("main").output
+        runtimeClasspath += sourceSets.getByName("main").output
+    }
+    named("test") {
+        compileClasspath += sourceSets.getByName("checkstyle").output
+        runtimeClasspath += sourceSets.getByName("checkstyle").output
+    }
+}
+
+java {
+    registerFeature("checkstyle") {
+        usingSourceSet(sourceSets.getByName("checkstyle"))
+    }
+}
+
 dependencies {
     api(project(":rewrite-core"))
 
@@ -18,7 +36,8 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
 
     implementation("org.antlr:antlr4:4.8-1")
-    implementation("com.puppycrawl.tools:checkstyle:latest.release")
+    "checkstyleImplementation"("com.puppycrawl.tools:checkstyle:latest.release")
+    "checkstyleImplementation"(project(":rewrite-core"))
     implementation("commons-lang:commons-lang:latest.release")
 
     api("com.fasterxml.jackson.core:jackson-annotations:2.12.+")
@@ -27,6 +46,11 @@ dependencies {
     implementation("org.ow2.asm:asm-util:latest.release")
 
     testImplementation("org.yaml:snakeyaml:latest.release")
+    testImplementation("com.puppycrawl.tools:checkstyle:latest.release")
+}
+
+tasks.named<Jar>("jar") {
+    from(sourceSets.getByName("checkstyle").output)
 }
 
 tasks.withType<Javadoc> {

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
 
     implementation("org.antlr:antlr4:4.8-1")
-
+    implementation("com.puppycrawl.tools:checkstyle:latest.release")
     implementation("commons-lang:commons-lang:latest.release")
 
     api("com.fasterxml.jackson.core:jackson-annotations:2.12.+")

--- a/rewrite-java/src/checkstyle/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
+++ b/rewrite-java/src/checkstyle/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.style;
+
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.intellij.lang.annotations.Language;
+import org.openrewrite.java.cleanup.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.xml.sax.InputSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static java.lang.Boolean.parseBoolean;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.*;
+import static org.openrewrite.java.style.Checkstyle.defaultBlockPolicy;
+
+public class CheckstyleConfigLoader {
+    private CheckstyleConfigLoader() {}
+
+    public static Checkstyle loadCheckstyleConfig(Path checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
+        try(InputStream is = Files.newInputStream(checkstyleConf)) {
+            return loadCheckstyleConfig(is, properties);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Checkstyle loadCheckstyleConfig(@Language("XML") String checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
+        try(InputStream is = new ByteArrayInputStream(checkstyleConf.getBytes(UTF_8))) {
+            return loadCheckstyleConfig(is, properties);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Checkstyle loadCheckstyleConfig(InputStream checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
+        Map<String, Module> conf = loadConfiguration(checkstyleConf, properties);
+
+        return new Checkstyle(Stream.of(
+                defaultComesLast(conf),
+                emptyBlock(conf),
+                equalsAvoidsNull(conf),
+                explicitInitialization(conf),
+                fallThrough(conf),
+                hiddenFieldStyle(conf),
+                hideUtilityClassConstructorStyle(conf),
+                unnecessaryParentheses(conf)
+        )
+                .filter(Objects::nonNull)
+                .collect(toSet()));
+    }
+
+    @Nullable
+    private static DefaultComesLastStyle defaultComesLast(Map<String, Module> conf) {
+        Module defaultComesLastRaw = conf.get("DefaultComesLast");
+        if(defaultComesLastRaw == null) {
+            return null;
+        }
+        return new DefaultComesLastStyle(parseBoolean(defaultComesLastRaw.properties.get("skipIfLastAndSharedWithCase")));
+    }
+
+    @Nullable
+    private static EmptyBlockStyle emptyBlock(Map<String, Module> conf) {
+        Module emptyBlockRaw = conf.get("EmptyBlock");
+        if(emptyBlockRaw == null) {
+            return null;
+        }
+        String rawOption = emptyBlockRaw.properties.get("option");
+        EmptyBlockStyle.BlockPolicy blockPolicy = defaultBlockPolicy;
+        if(rawOption != null) {
+            blockPolicy = Enum.valueOf(EmptyBlockStyle.BlockPolicy.class, rawOption.toUpperCase());
+        }
+        String rawTokens = emptyBlockRaw.properties.get("tokens");
+        boolean instanceInit = true;
+        boolean literalCatch = true;
+        boolean literalDo = true;
+        boolean literalElse = true;
+        boolean literalFinally = true;
+        boolean literalFor = true;
+        boolean literalIf = true;
+        boolean literalSwitch = true;
+        boolean literalSynchronized = true;
+        boolean literalTry = true;
+        boolean literalWhile = true;
+        boolean staticInit = true;
+        if(rawTokens != null) {
+            Set<String> tokens = Arrays.stream(rawTokens.split("\\s*,\\s*"))
+                    .collect(toSet());
+            instanceInit = tokens.contains("INSTANCE_INIT");
+            literalCatch = tokens.contains("LITERAL_CATCH");
+            literalDo = tokens.contains("LITERAL_DO");
+            literalElse = tokens.contains("LITERAL_ELSE");
+            literalFinally = tokens.contains("LITERAL_FINALLY");
+            literalFor = tokens.contains("LITERAL_FOR");
+            literalIf = tokens.contains("LITERAL_IF");
+            literalSwitch = tokens.contains("LITERAL_SWITCH");
+            literalSynchronized = tokens.contains("LITERAL_SYNCHRONIZED");
+            literalTry = tokens.contains("LITERAL_TRY");
+            literalWhile = tokens.contains("LITERAL_WHILE");
+            staticInit = tokens.contains("STATIC_INIT");
+        }
+
+        return new EmptyBlockStyle(blockPolicy, instanceInit, literalCatch, literalDo,
+                literalElse, literalFinally, literalFor, literalIf, literalSwitch, literalSynchronized, literalTry,
+                literalWhile, staticInit);
+    }
+
+    @Nullable
+    private static EqualsAvoidsNullStyle equalsAvoidsNull(Map<String, Module> conf) {
+        Module module = conf.get("EqualsAvoidsNull");
+        if(module == null) {
+            return null;
+        }
+        return new EqualsAvoidsNullStyle(module.prop("ignoreEqualsIgnoreCase", false));
+    }
+
+
+    @Nullable
+    private static FallThroughStyle fallThrough(Map<String, Module> conf) {
+        Module module = conf.get("FallThrough");
+        if(module == null) {
+            return null;
+        }
+        return new FallThroughStyle(module.prop("checkLastCaseGroup", false));
+    }
+
+    @Nullable
+    private static HiddenFieldStyle hiddenFieldStyle(Map<String, Module> conf) {
+        Module module = conf.get("HiddenField");
+        if(module == null) {
+            return null;
+        }
+        return new HiddenFieldStyle(
+                module.prop("ignoreConstructorParameter", false),
+                module.prop("ignoreSetter", false),
+                module.prop("setterCanReturnItsClass", false),
+                module.prop("ignoreAbstractMethods", false)
+        );
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    @Nullable
+    private static UnnecessaryParenthesesStyle unnecessaryParentheses(Map<String, Module> conf) {
+        Module module = conf.get("UnnecessaryParentheses");
+        if(module == null) {
+            return null;
+        }
+        String rawTokens = module.properties.get("tokens");
+        boolean expr = true;
+        boolean ident = true;
+        boolean numDouble = true;
+        boolean numFloat = true;
+        boolean numInt = true;
+        boolean numLong = true;
+        boolean stringLiteral = true;
+        boolean literalNull = true;
+        boolean literalFalse = true;
+        boolean literalTrue = true;
+        boolean assign = true;
+        boolean bitAndAssign = true;
+        boolean bitOrAssign = true;
+        boolean bitShiftRightAssign = true;
+        boolean bitXorAssign = true;
+        boolean divAssign = true;
+        boolean minusAssign = true;
+        boolean modAssign = true;
+        boolean plusAssign = true;
+        boolean shiftLeftAssign = true;
+        boolean shiftRightAssign = true;
+        boolean starAssign = true;
+        boolean lambda = true;
+        if(rawTokens != null) {
+            Set<String> tokens = Arrays.stream(rawTokens.split("\\s*,\\s*"))
+                    .collect(toSet());
+            expr = tokens.contains("EXPR");
+            ident = tokens.contains("IDENT");
+            numDouble = tokens.contains("NUM_DOUBLE");
+            numFloat = tokens.contains("NUM_FLOAT");
+            numInt = tokens.contains("NUM_INT");
+            numLong = tokens.contains("NUM_LONG");
+            stringLiteral = tokens.contains("STRING_LITERAL");
+            literalNull = tokens.contains("LITERAL_NULL");
+            literalFalse = tokens.contains("LITERAL_FALSE");
+            literalTrue = tokens.contains("LITERAL_TRUE");
+            assign = tokens.contains("ASSIGN");
+            bitAndAssign = tokens.contains("BIT_AND_ASSIGN");
+            bitOrAssign = tokens.contains("BIT_OR_ASSIGN");
+            bitShiftRightAssign = tokens.contains("BIT_SHIFT_RIGHT_ASSIGN");
+            bitXorAssign = tokens.contains("BIT_XOR_ASSIGN");
+            divAssign = tokens.contains("DIV_ASSIGN");
+            minusAssign = tokens.contains("MINUS_ASSIGN");
+            modAssign = tokens.contains("MOD_ASSIGN");
+            plusAssign = tokens.contains("PLUS_ASSIGN");
+            shiftLeftAssign = tokens.contains("SHIFT_LEFT_ASSIGN");
+            shiftRightAssign = tokens.contains("SHIFT_RIGHT_ASSIGN");
+            starAssign = tokens.contains("STAR_ASSIGN");
+            lambda = tokens.contains("LAMBDA");
+        }
+        return new UnnecessaryParenthesesStyle(expr, ident, numDouble, numFloat, numInt, numLong, stringLiteral,
+                literalNull, literalFalse, literalTrue, assign, bitAndAssign, bitOrAssign, bitShiftRightAssign,
+                bitXorAssign, divAssign, minusAssign, modAssign, plusAssign, shiftLeftAssign, shiftRightAssign,
+                starAssign, lambda
+        );
+    }
+
+    @Nullable
+    private static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle(Map<String, Module> conf) {
+        Module module = conf.get("HiddenField");
+        if(module == null) {
+            return null;
+        }
+        return Checkstyle.hideUtilityClassConstructorStyle();
+    }
+
+    protected static class Module {
+        private final String name;
+        private final Map<String, String> properties;
+
+        public Module(String name, Map<String, String> properties) {
+            this.name = name;
+            this.properties = properties;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean prop(String key, boolean defaultValue) {
+            return properties.containsKey(key) ? parseBoolean(properties.get(key))
+                    : defaultValue;
+        }
+    }
+
+
+    @Nullable
+    private static ExplicitInitializationStyle explicitInitialization(Map<String, Module> conf) {
+        Module module = conf.get("ExplicitInitialization");
+        if(module == null) {
+            return null;
+        }
+        return new ExplicitInitializationStyle(module.prop("onlyObjectReferences", false));
+    }
+
+    private static Map<String, Module> loadConfiguration(InputStream inputStream, Map<String, Object> properties) throws CheckstyleException {
+        Configuration checkstyleConfig = ConfigurationLoader.loadConfiguration(new InputSource(inputStream),
+                name -> {
+                    Object prop = properties.get(name);
+                    return prop == null ?
+                            name.equals("config_loc") ? "config/checkstyle" : null :
+                            prop.toString();
+                },
+                ConfigurationLoader.IgnoredModulesOptions.OMIT);
+
+        List<Module> modules = new ArrayList<>();
+        for (Configuration firstLevelChild : checkstyleConfig.getChildren()) {
+            if ("TreeWalker".equals(firstLevelChild.getName())) {
+
+                modules.addAll(Arrays.stream(firstLevelChild.getChildren())
+                        .map(child -> {
+                            try {
+                                Map<String, String> props = new HashMap<>();
+                                for (String propertyName : child.getAttributeNames()) {
+                                    props.put(propertyName, child.getAttribute(propertyName));
+                                }
+                                return new Module(child.getName(), props);
+                            } catch (CheckstyleException e) {
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(toList())
+                );
+            } else if("SuppressionFilter".equals(firstLevelChild.getName())) {
+                continue;
+            }else {
+                Map<String, String> props = new HashMap<>();
+                for (String propertyName : firstLevelChild.getAttributeNames()) {
+                    props.put(propertyName, firstLevelChild.getAttribute(propertyName));
+                }
+                modules.add(new Module(firstLevelChild.getName(), props));
+            }
+        }
+
+        return modules.stream()
+                .collect(toMap(Module::getName, identity()));
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/DefaultComesLast.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/DefaultComesLast.java
@@ -19,6 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 public class DefaultComesLast extends Recipe {
@@ -43,7 +44,7 @@ public class DefaultComesLast extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             DefaultComesLastStyle style = cu.getStyle(DefaultComesLastStyle.class);
             if (style == null) {
-                style = DefaultComesLastStyle.defaultComesLastStyle();
+                style = Checkstyle.defaultComesLast();
             }
             doAfterVisit(new DefaultComesLastVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/DefaultComesLastStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/DefaultComesLastStyle.java
@@ -17,29 +17,20 @@ package org.openrewrite.java.cleanup;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.style.StyleHelper;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 @Value
 @With
 public class DefaultComesLastStyle implements Style {
     /**
-     * Whether to allow the default label to be not last if it's evaluation is shared with a case.
+     * Whether to allow the default label to be not last if its evaluation is shared with a case.
      */
     Boolean skipIfLastAndSharedWithCase;
 
     @Override
     public Style applyDefaults() {
-        return StyleHelper.merge(defaultComesLastStyle(), this);
-    }
-
-    /**
-     * The default of what would be part of {@link org.openrewrite.java.style.IntelliJ} (as the time of writing) is to not
-     * inspect on whether the "default" case comes last in a switch block at all. Therefore, it is not included as a default there.
-     *
-     * @return instantiation of DefaultComesLastStyle with default settings.
-     */
-    public static DefaultComesLastStyle defaultComesLastStyle() {
-        return new DefaultComesLastStyle(false);
+        return StyleHelper.merge(Checkstyle.defaultComesLast(), this);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlock.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlock.java
@@ -19,7 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 public class EmptyBlock extends Recipe {
@@ -44,7 +44,7 @@ public class EmptyBlock extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             EmptyBlockStyle style = cu.getStyle(EmptyBlockStyle.class);
             if (style == null) {
-                style = IntelliJ.emptyBlock();
+                style = Checkstyle.emptyBlock();
             }
             doAfterVisit(new EmptyBlockVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlockStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlockStyle.java
@@ -19,9 +19,9 @@ import lombok.Value;
 import lombok.With;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.NullFields;
-import org.openrewrite.java.style.IntelliJ;
-import org.openrewrite.style.StyleHelper;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 @Value
 @With
@@ -50,7 +50,7 @@ public class EmptyBlockStyle implements Style {
          *         // This is a bad coding practice
          *     }
          */
-        Text,
+        TEXT,
 
         /**
          * Require that there is a statement in the block. For example:
@@ -58,11 +58,11 @@ public class EmptyBlockStyle implements Style {
          *         lock.release();
          *     }
          */
-        Statement
+        STATEMENT
     }
 
     @Override
     public Style applyDefaults() {
-        return StyleHelper.merge(IntelliJ.emptyBlock(), this);
+        return StyleHelper.merge(Checkstyle.emptyBlock(), this);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlockVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlockVisitor.java
@@ -218,7 +218,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private boolean isEmptyBlock(Statement blockNode) {
-        return EmptyBlockStyle.BlockPolicy.Statement.equals(emptyBlockStyle.getBlockPolicy()) &&
+        return EmptyBlockStyle.BlockPolicy.STATEMENT.equals(emptyBlockStyle.getBlockPolicy()) &&
                 blockNode instanceof J.Block &&
                 ((J.Block) blockNode).getStatements().isEmpty();
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EqualsAvoidsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EqualsAvoidsNull.java
@@ -19,7 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 public class EqualsAvoidsNull extends Recipe {
@@ -44,7 +44,7 @@ public class EqualsAvoidsNull extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             EqualsAvoidsNullStyle style = cu.getStyle(EqualsAvoidsNullStyle.class);
             if (style == null) {
-                style = IntelliJ.equalsAvoidsNull();
+                style = Checkstyle.equalsAvoidsNull();
             }
             doAfterVisit(new EqualsAvoidsNullVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EqualsAvoidsNullStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EqualsAvoidsNullStyle.java
@@ -16,9 +16,9 @@
 package org.openrewrite.java.cleanup;
 
 import lombok.Value;
-import org.openrewrite.java.style.IntelliJ;
-import org.openrewrite.style.StyleHelper;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 @Value
 public class EqualsAvoidsNullStyle implements Style {
@@ -26,6 +26,6 @@ public class EqualsAvoidsNullStyle implements Style {
 
     @Override
     public Style applyDefaults() {
-        return StyleHelper.merge(IntelliJ.equalsAvoidsNull(), this);
+        return StyleHelper.merge(Checkstyle.equalsAvoidsNull(), this);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EqualsAvoidsNullStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EqualsAvoidsNullStyle.java
@@ -16,10 +16,12 @@
 package org.openrewrite.java.cleanup;
 
 import lombok.Value;
+import lombok.With;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
 import org.openrewrite.style.StyleHelper;
 
+@With
 @Value
 public class EqualsAvoidsNullStyle implements Style {
     Boolean ignoreEqualsIgnoreCase;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitInitialization.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitInitialization.java
@@ -19,7 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 public class ExplicitInitialization extends Recipe {
@@ -44,7 +44,7 @@ public class ExplicitInitialization extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             ExplicitInitializationStyle style = cu.getStyle(ExplicitInitializationStyle.class);
             if (style == null) {
-                style = IntelliJ.explicitInitialization();
+                style = Checkstyle.explicitInitialization();
             }
             doAfterVisit(new ExplicitInitializationVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitInitializationStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitInitializationStyle.java
@@ -16,10 +16,12 @@
 package org.openrewrite.java.cleanup;
 
 import lombok.Value;
+import lombok.With;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
 import org.openrewrite.style.StyleHelper;
 
+@With
 @Value
 public class ExplicitInitializationStyle implements Style {
     Boolean onlyObjectReferences;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitInitializationStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitInitializationStyle.java
@@ -16,9 +16,9 @@
 package org.openrewrite.java.cleanup;
 
 import lombok.Value;
-import org.openrewrite.java.style.IntelliJ;
-import org.openrewrite.style.StyleHelper;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 @Value
 public class ExplicitInitializationStyle implements Style {
@@ -26,6 +26,6 @@ public class ExplicitInitializationStyle implements Style {
 
     @Override
     public Style applyDefaults() {
-        return StyleHelper.merge(IntelliJ.explicitInitialization(), this);
+        return StyleHelper.merge(Checkstyle.explicitInitialization(), this);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThrough.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThrough.java
@@ -19,6 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 public class FallThrough extends Recipe {
@@ -42,7 +43,7 @@ public class FallThrough extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             FallThroughStyle style = cu.getStyle(FallThroughStyle.class);
             if (style == null) {
-                style = FallThroughStyle.fallThroughStyle();
+                style = Checkstyle.fallThrough();
             }
             doAfterVisit(new FallThroughVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThroughStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FallThroughStyle.java
@@ -17,8 +17,9 @@ package org.openrewrite.java.cleanup;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.style.StyleHelper;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 import java.util.regex.Pattern;
 
@@ -38,16 +39,6 @@ public class FallThroughStyle implements Style {
 
     @Override
     public Style applyDefaults() {
-        return StyleHelper.merge(fallThroughStyle(), this);
-    }
-
-    /**
-     * The default of what would be part of {@link org.openrewrite.java.style.IntelliJ} (as of the time of writing) is to not
-     * include this at all. Therefore, it is not included as a default there.
-     *
-     * @return instantiation of {@link FallThroughStyle} with default settings.
-     */
-    public static FallThroughStyle fallThroughStyle() {
-        return new FallThroughStyle(false);
+        return StyleHelper.merge(Checkstyle.fallThrough(), this);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HiddenField.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HiddenField.java
@@ -20,6 +20,7 @@ import org.openrewrite.Incubating;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 @Incubating(since = "7.6.0")
@@ -44,7 +45,7 @@ public class HiddenField extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             HiddenFieldStyle style = cu.getStyle(HiddenFieldStyle.class);
             if (style == null) {
-                style = HiddenFieldStyle.hiddenFieldStyle();
+                style = Checkstyle.hiddenFieldStyle();
             }
             doAfterVisit(new HiddenFieldVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HiddenFieldStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HiddenFieldStyle.java
@@ -21,6 +21,8 @@ import org.openrewrite.Incubating;
 import org.openrewrite.style.StyleHelper;
 import org.openrewrite.style.Style;
 
+import static org.openrewrite.java.style.Checkstyle.hiddenFieldStyle;
+
 @Value
 @With
 @Incubating(since = "7.6.0")
@@ -51,10 +53,4 @@ public class HiddenFieldStyle implements Style {
         return StyleHelper.merge(hiddenFieldStyle(), this);
     }
 
-    /**
-     * @return instantiation of {@link HiddenFieldStyle} with default settings.
-     */
-    public static HiddenFieldStyle hiddenFieldStyle() {
-        return new HiddenFieldStyle(false, false, false, false);
-    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructor.java
@@ -20,6 +20,7 @@ import org.openrewrite.Incubating;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 @Incubating(since = "7.0.0")
@@ -45,7 +46,7 @@ public class HideUtilityClassConstructor extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             HideUtilityClassConstructorStyle style = cu.getStyle(HideUtilityClassConstructorStyle.class);
             if (style == null) {
-                style = HideUtilityClassConstructorStyle.hideUtilityClassConstructorStyle();
+                style = Checkstyle.hideUtilityClassConstructorStyle();
             }
             doAfterVisit(new HideUtilityClassConstructorVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorStyle.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Incubating;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaStyle;
+
+import java.util.Collection;
+
+@Incubating(since = "7.0.0")
+@Value
+@With
+public
+class HideUtilityClassConstructorStyle implements JavaStyle {
+    /**
+     * If any of the annotation signatures are present on the utility class, the visitor will ignore operating on the class.
+     * These should be {@link AnnotationMatcher}-compatible, fully-qualified annotation signature strings.
+     */
+    Collection<String> ignoreIfAnnotatedBy;
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorStyle.java
@@ -26,8 +26,7 @@ import java.util.Collection;
 @Incubating(since = "7.0.0")
 @Value
 @With
-public
-class HideUtilityClassConstructorStyle implements JavaStyle {
+public class HideUtilityClassConstructorStyle implements JavaStyle {
     /**
      * If any of the annotation signatures are present on the utility class, the visitor will ignore operating on the class.
      * These should be {@link AnnotationMatcher}-compatible, fully-qualified annotation signature strings.

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.cleanup;
 
-import lombok.Value;
-import lombok.With;
 import org.openrewrite.Incubating;
 import org.openrewrite.java.*;
 import org.openrewrite.java.tree.J;
@@ -24,7 +22,6 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -285,24 +282,4 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
 
 }
 
-/**
- * This style configuration is not intended for direct usage yet.
- * As such, this is not included in other named default styles.
- */
-@Incubating(since = "7.0.0")
-@Value
-@With
-class HideUtilityClassConstructorStyle implements JavaStyle {
-    /**
-     * If any of the annotation signatures are present on the utility class, the visitor will ignore operating on the class.
-     * These should be {@link AnnotationMatcher}-compatible, fully-qualified annotation signature strings.
-     */
-    Collection<String> ignoreIfAnnotatedBy;
 
-    static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle() {
-        return new HideUtilityClassConstructorStyle(Arrays.asList(
-                "@lombok.experimental.UtilityClass",
-                "@lombok.Data"
-        ));
-    }
-}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParentheses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParentheses.java
@@ -19,7 +19,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.J;
 
 public class UnnecessaryParentheses extends Recipe {
@@ -43,7 +43,7 @@ public class UnnecessaryParentheses extends Recipe {
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
             UnnecessaryParenthesesStyle style = cu.getStyle(UnnecessaryParenthesesStyle.class);
             if (style == null) {
-                style = IntelliJ.unnecessaryParentheses();
+                style = Checkstyle.unnecessaryParentheses();
             }
             doAfterVisit(new UnnecessaryParenthesesVisitor<>(style));
             return cu;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesStyle.java
@@ -18,9 +18,9 @@ package org.openrewrite.java.cleanup;
 import lombok.Value;
 import lombok.With;
 import org.openrewrite.java.JavaStyle;
-import org.openrewrite.java.style.IntelliJ;
-import org.openrewrite.style.StyleHelper;
+import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 @Value
 @With
@@ -51,6 +51,6 @@ public class UnnecessaryParenthesesStyle implements JavaStyle {
 
     @Override
     public Style applyDefaults() {
-        return StyleHelper.merge(IntelliJ.unnecessaryParentheses(), this);
+        return StyleHelper.merge(Checkstyle.unnecessaryParentheses(), this);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -179,12 +179,12 @@ public class Checkstyle extends NamedStyles {
     }
 
     @Nullable
-    private static DefaultComesLastStyle equalsAvoidsNull(Map<String, Module> conf) {
-        Module module = conf.get("EqualsAvoidNull");
+    private static EqualsAvoidsNullStyle equalsAvoidsNull(Map<String, Module> conf) {
+        Module module = conf.get("EqualsAvoidsNull");
         if(module == null) {
             return null;
         }
-        return new DefaultComesLastStyle(module.prop("ignoreEqualsIgnoreCase", false));
+        return new EqualsAvoidsNullStyle(module.prop("ignoreEqualsIgnoreCase", false));
     }
 
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -16,30 +16,14 @@
 package org.openrewrite.java.style;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
-import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
-import org.intellij.lang.annotations.Language;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.cleanup.*;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
-import org.xml.sax.InputSource;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Stream;
+import java.util.Arrays;
+import java.util.Collection;
 
-import static java.lang.Boolean.parseBoolean;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.*;
 import static org.openrewrite.Tree.randomId;
 
 public class Checkstyle extends NamedStyles {
@@ -66,7 +50,7 @@ public class Checkstyle extends NamedStyles {
                 ));
     }
 
-    private Checkstyle(Collection<Style> styles) {
+    Checkstyle(Collection<Style> styles) {
         super(randomId(), NAME, DISPLAY_NAME, DESCRIPTION, emptySet(), styles);
     }
 
@@ -75,161 +59,30 @@ public class Checkstyle extends NamedStyles {
         return INSTANCE;
     }
 
-    public static Checkstyle parseCheckstyleConfig(Path checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
-        try(InputStream is = Files.newInputStream(checkstyleConf)) {
-            return parseCheckstyleConfig(is, properties);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static Checkstyle parseCheckstyleConfig(@Language("XML") String checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
-        try(InputStream is = new ByteArrayInputStream(checkstyleConf.getBytes(UTF_8))) {
-            return parseCheckstyleConfig(is, properties);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static Checkstyle parseCheckstyleConfig(InputStream checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
-        Map<String, Module> conf = loadConfiguration(checkstyleConf, properties);
-
-        return new Checkstyle(Stream.of(
-                defaultComesLast(conf),
-                emptyBlock(conf),
-                equalsAvoidsNull(conf),
-                explicitInitialization(conf),
-                fallThrough(conf),
-                hiddenFieldStyle(conf),
-                hideUtilityClassConstructorStyle(conf),
-                unnecessaryParentheses(conf)
-        )
-                .filter(Objects::nonNull)
-                .collect(toSet()));
-    }
-
     public static DefaultComesLastStyle defaultComesLast() {
         return new DefaultComesLastStyle(false);
     }
 
-    @Nullable
-    private static DefaultComesLastStyle defaultComesLast(Map<String, Module> conf) {
-        Module defaultComesLastRaw = conf.get("DefaultComesLast");
-        if(defaultComesLastRaw == null) {
-            return null;
-        }
-        return new DefaultComesLastStyle(parseBoolean(defaultComesLastRaw.properties.get("skipIfLastAndSharedWithCase")));
-    }
-
-    private static final EmptyBlockStyle.BlockPolicy defaultBlockPolicy = EmptyBlockStyle.BlockPolicy.STATEMENT;
+    public static final EmptyBlockStyle.BlockPolicy defaultBlockPolicy = EmptyBlockStyle.BlockPolicy.STATEMENT;
     public static EmptyBlockStyle emptyBlock() {
         return new EmptyBlockStyle(defaultBlockPolicy, true, true, true, true,
                 true, true, true, true,true, true, true, true);
     }
 
-    @Nullable
-    private static EmptyBlockStyle emptyBlock(Map<String, Module> conf) {
-        Module emptyBlockRaw = conf.get("EmptyBlock");
-        if(emptyBlockRaw == null) {
-            return null;
-        }
-        String rawOption = emptyBlockRaw.properties.get("option");
-        EmptyBlockStyle.BlockPolicy blockPolicy = defaultBlockPolicy;
-        if(rawOption != null) {
-            blockPolicy = Enum.valueOf(EmptyBlockStyle.BlockPolicy.class, rawOption.toUpperCase());
-        }
-        String rawTokens = emptyBlockRaw.properties.get("tokens");
-        boolean instanceInit = true;
-        boolean literalCatch = true;
-        boolean literalDo = true;
-        boolean literalElse = true;
-        boolean literalFinally = true;
-        boolean literalFor = true;
-        boolean literalIf = true;
-        boolean literalSwitch = true;
-        boolean literalSynchronized = true;
-        boolean literalTry = true;
-        boolean literalWhile = true;
-        boolean staticInit = true;
-        if(rawTokens != null) {
-            Set<String> tokens = Arrays.stream(rawTokens.split("\\s*,\\s*"))
-                    .collect(toSet());
-            instanceInit = tokens.contains("INSTANCE_INIT");
-            literalCatch = tokens.contains("LITERAL_CATCH");
-            literalDo = tokens.contains("LITERAL_DO");
-            literalElse = tokens.contains("LITERAL_ELSE");
-            literalFinally = tokens.contains("LITERAL_FINALLY");
-            literalFor = tokens.contains("LITERAL_FOR");
-            literalIf = tokens.contains("LITERAL_IF");
-            literalSwitch = tokens.contains("LITERAL_SWITCH");
-            literalSynchronized = tokens.contains("LITERAL_SYNCHRONIZED");
-            literalTry = tokens.contains("LITERAL_TRY");
-            literalWhile = tokens.contains("LITERAL_WHILE");
-            staticInit = tokens.contains("STATIC_INIT");
-        }
-
-        return new EmptyBlockStyle(blockPolicy, instanceInit, literalCatch, literalDo,
-                literalElse, literalFinally, literalFor, literalIf, literalSwitch, literalSynchronized, literalTry,
-                literalWhile, staticInit);
-    }
-
-
     public static EqualsAvoidsNullStyle equalsAvoidsNull() {
         return new EqualsAvoidsNullStyle(false);
     }
 
-    @Nullable
-    private static EqualsAvoidsNullStyle equalsAvoidsNull(Map<String, Module> conf) {
-        Module module = conf.get("EqualsAvoidsNull");
-        if(module == null) {
-            return null;
-        }
-        return new EqualsAvoidsNullStyle(module.prop("ignoreEqualsIgnoreCase", false));
-    }
-
-
     public static ExplicitInitializationStyle explicitInitialization() {
         return new ExplicitInitializationStyle(false);
-    }
-
-    @Nullable
-    private static ExplicitInitializationStyle explicitInitialization(Map<String, Module> conf) {
-        Module module = conf.get("ExplicitInitialization");
-        if(module == null) {
-            return null;
-        }
-        return new ExplicitInitializationStyle(module.prop("onlyObjectReferences", false));
     }
 
     public static FallThroughStyle fallThrough() {
         return new FallThroughStyle(false);
     }
 
-    @Nullable
-    private static FallThroughStyle fallThrough(Map<String, Module> conf) {
-        Module module = conf.get("FallThrough");
-        if(module == null) {
-            return null;
-        }
-        return new FallThroughStyle(module.prop("checkLastCaseGroup", false));
-    }
-
     public static HiddenFieldStyle hiddenFieldStyle() {
         return new HiddenFieldStyle(false, false, false, false);
-    }
-
-    @Nullable
-    private static HiddenFieldStyle hiddenFieldStyle(Map<String, Module> conf) {
-        Module module = conf.get("HiddenField");
-        if(module == null) {
-            return null;
-        }
-        return new HiddenFieldStyle(
-                module.prop("ignoreConstructorParameter", false),
-                module.prop("ignoreSetter", false),
-                module.prop("setterCanReturnItsClass", false),
-                module.prop("ignoreAbstractMethods", false)
-            );
     }
 
     public static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle() {
@@ -239,146 +92,10 @@ public class Checkstyle extends NamedStyles {
         ));
     }
 
-    @Nullable
-    private static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle(Map<String, Module> conf) {
-        Module module = conf.get("HiddenField");
-        if(module == null) {
-            return null;
-        }
-        return hideUtilityClassConstructorStyle();
-    }
-
     public static UnnecessaryParenthesesStyle unnecessaryParentheses() {
         return new UnnecessaryParenthesesStyle(true, true, true, true, true,
                 true, true, true, true, true, true, true,
                 true, true, true, true, true, true,
                 true, true, true, true, true);
-    }
-
-    @SuppressWarnings("DuplicatedCode")
-    @Nullable
-    private static UnnecessaryParenthesesStyle unnecessaryParentheses(Map<String, Module> conf) {
-        Module module = conf.get("UnnecessaryParentheses");
-        if(module == null) {
-            return null;
-        }
-        String rawTokens = module.properties.get("tokens");
-        boolean expr = true;
-        boolean ident = true;
-        boolean numDouble = true;
-        boolean numFloat = true;
-        boolean numInt = true;
-        boolean numLong = true;
-        boolean stringLiteral = true;
-        boolean literalNull = true;
-        boolean literalFalse = true;
-        boolean literalTrue = true;
-        boolean assign = true;
-        boolean bitAndAssign = true;
-        boolean bitOrAssign = true;
-        boolean bitShiftRightAssign = true;
-        boolean bitXorAssign = true;
-        boolean divAssign = true;
-        boolean minusAssign = true;
-        boolean modAssign = true;
-        boolean plusAssign = true;
-        boolean shiftLeftAssign = true;
-        boolean shiftRightAssign = true;
-        boolean starAssign = true;
-        boolean lambda = true;
-        if(rawTokens != null) {
-            Set<String> tokens = Arrays.stream(rawTokens.split("\\s*,\\s*"))
-                    .collect(toSet());
-            expr = tokens.contains("EXPR");
-            ident = tokens.contains("IDENT");
-            numDouble = tokens.contains("NUM_DOUBLE");
-            numFloat = tokens.contains("NUM_FLOAT");
-            numInt = tokens.contains("NUM_INT");
-            numLong = tokens.contains("NUM_LONG");
-            stringLiteral = tokens.contains("STRING_LITERAL");
-            literalNull = tokens.contains("LITERAL_NULL");
-            literalFalse = tokens.contains("LITERAL_FALSE");
-            literalTrue = tokens.contains("LITERAL_TRUE");
-            assign = tokens.contains("ASSIGN");
-            bitAndAssign = tokens.contains("BIT_AND_ASSIGN");
-            bitOrAssign = tokens.contains("BIT_OR_ASSIGN");
-            bitShiftRightAssign = tokens.contains("BIT_SHIFT_RIGHT_ASSIGN");
-            bitXorAssign = tokens.contains("BIT_XOR_ASSIGN");
-            divAssign = tokens.contains("DIV_ASSIGN");
-            minusAssign = tokens.contains("MINUS_ASSIGN");
-            modAssign = tokens.contains("MOD_ASSIGN");
-            plusAssign = tokens.contains("PLUS_ASSIGN");
-            shiftLeftAssign = tokens.contains("SHIFT_LEFT_ASSIGN");
-            shiftRightAssign = tokens.contains("SHIFT_RIGHT_ASSIGN");
-            starAssign = tokens.contains("STAR_ASSIGN");
-            lambda = tokens.contains("LAMBDA");
-        }
-        return new UnnecessaryParenthesesStyle(expr, ident, numDouble, numFloat, numInt, numLong, stringLiteral,
-                literalNull, literalFalse, literalTrue, assign, bitAndAssign, bitOrAssign, bitShiftRightAssign,
-                bitXorAssign, divAssign, minusAssign, modAssign, plusAssign, shiftLeftAssign, shiftRightAssign,
-                starAssign, lambda
-        );
-    }
-
-    protected static class Module {
-        private final String name;
-        private final Map<String, String> properties;
-
-        public Module(String name, Map<String, String> properties) {
-            this.name = name;
-            this.properties = properties;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public boolean prop(String key, boolean defaultValue) {
-            return properties.containsKey(key) ? parseBoolean(properties.get(key))
-                    : defaultValue;
-        }
-    }
-
-    private static Map<String, Module> loadConfiguration(InputStream inputStream, Map<String, Object> properties) throws CheckstyleException {
-        Configuration checkstyleConfig = ConfigurationLoader.loadConfiguration(new InputSource(inputStream),
-                name -> {
-                    Object prop = properties.get(name);
-                    return prop == null ?
-                            name.equals("config_loc") ? "config/checkstyle" : null :
-                            prop.toString();
-                },
-                ConfigurationLoader.IgnoredModulesOptions.OMIT);
-
-        List<Module> modules = new ArrayList<>();
-        for (Configuration firstLevelChild : checkstyleConfig.getChildren()) {
-            if ("TreeWalker".equals(firstLevelChild.getName())) {
-                modules.addAll(stream(firstLevelChild.getChildren())
-                        .map(child -> {
-                            try {
-                                Map<String, String> props = new HashMap<>();
-                                for (String propertyName : child.getAttributeNames()) {
-                                    props.put(propertyName, child.getAttribute(propertyName));
-                                }
-                                return new Module(child.getName(), props);
-                            } catch (CheckstyleException e) {
-                                return null;
-                            }
-                        })
-                        .filter(Objects::nonNull)
-                        .collect(toList())
-                );
-            } else if("SuppressionFilter".equals(firstLevelChild.getName())) {
-                continue;
-            }else {
-                Map<String, String> props = new HashMap<>();
-                for (String propertyName : firstLevelChild.getAttributeNames()) {
-                    props.put(propertyName, firstLevelChild.getAttribute(propertyName));
-                }
-                modules.add(new Module(firstLevelChild.getName(), props));
-            }
-        }
-
-        return modules.stream()
-                .collect(toMap(Module::getName, identity()));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -184,7 +184,7 @@ public class Checkstyle extends NamedStyles {
         if(module == null) {
             return null;
         }
-        return new DefaultComesLastStyle(module.prop("skipIfLastAndSharedWithCase", false));
+        return new DefaultComesLastStyle(module.prop("ignoreEqualsIgnoreCase", false));
     }
 
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.style;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.intellij.lang.annotations.Language;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.cleanup.*;
+import org.openrewrite.style.NamedStyles;
+import org.openrewrite.style.Style;
+import org.xml.sax.InputSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptySet;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.*;
+import static org.openrewrite.Tree.randomId;
+
+public class Checkstyle extends NamedStyles {
+    private static final Checkstyle INSTANCE = new Checkstyle();
+    private static final String NAME = "org.openrewrite.java.Checkstyle";
+    private static final String DISPLAY_NAME = "Checkstyle";
+    private static final String DESCRIPTION = "Checkstyle defaults for styles";
+
+    private Checkstyle() {
+        super(randomId(),
+                NAME,
+                DISPLAY_NAME,
+                DESCRIPTION,
+                emptySet(),
+                Arrays.asList(
+                        defaultComesLast(),
+                        emptyBlock(),
+                        equalsAvoidsNull(),
+                        explicitInitialization(),
+                        fallThrough(),
+                        hiddenFieldStyle(),
+                        hideUtilityClassConstructorStyle(),
+                        unnecessaryParentheses()
+                ));
+    }
+
+    private Checkstyle(Collection<Style> styles) {
+        super(randomId(), NAME, DISPLAY_NAME, DESCRIPTION, emptySet(), styles);
+    }
+
+    @JsonCreator
+    public static Checkstyle defaults() {
+        return INSTANCE;
+    }
+
+    public static Checkstyle parseCheckstyleConfig(Path checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
+        try(InputStream is = Files.newInputStream(checkstyleConf)) {
+            return parseCheckstyleConfig(is, properties);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Checkstyle parseCheckstyleConfig(@Language("XML") String checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
+        try(InputStream is = new ByteArrayInputStream(checkstyleConf.getBytes(UTF_8))) {
+            return parseCheckstyleConfig(is, properties);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Checkstyle parseCheckstyleConfig(InputStream checkstyleConf, Map<String, Object> properties) throws CheckstyleException {
+        Map<String, Module> conf = loadConfiguration(checkstyleConf, properties);
+
+        return new Checkstyle(Stream.of(
+                defaultComesLast(conf),
+                emptyBlock(conf),
+                equalsAvoidsNull(conf),
+                explicitInitialization(conf),
+                fallThrough(conf),
+                hiddenFieldStyle(conf),
+                hideUtilityClassConstructorStyle(conf),
+                unnecessaryParentheses(conf)
+        )
+                .filter(Objects::nonNull)
+                .collect(toSet()));
+    }
+
+    public static DefaultComesLastStyle defaultComesLast() {
+        return new DefaultComesLastStyle(false);
+    }
+
+    @Nullable
+    private static DefaultComesLastStyle defaultComesLast(Map<String, Module> conf) {
+        Module defaultComesLastRaw = conf.get("DefaultComesLast");
+        if(defaultComesLastRaw == null) {
+            return null;
+        }
+        return new DefaultComesLastStyle(parseBoolean(defaultComesLastRaw.properties.get("skipIfLastAndSharedWithCase")));
+    }
+
+    private static final EmptyBlockStyle.BlockPolicy defaultBlockPolicy = EmptyBlockStyle.BlockPolicy.STATEMENT;
+    public static EmptyBlockStyle emptyBlock() {
+        return new EmptyBlockStyle(defaultBlockPolicy, true, true, true, true,
+                true, true, true, true,true, true, true, true);
+    }
+
+    @Nullable
+    private static EmptyBlockStyle emptyBlock(Map<String, Module> conf) {
+        Module emptyBlockRaw = conf.get("EmptyBlock");
+        if(emptyBlockRaw == null) {
+            return null;
+        }
+        String rawOption = emptyBlockRaw.properties.get("option");
+        EmptyBlockStyle.BlockPolicy blockPolicy = defaultBlockPolicy;
+        if(rawOption != null) {
+            blockPolicy = Enum.valueOf(EmptyBlockStyle.BlockPolicy.class, rawOption.toUpperCase());
+        }
+        String rawTokens = emptyBlockRaw.properties.get("tokens");
+        boolean instanceInit = true;
+        boolean literalCatch = true;
+        boolean literalDo = true;
+        boolean literalElse = true;
+        boolean literalFinally = true;
+        boolean literalFor = true;
+        boolean literalIf = true;
+        boolean literalSwitch = true;
+        boolean literalSynchronized = true;
+        boolean literalTry = true;
+        boolean literalWhile = true;
+        boolean staticInit = true;
+        if(rawTokens != null) {
+            Set<String> tokens = Arrays.stream(rawTokens.split("\\s*,\\s*"))
+                    .collect(toSet());
+            instanceInit = tokens.contains("INSTANCE_INIT");
+            literalCatch = tokens.contains("LITERAL_CATCH");
+            literalDo = tokens.contains("LITERAL_DO");
+            literalElse = tokens.contains("LITERAL_ELSE");
+            literalFinally = tokens.contains("LITERAL_FINALLY");
+            literalFor = tokens.contains("LITERAL_FOR");
+            literalIf = tokens.contains("LITERAL_IF");
+            literalSwitch = tokens.contains("LITERAL_SWITCH");
+            literalSynchronized = tokens.contains("LITERAL_SYNCHRONIZED");
+            literalTry = tokens.contains("LITERAL_TRY");
+            literalWhile = tokens.contains("LITERAL_WHILE");
+            staticInit = tokens.contains("STATIC_INIT");
+        }
+
+        return new EmptyBlockStyle(blockPolicy, instanceInit, literalCatch, literalDo,
+                literalElse, literalFinally, literalFor, literalIf, literalSwitch, literalSynchronized, literalTry,
+                literalWhile, staticInit);
+    }
+
+
+    public static EqualsAvoidsNullStyle equalsAvoidsNull() {
+        return new EqualsAvoidsNullStyle(false);
+    }
+
+    @Nullable
+    private static DefaultComesLastStyle equalsAvoidsNull(Map<String, Module> conf) {
+        Module module = conf.get("EqualsAvoidNull");
+        if(module == null) {
+            return null;
+        }
+        return new DefaultComesLastStyle(module.prop("skipIfLastAndSharedWithCase", false));
+    }
+
+
+    public static ExplicitInitializationStyle explicitInitialization() {
+        return new ExplicitInitializationStyle(false);
+    }
+
+    @Nullable
+    private static ExplicitInitializationStyle explicitInitialization(Map<String, Module> conf) {
+        Module module = conf.get("ExplicitInitialization");
+        if(module == null) {
+            return null;
+        }
+        return new ExplicitInitializationStyle(module.prop("onlyObjectReferences", false));
+    }
+
+    public static FallThroughStyle fallThrough() {
+        return new FallThroughStyle(false);
+    }
+
+    @Nullable
+    private static FallThroughStyle fallThrough(Map<String, Module> conf) {
+        Module module = conf.get("FallThrough");
+        if(module == null) {
+            return null;
+        }
+        return new FallThroughStyle(module.prop("checkLastCaseGroup", false));
+    }
+
+    public static HiddenFieldStyle hiddenFieldStyle() {
+        return new HiddenFieldStyle(false, false, false, false);
+    }
+
+    @Nullable
+    private static HiddenFieldStyle hiddenFieldStyle(Map<String, Module> conf) {
+        Module module = conf.get("HiddenField");
+        if(module == null) {
+            return null;
+        }
+        return new HiddenFieldStyle(
+                module.prop("ignoreConstructorParameter", false),
+                module.prop("ignoreSetter", false),
+                module.prop("setterCanReturnItsClass", false),
+                module.prop("ignoreAbstractMethods", false)
+            );
+    }
+
+    public static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle() {
+        return new HideUtilityClassConstructorStyle(Arrays.asList(
+                "@lombok.experimental.UtilityClass",
+                "@lombok.Data"
+        ));
+    }
+
+    @Nullable
+    private static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle(Map<String, Module> conf) {
+        Module module = conf.get("HiddenField");
+        if(module == null) {
+            return null;
+        }
+        return hideUtilityClassConstructorStyle();
+    }
+
+    public static UnnecessaryParenthesesStyle unnecessaryParentheses() {
+        return new UnnecessaryParenthesesStyle(true, true, true, true, true,
+                true, true, true, true, true, true, true,
+                true, true, true, true, true, true,
+                true, true, true, true, true);
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    @Nullable
+    private static UnnecessaryParenthesesStyle unnecessaryParentheses(Map<String, Module> conf) {
+        Module module = conf.get("UnnecessaryParentheses");
+        if(module == null) {
+            return null;
+        }
+        String rawTokens = module.properties.get("tokens");
+        boolean expr = true;
+        boolean ident = true;
+        boolean numDouble = true;
+        boolean numFloat = true;
+        boolean numInt = true;
+        boolean numLong = true;
+        boolean stringLiteral = true;
+        boolean literalNull = true;
+        boolean literalFalse = true;
+        boolean literalTrue = true;
+        boolean assign = true;
+        boolean bitAndAssign = true;
+        boolean bitOrAssign = true;
+        boolean bitShiftRightAssign = true;
+        boolean bitXorAssign = true;
+        boolean divAssign = true;
+        boolean minusAssign = true;
+        boolean modAssign = true;
+        boolean plusAssign = true;
+        boolean shiftLeftAssign = true;
+        boolean shiftRightAssign = true;
+        boolean starAssign = true;
+        boolean lambda = true;
+        if(rawTokens != null) {
+            Set<String> tokens = Arrays.stream(rawTokens.split("\\s*,\\s*"))
+                    .collect(toSet());
+            expr = tokens.contains("EXPR");
+            ident = tokens.contains("IDENT");
+            numDouble = tokens.contains("NUM_DOUBLE");
+            numFloat = tokens.contains("NUM_FLOAT");
+            numInt = tokens.contains("NUM_INT");
+            numLong = tokens.contains("NUM_LONG");
+            stringLiteral = tokens.contains("STRING_LITERAL");
+            literalNull = tokens.contains("LITERAL_NULL");
+            literalFalse = tokens.contains("LITERAL_FALSE");
+            literalTrue = tokens.contains("LITERAL_TRUE");
+            assign = tokens.contains("ASSIGN");
+            bitAndAssign = tokens.contains("BIT_AND_ASSIGN");
+            bitOrAssign = tokens.contains("BIT_OR_ASSIGN");
+            bitShiftRightAssign = tokens.contains("BIT_SHIFT_RIGHT_ASSIGN");
+            bitXorAssign = tokens.contains("BIT_XOR_ASSIGN");
+            divAssign = tokens.contains("DIV_ASSIGN");
+            minusAssign = tokens.contains("MINUS_ASSIGN");
+            modAssign = tokens.contains("MOD_ASSIGN");
+            plusAssign = tokens.contains("PLUS_ASSIGN");
+            shiftLeftAssign = tokens.contains("SHIFT_LEFT_ASSIGN");
+            shiftRightAssign = tokens.contains("SHIFT_RIGHT_ASSIGN");
+            starAssign = tokens.contains("STAR_ASSIGN");
+            lambda = tokens.contains("LAMBDA");
+        }
+        return new UnnecessaryParenthesesStyle(expr, ident, numDouble, numFloat, numInt, numLong, stringLiteral,
+                literalNull, literalFalse, literalTrue, assign, bitAndAssign, bitOrAssign, bitShiftRightAssign,
+                bitXorAssign, divAssign, minusAssign, modAssign, plusAssign, shiftLeftAssign, shiftRightAssign,
+                starAssign, lambda
+        );
+    }
+
+    protected static class Module {
+        private final String name;
+        private final Map<String, String> properties;
+
+        public Module(String name, Map<String, String> properties) {
+            this.name = name;
+            this.properties = properties;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean prop(String key, boolean defaultValue) {
+            return properties.containsKey(key) ? parseBoolean(properties.get(key))
+                    : defaultValue;
+        }
+    }
+
+    private static Map<String, Module> loadConfiguration(InputStream inputStream, Map<String, Object> properties) throws CheckstyleException {
+        Configuration checkstyleConfig = ConfigurationLoader.loadConfiguration(new InputSource(inputStream),
+                name -> {
+                    Object prop = properties.get(name);
+                    return prop == null ?
+                            name.equals("config_loc") ? "config/checkstyle" : null :
+                            prop.toString();
+                },
+                ConfigurationLoader.IgnoredModulesOptions.OMIT);
+
+        List<Module> modules = new ArrayList<>();
+        for (Configuration firstLevelChild : checkstyleConfig.getChildren()) {
+            if ("TreeWalker".equals(firstLevelChild.getName())) {
+                modules.addAll(stream(firstLevelChild.getChildren())
+                        .map(child -> {
+                            try {
+                                Map<String, String> props = new HashMap<>();
+                                for (String propertyName : child.getAttributeNames()) {
+                                    props.put(propertyName, child.getAttribute(propertyName));
+                                }
+                                return new Module(child.getName(), props);
+                            } catch (CheckstyleException e) {
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(toList())
+                );
+            } else if("SuppressionFilter".equals(firstLevelChild.getName())) {
+                continue;
+            }else {
+                Map<String, String> props = new HashMap<>();
+                for (String propertyName : firstLevelChild.getAttributeNames()) {
+                    props.put(propertyName, firstLevelChild.getAttribute(propertyName));
+                }
+                modules.add(new Module(firstLevelChild.getName(), props));
+            }
+        }
+
+        return modules.stream()
+                .collect(toMap(Module::getName, identity()));
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -26,10 +26,8 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.With;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaStyle;
@@ -65,20 +63,16 @@ import static org.openrewrite.internal.StreamUtils.distinctBy;
  */
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
-@AllArgsConstructor
 @JsonDeserialize(using = Deserializer.class)
 @JsonSerialize(using = Serializer.class)
 public class ImportLayoutStyle implements JavaStyle {
 
-    @With
     @EqualsAndHashCode.Include
     private final int classCountToUseStarImport;
 
-    @With
     @EqualsAndHashCode.Include
     private final int nameCountToUseStarImport;
 
-    @With
     @EqualsAndHashCode.Include
     private final List<Block> layout;
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -26,8 +26,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.With;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaStyle;
@@ -63,15 +65,20 @@ import static org.openrewrite.internal.StreamUtils.distinctBy;
  */
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
+@AllArgsConstructor
 @JsonDeserialize(using = Deserializer.class)
 @JsonSerialize(using = Serializer.class)
 public class ImportLayoutStyle implements JavaStyle {
+
+    @With
     @EqualsAndHashCode.Include
     private final int classCountToUseStarImport;
 
+    @With
     @EqualsAndHashCode.Include
     private final int nameCountToUseStarImport;
 
+    @With
     @EqualsAndHashCode.Include
     private final List<Block> layout;
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
@@ -16,10 +16,6 @@
 package org.openrewrite.java.style;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.openrewrite.java.cleanup.EmptyBlockStyle;
-import org.openrewrite.java.cleanup.EqualsAvoidsNullStyle;
-import org.openrewrite.java.cleanup.ExplicitInitializationStyle;
-import org.openrewrite.java.cleanup.UnnecessaryParenthesesStyle;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
 
@@ -43,11 +39,7 @@ public class IntelliJ extends NamedStyles {
                         blankLines(),
                         tabsAndIndents(),
                         spaces(),
-                        wrappingAndBraces(),
-                        unnecessaryParentheses(),
-                        emptyBlock(),
-                        equalsAvoidsNull(),
-                        explicitInitialization()
+                        wrappingAndBraces()
                 )
         );
     }
@@ -103,19 +95,4 @@ public class IntelliJ extends NamedStyles {
         return new WrappingAndBracesStyle();
     }
 
-    public static UnnecessaryParenthesesStyle unnecessaryParentheses() {
-        return new UnnecessaryParenthesesStyle(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
-    }
-
-    public static EmptyBlockStyle emptyBlock() {
-        return new EmptyBlockStyle(EmptyBlockStyle.BlockPolicy.Statement, true, true, true, true, true, true, true, true, true, true, true, true);
-    }
-
-    public static EqualsAvoidsNullStyle equalsAvoidsNull() {
-        return new EqualsAvoidsNullStyle(false);
-    }
-
-    public static ExplicitInitializationStyle explicitInitialization() {
-        return new ExplicitInitializationStyle(false);
-    }
 }

--- a/rewrite-java/src/main/resources/META-INF/rewrite/cleanup.yml
+++ b/rewrite-java/src/main/resources/META-INF/rewrite/cleanup.yml
@@ -36,3 +36,4 @@ recipeList:
   - org.openrewrite.java.cleanup.UseDiamondOperator
   - org.openrewrite.java.cleanup.PrimitiveWrapperClassConstructorToValueOf
   - org.openrewrite.java.cleanup.BigDecimalRoundingConstantsToEnums
+  - org.openrewrite.java.cleanup.FinalClass

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleConfigLoaderTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleConfigLoaderTest.kt
@@ -20,13 +20,13 @@ import org.junit.jupiter.api.Test
 import org.openrewrite.java.cleanup.DefaultComesLastStyle
 import org.openrewrite.java.cleanup.EmptyBlockStyle
 import org.openrewrite.java.cleanup.EqualsAvoidsNullStyle
-import org.openrewrite.java.style.Checkstyle.parseCheckstyleConfig
+import org.openrewrite.java.style.CheckstyleConfigLoader.loadCheckstyleConfig
 
-class CheckstyleTest {
+class CheckstyleConfigLoaderTest {
 
     @Test
     fun basicSingleStyle() {
-        val checkstyle = parseCheckstyleConfig("""
+        val checkstyle = loadCheckstyleConfig("""
             <!DOCTYPE module PUBLIC
                 "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
                 "https://checkstyle.org/dtds/configuration_1_2.dtd">
@@ -45,7 +45,7 @@ class CheckstyleTest {
 
     @Test
     fun singleStyleWithProperty() {
-        val checkstyle = parseCheckstyleConfig("""
+        val checkstyle = loadCheckstyleConfig("""
             <!DOCTYPE module PUBLIC
                 "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
                 "https://checkstyle.org/dtds/configuration_1_2.dtd">
@@ -66,7 +66,7 @@ class CheckstyleTest {
 
     @Test
     fun emptyBlockStyle() {
-        val checkstyle = parseCheckstyleConfig("""
+        val checkstyle = loadCheckstyleConfig("""
             <!DOCTYPE module PUBLIC
                 "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
                 "https://checkstyle.org/dtds/configuration_1_2.dtd">
@@ -92,7 +92,7 @@ class CheckstyleTest {
 
     @Test
     fun equalsAvoidsNull() {
-        val checkstyle = parseCheckstyleConfig("""
+        val checkstyle = loadCheckstyleConfig("""
             <!DOCTYPE module PUBLIC
                 "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
                 "https://checkstyle.org/dtds/configuration_1_2.dtd">

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.style
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.cleanup.DefaultComesLastStyle
+import org.openrewrite.java.cleanup.EmptyBlockStyle
+import org.openrewrite.java.style.Checkstyle.parseCheckstyleConfig
+
+class CheckstyleTest {
+
+    @Test
+    fun basicSingleStyle() {
+        val checkstyle = parseCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="DefaultComesLast"/>
+            </module>
+        """.trimIndent(), emptyMap())
+
+        assertThat(checkstyle.styles)
+                .hasSize(1)
+
+        assertThat(checkstyle.styles.first())
+                .isExactlyInstanceOf(DefaultComesLastStyle::class.java)
+                .matches { (it as DefaultComesLastStyle).skipIfLastAndSharedWithCase == false }
+    }
+
+    @Test
+    fun singleStyleWithProperty() {
+        val checkstyle = parseCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="DefaultComesLast">
+                    <property name="skipIfLastAndSharedWithCase" value="true"/>
+                </module>
+            </module>
+        """.trimIndent(), emptyMap())
+
+        assertThat(checkstyle.styles)
+                .hasSize(1)
+
+        assertThat(checkstyle.styles.first())
+                .isExactlyInstanceOf(DefaultComesLastStyle::class.java)
+                .matches { (it as DefaultComesLastStyle).skipIfLastAndSharedWithCase }
+    }
+
+    @Test
+    fun emptyBlockStyle() {
+        val checkstyle = parseCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="EmptyBlock">
+                    <property name="option" value="text" />
+                    <property name="tokens" value="LITERAL_WHILE, LITERAL_TRY"/>
+                </module>
+            </module>
+        """.trimIndent(), emptyMap())
+
+        assertThat(checkstyle.styles)
+                .hasSize(1)
+
+        assertThat(checkstyle.styles.first()).isExactlyInstanceOf(EmptyBlockStyle::class.java)
+        val blockStyle = checkstyle.styles.first() as EmptyBlockStyle
+
+        assertThat(blockStyle.blockPolicy).isEqualTo(EmptyBlockStyle.BlockPolicy.TEXT)
+        assertThat(blockStyle.literalWhile).isTrue
+        assertThat(blockStyle.literalTry).isTrue
+        assertThat(blockStyle.literalCatch).isFalse
+    }
+}

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleTest.kt
@@ -19,6 +19,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.openrewrite.java.cleanup.DefaultComesLastStyle
 import org.openrewrite.java.cleanup.EmptyBlockStyle
+import org.openrewrite.java.cleanup.EqualsAvoidsNullStyle
 import org.openrewrite.java.style.Checkstyle.parseCheckstyleConfig
 
 class CheckstyleTest {
@@ -87,5 +88,27 @@ class CheckstyleTest {
         assertThat(blockStyle.literalWhile).isTrue
         assertThat(blockStyle.literalTry).isTrue
         assertThat(blockStyle.literalCatch).isFalse
+    }
+
+    @Test
+    fun equalsAvoidsNull() {
+        val checkstyle = parseCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+                <module name="EqualsAvoidsNull">
+                    <property name="ignoreEqualsIgnoreCase" value="true" />
+                </module>
+            </module>
+        """.trimIndent(), emptyMap())
+
+        assertThat(checkstyle.styles)
+                .hasSize(1)
+
+        assertThat(checkstyle.styles.first()).isExactlyInstanceOf(EqualsAvoidsNullStyle::class.java)
+        val equalsAvoidsNullStyle = checkstyle.styles.first() as EqualsAvoidsNullStyle
+
+        assertThat(equalsAvoidsNullStyle.ignoreEqualsIgnoreCase).isTrue
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/UseStaticImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/UseStaticImportTest.kt
@@ -53,7 +53,9 @@ interface UseStaticImportTest : JavaRecipeTest {
         after = """
             package test;
             
-            import static asserts.Assert.*;
+            import static asserts.Assert.assertEquals;
+            import static asserts.Assert.assertFalse;
+            import static asserts.Assert.assertTrue;
             
             class Test {
                 void test() {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EqualsAvoidsNullTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EqualsAvoidsNullTest.kt
@@ -17,7 +17,10 @@ package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test
 import org.openrewrite.Recipe
+import org.openrewrite.Tree.randomId
+import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.style.NamedStyles
 
 @Suppress("ClassInitializerMayBeStatic", "StatementWithEmptyBody", "ConstantConditions")
 interface EqualsAvoidsNullTest: JavaRecipeTest {
@@ -25,7 +28,8 @@ interface EqualsAvoidsNullTest: JavaRecipeTest {
         get() = EqualsAvoidsNull()
 
     @Test
-    fun invertConditional() = assertChanged(
+    fun invertConditional(jp: JavaParser) = assertChanged(
+        jp,
         before = """
             public class A {
                 {
@@ -47,7 +51,33 @@ interface EqualsAvoidsNullTest: JavaRecipeTest {
     )
 
     @Test
-    fun removeUnnecessaryNullCheckAndParens() = assertChanged(
+    fun ignoreEqualsIgnoreCase(jp: JavaParser.Builder<*,*>) = assertChanged(
+        jp.styles(listOf(
+                NamedStyles(randomId(), "test", "", "", emptySet(), listOf(EqualsAvoidsNullStyle(true)))
+        )).build(),
+        before = """
+            public class A {
+                {
+                    String s = null;
+                    if(s.equals("test")) {}
+                    if(s.equalsIgnoreCase("test")) {}
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    String s = null;
+                    if("test".equals(s)) {}
+                    if(s.equalsIgnoreCase("test")) {}
+                }
+            }
+        """
+    )
+
+    @Test
+    fun removeUnnecessaryNullCheckAndParens(jp: JavaParser) = assertChanged(
+        jp,
         before = """
             public class A {
                 {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
@@ -20,6 +20,7 @@ import org.openrewrite.Recipe
 import org.openrewrite.Tree
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.java.style.Checkstyle
 import org.openrewrite.style.NamedStyles
 
 interface HiddenFieldTest : JavaRecipeTest {
@@ -30,7 +31,7 @@ interface HiddenFieldTest : JavaRecipeTest {
         listOf(
             NamedStyles(
                 Tree.randomId(), "test", "test", "test", emptySet(), listOf(
-                    HiddenFieldStyle.hiddenFieldStyle().run { with(this) }
+                    Checkstyle.hiddenFieldStyle().run { with(this) }
                 )
             )
         )

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UnnecessaryParenthesesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UnnecessaryParenthesesTest.kt
@@ -21,6 +21,7 @@ import org.openrewrite.Recipe
 import org.openrewrite.Tree.randomId
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.java.style.Checkstyle
 import org.openrewrite.java.style.IntelliJ
 import org.openrewrite.style.NamedStyles
 
@@ -77,7 +78,7 @@ interface UnnecessaryParenthesesTest : JavaRecipeTest {
             listOf(
                 NamedStyles(
                         randomId(), "test", "test", "test", emptySet(), listOf(
-                        IntelliJ.unnecessaryParentheses()
+                        Checkstyle.unnecessaryParentheses()
                     )
                 )
             )


### PR DESCRIPTION
I've validated that this can be used successfully in rewrite-gradle-plugin to load checkstyle.xml and have the active recipes respond to those styles.

I've validated that the pom.xml produced for this lists "com.puppycrawl.tools:checkstyle" as an optional dependency.

I haven't yet tried incorporating this into rewrite-maven-plugin or ingest.

If you remember the old `CheckstyleRefactorVisitor` this has some fundamental differences. This approach regards checkstyle configuration as informing _only_ our styles, _not_  which recipes are active. So the guide on auto-remediating checkstyle issues will instruct users to activate the cleanup recipe. In the Gradle plugin I can detect whether the Checkstyle plugin is also applied, so no manual configuration will be required there to get checkstyle parsing. I'll probably be able to figure out something similar for the maven plugin.