### PR TITLE
SpacesStyle.withBeforeParentheses.withMethodCall controls spacing on class constructors

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -1029,6 +1029,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
     public J.NewClass visitNewClass(J.NewClass newClass, P p) {
         J.NewClass nc = super.visitNewClass(newClass, p);
         if (nc.getPadding().getArguments() != null) {
+            nc = nc.getPadding().withArguments(spaceBefore(nc.getPadding().getArguments(), style.getBeforeParentheses().getMethodCall()));
             int argsSize = nc.getPadding().getArguments().getElements().size();
             nc = nc.getPadding().withArguments(
                     nc.getPadding().getArguments().getPadding().withElements(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/SpacesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/SpacesTest.kt
@@ -104,6 +104,7 @@ interface SpacesTest : JavaRecipeTest {
                 class Test {
                     void foo() {
                         foo();
+                        Test test = new Test();
                     }
                 }
             """,
@@ -111,6 +112,7 @@ interface SpacesTest : JavaRecipeTest {
                 class Test {
                     void foo() {
                         foo ();
+                        Test test = new Test ();
                     }
                 }
             """
@@ -129,6 +131,7 @@ interface SpacesTest : JavaRecipeTest {
                 class Test {
                     void foo() {
                         foo ();
+                        Test test = new Test ();
                     }
                 }
             """,
@@ -136,6 +139,7 @@ interface SpacesTest : JavaRecipeTest {
                 class Test {
                     void foo() {
                         foo();
+                        Test test = new Test();
                     }
                 }
             """


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite/issues/785