### PR TITLE
Fixing the logic in addImports

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -167,7 +167,7 @@ public class ImportLayoutStyle implements JavaStyle {
                     //Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {
                         if (after.getElement().equals(originalImports.get(j).getElement())) {
-                            insertPosition = j - 1;
+                            insertPosition = j;
                             before = j > 0 ? originalImports.get(insertPosition) : null;
                             break;
                         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -140,12 +140,6 @@ public class ImportLayoutStyle implements JavaStyle {
         Block addToBlock = block(paddedToAdd);
         int insertPosition = 0;
 
-        // Using the ideal ordering, find the imports immediately before/after.
-        //
-        // Pick either the before/after as context for insertion based on:
-        // - Does the import's block match that of the import being added?
-        // - If neither the before/after have the same block, prefer the import that has the same static flag.
-        // - If there is any ambiguity, the default is to use the "after"
         for (int i = 0; i < ideallyOrdered.size(); i++) {
             JRightPadded<J.Import> anImport = ideallyOrdered.get(i);
             if (anImport.getElement().isScope(paddedToAdd.getElement())) {
@@ -182,6 +176,13 @@ public class ImportLayoutStyle implements JavaStyle {
                 paddedToAdd = paddedToAdd.withElement(paddedToAdd.getElement().withPrefix(prefix));
             }
         } else if (block(before) != addToBlock) {
+            for (int j = insertPosition; j < originalImports.size(); j++) {
+                if (block(originalImports.get(j)) == addToBlock) {
+                    insertPosition = j;
+                    after = originalImports.get(j);
+                    break;
+                }
+            }
             paddedToAdd = paddedToAdd.withElement(paddedToAdd.getElement().withPrefix(Space.format("\n\n")));
         } else {
             paddedToAdd = paddedToAdd.withElement(paddedToAdd.getElement().withPrefix(Space.format("\n")));

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -151,8 +151,7 @@ public class ImportLayoutStyle implements JavaStyle {
             if (anImport.getElement().isScope(paddedToAdd.getElement())) {
                 before = i > 0 ? ideallyOrdered.get(i - 1) : null;
                 after = i + 1 < ideallyOrdered.size() ? ideallyOrdered.get(i + 1) : null;
-                if (before != null && (block(before) == addToBlock || after == null
-                        || (block(after) != addToBlock && after.getElement().isStatic() != toAdd.isStatic() && before.getElement().isStatic() == toAdd.isStatic()))) {
+                if (before != null) {
                     // Use the "before" import to determine insertion point.
                     // Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -140,9 +140,9 @@ public class ImportLayoutStyle implements JavaStyle {
         Block addToBlock = block(paddedToAdd);
         int insertPosition = 0;
 
-        //Using the ideal ordering, find the imports immediately before/after.
+        // Using the ideal ordering, find the imports immediately before/after.
         //
-        //Pick either the before/after as context for insertion based on:
+        // Pick either the before/after as context for insertion based on:
         // - Does the import's block match that of the import being added?
         // - If neither the before/after have the same block, prefer the import that has the same static flag.
         // - If there is any ambiguity, the default is to use the "after"
@@ -153,8 +153,8 @@ public class ImportLayoutStyle implements JavaStyle {
                 after = i + 1 < ideallyOrdered.size() ? ideallyOrdered.get(i + 1) : null;
                 if (before != null && (block(before) == addToBlock || after == null
                         || (block(after) != addToBlock && after.getElement().isStatic() != toAdd.isStatic() && before.getElement().isStatic() == toAdd.isStatic()))) {
-                    //Use the "before" import to determine insertion point.
-                    //Find the import in the original list to establish insertion position.
+                    // Use the "before" import to determine insertion point.
+                    // Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {
                         if (before.getElement().equals(originalImports.get(j).getElement())) {
                             insertPosition = j + 1;
@@ -163,8 +163,8 @@ public class ImportLayoutStyle implements JavaStyle {
                         }
                     }
                 } else if (after != null) {
-                    //Otherwise, "after" as the basis for the insertion.
-                    //Find the import in the original list to establish insertion position.
+                    // Otherwise, "after" as the basis for the insertion.
+                    // Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {
                         if (after.getElement().equals(originalImports.get(j).getElement())) {
                             insertPosition = j;

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -140,22 +140,39 @@ public class ImportLayoutStyle implements JavaStyle {
         Block addToBlock = block(paddedToAdd);
         int insertPosition = 0;
 
+        //Using the ideal ordering, find the imports immediately before/after.
+        //
+        //Pick either the before/after as context for insertion based on:
+        // - Does the import's block match that of the import being added?
+        // - If neither the before/after have the same block, prefer the import that has the same static flag.
+        // - If there is any ambiguity, the default is to use the "after"
         for (int i = 0; i < ideallyOrdered.size(); i++) {
             JRightPadded<J.Import> anImport = ideallyOrdered.get(i);
             if (anImport.getElement().isScope(paddedToAdd.getElement())) {
                 before = i > 0 ? ideallyOrdered.get(i - 1) : null;
-                if (before == null) {
-                    after = originalImports.isEmpty() ? null : originalImports.get(0);
-                } else {
+                after = i + 1 < ideallyOrdered.size() ? ideallyOrdered.get(i + 1) : null;
+                if (before != null && (block(before) == addToBlock || after == null
+                        || (after.getElement().isStatic() != toAdd.isStatic() && before.getElement().isStatic() == toAdd.isStatic()))) {
+                    //Use the "before" import to determine insertion point.
+                    //Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {
-                        if (before == originalImports.get(j)) {
-                            after = originalImports.size() > j + 1 ? originalImports.get(j + 1) : null;
+                        if (before.getElement().equals(originalImports.get(j).getElement())) {
+                            insertPosition = j + 1;
+                            after = j + 1 < originalImports.size() ? originalImports.get(j + 1) : null;
+                            break;
+                        }
+                    }
+                } else if (after != null) {
+                    //Otherwise, "after" as the basis for the insertion.
+                    //Find the import in the original list to establish insertion position.
+                    for (int j = 0; j < originalImports.size(); j++) {
+                        if (after.getElement().equals(originalImports.get(j).getElement())) {
+                            insertPosition = j + 1;
+                            before = j > 0 ? originalImports.get(j - 1) : null;
                             break;
                         }
                     }
                 }
-
-                insertPosition = i;
                 break;
             }
         }
@@ -171,30 +188,36 @@ public class ImportLayoutStyle implements JavaStyle {
             paddedToAdd = paddedToAdd.withElement(paddedToAdd.getElement().withPrefix(Space.format("\n")));
         }
 
-        AtomicInteger starFoldFrom = new AtomicInteger(0);
-        AtomicInteger starFoldTo = new AtomicInteger(0);
+        //Walk both directions from the insertion point, looking for imports that are in the same block and have the
+        //same package/outerclassname.
+        AtomicInteger starFoldFrom = new AtomicInteger(insertPosition);
+        AtomicInteger starFoldTo = new AtomicInteger(insertPosition);
         AtomicBoolean starFold = new AtomicBoolean(false);
+        int sameCount = 1; //start at 1 to account for the import being added.
+
         for (int i = insertPosition; i < originalImports.size(); i++) {
             JRightPadded<J.Import> anImport = originalImports.get(i);
             if (block(anImport) == addToBlock && packageOrOuterClassName(anImport)
                     .equals(packageOrOuterClassName(paddedToAdd))) {
                 starFoldTo.set(i);
+                sameCount++;
             } else {
                 break;
             }
         }
-        for (int i = starFoldTo.get() - 1; i >= insertPosition ; i--) {
+        for (int i = insertPosition - 1; i >= 0 ; i--) {
             JRightPadded<J.Import> anImport = originalImports.get(i);
             if (block(anImport) == addToBlock && packageOrOuterClassName(anImport)
                     .equals(packageOrOuterClassName(paddedToAdd))) {
                 starFoldFrom.set(i);
+                sameCount++;
             } else {
                 break;
             }
         }
 
-        if ((paddedToAdd.getElement().isStatic() && nameCountToUseStarImport <= starFoldTo.get() - starFoldFrom.get() + 2) ||
-                (!paddedToAdd.getElement().isStatic() && classCountToUseStarImport <= starFoldTo.get() - starFoldFrom.get() + 2)) {
+        if ((paddedToAdd.getElement().isStatic() && nameCountToUseStarImport <= sameCount) ||
+                (!paddedToAdd.getElement().isStatic() && classCountToUseStarImport <= sameCount)) {
             starFold.set(true);
             if (insertPosition != starFoldFrom.get()) {
                 // if we're adding to the middle of a group of imports that are getting star folded,

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -168,7 +168,7 @@ public class ImportLayoutStyle implements JavaStyle {
                     for (int j = 0; j < originalImports.size(); j++) {
                         if (after.getElement().equals(originalImports.get(j).getElement())) {
                             insertPosition = j;
-                            before = j > 0 ? originalImports.get(insertPosition) : null;
+                            before = j > 0 ? originalImports.get(insertPosition - 1) : null;
                             break;
                         }
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -152,13 +152,13 @@ public class ImportLayoutStyle implements JavaStyle {
                 before = i > 0 ? ideallyOrdered.get(i - 1) : null;
                 after = i + 1 < ideallyOrdered.size() ? ideallyOrdered.get(i + 1) : null;
                 if (before != null && (block(before) == addToBlock || after == null
-                        || (after.getElement().isStatic() != toAdd.isStatic() && before.getElement().isStatic() == toAdd.isStatic()))) {
+                        || (block(after) != addToBlock && after.getElement().isStatic() != toAdd.isStatic() && before.getElement().isStatic() == toAdd.isStatic()))) {
                     //Use the "before" import to determine insertion point.
                     //Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {
                         if (before.getElement().equals(originalImports.get(j).getElement())) {
                             insertPosition = j + 1;
-                            after = j + 1 < originalImports.size() ? originalImports.get(j + 1) : null;
+                            after = insertPosition < originalImports.size() ? originalImports.get(insertPosition) : null;
                             break;
                         }
                     }
@@ -167,8 +167,8 @@ public class ImportLayoutStyle implements JavaStyle {
                     //Find the import in the original list to establish insertion position.
                     for (int j = 0; j < originalImports.size(); j++) {
                         if (after.getElement().equals(originalImports.get(j).getElement())) {
-                            insertPosition = j + 1;
-                            before = j > 0 ? originalImports.get(j - 1) : null;
+                            insertPosition = j - 1;
+                            before = j > 0 ? originalImports.get(insertPosition) : null;
                             break;
                         }
                     }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -82,16 +82,16 @@ interface AddImportTest : JavaRecipeTest {
             AddImport("org.springframework.http.HttpHeaders", null, false),
         ),
         before = """
-            import java.util.Locale;
             import javax.ws.rs.core.Response.ResponseBuilder;
+            import java.util.Locale;
 
             class A {}
         """,
         after = """
             import org.springframework.http.HttpHeaders;
 
-            import java.util.Locale;
             import javax.ws.rs.core.Response.ResponseBuilder;
+            import java.util.Locale;
 
             class A {}
         """
@@ -589,7 +589,7 @@ interface AddImportTest : JavaRecipeTest {
         before = """
             import foo.B;
             import foo.C;
-            import java.util.LinkedHashMap;
+            import java.util.Collections;
             import java.util.List;
             import java.util.HashSet;
             import java.util.HashMap;
@@ -597,25 +597,24 @@ interface AddImportTest : JavaRecipeTest {
             class A {
                 B b = new B();
                 C c = new C();
-                Map<String, String> importUse1 = new HashMap<>();
-                Map<String, String> importUse2 = new LinkedHashMap<>();
-                Set<String> importUse3 = new HashSet<>();
-                List<String> importUse4 = new ArrayList<>();
+                Map<String, String> map = new HashMap<>();
+                Set<String> set = new HashSet<>();
+                List<String> test = Collections.singletonList("test");
+                List<String> test2 = new ArrayList<>();
             }
         """,
         after = """
             import foo.B;
             import foo.C;
-            
             import java.util.*;
 
             class A {
                 B b = new B();
                 C c = new C();
-                Map<String, String> importUse1 = new HashMap<>();
-                Map<String, String> importUse2 = new LinkedHashMap<>();
-                Set<String> importUse3 = new HashSet<>();
-                List<String> importUse4 = new ArrayList<>();
+                Map<String, String> map = new HashMap<>();
+                Set<String> set = new HashSet<>();
+                List<String> test = Collections.singletonList("test");
+                List<String> test2 = new ArrayList<>();
             }
         """
     )

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -606,6 +606,7 @@ interface AddImportTest : JavaRecipeTest {
         after = """
             import foo.B;
             import foo.C;
+            
             import java.util.*;
 
             class A {


### PR DESCRIPTION
This fixes how `addImports()` selects its insertion point to make minimal changes to a file's existing imports.