### PR TITLE
Added new line character stats to TabsAndIndentsStyle in Autodetect.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
@@ -66,7 +66,7 @@ public class IntelliJ extends NamedStyles {
     }
 
     public static TabsAndIndentsStyle tabsAndIndents() {
-        return new TabsAndIndentsStyle(false, 4, 4, 8, false);
+        return new TabsAndIndentsStyle(false, 4, 4, 8, false, false);
     }
 
     public static BlankLinesStyle blankLines() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/TabsAndIndentsStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/TabsAndIndentsStyle.java
@@ -32,6 +32,7 @@ public class TabsAndIndentsStyle implements JavaStyle {
     private Integer indentSize;
     private Integer continuationIndent;
     private Boolean indentsRelativeToExpressionStart;
+    private Boolean useCRLFNewLines;
 
     @Override
     public Style applyDefaults() {

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/StyleHelperTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/StyleHelperTest.kt
@@ -23,7 +23,7 @@ class StyleHelperTest {
 
     @Test
     fun mergeTabsAndIndentsStyles() {
-        val merged = StyleHelper.merge(IntelliJ.tabsAndIndents(), TabsAndIndentsStyle(true, 1, 1, 2, true))
+        val merged = StyleHelper.merge(IntelliJ.tabsAndIndents(), TabsAndIndentsStyle(true, 1, 1, 2, true, false))
         assertThat(merged.useTabCharacter).isTrue
         assertThat(merged.tabSize).isEqualTo(1)
         assertThat(merged.indentSize).isEqualTo(1)


### PR DESCRIPTION
fixes #789

Added new line character counts of CRLF and LF to TabsAndIndentsStyle in Autodetect.
Similar to tabs and indents the code defaults to `\n` or prioritizes the more common practice of using `\n` if the counts are equal.

Note: the changes can't directly be tested, since IDEs normalize the new line characters automatically.
The new line count is primarily based on:

```
                    if (c == '\n') {
                        if (i == 0 || chars[i - 1] != '\r') {
```