### PR TITLE
String#indexOf and List#indexOf replaceable by contains

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -187,6 +187,10 @@ class Java11HideUtilityClassConstructorTest : Java11Test, HideUtilityClassConstr
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11IndexOfReplaceableByContainsTest : Java11Test, IndexOfReplaceableByContainsTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11IndexOfShouldNotCompareGreaterThanZeroTest : Java11Test, IndexOfShouldNotCompareGreaterThanZeroTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -187,6 +187,10 @@ class Java8HideUtilityClassConstructorTest : Java8Test, HideUtilityClassConstruc
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8IndexOfReplaceableByContainsTest : Java8Test, IndexOfReplaceableByContainsTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8IndexOfShouldNotCompareGreaterThanZeroTest : Java8Test, IndexOfShouldNotCompareGreaterThanZeroTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/IndexOfReplaceableByContains.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/IndexOfReplaceableByContains.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+@Incubating(since = "7.10.0")
+public class IndexOfReplaceableByContains extends Recipe {
+    private static final MethodMatcher STRING_INDEX_MATCHER = new MethodMatcher("java.lang.String indexOf(String)");
+    private static final MethodMatcher LIST_INDEX_MATCHER = new MethodMatcher("java.util.List indexOf(Object)");
+
+    @Override
+    public String getDisplayName() {
+        return "`indexOf()` replaceable by `contains()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checking if a value is included in a `String` or `List` using `indexOf(value)>-1` or `indexOf(value)>=0` can be replaced with `contains(value)`.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new IndexOfReplaceableByContainsVisitor();
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                doAfterVisit(new UsesMethod<>(STRING_INDEX_MATCHER));
+                doAfterVisit(new UsesMethod<>(LIST_INDEX_MATCHER));
+                return cu;
+            }
+        };
+    }
+
+    private static class IndexOfReplaceableByContainsVisitor extends JavaVisitor<ExecutionContext> {
+        private final JavaTemplate stringContains = JavaTemplate.builder(this::getCursor, "#{any(java.lang.String)}.contains(#{any(java.lang.String)})").build();
+        private final JavaTemplate listContains = JavaTemplate.builder(this::getCursor, "#{any(java.util.List)}.contains(#{any(java.lang.Object)})").build();
+
+        @Override
+        public J visitBinary(J.Binary binary, ExecutionContext ctx) {
+            J j = super.visitBinary(binary, ctx);
+            J.Binary asBinary = (J.Binary) j;
+            if (asBinary.getLeft() instanceof J.MethodInvocation) {
+                J.MethodInvocation mi = ((J.MethodInvocation) asBinary.getLeft());
+                if (STRING_INDEX_MATCHER.matches(mi) || LIST_INDEX_MATCHER.matches(mi)) {
+                    if (asBinary.getRight() instanceof J.Literal) {
+                        String valueSource = ((J.Literal) asBinary.getRight()).getValueSource();
+                        boolean isGreaterThanNegativeOne = asBinary.getOperator() == J.Binary.Type.GreaterThan && "-1".equals(valueSource);
+                        boolean isGreaterThanOrEqualToZero = asBinary.getOperator() == J.Binary.Type.GreaterThanOrEqual && "0".equals(valueSource);
+                        if (isGreaterThanNegativeOne || isGreaterThanOrEqualToZero) {
+                            j = mi.withTemplate(STRING_INDEX_MATCHER.matches(mi) ? stringContains : listContains,
+                                    mi.getCoordinates().replace(), mi.getSelect(), mi.getArguments().get(0)).withPrefix(asBinary.getPrefix());
+                        }
+                    }
+                }
+            }
+            return j;
+        }
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -155,6 +155,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class HideUtilityClassConstructorTck : HideUtilityClassConstructorTest
 
     @Nested
+    inner class IndexOfReplaceableByContainsTck : IndexOfReplaceableByContainsTest
+
+    @Nested
     inner class IndexOfShouldNotCompareGreaterThanZeroTckTest : IndexOfShouldNotCompareGreaterThanZeroTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/IndexOfReplaceableByContainsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/IndexOfReplaceableByContainsTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+@Suppress("StatementWithEmptyBody")
+interface IndexOfReplaceableByContainsTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = IndexOfReplaceableByContains()
+
+    @Test
+    fun stringIndexOfReplaceableByContains(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                static boolean hasIndex(String str) {
+                    if (str.indexOf("str") > -1) {
+                    }
+                    return str.indexOf("str") >= 0;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static boolean hasIndex(String str) {
+                    if (str.contains("str")) {
+                    }
+                    return str.contains("str");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun listIndexOfReplaceableByContains(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            import java.util.List;
+
+            class Test {
+                static boolean hasIndex(List<String> strList, String str) {
+                    if (strList.indexOf(str) > -1) {
+                    }
+                    return strList.indexOf(str) >= 0;
+                }
+            }
+        """,
+        after = """
+            import java.util.List;
+
+            class Test {
+                static boolean hasIndex(List<String> strList, String str) {
+                    if (strList.contains(str)) {
+                    }
+                    return strList.contains(str);
+                }
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Inspired by https://github.com/openrewrite/rewrite/pull/814

>If the intent is merely to check inclusion of a value in a String or a List, the contains method is better suited to express this intent.

<!--
see: https://jsparrow.github.io/rules/index-of-to-contains.html#tags
-->
