### PR TITLE
Remove unused assignments

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -292,6 +292,10 @@ class Java11RemoveExtraSemicolonsTest : Java11Test, RemoveExtraSemicolonsTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11RemoveUnusedAssignmentsTest : Java11Test, RemoveUnusedAssignmentsTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11RemoveUnusedLocalVariablesTest : Java11Test, RemoveUnusedLocalVariablesTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -288,6 +288,10 @@ class Java8RemoveExtraSemicolonsTest : Java8Test, RemoveExtraSemicolonsTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8RemoveUnusedAssignmentsTest : Java8Test, RemoveUnusedAssignmentsTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8RemoveUnusedLocalVariablesTest : Java8Test, RemoveUnusedLocalVariablesTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnusedAssignments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnusedAssignments.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.DeleteStatement;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Determines if an assignment to an identifier has any read operations performed on it.
+ * Any read operations performed on an assignment LHS (left-hand side) means the assignment RHS (right-hand side) is used.
+ * <p>
+ * If an assignment is overwritten by a reassignment later, the previous assignment may need to be removed.
+ * In that case, we need to look at whether there are read operations performed on the LHS assignment
+ * in the scope between the assignment and the reassignment.
+ * <p>
+ * If there are read operations, we should not remove the assignment. But if there are not any LHS read operations
+ * between the first assignment and the reassignment, then we can prune the original assignment. It's dead code.
+ */
+@Incubating(since = "7.10.0")
+@SuppressWarnings("AnonymousInnerClassMayBeStatic")
+public class RemoveUnusedAssignments extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Remove unused assignments";
+    }
+
+    @Override
+    public String getDescription() {
+        return "An assignment is unused when a local variable is assigned a value that is not read by any subsequent instruction. " +
+                "Calculating a value followed by overwriting it could indicate a coding error, or at least a waste of resources. " +
+                "Assignments without a subsequent read which are overwritten by a reassignment are removed.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("RSPEC-1854");
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                final Map<String, List<J.Assignment>> identifierAssignments = new HashMap<>();
+                final List<J.VariableDeclarations.NamedVariable> variablesDeclaredWithinScope = new ArrayList<>();
+
+                final JavaIsoVisitor<ExecutionContext> markAssignments = new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                        variablesDeclaredWithinScope.addAll(multiVariable.getVariables());
+                        return super.visitVariableDeclarations(multiVariable, ctx);
+                    }
+
+                    @Override
+                    public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
+                        if (assignment.getVariable() instanceof J.Identifier) {
+                            J.Identifier lhs = (J.Identifier) assignment.getVariable();
+                            if (variablesDeclaredWithinScope.stream().anyMatch(vd -> vd.getName().getSimpleName().equals(lhs.getSimpleName()))) {
+                                identifierAssignments.computeIfAbsent(lhs.getSimpleName(), f -> new ArrayList<>()).add(assignment);
+                            }
+                        }
+                        return super.visitAssignment(assignment, ctx);
+                    }
+                };
+                markAssignments.visit(method, ctx);
+
+                final JavaIsoVisitor<ExecutionContext> sweepAssignments = new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
+                        if (assignment.getVariable() instanceof J.Identifier) {
+                            J.Identifier lhs = (J.Identifier) assignment.getVariable();
+                            if (identifierAssignments.containsKey(lhs.getSimpleName())) {
+                                List<J.Assignment> assignments = identifierAssignments.get(lhs.getSimpleName());
+                                if (assignments.contains(assignment)) {
+                                    ListIterator<J.Assignment> assignmentIterator = assignments.listIterator(assignments.indexOf(assignment) + 1);
+                                    // "null" implying "end of list"; as in, no other assignments to this identifier.
+                                    J.Assignment nextAssignment = assignmentIterator.hasNext() ? assignmentIterator.next() : null;
+                                    // check for any read operations performed on the assignment identifier between the last seen assignment and the current reassignment.
+                                    Set<J> readReferences = References.findRhsReferences(getCursor().firstEnclosingOrThrow(J.MethodDeclaration.class), assignment, nextAssignment, lhs);
+                                    if (readReferences.isEmpty()) {
+                                        doAfterVisit(new DeleteStatement<>(assignment));
+                                        assignments.remove(assignment);
+                                    }
+                                }
+                            }
+                        }
+                        return super.visitAssignment(assignment, ctx);
+                    }
+                };
+                method = (J.MethodDeclaration) sweepAssignments.visit(method, ctx);
+
+                return super.visitMethodDeclaration(method, ctx);
+            }
+        };
+    }
+
+    private static class References {
+        private static Set<J> findRhsReferences(J j, @Nullable Tree startAt, @Nullable Tree stopAt, J.Identifier target) {
+            final AtomicBoolean withinScope = new AtomicBoolean(false);
+            final Set<J> refs = new HashSet<>();
+            new JavaIsoVisitor<Set<J>>() {
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, Set<J> ctx) {
+                    J.Identifier i = super.visitIdentifier(identifier, ctx);
+                    if ((startAt != null || stopAt != null) && !withinScope.get()) {
+                        return i;
+                    }
+                    if (i.getSimpleName().equals(target.getSimpleName())) {
+                        J parent = getCursor().dropParentUntil(J.class::isInstance).getValue();
+                        if (parent instanceof J.Assignment) {
+                            J.Assignment parentTree = (J.Assignment) parent;
+                            if (!parentTree.getVariable().isScope(i)) {
+                                ctx.add(parentTree);
+                            }
+                        } else if (parent instanceof J.AssignmentOperation) {
+                            J.AssignmentOperation parentTree = (J.AssignmentOperation) parent;
+                            if (parentTree.getVariable().isScope(i)) {
+                                assert getCursor().getParent() != null;
+                                J grandParent = getCursor().getParent().dropParentUntil(J.class::isInstance).getValue();
+                                if (grandParent instanceof Expression || grandParent instanceof J.Return) {
+                                    ctx.add(grandParent);
+                                }
+                            } else {
+                                ctx.add(parent);
+                            }
+                        } else if (parent instanceof J.VariableDeclarations.NamedVariable) {
+                            J.VariableDeclarations.NamedVariable parentTree = (J.VariableDeclarations.NamedVariable) parent;
+                            if (!parentTree.getName().getSimpleName().equals(target.getSimpleName())) {
+                                ctx.add(parentTree);
+                            }
+                        } else {
+                            ctx.add(parent);
+                        }
+                    }
+                    return i;
+                }
+
+                @Nullable
+                @Override
+                public J visit(@Nullable Tree tree, Set<J> ctx) {
+                    if (startAt != null && startAt.isScope(tree)) {
+                        withinScope.set(true);
+                    }
+                    if (stopAt != null && stopAt.isScope(tree)) {
+                        withinScope.set(false);
+                        return (J) tree;
+                    }
+                    return super.visit(tree, ctx);
+                }
+
+            }.visit(j, refs);
+            return refs;
+        }
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -243,6 +243,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class RemoveUnusedPrivateMethodsTck : RemoveUnusedPrivateMethodsTest
 
     @Nested
+    inner class RemoveUnusedAssignmentsTck : RemoveUnusedAssignmentsTest
+
+    @Nested
     inner class RemoveImportTck : RemoveImportTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnusedAssignmentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnusedAssignmentsTest.kt
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaRecipeTest
+
+@Suppress(
+    "StatementWithEmptyBody",
+    "ConstantConditions",
+    "InfiniteLoopStatement",
+    "AssignmentToForLoopParameter",
+    "EmptyClassInitializer",
+    "AccessStaticViaInstance",
+    "ClassInitializerMayBeStatic",
+    "ParameterCanBeLocal",
+    "PointlessArithmeticExpression",
+    "EmptyTryBlock",
+    "AssignmentReplaceableWithOperatorAssignment",
+    "AnonymousInnerClassMayBeStatic"
+)
+interface RemoveUnusedAssignmentsTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = RemoveUnusedAssignments()
+
+    @Test
+    fun localVariableUnusedAssignment() = assertChanged(
+        before = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    a = 99;
+                    return a;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 99;
+                    return a;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableReadAfterReassignment() = assertUnchanged(
+        before = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    int b = a;
+                    a = 99;
+                    return a;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableUnusedAfterReassignment() = assertChanged(
+        before = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    int b = a;
+                    a = 99;
+                    return b;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    int b = a;
+                    return b;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun multipleLocalVariableUnusedAfterReassignment() = assertChanged(
+        before = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    int b = a;
+                    b = 1;
+                    b = 2;
+                    b = 3;
+                    a = 99;
+                    System.out.println(b);
+                    b = 2;
+                    return b;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    int b = a;
+                    b = 3;
+                    System.out.println(b);
+                    b = 2;
+                    return b;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableReadAfterReassignmentMethodInvocation() = assertChanged(
+        before = """
+            class Test {
+                static void method() {
+                    Object a;
+                    a = new Object();
+                    System.out.println(a);
+                    a = null;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static void method() {
+                    Object a;
+                    a = new Object();
+                    System.out.println(a);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableNameScopeBetweenMethods() = assertChanged(
+        before = """
+            class Test {
+                static void method0() {
+                    int a = 1;
+                    a = 2;
+                }
+
+                static void method1() {
+                    int a = 3;
+                    a = 4;
+                    System.out.println(a);
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static void method0() {
+                    int a = 1;
+                }
+
+                static void method1() {
+                    int a = 3;
+                    a = 4;
+                    System.out.println(a);
+                }
+            }
+        """
+    )
+
+    @Test
+    @Disabled
+    fun localVariableAssignmentPathsWithinIfStatements() = assertUnchanged(
+        before = """
+            class Test {
+                static String method(int a) {
+                    String str;
+                    if (a == 0) {
+                        str = "zero";
+                    } else {
+                        str = "not zero";
+                    }
+                    return str;
+                }
+            }
+        """
+    )
+
+    @Test
+    @Disabled
+    fun localVariableIdentifierEnclosedInParentheses() = assertChanged(
+        before = """
+            class Test {
+                static void method() {
+                    int i = 0;
+                    System.out.println(i);
+                    (i) = 99;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static void method() {
+                    int i = 0;
+                    System.out.println(i);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableReadInAssertStatement() = assertUnchanged(
+        before = """
+            class Test {
+                static void method(boolean x) {
+                    boolean y = !x;
+                    assert y;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun localVariableSelfAssignmentOperation() = assertUnchanged(
+        before = """
+            class Test {
+                static int method() {
+                    int a;
+                    a = 0;
+                    a += 1;
+                    return a;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun shadowedNameScope() = assertChanged(
+        before = """
+            class Test {
+                int a = 0;
+
+                static Object method() {
+                    int a = 1;
+                    a = 2;
+
+                    class InnerTest {
+                        int innerMethod() {
+                            int a = 0;
+                            a = 3;
+                            a = 4;
+                            return a;
+                        }
+                    }
+                    return new InnerTest();
+                }
+            }
+        """,
+        after = """
+            class Test {
+                int a = 0;
+
+                static Object method() {
+                    int a = 1;
+
+                    class InnerTest {
+                        int innerMethod() {
+                            int a = 0;
+                            a = 4;
+                            return a;
+                        }
+                    }
+                    return new InnerTest();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun recognizeReadsFromInnerClass() = assertUnchanged(
+        before = """
+            class Test {
+                int a = 0;
+
+                Object method() {
+                    class InnerTest {
+                        int innerMethod() {
+                            return a;
+                        }
+                    }
+                    return new InnerTest();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun ignoreFields0() = assertUnchanged(
+        before = """
+            class Test {
+                int a;
+
+                void method() {
+                    this.a = 0;
+                    a = 1;
+                    a = 2;
+                    System.out.println(a);
+                    a = 3;
+                    a = 4;
+                }
+            }
+        """
+    )
+
+    @Test
+    @Disabled
+    // reformation of noticing an issue where "builder" is being removed in:
+    // https://github.com/apache/drill/blob/958d849144a662a781e4d7d59adbf3300ad3bdea/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java#L93
+    fun ignoreFields1() = assertUnchanged(
+        before = """
+            class Test {
+                Test builder;
+
+                void addContext(Test builder) {
+                    this.builder = builder;
+                }
+
+                void doWork() {
+                    // nothing
+                }
+
+                void someInitialization() {
+                    Test anotherTest = new Test() {
+                        @Override
+                        void addContext(Test builder) {
+                            this.builder = builder;
+                        }
+                    };
+
+                    builder = new Test();
+                }
+
+                void someUsage() {
+                    builder.doWork();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun parameterReassignment() = assertChanged(
+        before = """
+            class Test {
+                static int method(int a) {
+                    a = 99;
+                    a = 0;
+                    return a;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static int method(int a) {
+                    a = 0;
+                    return a;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun forLoop() = assertUnchanged(
+        before = """
+            class Test {
+                static void method(int j) {
+                    int k = 0;
+                    for (int i = 0; j < 10; j++) {
+                        k += j;
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun ignoreUnusedForEachInitialization() = assertUnchanged(
+        before = """
+            import java.util.List;
+
+            class Test {
+                static void method(List<String> list) {
+                    int a = 0;
+                    for (String elem : list) {
+                        System.out.println(a);
+                        a = 2;
+                    }
+                    System.out.println(a);
+                }
+            }
+        """
+    )
+
+    @Test
+    // This shows how there may be unwanted removal of unused assignments in situations
+    // where the assignment is technically "unused", but it's an intentional choice.
+    // https://github.com/apache/drill/blob/958d849144a662a781e4d7d59adbf3300ad3bdea/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java#L298-L316
+    fun removesUnusedAssignmentToNull() = assertChanged(
+        before = """
+            import java.io.IOException;
+            import java.io.InputStream;
+
+            class Test {
+                static void closeStream(InputStream inputStream, String name) {
+                    if (inputStream == null) {
+                        return;
+                    }
+                    try {
+                        inputStream.close();
+                    } catch (IOException e) {
+                        System.out.println(String.format("Error when closing {}: {}", name, e.getMessage()));
+                    }
+                    inputStream = null;
+                }
+            }
+        """,
+        after = """
+            import java.io.IOException;
+            import java.io.InputStream;
+
+            class Test {
+                static void closeStream(InputStream inputStream, String name) {
+                    if (inputStream == null) {
+                        return;
+                    }
+                    try {
+                        inputStream.close();
+                    } catch (IOException e) {
+                        System.out.println(String.format("Error when closing {}: {}", name, e.getMessage()));
+                    }
+                }
+            }
+        """
+    )
+
+
+}


### PR DESCRIPTION
See: #821

Re-addition of code pruned in https://github.com/openrewrite/rewrite/pull/855 - Removed before release due to being unaware of conditional execution paths.

Note, that this problem, "dead code analysis", among others, is one of the posterchild problems solved by representing the tree as a Control Flow Graph.

See also: https://www.cs.utexas.edu/~pingali/CS380C/2020/lectures/CFG.pdf