### PR TITLE
TypeValidator also validates that Identifiers have type information. Fixes #868

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -191,8 +191,14 @@ public class ChangeType extends Recipe {
                 JavaType.Class oldType = JavaType.Class.build(oldFullyQualifiedTypeName);
                 if (maybeClass.toString().equals(oldType.getClassName())) {
                     maybeRemoveImport(oldType.getOwningClass());
-                    return updateOuterClassTypes(TypeTree.build(((JavaType.FullyQualified) targetType).getClassName())
+                    Expression e = updateOuterClassTypes(TypeTree.build(((JavaType.FullyQualified) targetType).getClassName())
                             .withPrefix(fieldAccess.getPrefix()));
+                    // If a FieldAccess like Map.Entry has been replaced with an Identifier, ensure that identifier has the correct type
+                    if(e instanceof J.Identifier && e.getType() == null) {
+                        J.Identifier i = (J.Identifier) e;
+                        e = i.withType(targetType);
+                    }
+                    return e;
                 }
             }
             return super.visitFieldAccess(fieldAccess, ctx);

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangePackageTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangePackageTest.kt
@@ -184,7 +184,7 @@ interface ChangePackageTest: JavaRecipeTest {
     @Test
     fun classDecl(jp: JavaParser) = assertChanged(
         jp,
-        dependsOn = arrayOf(testClass),
+        dependsOn = arrayOf(testClass, "public interface I1 {}"),
         before = """
             public class B extends org.openrewrite.Test implements I1 {}
         """,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeTypeTest.kt
@@ -69,6 +69,7 @@ interface ChangeTypeTest : JavaRecipeTest {
         """.trimIndent())
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/868")
     @Test
     fun changeInnerClassToOuterClass(jp: JavaParser) = assertChanged(
         jp,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeTypeTest.kt
@@ -72,7 +72,7 @@ interface ChangeTypeTest : JavaRecipeTest {
     @Test
     fun changeInnerClassToOuterClass(jp: JavaParser) = assertChanged(
         jp,
-        recipe = ChangeType("java.util.Map.Entry", "my.pkg.List"),
+        recipe = ChangeType("java.util.Map.Entry", "java.util.List"),
         before = """
             import java.util.Map;
             import java.util.Map.Entry;
@@ -83,7 +83,7 @@ interface ChangeTypeTest : JavaRecipeTest {
             }
         """,
         after = """
-            import my.pkg.List;
+            import java.util.List;
             
             class Test {
                 List p;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
@@ -48,17 +48,14 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
         @Language("java") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
-        skipEnhancedTypeValidation: Boolean = false,
+        typeValidation: TypeValidator.ValidationOptions.Companion.Builder.()->Unit = {},
         afterConditions: (J.CompilationUnit) -> Unit = { }
     ) {
-        val typeValidatingAfterConditions: (J.CompilationUnit) -> Unit = if(skipEnhancedTypeValidation) {
-            afterConditions
-        } else {
-            {
-                TypeValidator.assertTypesValid(it)
-                afterConditions(it)
+        val typeValidatingAfterConditions: (J.CompilationUnit) -> Unit = { cu ->
+                TypeValidator.assertTypesValid(cu, TypeValidator.ValidationOptions.builder(typeValidation))
+                afterConditions(cu)
             }
-        }
+
         super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, typeValidatingAfterConditions)
     }
 
@@ -71,17 +68,13 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
         @Language("java") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
-        skipEnhancedTypeValidation: Boolean = false,
+        typeValidation: TypeValidator.ValidationOptions.Companion.Builder.()->Unit = {},
         afterConditions: (J.CompilationUnit) -> Unit = { }
     ) {
-        val typeValidatingAfterConditions: (J.CompilationUnit) -> Unit = if(skipEnhancedTypeValidation) {
-            afterConditions
-        } else {
-            {
-                TypeValidator.assertTypesValid(it)
-                afterConditions(it)
+        val typeValidatingAfterConditions: (J.CompilationUnit) -> Unit = { cu ->
+                TypeValidator.assertTypesValid(cu, TypeValidator.ValidationOptions.builder(typeValidation))
+                afterConditions(cu)
             }
-        }
         super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, typeValidatingAfterConditions)
     }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
@@ -149,6 +149,9 @@ interface JavaTemplateTest : JavaRecipeTest {
                 return m
             }
         }.toRecipe(),
+        typeValidation = {
+            identifiers = false
+        },
         before = """
             import org.openrewrite.Test;
             class A {
@@ -1005,6 +1008,9 @@ interface JavaTemplateTest : JavaRecipeTest {
                 }
             }
         """,
+        typeValidation = {
+            identifiers = false
+        },
         afterConditions = { cu ->
             val type = (cu.classes.first().body.statements.first() as J.MethodDeclaration).type!!
             assertThat(type).isNotNull
@@ -1025,6 +1031,21 @@ interface JavaTemplateTest : JavaRecipeTest {
                     }
         }
     )
+
+    @Test
+    fun foo(jp: JavaParser) {
+        val cu = jp.parse("""
+                        import java.util.List;
+                        
+                        class Test {
+                        
+                            <T, U> void test(List<T> t, U u) {
+                            }
+                        }
+        """.trimIndent()).first()
+        val md = cu.classes[0].body.statements[0]
+        md
+    }
 
     @Test
     fun replaceClassTypeParameters(jp: JavaParser) = assertChanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/PadEmptyForLoopComponentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/PadEmptyForLoopComponentsTest.kt
@@ -48,6 +48,8 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         before = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for (; i < j; i++, j--) { }
                 }
             }
@@ -55,6 +57,8 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         after = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for ( ; i < j; i++, j--) { }
                 }
             }
@@ -72,6 +76,8 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         before = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for ( ; i < j; i++, j--) { }
                 }
             }
@@ -79,6 +85,8 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         after = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for (; i < j; i++, j--) { }
                 }
             }
@@ -96,6 +104,7 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         before = """
             public class A {
                 {
+                    int i = 0;
                     for (int i = 0; i < 10;) { i++; }
                 }
             }
@@ -103,6 +112,7 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         after = """
             public class A {
                 {
+                    int i = 0;
                     for (int i = 0; i < 10; ) { i++; }
                 }
             }
@@ -120,6 +130,7 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         before = """
             public class A {
                 {
+                    int i = 0;
                     for (int i = 0; i < 10; ) { i++; }
                 }
             }
@@ -127,6 +138,7 @@ interface PadEmptyForLoopComponentsTest : JavaRecipeTest {
         after = """
             public class A {
                 {
+                    int i = 0;
                     for (int i = 0; i < 10;) { i++; }
                 }
             }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RenameVariableTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RenameVariableTest.kt
@@ -213,6 +213,7 @@ interface RenameVariableTest : JavaRecipeTest {
             package org.openrewrite;
 
             import java.io.FileInputStream;
+            import java.io.FileDescriptor;
 
             public class A {
                 public int val = 0;
@@ -232,6 +233,7 @@ interface RenameVariableTest : JavaRecipeTest {
             package org.openrewrite;
 
             import java.io.FileInputStream;
+            import java.io.FileDescriptor;
 
             public class A {
                 public int VALUE = 0;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/BooleanChecksNotInvertedTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/BooleanChecksNotInvertedTest.kt
@@ -30,6 +30,7 @@ interface BooleanChecksNotInvertedTest : JavaRecipeTest {
         jp,
         before = """
             public class Test {
+                int i;
                 int a;
                 void test() {
                     if ( !(a == 2)) {
@@ -40,6 +41,7 @@ interface BooleanChecksNotInvertedTest : JavaRecipeTest {
         """,
         after = """
             public class Test {
+                int i;
                 int a;
                 void test() {
                     if ( a != 2) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/MinimumSwitchCasesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/MinimumSwitchCasesTest.kt
@@ -57,7 +57,9 @@ interface MinimumSwitchCasesTest : JavaRecipeTest {
                 }
             }
         """,
-        skipEnhancedTypeValidation = true
+        typeValidation = {
+            methodInvocations = false
+        }
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
@@ -91,7 +93,9 @@ interface MinimumSwitchCasesTest : JavaRecipeTest {
                 }
             }
         """,
-        skipEnhancedTypeValidation = true
+        typeValidation = {
+            methodInvocations = false
+        }
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
@@ -125,7 +129,9 @@ interface MinimumSwitchCasesTest : JavaRecipeTest {
                 }
             }
         """,
-        skipEnhancedTypeValidation = true
+        typeValidation = {
+            methodInvocations = false
+        }
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
@@ -159,7 +165,9 @@ interface MinimumSwitchCasesTest : JavaRecipeTest {
                 }
             }
         """,
-        skipEnhancedTypeValidation = true
+        typeValidation = {
+            methodInvocations = false
+        }
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
@@ -188,7 +196,9 @@ interface MinimumSwitchCasesTest : JavaRecipeTest {
                 }
             }
         """,
-        skipEnhancedTypeValidation = true
+        typeValidation = {
+            methodInvocations = false
+        }
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
@@ -217,7 +227,9 @@ interface MinimumSwitchCasesTest : JavaRecipeTest {
                 }
             }
         """,
-        skipEnhancedTypeValidation = true
+        typeValidation = {
+            methodInvocations = false
+        }
     )
 
     @Suppress("StatementWithEmptyBody")

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/SpacesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/SpacesTest.kt
@@ -4743,6 +4743,8 @@ interface SpacesTest : JavaRecipeTest {
         before = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for (; i < j; i++, j--) { }
                 }
             }
@@ -4750,6 +4752,8 @@ interface SpacesTest : JavaRecipeTest {
         after = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for ( ; i < j; i++, j--) { }
                 }
             }
@@ -4762,6 +4766,8 @@ interface SpacesTest : JavaRecipeTest {
         before = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for ( ; i < j; i++, j--) { }
                 }
             }
@@ -4769,6 +4775,8 @@ interface SpacesTest : JavaRecipeTest {
         after = """
             public class A {
                 {
+                    int i = 0;
+                    int j = 10;
                     for (; i < j; i++, j--) { }
                 }
             }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -319,6 +319,12 @@ interface TabsAndIndentsTest : JavaRecipeTest {
     @Test
     fun tabsAndIndents(jp: JavaParser.Builder<*, *>) = assertChanged(
         jp.styles(tabsAndIndents()).build(),
+        dependsOn = arrayOf(
+            "public interface I1{}",
+            "public interface I2{}",
+            "public class E1 extends Exception{}",
+            "public class E2 extends Exception{}"
+        ),
         before = """
             public class Test {
             public int[] X = new int[]{1, 3, 5, 7, 9, 11};
@@ -1184,8 +1190,9 @@ interface TabsAndIndentsTest : JavaRecipeTest {
             import java.io.ByteArrayInputStream;
             import java.io.InputStream;
             import java.io.Serializable;
-            @Deprecated
-            (since = "1.0")
+            import java.lang.annotation.Retention;
+            @Retention
+            (value = "1.0")
             public
             class
             Test
@@ -1214,8 +1221,9 @@ interface TabsAndIndentsTest : JavaRecipeTest {
             import java.io.ByteArrayInputStream;
             import java.io.InputStream;
             import java.io.Serializable;
-            @Deprecated
-                    (since = "1.0")
+            import java.lang.annotation.Retention;
+            @Retention
+                    (value = "1.0")
             public
             class
             Test

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -43,27 +43,36 @@ interface TabsAndIndentsTest : JavaRecipeTest {
         jp,
         before = """
             class Test {{
-                if (condition)
+                if (true == false)
                 doTheThing();
             
                 doTheOtherThing();
                 somethingElseEntirely();
             
                 foo();
-            }}
+            }
+                public static void doTheThing() {}
+                public static void doTheOtherThing() {}
+                public static void somethingElseEntirely() {}
+                public static void foo() {}
+            }
         """,
         after = """
             class Test {{
-                if (condition)
+                if (true == false)
                     doTheThing();
             
                 doTheOtherThing();
                 somethingElseEntirely();
             
                 foo();
-            }}
-        """,
-        skipEnhancedTypeValidation = true
+            }
+                public static void doTheThing() {}
+                public static void doTheOtherThing() {}
+                public static void somethingElseEntirely() {}
+                public static void foo() {}
+            }
+        """
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/623")


### PR DESCRIPTION
New way to configure more granular type validation suppression for `JavaRecipeTest.assertChanged()`.
I haven't merged TypeValidator and FindMissingTypes yet, but I will in the future