### PR TITLE
[#797] MethodParamPad

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11TreeDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11TreeDebugTests.kt
@@ -149,6 +149,10 @@ class Java11MethodMatcherTest: Java11Test, MethodMatcherTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11MethodParamPadTest: Java11Test, MethodParamPadTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11NewArrayTest: Java11Test, NewArrayTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8TreeDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8TreeDebugTest.kt
@@ -145,6 +145,10 @@ class Java8MethodMatcherTest: Java8Test, MethodMatcherTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8MethodParamPadTest: Java8Test, MethodParamPadTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8NewArrayTest: Java8Test, NewArrayTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPad.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.format.SpacesVisitor;
+import org.openrewrite.java.marker.JavaSearchResult;
+import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.SpacesStyle;
+import org.openrewrite.java.tree.J;
+
+public class MethodParamPad extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Method parameter padding";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fixes whitespace padding between the identifier of a method definition or method invocation and the left parenthesis of the parameter list. " +
+                "For example, when configured to remove spacing, `someMethodInvocation (x);` becomes `someMethodInvocation(x)`.";
+    }
+
+    @Override
+    protected @Nullable JavaIsoVisitor<ExecutionContext> getSingleSourceApplicableTest() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                if (cu.getStyle(MethodParamPadStyle.class) != null) {
+                    return cu.withMarkers(cu.getMarkers().add(new JavaSearchResult(Tree.randomId(), MethodParamPad.this, null)));
+                }
+                return cu;
+            }
+        };
+    }
+
+    @Override
+    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new MethodParamPadVisitor();
+    }
+
+    private static class MethodParamPadVisitor extends JavaIsoVisitor<ExecutionContext> {
+        SpacesStyle spacesStyle;
+        MethodParamPadStyle methodParamPadStyle;
+
+        @Nullable
+        EmptyForInitializerPadStyle emptyForInitializerPadStyle;
+
+        @Nullable
+        EmptyForIteratorPadStyle emptyForIteratorPadStyle;
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
+            methodParamPadStyle = cu.getStyle(MethodParamPadStyle.class);
+            emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
+            emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
+
+            spacesStyle = spacesStyle.withBeforeParentheses(
+                    spacesStyle.getBeforeParentheses()
+                            .withMethodDeclaration(methodParamPadStyle.getSpace())
+                            .withMethodCall(methodParamPadStyle.getSpace())
+            );
+            return super.visitCompilationUnit(cu, ctx);
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+            J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
+            if (!methodParamPadStyle.getAllowLineBreaks() && md.getPadding().getParameters().getBefore().getWhitespace().contains("\n")) {
+                md = md.getPadding().withParameters(
+                        md.getPadding().getParameters().withBefore(
+                                md.getPadding().getParameters().getBefore().withWhitespace("")
+                        )
+                );
+            }
+            doAfterVisit(new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, md));
+            return md;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+            if (!methodParamPadStyle.getAllowLineBreaks() && mi.getPadding().getArguments().getBefore().getWhitespace().contains("\n")) {
+                mi = mi.getPadding().withArguments(
+                        mi.getPadding().getArguments().withBefore(
+                                mi.getPadding().getArguments().getBefore().withWhitespace("")
+                        )
+                );
+            }
+            doAfterVisit(new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, mi));
+            return mi;
+        }
+
+        @Override
+        public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+            J.NewClass nc = super.visitNewClass(newClass, ctx);
+            if (!methodParamPadStyle.getAllowLineBreaks() && nc.getPadding().getArguments() != null && nc.getPadding().getArguments().getBefore().getWhitespace().contains("\n")) {
+                nc = nc.getPadding().withArguments(
+                        nc.getPadding().getArguments().withBefore(
+                                nc.getPadding().getArguments().getBefore().withWhitespace("")
+                        )
+                );
+            }
+            doAfterVisit(new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, nc));
+            return nc;
+        }
+
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPadStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPadStyle.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.java.style.Checkstyle;
+import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
+
+@Value
+@With
+public class MethodParamPadStyle implements Style {
+    /**
+     * Whether to add spacing between the method declarations (or method invocations) identifier and the start of the left parenthesis.
+     * <p>
+     * When true:
+     * <p>
+     * {@code method (a, b);}
+     * <p>
+     * When false:
+     * <p>
+     * {@code method(a, b);}
+     */
+    Boolean space;
+
+    /**
+     * Whether to allow a linebreak between the method declaration (or method invocation) identifier and the start of the left parenthesis.
+     * Note this does not add a linebreak if one is missing. It only controls whether a linebreak is permitted.
+     * <p>
+     * When true:
+     * <pre>{@code method // acceptable
+     *      (a, b);
+     * }</pre>
+     * <p>
+     * When false, the linebreak would be removed, becoming:
+     * <p>
+     * {@code method(a, b);}
+     * <p>
+     */
+    Boolean allowLineBreaks;
+
+    @Override
+    public Style applyDefaults() {
+        return StyleHelper.merge(Checkstyle.methodParamPadStyle(), this);
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -48,6 +48,7 @@ public class Checkstyle extends NamedStyles {
                         fallThrough(),
                         hiddenFieldStyle(),
                         hideUtilityClassConstructorStyle(),
+                        methodParamPadStyle(),
                         unnecessaryParentheses()
                 ));
     }
@@ -107,5 +108,9 @@ public class Checkstyle extends NamedStyles {
 
     public static EmptyForIteratorPadStyle emptyForIteratorPadStyle() {
         return new EmptyForIteratorPadStyle(false);
+    }
+
+    public static MethodParamPadStyle methodParamPadStyle() {
+        return new MethodParamPadStyle(false, false);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
@@ -70,6 +70,7 @@ public class CheckstyleConfigLoader {
                 fallThrough(conf),
                 hiddenFieldStyle(conf),
                 hideUtilityClassConstructorStyle(conf),
+                methodParamPadStyle(conf),
                 unnecessaryParentheses(conf))
             .filter(Objects::nonNull)
             .flatMap(Set::stream)
@@ -206,6 +207,25 @@ public class CheckstyleConfigLoader {
                 module.prop("ignoreAbstractMethods", false)
             ))
             .collect(toSet());
+    }
+
+    @Nullable
+    private static Set<MethodParamPadStyle> methodParamPadStyle(Map<String, List<Module>> conf) {
+        List<Module> moduleList = conf.get("MethodParamPad");
+        if(moduleList == null) {
+            return null;
+        }
+        return moduleList.stream()
+                .map(module -> {
+                    String option = module.properties.get("option");
+                    // nospace is default, so no option means pad is false
+                    boolean pad = option != null && "space".equals(option.trim());
+                    return new MethodParamPadStyle(
+                            pad,
+                            module.prop("allowLineBreaks", false)
+                    );
+                })
+                .collect(toSet());
     }
 
     @SuppressWarnings("DuplicatedCode")

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleConfigLoaderTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleConfigLoaderTest.kt
@@ -17,11 +17,7 @@ package org.openrewrite.java.style
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.openrewrite.java.cleanup.DefaultComesLastStyle
-import org.openrewrite.java.cleanup.EmptyBlockStyle
-import org.openrewrite.java.cleanup.EmptyForInitializerPadStyle
-import org.openrewrite.java.cleanup.EqualsAvoidsNullStyle
-import org.openrewrite.java.cleanup.UnnecessaryParenthesesStyle
+import org.openrewrite.java.cleanup.*
 import org.openrewrite.java.style.CheckstyleConfigLoader.loadCheckstyleConfig
 
 class CheckstyleConfigLoaderTest {
@@ -180,6 +176,30 @@ class CheckstyleConfigLoaderTest {
         val emptyForPadInitializerStyle = checkstyle.styles.first() as EmptyForInitializerPadStyle
 
         assertThat(emptyForPadInitializerStyle.space).isTrue
+    }
+
+    @Test
+    fun methodParamPadStyle() {
+        val checkstyle = loadCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+              <module name="MethodParamPad">
+                <property name="option" value=" space"/>
+                <property name="allowLineBreaks" value="true" />
+              </module>
+            </module>
+        """.trimIndent(), emptyMap())
+
+        assertThat(checkstyle.styles)
+            .hasSize(1)
+
+        assertThat(checkstyle.styles.first()).isExactlyInstanceOf(MethodParamPadStyle::class.java)
+        val methodParamPadStyle = checkstyle.styles.first() as MethodParamPadStyle
+
+        assertThat(methodParamPadStyle.space).isTrue
+        assertThat(methodParamPadStyle.allowLineBreaks).isTrue
     }
 
     @Test

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTreeCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTreeCompatibilityKit.kt
@@ -122,6 +122,9 @@ abstract class JavaTreeCompatibilityKit {
     inner class MethodMatcherTck : MethodMatcherTest
 
     @Nested
+    inner class MethodParamPadTck : MethodParamPadTest
+
+    @Nested
     inner class NewArrayTck : NewArrayTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/MethodParamPadTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/MethodParamPadTest.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.Recipe
+import org.openrewrite.Tree
+import org.openrewrite.java.cleanup.MethodParamPad
+import org.openrewrite.java.cleanup.MethodParamPadStyle
+import org.openrewrite.java.format.AutoFormatVisitor
+import org.openrewrite.style.NamedStyles
+import org.openrewrite.style.Style
+
+@Suppress("InfiniteRecursion")
+interface MethodParamPadTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = MethodParamPad()
+
+    fun namedStyles(styles: Collection<Style>): Iterable<NamedStyles> {
+        return listOf(NamedStyles(Tree.randomId(), "Test", "test", "test", emptySet(), styles))
+    }
+
+    @Test
+    fun addSpacePadding(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(namedStyles(listOf(MethodParamPadStyle(true, false)))).build(),
+        before = """
+            enum E {
+                E1()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A() {
+                    super();
+                }
+
+                static void method(int x, int y) {
+                    A a = new A();
+                    method(0, 1);
+                }
+            }
+        """,
+        after = """
+            enum E {
+                E1 ()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A () {
+                    super ();
+                }
+
+                static void method (int x, int y) {
+                    A a = new A ();
+                    method (0, 1);
+                }
+            }
+        """,
+        afterConditions = { cu ->
+            val nucu = AutoFormatVisitor<ExecutionContext>().visit(cu, InMemoryExecutionContext {})
+            assertThat(nucu).isEqualTo(cu)
+        }
+    )
+
+    @Test
+    fun removeSpacePadding(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(namedStyles(listOf(MethodParamPadStyle(false, false)))).build(),
+        before = """
+            enum E {
+                E1 ()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A () {
+                    super ();
+                }
+
+                static void method (int x, int y) {
+                    A a = new A ();
+                    method (0, 1);
+                }
+            }
+        """,
+        after = """
+            enum E {
+                E1()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A() {
+                    super();
+                }
+
+                static void method(int x, int y) {
+                    A a = new A();
+                    method(0, 1);
+                }
+            }
+        """,
+        afterConditions = { cu ->
+            val nucu = AutoFormatVisitor<ExecutionContext>().visit(cu, InMemoryExecutionContext {})
+            assertThat(nucu).isEqualTo(cu)
+        }
+    )
+
+    @Test
+    fun allowLineBreaks(jp: JavaParser.Builder<*, *>) = assertUnchanged(
+        parser = jp.styles(namedStyles(listOf(MethodParamPadStyle(true, true)))).build(),
+        before = """
+            enum E {
+                E1
+                        ()
+            }
+            
+            class B {
+            }
+            
+            class A extends B {
+                A
+                        () {
+                    super
+                            ();
+                }
+            
+                static void method
+                        (int x, int y) {
+                    A a = new A
+                            ();
+                    method
+                            (0, 1);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun removeLineBreaks(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(namedStyles(listOf(MethodParamPadStyle(false, false)))).build(),
+        before = """
+            enum E {
+                E1
+                        ()
+            }
+            
+            class B {
+            }
+            
+            class A extends B {
+                A
+                        () {
+                    super
+                            ();
+                }
+            
+                static void method
+                        (int x, int y) {
+                    A a = new A
+                            ();
+                    method
+                            (0, 1);
+                }
+            }
+        """,
+        after = """
+            enum E {
+                E1()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A() {
+                    super();
+                }
+
+                static void method(int x, int y) {
+                    A a = new A();
+                    method(0, 1);
+                }
+            }
+        """,
+        afterConditions = { cu ->
+            val nucu = AutoFormatVisitor<ExecutionContext>().visit(cu, InMemoryExecutionContext {})
+            assertThat(nucu).isEqualTo(cu)
+        }
+    )
+
+    @Test
+    fun removeLineBreaksAndAddSpaces(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(namedStyles(listOf(MethodParamPadStyle(true, false)))).build(),
+        before = """
+            enum E {
+                E1
+                        ()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A
+                        () {
+                    super
+                            ();
+                }
+
+                static void method
+                        (int x, int y) {
+                    A a = new A
+                            ();
+                    method
+                            (0, 1);
+                }
+            }
+        """,
+        after = """
+            enum E {
+                E1 ()
+            }
+
+            class B {
+            }
+
+            class A extends B {
+                A () {
+                    super ();
+                }
+
+                static void method (int x, int y) {
+                    A a = new A ();
+                    method (0, 1);
+                }
+            }
+        """,
+        afterConditions = { cu ->
+            val nucu = AutoFormatVisitor<ExecutionContext>().visit(cu, InMemoryExecutionContext {})
+            assertThat(nucu).isEqualTo(cu)
+        }
+    )
+
+}


### PR DESCRIPTION
See #797 

I've included the formatting logic for `allowLineBreak` to remove newline characters in `MethodParamPadVisitor`. The alternative is to add this as a configurable style parameter to WrappingAndBracesStyle and have WrappingAndBracesVisitor take care of it. But it feels like it may be niche enough at the moment to allow it to stay in MethodParamPadVisitor. 

I'm happy to place the style/logic in `WrappingAndBraces` instead, though.

(Also note, I've placed this in the `cleanup` package, though I suppose there's no reason it couldn't go anywhere else such as format.)