### PR TITLE
[#797] TypecastParenPad

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -376,6 +376,10 @@ class Java11StringLiteralEqualityTest : Java11Test, StringLiteralEqualityTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11TypecastParenPadTest : Java11Test, TypecastParenPadTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11UnnecessaryExplicitTypeArgumentsTest : Java11Test, UnnecessaryExplicitTypeArgumentsTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -372,6 +372,10 @@ class Java8StringLiteralEqualityTest : Java8Test, StringLiteralEqualityTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8TypecastParenPadTest : Java8Test, TypecastParenPadTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8UnnecessaryExplicitTypeArgumentsTest : Java8Test, UnnecessaryExplicitTypeArgumentsTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.format.SpacesVisitor;
+import org.openrewrite.java.style.Checkstyle;
+import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.SpacesStyle;
+import org.openrewrite.java.tree.J;
+
+public class TypecastParenPad extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Typecast parenthesis padding";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fixes whitespace padding between a typecast type identifier and the enclosing left and right parenthesis. " +
+                "For example, when configured to remove spacing, `( int ) 0L;` becomes `(int) 0L;`.";
+    }
+
+    @Override
+    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new TypecastParenPadVisitor();
+    }
+
+    private static class TypecastParenPadVisitor extends JavaIsoVisitor<ExecutionContext> {
+        SpacesStyle spacesStyle;
+        TypecastParenPadStyle typecastParenPadStyle;
+
+        @Nullable
+        EmptyForInitializerPadStyle emptyForInitializerPadStyle;
+
+        @Nullable
+        EmptyForIteratorPadStyle emptyForIteratorPadStyle;
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
+            typecastParenPadStyle = cu.getStyle(TypecastParenPadStyle.class) == null ? Checkstyle.typecastParenPadStyle() : cu.getStyle(TypecastParenPadStyle.class);
+            emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
+            emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
+
+            spacesStyle = spacesStyle.withWithin(spacesStyle.getWithin().withTypeCastParentheses(typecastParenPadStyle.getSpace()));
+            return super.visitCompilationUnit(cu, ctx);
+        }
+
+        @Override
+        public J.TypeCast visitTypeCast(J.TypeCast typeCast, ExecutionContext ctx) {
+            J.TypeCast tc = super.visitTypeCast(typeCast, ctx);
+            doAfterVisit(new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, tc));
+            return tc;
+        }
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPadStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPadStyle.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.java.style.Checkstyle;
+import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
+
+@Value
+@With
+public class TypecastParenPadStyle implements Style {
+    /**
+     * Whether to add spacing between the typecast identifier and both the left and right parenthesis.
+     * <p>
+     * When true:
+     * <p>
+     * {@code ( int ) m;}
+     * <p>
+     * When false:
+     * <p>
+     * {@code (int) m;}
+     */
+    Boolean space;
+
+    @Override
+    public Style applyDefaults() {
+        return StyleHelper.merge(Checkstyle.typecastParenPadStyle(), this);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -50,6 +50,7 @@ public class Checkstyle extends NamedStyles {
                         hideUtilityClassConstructorStyle(),
                         methodParamPadStyle(),
                         needBracesStyle(),
+                        typecastParenPadStyle(),
                         unnecessaryParentheses()
                 ));
     }
@@ -98,6 +99,10 @@ public class Checkstyle extends NamedStyles {
 
     public static NeedBracesStyle needBracesStyle() {
         return new NeedBracesStyle(false, false);
+    }
+
+    public static TypecastParenPadStyle typecastParenPadStyle() {
+        return new TypecastParenPadStyle(false);
     }
 
     public static UnnecessaryParenthesesStyle unnecessaryParentheses() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
@@ -72,6 +72,7 @@ public class CheckstyleConfigLoader {
                 hideUtilityClassConstructorStyle(conf),
                 methodParamPadStyle(conf),
                 needBracesStyle(conf),
+                typecastParenPadStyle(conf),
                 unnecessaryParentheses(conf))
             .filter(Objects::nonNull)
             .flatMap(Set::stream)
@@ -240,6 +241,22 @@ public class CheckstyleConfigLoader {
                         module.prop("allowSingleLineStatement", false),
                         module.prop("allowEmptyLoopBody", false)
                 ))
+                .collect(toSet());
+    }
+
+    @Nullable
+    private static Set<TypecastParenPadStyle> typecastParenPadStyle(Map<String, List<Module>> conf) {
+        List<Module> moduleList = conf.get("TypecastParenPad");
+        if(moduleList == null) {
+            return null;
+        }
+        return moduleList.stream()
+                .map(module -> {
+                    String option = module.properties.get("option");
+                    // nospace is default, so no option means pad is false
+                    boolean pad = option != null && "space".equals(option.trim());
+                    return new TypecastParenPadStyle(pad);
+                })
                 .collect(toSet());
     }
 

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleConfigLoaderTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/CheckstyleConfigLoaderTest.kt
@@ -226,6 +226,30 @@ class CheckstyleConfigLoaderTest {
         assertThat(needBracesStyle.allowEmptyLoopBody).isTrue
     }
 
+
+    @Test
+    fun typecastParenPad() {
+        val checkstyle = loadCheckstyleConfig("""
+            <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+                "https://checkstyle.org/dtds/configuration_1_2.dtd">
+            <module name="Checker">
+              <module name="TypecastParenPad">
+                <property name="option" value=" space"/>
+              </module>
+            </module>
+        """.trimIndent(), emptyMap())
+
+        assertThat(checkstyle.styles)
+            .hasSize(1)
+
+        assertThat(checkstyle.styles.first()).isExactlyInstanceOf(TypecastParenPadStyle::class.java)
+        val needBracesStyle = checkstyle.styles.first() as TypecastParenPadStyle
+
+        assertThat(needBracesStyle.space).isTrue
+    }
+
+
     @Test
     fun duplicatedModuleNames() {
         val checkstyle = loadCheckstyleConfig("""

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -294,6 +294,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class StringLiteralEqualityTestTck : StringLiteralEqualityTest
 
     @Nested
+    inner class TypecastParenPadTestTck : TypecastParenPadTest
+
+    @Nested
     inner class UnnecessaryExplicitTypeArgumentsTck : UnnecessaryExplicitTypeArgumentsTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/TypecastParenPadTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/TypecastParenPadTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.Recipe
+import org.openrewrite.Tree
+import org.openrewrite.java.cleanup.TypecastParenPad
+import org.openrewrite.java.cleanup.TypecastParenPadStyle
+import org.openrewrite.java.format.AutoFormatVisitor
+import org.openrewrite.style.NamedStyles
+import org.openrewrite.style.Style
+
+@Suppress("UnusedAssignment", "ConstantConditions")
+interface TypecastParenPadTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = TypecastParenPad()
+
+    fun namedStyles(styles: Collection<Style>): Iterable<NamedStyles> {
+        return listOf(NamedStyles(Tree.randomId(), "Test", "test", "test", emptySet(), styles))
+    }
+
+    @Test
+    fun addTypecastPadding(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(namedStyles(listOf(TypecastParenPadStyle(true)))).build(),
+        before = """
+            class Test {
+                static void method() {
+                    long m = 0L;
+                    int n = (int) m;
+                    n = ( int) m;
+                    n = (int ) m;
+                    n = ( int ) m;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static void method() {
+                    long m = 0L;
+                    int n = ( int ) m;
+                    n = ( int ) m;
+                    n = ( int ) m;
+                    n = ( int ) m;
+                }
+            }
+        """,
+        afterConditions = { cu ->
+            val nucu = AutoFormatVisitor<ExecutionContext>().visit(cu, InMemoryExecutionContext {})
+            assertThat(nucu).isEqualTo(cu)
+        }
+    )
+
+    @Test
+    fun removeTypecastPadding(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(namedStyles(listOf(TypecastParenPadStyle(false)))).build(),
+        before = """
+            class Test {
+                static void method() {
+                    long m = 0L;
+                    int n = (int) m;
+                    n = ( int) m;
+                    n = (int ) m;
+                    n = ( int ) m;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                static void method() {
+                    long m = 0L;
+                    int n = (int) m;
+                    n = (int) m;
+                    n = (int) m;
+                    n = (int) m;
+                }
+            }
+        """,
+        afterConditions = { cu ->
+            val nucu = AutoFormatVisitor<ExecutionContext>().visit(cu, InMemoryExecutionContext {})
+            assertThat(nucu).isEqualTo(cu)
+        }
+    )
+
+}


### PR DESCRIPTION
See: https://github.com/openrewrite/rewrite/issues/797

Handles whitespace formatting between typecast parenthesis as configured by the TypecastParenPad checkstyle module.