### PR TITLE
RecipeTest `assertUnchanged` now runs every source through the test recipe.

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
@@ -20,7 +20,6 @@ import okhttp3.Request
 import okhttp3.ResponseBody
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.fail
-import org.openrewrite.java.tree.J
 import org.openrewrite.scheduling.ForkJoinScheduler
 import java.io.File
 import java.io.IOException
@@ -171,10 +170,9 @@ interface RecipeTest <T: SourceFile> {
     ) {
         assertThat(recipe).`as`("A recipe must be specified").isNotNull
 
-        val source = sources.first()
         val recipeSchedulerCheckingExpectedCycles = RecipeSchedulerCheckingExpectedCycles(ForkJoinScheduler.common(), 0)
         val results = recipe
-            .run(listOf(source),
+            .run(sources,
                 executionContext,
                 recipeSchedulerCheckingExpectedCycles,
                 2,
@@ -185,9 +183,6 @@ interface RecipeTest <T: SourceFile> {
             if (result.diff(treePrinter ?: TreePrinter.identity<Any>()).isEmpty()) {
                 fail("An empty diff was generated. The recipe incorrectly changed a reference without changing its contents.")
             }
-        }
-
-        for (result in results) {
             assertThat(result.after?.print(treePrinter ?: TreePrinter.identity<Any>(), null))
                 .`as`("The recipe must not make changes")
                 .isEqualTo(result.before?.print(treePrinter ?: TreePrinter.identity<Any>(), null))
@@ -334,12 +329,14 @@ interface RecipeTest <T: SourceFile> {
                 if (cyclesThatResultedInChanges > expectedCyclesThatMakeChanges &&
                     before.isNotEmpty() && afterList.isNotEmpty()
                 ) {
-                    assertThat(afterList[0]!!.printTrimmed())
-                        .`as`(
-                            "Expected recipe to complete in $expectedCyclesThatMakeChanges cycle${if (expectedCyclesThatMakeChanges == 1) "" else "s"}, " +
-                                    "but took at least one more cycle. Between the last two executed cycles there were changes."
-                        )
-                        .isEqualTo(before[0]!!.printTrimmed())
+                    for (i in before.indices) {
+                        assertThat(afterList[i]!!.printTrimmed())
+                            .`as`(
+                                "Expected recipe to complete in $expectedCyclesThatMakeChanges cycle${if (expectedCyclesThatMakeChanges == 1) "" else "s"}, " +
+                                        "but took at least one more cycle. Between the last two executed cycles there were changes."
+                            )
+                            .isEqualTo(before[i]!!.printTrimmed())
+                    }
                 }
             }
             return afterList


### PR DESCRIPTION
RecipeTest `assertUnchanged` now runs every source through the test recipe.  Fixes #878
