### PR TITLE
Fix concurrency issue in recipe test harness

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
@@ -188,11 +188,13 @@ interface RecipeTest <T: SourceFile> {
             }
     }
 
-    fun TreeVisitor<*, ExecutionContext>.toRecipe() = AdHocRecipe(this)
+    fun toRecipe(supplier : () -> TreeVisitor<*, ExecutionContext>) : Recipe {
+        return AdHocRecipe(supplier)
+    }
 
-    class AdHocRecipe(private val visitor: TreeVisitor<*, ExecutionContext>) : Recipe() {
+    class AdHocRecipe(private val visitor : () -> TreeVisitor<*, ExecutionContext>) : Recipe() {
         override fun getDisplayName(): String = "Ad hoc recipe"
-        override fun getVisitor(): TreeVisitor<*, ExecutionContext> = visitor
+        override fun getVisitor(): TreeVisitor<*, ExecutionContext> = visitor()
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -284,9 +286,9 @@ interface RecipeTest <T: SourceFile> {
                 }
 
                 for (result in results) {
-                    assertThat(result.after?.print(null))
+                    assertThat(result.after?.print())
                         .`as`("The recipe must not make changes")
-                        .isEqualTo(result.before?.print(null))
+                        .isEqualTo(result.before?.print())
                 }
             }
         } catch (e: IOException) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeFieldNameTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeFieldNameTest.kt
@@ -23,14 +23,16 @@ import org.openrewrite.java.tree.J
 import org.openrewrite.java.tree.JavaType
 
 interface ChangeFieldNameTest : JavaRecipeTest {
-    fun changeFieldName(enclosingClassFqn: String, from: String, to: String) =
+    fun changeFieldName(enclosingClassFqn: String, from: String, to: String) = toRecipe {
         object : JavaIsoVisitor<ExecutionContext>() {
             override fun visitCompilationUnit(cu: J.CompilationUnit, p: ExecutionContext): J.CompilationUnit {
                 doAfterVisit(ChangeFieldName(JavaType.Class.build(enclosingClassFqn), from, to))
                 return super.visitCompilationUnit(cu, p)
             }
-        }.toRecipe()
+        }
+    }
 
+    @Suppress("rawtypes")
     @Test
     fun changeFieldName(jp: JavaParser) = assertChanged(
         jp,
@@ -49,6 +51,7 @@ interface ChangeFieldNameTest : JavaRecipeTest {
         """
     )
 
+    @Suppress("StatementWithEmptyBody", "ConstantConditions")
     @Test
     fun changeFieldNameReferences(jp: JavaParser) = assertChanged(
         jp,
@@ -151,6 +154,7 @@ interface ChangeFieldNameTest : JavaRecipeTest {
         """
     )
 
+    @Suppress("rawtypes")
     @Test
     fun dontChangeNestedFieldsWithSameName(jp: JavaParser) = assertChanged(
         jp,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeFieldTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeFieldTypeTest.kt
@@ -20,9 +20,11 @@ import org.openrewrite.ExecutionContext
 import org.openrewrite.java.tree.JavaType
 
 interface ChangeFieldTypeTest : JavaRecipeTest {
-    fun changeFieldType(from: String, to: String) =
-        ChangeFieldType<ExecutionContext>(JavaType.Class.build(from, JavaType.Class.Kind.Interface), JavaType.Class.build(to, JavaType.Class.Kind.Interface)).toRecipe()
+    fun changeFieldType(from: String, to: String) = toRecipe {
+        ChangeFieldType<ExecutionContext>(JavaType.Class.build(from, JavaType.Class.Kind.Interface), JavaType.Class.build(to, JavaType.Class.Kind.Interface))
+    }
 
+    @Suppress("rawtypes")
     @Test
     fun changeFieldTypeDeclarative(jp: JavaParser) = assertChanged(
         jp,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/InvertConditionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/InvertConditionTest.kt
@@ -22,11 +22,13 @@ import org.openrewrite.java.tree.J
 
 interface InvertConditionTest : JavaRecipeTest {
     override val recipe: Recipe?
-        get() = object : JavaIsoVisitor<ExecutionContext>() {
-            override fun visitIf(iff: J.If, p: ExecutionContext): J.If {
-                return iff.withIfCondition(InvertCondition.invert(iff.ifCondition, cursor))
+        get() = toRecipe {
+            object : JavaIsoVisitor<ExecutionContext>() {
+                override fun visitIf(iff: J.If, p: ExecutionContext): J.If {
+                    return iff.withIfCondition(InvertCondition.invert(iff.ifCondition, cursor))
+                }
             }
-        }.toRecipe()
+        }
 
     @Suppress("StatementWithEmptyBody", "ConstantConditions", "InfiniteRecursion")
     @Test

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/LineCounterTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/LineCounterTest.kt
@@ -23,23 +23,26 @@ import org.openrewrite.java.tree.Space
 
 interface LineCounterTest: JavaRecipeTest {
 
+    @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @Test
     fun countLines() = assertChanged(
-        recipe = object: JavaIsoVisitor<ExecutionContext>() {
-            val lineCount = LineCounter()
+        recipe = toRecipe {
+            object : JavaIsoVisitor<ExecutionContext>() {
+                val lineCount = LineCounter()
 
-            override fun visitSpace(space: Space, loc: Space.Location, p: ExecutionContext): Space {
-                lineCount.count(space)
-                return super.visitSpace(space, loc, p)
-            }
-
-            override fun preVisit(tree: J, p: ExecutionContext): J? {
-                if(lineCount.line == 3) {
-                    return tree.withMarkers(tree.markers.addIfAbsent(JavaSearchResult(null)))
+                override fun visitSpace(space: Space, loc: Space.Location, p: ExecutionContext): Space {
+                    lineCount.count(space)
+                    return super.visitSpace(space, loc, p)
                 }
-                return super.preVisit(tree, p)
+
+                override fun preVisit(tree: J, p: ExecutionContext): J? {
+                    if (lineCount.line == 3) {
+                        return tree.withMarkers(tree.markers.addIfAbsent(JavaSearchResult(null)))
+                    }
+                    return super.preVisit(tree, p)
+                }
             }
-        }.toRecipe(),
+        },
         before = """
             class Test {
                 void test() {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
@@ -21,8 +21,9 @@ import org.openrewrite.ExecutionContext
 import org.openrewrite.Issue
 
 interface RemoveImportTest : JavaRecipeTest {
-    fun removeImport(type: String, force: Boolean = false) =
-            RemoveImport<ExecutionContext>(type, force).toRecipe()
+    fun removeImport(type: String, force: Boolean = false) = toRecipe {
+        RemoveImport<ExecutionContext>(type, force)
+    }
 
     @Test
     fun removeNamedImport(jp: JavaParser) = assertChanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/SameClassNameTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/SameClassNameTest.kt
@@ -21,7 +21,9 @@ import org.openrewrite.Recipe
 
 interface SameClassNameTest : JavaRecipeTest {
     override val recipe: Recipe
-        get() = object : JavaIsoVisitor<ExecutionContext>() {}.toRecipe()
+        get() = toRecipe {
+            object : JavaIsoVisitor<ExecutionContext>() {}
+        }
 
     @Test
     fun canParseTheSameJavaClass(jp: JavaParser) = assertUnchanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/UseStaticImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/UseStaticImportTest.kt
@@ -83,23 +83,34 @@ interface UseStaticImportTest : JavaRecipeTest {
                 }
             """
         ),
-        recipe = object : JavaIsoVisitor<ExecutionContext>() {
-            override fun visitClassDeclaration(classDecl: J.ClassDeclaration, p: ExecutionContext): J.ClassDeclaration {
-                val cd = super.visitClassDeclaration(classDecl, p)
-                return cd.withExtends(null)
+        recipe = toRecipe {
+            object : JavaIsoVisitor<ExecutionContext>() {
+                override fun visitClassDeclaration(
+                    classDecl: J.ClassDeclaration,
+                    p: ExecutionContext
+                ): J.ClassDeclaration {
+                    val cd = super.visitClassDeclaration(classDecl, p)
+                    return cd.withExtends(null)
+                }
+
+                override fun visitImport(_import: J.Import, p: ExecutionContext): J.Import? {
+                    return null
+                }
+
+                override fun visitMethodInvocation(
+                    method: J.MethodInvocation,
+                    p: ExecutionContext
+                ): J.MethodInvocation {
+                    val mi = super.visitMethodInvocation(method, p)
+                    return mi.withDeclaringType(JavaType.Class.build("asserts.Assert"))
+                }
+
+                override fun visitCompilationUnit(cu: J.CompilationUnit, p: ExecutionContext): J.CompilationUnit {
+                    doAfterVisit(UseStaticImport("asserts.Assert assert*(..)"))
+                    return super.visitCompilationUnit(cu, p)
+                }
             }
-            override fun visitImport(_import: J.Import, p: ExecutionContext): J.Import? {
-                return null
-            }
-            override fun visitMethodInvocation(method: J.MethodInvocation, p: ExecutionContext): J.MethodInvocation {
-                val mi = super.visitMethodInvocation(method, p)
-                return mi.withDeclaringType(JavaType.Class.build("asserts.Assert"))
-            }
-            override fun visitCompilationUnit(cu: J.CompilationUnit, p: ExecutionContext): J.CompilationUnit {
-                doAfterVisit(UseStaticImport("asserts.Assert assert*(..)"))
-                return super.visitCompilationUnit(cu, p)
-            }
-        }.toRecipe(),
+        },
         before = """
             package test;
             

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/MinimumViableSpacingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/MinimumViableSpacingTest.kt
@@ -32,14 +32,16 @@ import org.openrewrite.java.tree.Space
 @Suppress("StatementWithEmptyBody")
 interface MinimumViableSpacingTest : JavaRecipeTest {
     override val recipe: Recipe
-        get() = object : JavaVisitor<ExecutionContext>() {
-            override fun visitSpace(space: Space, loc: Space.Location, ctx: ExecutionContext): Space {
-                if(ctx.getMessage<Int>("cyclesThatResultedInChanges") == 0) {
-                    return space.withWhitespace("")
+        get() = toRecipe {
+            object : JavaVisitor<ExecutionContext>() {
+                override fun visitSpace(space: Space, loc: Space.Location, ctx: ExecutionContext): Space {
+                    if (ctx.getMessage<Int>("cyclesThatResultedInChanges") == 0) {
+                        return space.withWhitespace("")
+                    }
+                    return space
                 }
-                return space
             }
-        }.toRecipe().doNext(MinimumViableSpacingVisitor<ExecutionContext>(null).toRecipe())
+        }.doNext(toRecipe {MinimumViableSpacingVisitor<ExecutionContext>(null)})
 
     @Test
     fun method(jp: JavaParser) = assertChanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/NormalizeFormatTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/NormalizeFormatTest.kt
@@ -25,9 +25,11 @@ import org.openrewrite.java.tree.J
 
 interface NormalizeFormatTest : JavaRecipeTest {
     private val removeAnnotation: Recipe
-        get() = object : JavaIsoVisitor<ExecutionContext>() {
-            override fun visitAnnotation(annotation: J.Annotation, p: ExecutionContext): J.Annotation? = null
-        }.toRecipe()
+        get() = toRecipe {
+            object : JavaIsoVisitor<ExecutionContext>() {
+                override fun visitAnnotation(annotation: J.Annotation, p: ExecutionContext): J.Annotation? = null
+            }
+        }
 
     @Test
     fun removeAnnotationFromMethod(jp: JavaParser) = assertChanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/WrappingAndBracesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/WrappingAndBracesTest.kt
@@ -26,7 +26,7 @@ import org.openrewrite.java.style.WrappingAndBracesStyle
 @Suppress("UnusedAssignment", "ClassInitializerMayBeStatic")
 interface WrappingAndBracesTest : JavaRecipeTest {
     override val recipe: Recipe
-        get() = WrappingAndBracesVisitor<ExecutionContext>(WrappingAndBracesStyle()).toRecipe()
+        get() = toRecipe {WrappingAndBracesVisitor<ExecutionContext>(WrappingAndBracesStyle())}
 
     @Suppress("StatementWithEmptyBody", "ConstantConditions")
     @Issue("https://github.com/openrewrite/rewrite/issues/804")

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/MaybeUsesImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/MaybeUsesImportTest.kt
@@ -24,8 +24,9 @@ interface MaybeUsesImportTest : JavaRecipeTest {
     @Test
     fun usesType(jp: JavaParser) = assertChanged(
         jp,
-        recipe = MaybeUsesImport<ExecutionContext>("java.util.Collections")
-            .toRecipe(),
+        recipe = toRecipe {
+            MaybeUsesImport<ExecutionContext>("java.util.Collections")
+        },
         before = """
             import java.io.File;
             import java.util.Collections;
@@ -62,7 +63,9 @@ interface MaybeUsesImportTest : JavaRecipeTest {
     @Test
     fun usesTypeWildcard(jp: JavaParser) = assertChanged(
         jp,
-        recipe = MaybeUsesImport<ExecutionContext>("java.util.*").toRecipe(),
+        recipe = toRecipe {
+            MaybeUsesImport<ExecutionContext>("java.util.*")
+        },
         before = """
             import java.io.File;
             import java.util.Collections;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesMethodTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesMethodTest.kt
@@ -26,7 +26,9 @@ interface UsesMethodTest : JavaRecipeTest {
     @Test
     fun usesMethodReferences(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesMethod<ExecutionContext>("A singleArg(String)").toRecipe(),
+        recipe = toRecipe {
+            UsesMethod<ExecutionContext>("A singleArg(String)")
+        },
         before = """
             class Test {
                 void test() {
@@ -51,7 +53,9 @@ interface UsesMethodTest : JavaRecipeTest {
     @Test
     fun usesStaticMethodCalls(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesMethod<ExecutionContext>("java.util.Collections emptyList()").toRecipe(),
+        recipe = toRecipe {
+            UsesMethod<ExecutionContext>("java.util.Collections emptyList()")
+        },
         before = """
             import java.util.Collections;
             public class A {
@@ -69,7 +73,9 @@ interface UsesMethodTest : JavaRecipeTest {
     @Test
     fun usesStaticallyImportedMethodCalls(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesMethod<ExecutionContext>("java.util.Collections emptyList()").toRecipe(),
+        recipe = toRecipe {
+            UsesMethod<ExecutionContext>("java.util.Collections emptyList()")
+        },
         before = """
             import static java.util.Collections.emptyList;
             public class A {
@@ -87,7 +93,9 @@ interface UsesMethodTest : JavaRecipeTest {
     @Test
     fun matchVarargs(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesMethod<ExecutionContext>("A foo(String, Object...)").toRecipe(),
+        recipe = toRecipe {
+            UsesMethod<ExecutionContext>("A foo(String, Object...)")
+        },
         before = """
             public class B {
                public void test() {
@@ -112,7 +120,9 @@ interface UsesMethodTest : JavaRecipeTest {
     @Test
     fun matchOnInnerClass(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesMethod<ExecutionContext>("B.C foo()").toRecipe(),
+        recipe = toRecipe {
+            UsesMethod<ExecutionContext>("B.C foo()")
+        },
         before = """
             public class A {
                void test() {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesTypeTest.kt
@@ -24,8 +24,9 @@ interface UsesTypeTest : JavaRecipeTest {
     @Test
     fun usesTypeFindsImports(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesType<ExecutionContext>("java.util.Collections")
-            .toRecipe(),
+        recipe = toRecipe {
+            UsesType<ExecutionContext>("java.util.Collections")
+        },
         before = """
             import java.io.File;
             import java.util.Collections;
@@ -48,7 +49,9 @@ interface UsesTypeTest : JavaRecipeTest {
     @Test
     fun usesTypeWildcardFindsImports(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesType<ExecutionContext>("java.util.*").toRecipe(),
+        recipe = toRecipe {
+            UsesType<ExecutionContext>("java.util.*")
+        },
         before = """
             import java.io.File;
             import static java.util.Collections.singleton;
@@ -68,7 +71,9 @@ interface UsesTypeTest : JavaRecipeTest {
     @Test
     fun usesFullyQualifiedReference(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesType<ExecutionContext>("java.util.*").toRecipe(),
+        recipe = toRecipe {
+            UsesType<ExecutionContext>("java.util.*")
+        },
         before = """
             import java.util.Set;
             class Test {
@@ -90,8 +95,9 @@ interface UsesTypeTest : JavaRecipeTest {
     @Test
     fun usesTypeFindsInheritedTypes(jp: JavaParser) = assertChanged(
         jp,
-        recipe = UsesType<ExecutionContext>("java.util.Collection")
-            .toRecipe(),
+        recipe = toRecipe {
+            UsesType<ExecutionContext>("java.util.Collection")
+        },
         before = """
             import java.util.List;
             

--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/AddToTagTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/AddToTagTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("CheckTagEmptyBody")
+
 package org.openrewrite.xml
 
 import org.junit.jupiter.api.Test
@@ -23,15 +25,18 @@ class AddToTagTest : XmlRecipeTest {
 
     @Test
     fun addElement() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                val bean2Tag =  x.root.children.find { it.attributes.find { attr -> attr.key.name == "id" && attr.value.value == "myBean2" } != null }
-                if(bean2Tag == null) {
-                    doAfterVisit(AddToTagVisitor(x.root, Xml.Tag.build("""<bean id="myBean2"/>""")))
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    val bean2Tag =
+                        x.root.children.find { it.attributes.find { attr -> attr.key.name == "id" && attr.value.value == "myBean2" } != null }
+                    if (bean2Tag == null) {
+                        doAfterVisit(AddToTagVisitor(x.root, Xml.Tag.build("""<bean id="myBean2"/>""")))
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <beans>
                 <bean id="myBean"/>
@@ -48,19 +53,21 @@ class AddToTagTest : XmlRecipeTest {
 
     @Test
     fun addElementToSlashClosedTag() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                if(x.root.children.first().children.size == 0) {
-                    doAfterVisit(
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    if (x.root.children.first().children.size == 0) {
+                        doAfterVisit(
                             AddToTagVisitor(
-                                    x.root.content[0] as Xml.Tag,
-                                    Xml.Tag.build("""<property name="myprop" ref="collaborator"/>""")
+                                x.root.content[0] as Xml.Tag,
+                                Xml.Tag.build("""<property name="myprop" ref="collaborator"/>""")
                             )
-                    )
+                        )
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <beans >
                 <bean id="myBean" />
@@ -78,14 +85,16 @@ class AddToTagTest : XmlRecipeTest {
 
     @Test
     fun addElementToEmptyTagOnSameLine() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                if(x.root.children.isEmpty()) {
-                    doAfterVisit(AddToTagVisitor(x.root, Xml.Tag.build("""<bean id="myBean"/>""")))
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    if (x.root.children.isEmpty()) {
+                        doAfterVisit(AddToTagVisitor(x.root, Xml.Tag.build("""<bean id="myBean"/>""")))
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <beans></beans>
         """,
@@ -99,17 +108,19 @@ class AddToTagTest : XmlRecipeTest {
 
     @Test
     fun addElementInOrder() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                if(x.root.children.find { it.name == "apple" } == null) {
-                    doAfterVisit(AddToTagVisitor(
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    if (x.root.children.find { it.name == "apple" } == null) {
+                        doAfterVisit(AddToTagVisitor(
                             x.root, Xml.Tag.build("""<apple/>"""),
                             Comparator.comparing(Xml.Tag::getName)
-                    ))
+                        ))
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <beans >
                 <banana/>

--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/ChangeTagValueVisitorTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/ChangeTagValueVisitorTest.kt
@@ -23,12 +23,14 @@ class ChangeTagValueVisitorTest : XmlRecipeTest {
 
     @Test
     fun changeTagValue() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                doAfterVisit(ChangeTagValueVisitor(x.root.content[0] as Xml.Tag, "2.0"))
-                return super.visitDocument(x, p)
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    doAfterVisit(ChangeTagValueVisitor(x.root.content[0] as Xml.Tag, "2.0"))
+                    return super.visitDocument(x, p)
+                }
             }
-        }.toRecipe(),
+        },
         before = """
             <dependency>
                 <version/>
@@ -43,12 +45,14 @@ class ChangeTagValueVisitorTest : XmlRecipeTest {
 
     @Test
     fun preserveOriginalFormatting() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                doAfterVisit(ChangeTagValueVisitor(x.root.content[0] as Xml.Tag, "3.0"))
-                return super.visitDocument(x, p)
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    doAfterVisit(ChangeTagValueVisitor(x.root.content[0] as Xml.Tag, "3.0"))
+                    return super.visitDocument(x, p)
+                }
             }
-        }.toRecipe(),
+        },
         before = """
             <dependency>
                 <version>

--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/RemoveContentTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/RemoveContentTest.kt
@@ -23,14 +23,16 @@ class RemoveContentTest : XmlRecipeTest {
 
     @Test
     fun removeContent() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                if (p.getMessage("cyclesThatResultedInChanges", 0) == 0) {
-                    doAfterVisit(RemoveContentVisitor(x.root.content[1] as Xml.Tag, false))
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    if (p.getMessage("cyclesThatResultedInChanges", 0) == 0) {
+                        doAfterVisit(RemoveContentVisitor(x.root.content[1] as Xml.Tag, false))
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <dependency>
                 <groupId>group</groupId>
@@ -46,15 +48,17 @@ class RemoveContentTest : XmlRecipeTest {
 
     @Test
     fun removeAncestorsThatBecomeEmpty() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                if (p.getMessage("cyclesThatResultedInChanges", 0) == 0) {
-                    val groupId = x.root.children[1].children.first().children.first()
-                    doAfterVisit(RemoveContentVisitor(groupId, true))
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    if (p.getMessage("cyclesThatResultedInChanges", 0) == 0) {
+                        val groupId = x.root.children[1].children.first().children.first()
+                        doAfterVisit(RemoveContentVisitor(groupId, true))
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <project>
                 <name>my.company</name>
@@ -74,15 +78,17 @@ class RemoveContentTest : XmlRecipeTest {
 
     @Test
     fun rootChangedToEmptyTagIfLastRemainingTag() = assertChanged(
-        recipe = object : XmlVisitor<ExecutionContext>() {
-            override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-                if (p.getMessage("cyclesThatResultedInChanges", 0) == 0) {
-                    val groupId = x.root.children.first().children.first().children.first()
-                    doAfterVisit(RemoveContentVisitor(groupId, true))
+        recipe = toRecipe {
+            object : XmlVisitor<ExecutionContext>() {
+                override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+                    if (p.getMessage("cyclesThatResultedInChanges", 0) == 0) {
+                        val groupId = x.root.children.first().children.first().children.first()
+                        doAfterVisit(RemoveContentVisitor(groupId, true))
+                    }
+                    return super.visitDocument(x, p)
                 }
-                return super.visitDocument(x, p)
             }
-        }.toRecipe(),
+        },
         before = """
             <project>
                 <dependencyManagement>

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/format/IndentsTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/format/IndentsTest.kt
@@ -23,11 +23,12 @@ import org.openrewrite.yaml.style.YamlDefaultStyles
 
 class IndentsTest : YamlRecipeTest {
     override val recipe: Recipe
-        get() = IndentsVisitor<ExecutionContext>(
-            YamlDefaultStyles.indents(),
-            null
-        )
-            .toRecipe()
+        get() = toRecipe {
+            IndentsVisitor<ExecutionContext>(
+                YamlDefaultStyles.indents(),
+                null
+            )
+        }
 
     @Test
     fun indentSequence() = assertChanged(


### PR DESCRIPTION
The recipe test harness provides a mechanism for creating an ad-hoc recipe from a visitor. This resulted in the same visitor instance being used for all source files, leading to concurrency issues with the cursor state.

This PR changes the harness to accept a visitor supplier, this requires a sweep for all recipes that were using the `toRecipe` method.