### PR TITLE
 Produce examples of Recipe execution for use in documentation. CLoses #893 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: publish-candidate
         if: contains(github.ref, '-rc.')
         timeout-minutes: 30
-        run: ./gradlew ${GRADLE_SWITCHES} -Prelease.disableGitChecks=true -Prelease.useLastTag=true candidate publish closeAndReleaseSonatypeStagingRepository -x test
+        run: ./gradlew ${GRADLE_SWITCHES} -Preleasing -Prelease.disableGitChecks=true -Prelease.useLastTag=true candidate publish closeAndReleaseSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
       - name: publish-release
         if: (!contains(github.ref, '-rc.'))
         timeout-minutes: 30
-        run: ./gradlew ${GRADLE_SWITCHES} -Prelease.disableGitChecks=true -Prelease.useLastTag=true final publish closeAndReleaseSonatypeStagingRepository -x test
+        run: ./gradlew ${GRADLE_SWITCHES} -Preleasing -Prelease.disableGitChecks=true -Prelease.useLastTag=true final publish closeAndReleaseSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,6 +177,7 @@ subprojects {
             showStackTraces = true
         }
     }
+
     // Tests produce examples which can then be used to generate documentation
     val releasing = project.hasProperty("releasing")
     tasks.register<Jar>("jarWithExamples") {

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -56,6 +56,14 @@ public class Environment {
                 .collect(toList());
     }
 
+    public Collection<RecipeExampleDescriptor> listRecipeExamples() {
+        return resourceLoaders.stream()
+                .filter(r -> r instanceof ClasspathScanningLoader)
+                .map(ClasspathScanningLoader.class::cast)
+                .flatMap(r -> r.listRecipeExamples().stream())
+                .collect(toList());
+    }
+
     public Recipe activateRecipes(Iterable<String> activeRecipes) {
         Recipe root = new CompositeRecipe();
         Collection<Recipe> recipes = listRecipes();

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -58,8 +58,6 @@ public class Environment {
 
     public Collection<RecipeExampleDescriptor> listRecipeExamples() {
         return resourceLoaders.stream()
-                .filter(r -> r instanceof ClasspathScanningLoader)
-                .map(ClasspathScanningLoader.class::cast)
                 .flatMap(r -> r.listRecipeExamples().stream())
                 .collect(toList());
     }

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeExampleDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeExampleDescriptor.java
@@ -1,0 +1,77 @@
+package org.openrewrite.config;
+
+import lombok.Value;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+@Value
+public class RecipeExampleDescriptor {
+    String recipe;
+    String before;
+    String after;
+    String testClassName;
+    String testMethodName;
+    List<RecipeExampleParameterDescriptor> parameters;
+
+    @Value
+    public static class RecipeExampleParameterDescriptor {
+        String name;
+        String type;
+        String value;
+    }
+
+    @Nullable
+    public static RecipeExampleDescriptor fromProperties(Properties props) {
+        Object recipeName = props.get("recipe");
+        Object before = props.get("before");
+        Object after = props.get("after");
+        if(recipeName == null || before == null || after == null) {
+            // We're probably looking at some other properties file and not a Recipe Example
+            return null;
+        }
+
+        Set<String> recipeOptionNames = props.keySet().stream()
+                .map(Object::toString)
+                .filter(it -> it.startsWith("recipeOption."))
+                .map(it -> {
+                    int startIndex = 13; // index of character just after "recipeOption."
+                    int endIndex = it.indexOf('.', startIndex);
+                    if(endIndex == -1) {
+                        endIndex = it.length();
+                    }
+                    return it.substring(startIndex, endIndex);
+                })
+                .collect(toSet());
+
+        List<RecipeExampleParameterDescriptor> params = new ArrayList<>();
+        for(String recipeOptionName : recipeOptionNames) {
+            Object type = props.get("recipeOption." + recipeOptionName + ".type");
+            Object value = props.get("recipeOption." + recipeOptionName);
+            if(type == null || value == null) {
+                // Some kind of problem with this example, just ignore it in favor of other examples that did work correctly
+                return null;
+            }
+
+            params.add(new RecipeExampleParameterDescriptor(
+                    recipeOptionName,
+                    type.toString(),
+                    value.toString()
+            ));
+        }
+
+        return new RecipeExampleDescriptor(
+                recipeName.toString(),
+                before.toString(),
+                after.toString(),
+                props.get("testClassName").toString(),
+                props.get("testMethodName").toString(),
+                params
+        );
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeExampleDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeExampleDescriptor.java
@@ -15,8 +15,12 @@ public class RecipeExampleDescriptor {
     String recipe;
     String before;
     String after;
+
+    @Nullable
     String testClassName;
+    @Nullable
     String testMethodName;
+
     List<RecipeExampleParameterDescriptor> parameters;
 
     @Value

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeExampleDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeExampleDescriptor.java
@@ -1,14 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.config;
 
 import lombok.Value;
 import org.openrewrite.internal.lang.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-
-import static java.util.stream.Collectors.toSet;
 
 @Value
 public class RecipeExampleDescriptor {
@@ -28,54 +38,5 @@ public class RecipeExampleDescriptor {
         String name;
         String type;
         String value;
-    }
-
-    @Nullable
-    public static RecipeExampleDescriptor fromProperties(Properties props) {
-        Object recipeName = props.get("recipe");
-        Object before = props.get("before");
-        Object after = props.get("after");
-        if(recipeName == null || before == null || after == null) {
-            // We're probably looking at some other properties file and not a Recipe Example
-            return null;
-        }
-
-        Set<String> recipeOptionNames = props.keySet().stream()
-                .map(Object::toString)
-                .filter(it -> it.startsWith("recipeOption."))
-                .map(it -> {
-                    int startIndex = 13; // index of character just after "recipeOption."
-                    int endIndex = it.indexOf('.', startIndex);
-                    if(endIndex == -1) {
-                        endIndex = it.length();
-                    }
-                    return it.substring(startIndex, endIndex);
-                })
-                .collect(toSet());
-
-        List<RecipeExampleParameterDescriptor> params = new ArrayList<>();
-        for(String recipeOptionName : recipeOptionNames) {
-            Object type = props.get("recipeOption." + recipeOptionName + ".type");
-            Object value = props.get("recipeOption." + recipeOptionName);
-            if(type == null || value == null) {
-                // Some kind of problem with this example, just ignore it in favor of other examples that did work correctly
-                return null;
-            }
-
-            params.add(new RecipeExampleParameterDescriptor(
-                    recipeOptionName,
-                    type.toString(),
-                    value.toString()
-            ));
-        }
-
-        return new RecipeExampleDescriptor(
-                recipeName.toString(),
-                before.toString(),
-                after.toString(),
-                props.get("testClassName").toString(),
-                props.get("testMethodName").toString(),
-                params
-        );
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
@@ -28,4 +28,6 @@ public interface ResourceLoader {
     Collection<NamedStyles> listStyles();
 
     Collection<CategoryDescriptor> listCategoryDescriptors();
+
+    Collection<RecipeExampleDescriptor> listRecipeExamples();
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.openrewrite.Recipe;
 import org.openrewrite.RecipeException;
 import org.openrewrite.Validated;
+import org.openrewrite.config.RecipeExampleDescriptor.RecipeExampleParameterDescriptor;
 import org.openrewrite.internal.PropertyPlaceholderHelper;
 import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -306,6 +307,7 @@ public class YamlResourceLoader implements ResourceLoader {
                     String packageName = (String) c.get("packageName");
                     String description = (String) c.get("description");
                     Set<String> tags = Collections.emptySet();
+                    @SuppressWarnings("unchecked")
                     List<String> rawTags = (List<String>) c.get("tags");
                     if (rawTags != null) {
                         tags = new HashSet<>(rawTags);
@@ -324,7 +326,7 @@ public class YamlResourceLoader implements ResourceLoader {
                     String testMethodName = (String) c.get("testMethodName");
                     String before = (String) c.get("before");
                     String after = (String) c.get("after");
-                    List<RecipeExampleDescriptor.RecipeExampleParameterDescriptor> parameters = Collections.emptyList();
+                    List<RecipeExampleParameterDescriptor> parameters = Collections.emptyList();
                     @SuppressWarnings("unchecked")
                     List<Map<String, String>> rawParameters = (List<Map<String, String>>) c.get("parameters");
                     if(rawParameters != null) {
@@ -333,6 +335,7 @@ public class YamlResourceLoader implements ResourceLoader {
                             String name = rawParameter.get("name");
                             String type = rawParameter.get("type");
                             String value = rawParameter.get("value");
+                            parameters.add(new RecipeExampleParameterDescriptor(name, type, value));
                         }
                     }
                     return new RecipeExampleDescriptor(recipe, before, after, testClassName, testMethodName, parameters);

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -63,7 +63,8 @@ public class YamlResourceLoader implements ResourceLoader {
     private enum ResourceType {
         Recipe("specs.openrewrite.org/v1beta/recipe"),
         Style("specs.openrewrite.org/v1beta/style"),
-        Category("specs.openrewrite.org/v1beta/category");
+        Category("specs.openrewrite.org/v1beta/category"),
+        Exemplar("specs.openrewrite.org/v1beta/exemplar");
 
         private final String spec;
 
@@ -312,5 +313,29 @@ public class YamlResourceLoader implements ResourceLoader {
                     return new CategoryDescriptor(name, packageName, description, tags);
                 })
                 .collect(toList());
+    }
+
+    @Override
+    public Collection<RecipeExampleDescriptor> listRecipeExamples() {
+        return loadResources(ResourceType.Exemplar).stream()
+                .map(c -> {
+                    String recipe = (String) c.get("type");
+                    String testClassName = (String) c.get("testClassName");
+                    String testMethodName = (String) c.get("testMethodName");
+                    String before = (String) c.get("before");
+                    String after = (String) c.get("after");
+                    List<RecipeExampleDescriptor.RecipeExampleParameterDescriptor> parameters = Collections.emptyList();
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, String>> rawParameters = (List<Map<String, String>>) c.get("parameters");
+                    if(rawParameters != null) {
+                        parameters = new ArrayList<>(rawParameters.size());
+                        for (Map<String, String> rawParameter : rawParameters) {
+                            String name = rawParameter.get("name");
+                            String type = rawParameter.get("type");
+                            String value = rawParameter.get("value");
+                        }
+                    }
+                    return new RecipeExampleDescriptor(recipe, before, after, testClassName, testMethodName, parameters);
+                }).collect(toList());
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
@@ -188,7 +188,7 @@ interface RecipeTest <T: SourceFile> {
             }
         }.toString()
 
-        File(exampleOutputDir, "${recipe.name}.$testMethodName.yaml")
+        File(exampleOutputDir, "${recipe.name}.$testMethodName.yml")
                 .writeText(report)
     }
 


### PR DESCRIPTION
With this we'll be publishing new (small) jars for each project containing properties files that detail successful invocations of `RecipeTest.assertChanged()`.

This information can then be read out of `Environment` and used to generate documentation. 