### PR TITLE
UpgradeDependencyVersion handling of dependencies within dependencyManagement

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -212,6 +212,14 @@ public class UpgradeDependencyVersion extends Recipe {
                         }
                     }
 
+                    for (DependencyManagementDependency dependency : module.getDependencyManagement().getDependencies()) {
+                        if (artifactId.equals(dependency.getArtifactId()) && propertyKeyRef.equals(dependency.getRequestedVersion())) {
+                            doAfterVisit(new ChangeTagValueVisitor<>(tag, newVersion));
+                            doAfterVisit(new RemoveRedundantDependencyVersions());
+                            break OUTER;
+                        }
+                    }
+
                 }
             }
 


### PR DESCRIPTION
Without this, if a `dependencyManagement` `dependency` has its `version` specified as a property, it won't be upgraded.

Noticed this as part of https://github.com/openrewrite/rewrite-micronaut/blob/8a4a9d08f39a6c80037ce972c907dcf80f64ab1e/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml#L34-L41