### PR TITLE
fix: use lowercase `json` for accept check

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
@@ -75,7 +75,7 @@ public class JsonParser implements Parser<Json.Document> {
 
     @Override
     public boolean accept(Path path) {
-        return path.toString().endsWith(".Json");
+        return path.toString().endsWith(".json");
     }
 
     private static class ForwardingErrorListener extends BaseErrorListener {


### PR DESCRIPTION
### Problem
As an example, `package.json` was not being recognized unless they were renamed to `package.Json`

### Solution
Use lowercase `.json` when testing file path.  Follows convention from YML/ XML `accept` methods