### PR TITLE
Pin resilience4j-retry version temporarily

### DIFF
--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -15,7 +15,9 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:2.12.+")
 
     implementation("org.antlr:antlr4:latest.release")
-    implementation("io.github.resilience4j:resilience4j-retry:latest.release")
+    // FIXME: switch to `latest.release`
+    // when https://github.com/resilience4j/resilience4j/issues/1472 is resolved
+    implementation("io.github.resilience4j:resilience4j-retry:1.7.0")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.+")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.+")
     implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.+")


### PR DESCRIPTION
Due to https://github.com/resilience4j/resilience4j/issues/1472, `resilience4j-all:1.7.1` pom is broken and there is no `resilience4j-bom:1.7.1` released either. Does it make sense to stay on a healthy version instead of this partially broken release?