### PR TITLE
feat(core): add CreateTextFile recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -15,7 +15,11 @@
  */
 package org.openrewrite.text;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
 import java.nio.file.Path;
@@ -23,32 +27,25 @@ import java.nio.file.Paths;
 import java.util.*;
 
 @Incubating(since = "7.12.0")
+@Value
+@EqualsAndHashCode(callSuper = false)
 public class CreateTextFile extends Recipe {
 
     @Option(displayName = "File Contents",
             description = "Multiline text content for the file.",
             example = "Some text.")
-    private final String fileContents;
+    String fileContents;
 
     @Option(displayName = "Relative File Path",
             description = "File path of new file.",
             example = "foo/bar/baz.txt")
-    private final String relativeFileName;
+    String relativeFileName;
 
     @Option(displayName = "Overwrite existing file",
-            description = "If there is an existing file, should it be overwritten.")
-    private final Boolean overwriteExisting;
-
-    public CreateTextFile(String fileContents, String relativeFileName, Boolean overwriteExisting) {
-        this.fileContents = fileContents;
-        this.relativeFileName = relativeFileName;
-        this.overwriteExisting = overwriteExisting;
-    }
-
-    @Override
-    public Set<String> getTags() {
-        return Collections.singleton("plain text");
-    }
+            description = "If there is an existing file, should it be overwritten.",
+            required = false)
+    @Nullable
+    Boolean overwriteExisting;
 
     @Override
     public String getDisplayName() {
@@ -63,21 +60,25 @@ public class CreateTextFile extends Recipe {
     @Override
     protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
         Path path = Paths.get(relativeFileName);
-        Optional<SourceFile> matchingFile = before.stream().filter(sourceFile -> path.toString().equals(sourceFile.getSourcePath().toString())).findFirst();
+        SourceFile matchingFile = null;
+
+        for (SourceFile sourceFile: before) {
+            if (path.toString().equals(sourceFile.getSourcePath().toString())) {
+                matchingFile = sourceFile;
+            }
+        }
 
         // return early if file exists and there's no explicit permission to overwrite
-        if (matchingFile.isPresent() && overwriteExisting == false) {
+        if (matchingFile != null && (overwriteExisting == null  || Boolean.FALSE.equals(overwriteExisting))) {
             return before;
         }
 
-        List<SourceFile> results = new ArrayList<>(before);
         PlainText brandNewFile = new PlainText(Tree.randomId(), path, Markers.EMPTY, fileContents);
 
-        if (matchingFile.isPresent() && overwriteExisting) {
-            brandNewFile = new PlainText(matchingFile.get().getId(), brandNewFile.getSourcePath(), brandNewFile.getMarkers(), brandNewFile.getText());
+        if (matchingFile != null && Boolean.TRUE.equals(overwriteExisting)) {
+            brandNewFile = new PlainText(matchingFile.getId(), brandNewFile.getSourcePath(), brandNewFile.getMarkers(), brandNewFile.getText());
         }
 
-        results.add(brandNewFile);
-        return results;
+        return ListUtils.concat(before,brandNewFile);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -69,7 +69,7 @@ public class CreateTextFile extends Recipe {
         }
 
         // return early if file exists and there's no explicit permission to overwrite
-        if (matchingFile != null && (overwriteExisting == null  || Boolean.FALSE.equals(overwriteExisting))) {
+        if (matchingFile != null && !Boolean.TRUE.equals(overwriteExisting)) {
             return before;
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -79,6 +79,6 @@ public class CreateTextFile extends Recipe {
             brandNewFile = new PlainText(matchingFile.getId(), brandNewFile.getSourcePath(), brandNewFile.getMarkers(), brandNewFile.getText());
         }
 
-        return ListUtils.concat(before,brandNewFile);
+        return ListUtils.concat(before, brandNewFile);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.text;
+
+import org.openrewrite.*;
+import org.openrewrite.marker.Markers;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+@Incubating(since = "7.12.0")
+public class CreateTextFile extends Recipe {
+
+    @Option(displayName = "File Contents",
+            description = "Multiline text content for the file.",
+            example = "Some text.")
+    private final String fileContents;
+
+    @Option(displayName = "Relative File Path",
+            description = "File path of new file.",
+            example = "foo/bar/baz.txt")
+    private final String relativeFileName;
+
+    @Option(displayName = "Overwrite existing file",
+            description = "If there is an existing file, should it be overwritten.")
+    private final Boolean overwriteExisting;
+
+    public CreateTextFile(String fileContents, String relativeFileName, Boolean overwriteExisting) {
+        this.fileContents = fileContents;
+        this.relativeFileName = relativeFileName;
+        this.overwriteExisting = overwriteExisting;
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("plain text");
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Create text file";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Creates a new plain text file.";
+    }
+
+    @Override
+    protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
+        Path path = Paths.get(relativeFileName);
+        Optional<SourceFile> matchingFile = before.stream().filter(sourceFile -> path.toString().equals(sourceFile.getSourcePath().toString())).findFirst();
+
+        // return early if file exists and there's no explicit permission to overwrite
+        if (matchingFile.isPresent() && overwriteExisting == false) {
+            return before;
+        }
+
+        List<SourceFile> results = new ArrayList<>(before);
+        PlainText brandNewFile = new PlainText(Tree.randomId(), path, Markers.EMPTY, fileContents);
+
+        if (matchingFile.isPresent() && overwriteExisting) {
+            brandNewFile = new PlainText(matchingFile.get().getId(), brandNewFile.getSourcePath(), brandNewFile.getMarkers(), brandNewFile.getText());
+        }
+
+        results.add(brandNewFile);
+        return results;
+    }
+}

--- a/rewrite-test/src/test/kotlin/org/openrewrite/text/CreateTextFileTest.kt
+++ b/rewrite-test/src/test/kotlin/org/openrewrite/text/CreateTextFileTest.kt
@@ -35,7 +35,6 @@ class CreateTextFileTest : RecipeTest<PlainText> {
         val results = recipe.run(emptyList());
         assertThat(results).hasSize(1);
         assertThat(results[0].after.print()).isEqualTo("foo");
-
     }
 
     @Test

--- a/rewrite-test/src/test/kotlin/org/openrewrite/text/CreateTextFileTest.kt
+++ b/rewrite-test/src/test/kotlin/org/openrewrite/text/CreateTextFileTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.text
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.*
+import org.openrewrite.marker.Markers
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.*
+
+class CreateTextFileTest : RecipeTest<PlainText> {
+    override val parser: Parser<PlainText>
+        get() = PlainTextParser()
+
+    override val recipe: Recipe
+        get() = CreateTextFile("foo", ".github/CODEOWNERS", false)
+
+    @Test
+    fun hasCreatedFile(@TempDir tempDir: Path) {
+        val results = recipe.run(Collections.emptyList());
+        Assertions.assertThat(results).hasSize(1);
+        Assertions.assertThat(results[0].after.print()).isEqualTo("foo");
+
+    }
+
+    @Test
+    fun hasOverwrittenFile(@TempDir tempDir: Path) {
+        val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERS", true)
+        val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
+
+        Assertions.assertThat(results).hasSize(1);
+        Assertions.assertThat(results[0].after.print()).isEqualTo("foo");
+    }
+
+    @Test
+    fun shouldNotChangeExistingFile(@TempDir tempDir: Path) {
+        val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERS", false)
+        val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
+
+        Assertions.assertThat(results).hasSize(0);
+    }
+
+    @Test
+    fun shouldAddAnotherFile(@TempDir tempDir: Path) {
+        val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERSZ", false)
+        val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
+
+        Assertions.assertThat(results).hasSize(1);
+        Assertions.assertThat(results[0].after.print()).isEqualTo("foo");
+
+    }
+}

--- a/rewrite-test/src/test/kotlin/org/openrewrite/text/CreateTextFileTest.kt
+++ b/rewrite-test/src/test/kotlin/org/openrewrite/text/CreateTextFileTest.kt
@@ -15,14 +15,13 @@
  */
 package org.openrewrite.text
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.*
 import org.openrewrite.marker.Markers
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
 
 class CreateTextFileTest : RecipeTest<PlainText> {
     override val parser: Parser<PlainText>
@@ -33,9 +32,9 @@ class CreateTextFileTest : RecipeTest<PlainText> {
 
     @Test
     fun hasCreatedFile(@TempDir tempDir: Path) {
-        val results = recipe.run(Collections.emptyList());
-        Assertions.assertThat(results).hasSize(1);
-        Assertions.assertThat(results[0].after.print()).isEqualTo("foo");
+        val results = recipe.run(emptyList());
+        assertThat(results).hasSize(1);
+        assertThat(results[0].after.print()).isEqualTo("foo");
 
     }
 
@@ -44,8 +43,8 @@ class CreateTextFileTest : RecipeTest<PlainText> {
         val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERS", true)
         val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
 
-        Assertions.assertThat(results).hasSize(1);
-        Assertions.assertThat(results[0].after.print()).isEqualTo("foo");
+        assertThat(results).hasSize(1);
+        assertThat(results[0].after.print()).isEqualTo("foo");
     }
 
     @Test
@@ -53,7 +52,15 @@ class CreateTextFileTest : RecipeTest<PlainText> {
         val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERS", false)
         val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
 
-        Assertions.assertThat(results).hasSize(0);
+        assertThat(results).hasSize(0);
+    }
+
+    @Test
+    fun shouldNotChangeExistingFileWhenOverwriteNull(@TempDir tempDir: Path) {
+        val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERS", null)
+        val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
+
+        assertThat(results).hasSize(0);
     }
 
     @Test
@@ -61,8 +68,7 @@ class CreateTextFileTest : RecipeTest<PlainText> {
         val overwriteRecipe: Recipe = CreateTextFile("foo", ".github/CODEOWNERSZ", false)
         val results = overwriteRecipe.run(listOf(PlainText(Tree.randomId(), Paths.get(".github/CODEOWNERS"), Markers.EMPTY, "hello")));
 
-        Assertions.assertThat(results).hasSize(1);
-        Assertions.assertThat(results[0].after.print()).isEqualTo("foo");
-
+        assertThat(results).hasSize(1);
+        assertThat(results[0].after.print()).isEqualTo("foo");
     }
 }


### PR DESCRIPTION
### Problem
There was no imperative recipe for creating plain text files. As an example, this would be useful for creating a declarative recipe in the future for applying best practices to GitHub projects wherein we could create `CODEOWNERS` files.

### Solution
Add a `CreateTextFile` recipe that creates a plain text file. Optionally, this recipe can be enabled to overwrite an existing file should one exist. 