### PR TITLE
Add DirectScheduler for tests

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/DirectScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/DirectScheduler.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.scheduling;
+
+import org.openrewrite.RecipeScheduler;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+public class DirectScheduler implements RecipeScheduler {
+
+    private static final DirectScheduler COMMON = new DirectScheduler();
+
+    public static RecipeScheduler common() {
+        return COMMON;
+    }
+
+    @Override
+    public <T> CompletableFuture<T> schedule(Callable<T> fn) {
+        try {
+            return CompletableFuture.completedFuture(fn.call());
+        } catch (Exception e) {
+            CompletableFuture<T> f = new CompletableFuture<>();
+            f.completeExceptionally(e);
+            return f;
+        }
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
@@ -20,6 +20,7 @@ import okhttp3.Request
 import okhttp3.ResponseBody
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.fail
+import org.openrewrite.scheduling.DirectScheduler
 import org.openrewrite.scheduling.ForkJoinScheduler
 import java.io.File
 import java.io.IOException
@@ -108,7 +109,7 @@ interface RecipeTest <T: SourceFile> {
         }
 
         val recipeSchedulerCheckingExpectedCycles =
-            RecipeSchedulerCheckingExpectedCycles(ForkJoinScheduler(ForkJoinPool(1)), expectedCyclesThatMakeChanges)
+            RecipeSchedulerCheckingExpectedCycles(DirectScheduler.common(), expectedCyclesThatMakeChanges)
 
         var results = recipe.run(
             sources,


### PR DESCRIPTION
Helps with readability of stack traces.