### PR TITLE
Introduce Maven Pom flyweights

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -248,7 +248,9 @@ public class AddDependency extends Recipe {
                             classifier,
                             type,
                             optional != null && optional,
-                            Pom.build(groupId, artifactId, dependencyVersion, null, packaging, classifier),
+                            Pom.build(groupId, artifactId, dependencyVersion, null, null, null, packaging, classifier,
+                                    null, emptyList(), Pom.DependencyManagement.empty(), emptyList(), emptyList(), emptyMap(),
+                                    emptyMap(), true),
                             dependencyVersion,
                             emptySet()
                     )

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -248,8 +248,7 @@ public class AddDependency extends Recipe {
                             classifier,
                             type,
                             optional != null && optional,
-                            new Pom(groupId, artifactId, dependencyVersion, null, null, null, packaging, classifier, null,
-                                    emptyList(), new Pom.DependencyManagement(emptyList()), emptyList(), emptyList(), emptyMap(), emptyMap()),
+                            Pom.build(groupId, artifactId, dependencyVersion, null, packaging, classifier),
                             dependencyVersion,
                             emptySet()
                     )

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawMavenResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawMavenResolver.java
@@ -141,6 +141,7 @@ public class RawMavenResolver {
         if (task.getRawMaven().getPom().getProperties() != null) {
             partialMaven.setProperties(task.getRawMaven().getPom().getProperties());
         }
+
         partialMaven.setEffectiveProperties(task.getEffectiveProperties());
     }
 
@@ -619,6 +620,7 @@ public class RawMavenResolver {
                         }
                     });
                 }
+
                 result = Optional.of(
                         Pom.build(
                                 groupId,

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -37,6 +37,7 @@ import static java.util.Collections.emptyMap;
 public class Pom {
 
     private static final PropertyPlaceholderHelper placeholderHelper = new PropertyPlaceholderHelper("${", "}", null);
+
     private static final Map<Pom, Set<Pom>> flyweights = new WeakHashMap<>();
 
     @EqualsAndHashCode.Include
@@ -319,6 +320,7 @@ public class Pom {
                 false
         );
     }
+
     public Pom withDependencies(List<Dependency> dependencies) {
         if (Objects.equals(this.dependencies, dependencies)) {
             return this;
@@ -342,6 +344,7 @@ public class Pom {
                 false
         );
     }
+
     public Pom withDependencyManagement(DependencyManagement dependencyManagement) {
         if (Objects.equals(this.dependencyManagement, dependencyManagement)) {
             return this;
@@ -366,6 +369,7 @@ public class Pom {
                 false
         );
     }
+
     public Pom withLicenses(List<License> licenses) {
         if (Objects.equals(this.licenses, licenses)) {
             return this;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -383,7 +383,7 @@ public class Pom {
             @Nullable String datedSnapshotVersion) {
 
         return build(groupId, artifactId, version, datedSnapshotVersion, null, null, null, null,
-                null, emptyList(), DependencyManagement.EMPTY, emptyList(), emptyList(), emptyMap(),
+                null, emptyList(), DependencyManagement.empty(), emptyList(), emptyList(), emptyMap(),
                 emptyMap(), true);
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -380,12 +380,10 @@ public class Pom {
             @Nullable String groupId,
             String artifactId,
             @Nullable String version,
-            @Nullable String datedSnapshotVersion,
-            @Nullable String packaging,
-            @Nullable String classifier) {
+            @Nullable String datedSnapshotVersion) {
 
-        return build(groupId, artifactId, version, datedSnapshotVersion, null, null, packaging, classifier,
-                null, emptyList(), emptyDependencyManagement, emptyList(), emptyList(), emptyMap(),
+        return build(groupId, artifactId, version, datedSnapshotVersion, null, null, null, null,
+                null, emptyList(), DependencyManagement.EMPTY, emptyList(), emptyList(), emptyMap(),
                 emptyMap(), true);
     }
 
@@ -603,11 +601,16 @@ public class Pom {
         }
     }
 
-    private static final DependencyManagement emptyDependencyManagement = new DependencyManagement(emptyList());
-
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @Data
     public static class DependencyManagement {
+
+        private static final DependencyManagement EMPTY = new DependencyManagement(emptyList());
+
+        public static DependencyManagement empty() {
+            return EMPTY;
+        }
+
         @With
         List<DependencyManagementDependency> dependencies;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -51,7 +51,6 @@ public class Pom {
 
     @EqualsAndHashCode.Include
     @Nullable
-    @With
     String version;
 
     /**
@@ -77,15 +76,9 @@ public class Pom {
     @Nullable
     Pom parent;
 
-    @With
     List<Dependency> dependencies;
-
-    @With
     DependencyManagement dependencyManagement;
-
-    @With
     Collection<License> licenses;
-
     Collection<MavenRepository> repositories;
 
     /**
@@ -285,6 +278,101 @@ public class Pom {
                 Objects.equals(this.repositories, other.repositories) &&
                 Objects.equals(this.licenses, other.licenses) &&
                 Objects.equals(this.properties, other.properties)
+        );
+    }
+
+    public Pom withVersion(String version) {
+        if (Objects.equals(this.version, version)) {
+            return this;
+        }
+        return Pom.build(
+                this.groupId,
+                this.artifactId,
+                version,
+                this.datedSnapshotVersion,
+                this.name,
+                this.description,
+                this.packaging,
+                this.classifier,
+                this.parent,
+                this.dependencies,
+                this.dependencyManagement,
+                this.licenses,
+                this.repositories,
+                this.properties,
+                this.propertyOverrides,
+                false
+        );
+    }
+    public Pom withDependencies(List<Dependency> dependencies) {
+        if (Objects.equals(this.dependencies, dependencies)) {
+            return this;
+        }
+        return Pom.build(
+                this.groupId,
+                this.artifactId,
+                this.version,
+                this.datedSnapshotVersion,
+                this.name,
+                this.description,
+                this.packaging,
+                this.classifier,
+                this.parent,
+                dependencies,
+                this.dependencyManagement,
+                this.licenses,
+                this.repositories,
+                this.properties,
+                this.propertyOverrides,
+                false
+        );
+    }
+    public Pom withDependencyManagement(DependencyManagement dependencyManagement) {
+        if (Objects.equals(this.dependencyManagement, dependencyManagement)) {
+            return this;
+        }
+
+        return Pom.build(
+                this.groupId,
+                this.artifactId,
+                this.version,
+                this.datedSnapshotVersion,
+                this.name,
+                this.description,
+                this.packaging,
+                this.classifier,
+                this.parent,
+                this.dependencies,
+                dependencyManagement,
+                this.licenses,
+                this.repositories,
+                this.properties,
+                this.propertyOverrides,
+                false
+        );
+    }
+    public Pom withLicenses(List<License> licenses) {
+        if (Objects.equals(this.licenses, licenses)) {
+            return this;
+        }
+
+        return Pom.build(
+                this.groupId,
+                this.artifactId,
+                this.version,
+                this.datedSnapshotVersion,
+                this.name,
+                this.description,
+                this.packaging,
+                this.classifier,
+                this.parent,
+                this.dependencies,
+                this.dependencyManagement,
+                licenses,
+                this.repositories,
+                this.properties,
+                this.propertyOverrides,
+                false
         );
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenProjectParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenProjectParser.java
@@ -114,11 +114,11 @@ public class MavenProjectParser {
         String javaVendor = System.getProperty("java.vm.vendor");
         String sourceCompatibility = javaRuntimeVersion;
         String targetCompatibility = javaRuntimeVersion;
-        String propertiesSourceCompatibility = mavenModel.getValue(mavenModel.getEffectiveProperties().get("maven.compiler.source"));
+        String propertiesSourceCompatibility = mavenModel.getValue(mavenModel.getValue("maven.compiler.source"));
         if (propertiesSourceCompatibility != null) {
             sourceCompatibility = propertiesSourceCompatibility;
         }
-        String propertiesTargetCompatibility = mavenModel.getValue(mavenModel.getEffectiveProperties().get("maven.compiler.target"));
+        String propertiesTargetCompatibility = mavenModel.getValue(mavenModel.getValue("maven.compiler.target"));
         if (propertiesTargetCompatibility != null) {
             targetCompatibility = propertiesTargetCompatibility;
         }


### PR DESCRIPTION
This PR introduced flyweights for Pom model objects.

To enable the re-use of existing Pom instances, the `effectiveProperties` were replaced with `propertyOverrides`.  The RawMavenResolver still computes `effectiveProperties` when building the partial maven results. However, when creating the final Pom model, the resolver will look at the keys for the original properties defined in the raw maven file and only populated `propertyOverrides` if that key's effective value is different than its original value. The `getValue` method on the Pom will now correctly use property overrides, the original properties, and if not found, it will recursively call its parent.

An overloaded `build()` method allows relaxed matching using just the GAV coordinates and datedSnapshotVersion.
