### PR TITLE
ChangeType should allow nested java.lang package imports

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -116,10 +116,10 @@ public class ChangeType extends Recipe {
             }
             JavaType.FullyQualified fullyQualifiedTarget = TypeUtils.asFullyQualified(targetType);
             if (fullyQualifiedTarget != null) {
-                if (fullyQualifiedTarget.getOwningClass() != null && !fullyQualifiedTarget.getPackageName().startsWith("java.lang")) {
+                if (fullyQualifiedTarget.getOwningClass() != null && !fullyQualifiedTarget.getPackageName().equals("java.lang")) {
                     c = (J.CompilationUnit)  new AddImport(fullyQualifiedTarget.getOwningClass().getFullyQualifiedName(), null, true).visit(c, ctx);
                 }
-                if (!fullyQualifiedTarget.getFullyQualifiedName().startsWith("java.lang")) {
+                if (!fullyQualifiedTarget.getPackageName().equals("java.lang")) {
                     c = (J.CompilationUnit) new AddImport(fullyQualifiedTarget.getFullyQualifiedName(), null, true).visit(c, ctx);
                 }
             }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeTypeTest.kt
@@ -43,11 +43,36 @@ interface ChangeTypeTest : JavaRecipeTest {
     }
 
     @Test
-    fun doNotAddJavaLangImports(jp: JavaParser) = assertChanged(
+    fun doNotAddJavaLangWrapperImports(jp: JavaParser) = assertChanged(
         jp,
         recipe = ChangeType("java.lang.Integer","java.lang.Long"),
         before = "public class ThinkPositive { private Integer fred = 1;}",
         after = "public class ThinkPositive { private Long fred = 1;}"
+    )
+
+    @Test
+    @Suppress("deprecation")
+    fun allowJavaLangSubpackages(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = ChangeType("java.util.logging.LoggingMXBean","java.lang.management.PlatformLoggingMXBean"),
+        before = """
+            import java.util.logging.LoggingMXBean;
+
+            class Test {
+                static void method() {
+                    LoggingMXBean loggingBean = null;
+                }
+            }
+        """,
+        after = """
+            import java.lang.management.PlatformLoggingMXBean;
+
+            class Test {
+                static void method() {
+                    PlatformLoggingMXBean loggingBean = null;
+                }
+            }
+        """
     )
 
     @Suppress("InstantiationOfUtilityClass")


### PR DESCRIPTION
Noticed while fixing tests in rewrite-migrate-java involving types under `java.lang.management..*`.

Only wrapper types such as `java.lang.{Integer,String,etc.}` are auto-imported. `getPackage()` will return `java.lang` for `java.lang.Integer`, and returns `java.lang.management` as the package for `java.lang.management.Foo`, meaning `getPackage()` should be able to be used directly without needing the `startsWith` qualifier.