### PR TITLE
Add NormalizeLineBreaks along with new general FormatStyle

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/style/GeneralFormatStyle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/GeneralFormatStyle.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.style;
+
+import lombok.Value;
+
+@Value
+public class GeneralFormatStyle implements Style{
+    public static GeneralFormatStyle DEFAULT = new GeneralFormatStyle(
+            System.lineSeparator().equals("\r\n")
+    );
+
+    Boolean useCRLFNewLines;
+
+}

--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -288,6 +288,10 @@ class Java11NormalizeFormatTest : Java11Test, NormalizeFormatTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11NormalizeLineBreaksTest : Java11Test, NormalizeLineBreaksTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11NormalizeTabsOrSpacesTest : Java11Test, NormalizeTabsOrSpacesTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -280,6 +280,10 @@ class Java8NormalizeFormatTest : Java8Test, NormalizeFormatTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8NormalizeLineBreaksTest : Java8Test, NormalizeLineBreaksTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8NormalizeTabsOrSpacesTest : Java8Test, NormalizeTabsOrSpacesTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.cleanup.EmptyForInitializerPadStyle;
 import org.openrewrite.java.cleanup.EmptyForIteratorPadStyle;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.style.GeneralFormatStyle;
 
 import java.util.Optional;
 
@@ -69,6 +70,10 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
 
         t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
                 .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+                .visit(t, p, cursor.fork());
+
+        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))
+                .orElse(GeneralFormatStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         return t;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaks.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaks.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.format;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.style.GeneralFormatStyle;
+
+public class NormalizeLineBreaks extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Normalize the line breaks";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Consistently use either Windows or Linux line breaks.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new LineBreaksFromCompilationUnitStyle();
+    }
+
+    private static class LineBreaksFromCompilationUnitStyle extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            GeneralFormatStyle style = cu.getStyle(GeneralFormatStyle.class);
+            if (style == null) {
+                style = GeneralFormatStyle.DEFAULT;
+            }
+            doAfterVisit(new NormalizeLineBreaksVisitor<>(style));
+            return cu;
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.format;
+
+import org.openrewrite.Tree;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.style.GeneralFormatStyle;
+
+public class NormalizeLineBreaksVisitor<P> extends JavaIsoVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    private final GeneralFormatStyle style;
+
+    private final JavadocVisitor<Integer> lineBreakJavadocVisitor = new JavadocVisitor<Integer>() {
+        @Override
+        public Javadoc visitLineBreak(Javadoc.LineBreak lineBreak, Integer integer) {
+            return lineBreak.withMargin(normalizeNewLines(lineBreak.getMargin(), style.getUseCRLFNewLines()));
+        }
+    };
+
+    public NormalizeLineBreaksVisitor(GeneralFormatStyle style) {
+        this(style, null);
+    }
+
+    public NormalizeLineBreaksVisitor(GeneralFormatStyle style, @Nullable Tree stopAfter) {
+        this.style = style;
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public Space visitSpace(Space space, Space.Location loc, P p) {
+        Space s = space.withWhitespace(normalizeNewLines(space.getWhitespace(), style.getUseCRLFNewLines()));
+
+        return s.withComments(ListUtils.map(s.getComments(), comment -> {
+            Comment c = comment;
+            if (c.isMultiline()) {
+                if (c instanceof Javadoc) {
+                    c = c.withSuffix(normalizeNewLines(c.getSuffix(), style.getUseCRLFNewLines()));
+                    return (Comment) lineBreakJavadocVisitor.visitNonNull((Javadoc) c, 0);
+                } else {
+                    TextComment textComment = (TextComment) c;
+                    if (textComment.getText().contains("\n")) {
+                        c = textComment.withText(normalizeNewLines(textComment.getText(), style.getUseCRLFNewLines()));
+                    }
+                }
+            }
+
+            return c.withSuffix(normalizeNewLines(c.getSuffix(), style.getUseCRLFNewLines()));
+        }));
+    }
+
+    private static String normalizeNewLines(String text, boolean useClrf){
+        StringBuilder stringBuilder = new StringBuilder();
+        char[] charArray = text.toCharArray();
+        for (int i = 0; i < charArray.length; i++) {
+            char c = charArray[i];
+            if (useClrf && c == '\n' && (i == 0 || text.charAt(i-1) != '\r')) {
+                stringBuilder.append('\r');
+            } else if (!useClrf && c == '\r') {
+                continue;
+            }
+            stringBuilder.append(c);
+        }
+        return stringBuilder.toString();
+    }
+
+    @Nullable
+    @Override
+    public J postVisit(J tree, P p) {
+        if (stopAfter != null && stopAfter.isScope(tree)) {
+            getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, "stop", true);
+        }
+        return super.postVisit(tree, p);
+    }
+
+    @Nullable
+    @Override
+    public J visit(@Nullable Tree tree, P p) {
+        if (getCursor().getNearestMessage("stop") != null) {
+            return (J) tree;
+        }
+        return super.visit(tree, p);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
@@ -57,9 +57,7 @@ public class NormalizeLineBreaksVisitor<P> extends JavaIsoVisitor<P> {
                     return (Comment) lineBreakJavadocVisitor.visitNonNull((Javadoc) c, 0);
                 } else {
                     TextComment textComment = (TextComment) c;
-                    if (textComment.getText().contains("\n")) {
-                        c = textComment.withText(normalizeNewLines(textComment.getText(), style.getUseCRLFNewLines()));
-                    }
+                    c = textComment.withText(normalizeNewLines(textComment.getText(), style.getUseCRLFNewLines()));
                 }
             }
 
@@ -68,6 +66,9 @@ public class NormalizeLineBreaksVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private static String normalizeNewLines(String text, boolean useClrf){
+        if (!text.contains("\n")) {
+            return text;
+        }
         StringBuilder stringBuilder = new StringBuilder();
         char[] charArray = text.toCharArray();
         for (int i = 0; i < charArray.length; i++) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaksVisitor.java
@@ -80,7 +80,7 @@ public class NormalizeLineBreaksVisitor<P> extends JavaIsoVisitor<P> {
             }
             stringBuilder.append(c);
         }
-        return stringBuilder.toString();
+        return text.equals(stringBuilder.toString()) ? text : stringBuilder.toString();
     }
 
     @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
@@ -66,7 +66,7 @@ public class IntelliJ extends NamedStyles {
     }
 
     public static TabsAndIndentsStyle tabsAndIndents() {
-        return new TabsAndIndentsStyle(false, 4, 4, 8, false, false);
+        return new TabsAndIndentsStyle(false, 4, 4, 8, false);
     }
 
     public static BlankLinesStyle blankLines() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/TabsAndIndentsStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/TabsAndIndentsStyle.java
@@ -32,7 +32,6 @@ public class TabsAndIndentsStyle implements JavaStyle {
     private Integer indentSize;
     private Integer continuationIndent;
     private Boolean indentsRelativeToExpressionStart;
-    private Boolean useCRLFNewLines;
 
     @Override
     public Style applyDefaults() {

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/StyleHelperTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/StyleHelperTest.kt
@@ -23,7 +23,7 @@ class StyleHelperTest {
 
     @Test
     fun mergeTabsAndIndentsStyles() {
-        val merged = StyleHelper.merge(IntelliJ.tabsAndIndents(), TabsAndIndentsStyle(true, 1, 1, 2, true, false))
+        val merged = StyleHelper.merge(IntelliJ.tabsAndIndents(), TabsAndIndentsStyle(true, 1, 1, 2, true))
         assertThat(merged.useTabCharacter).isTrue
         assertThat(merged.tabSize).isEqualTo(1)
         assertThat(merged.indentSize).isEqualTo(1)

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/NormalizeLineBreaksTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/NormalizeLineBreaksTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.format
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.java.JavaParser
+import org.openrewrite.style.GeneralFormatStyle
+
+interface NormalizeLineBreaksTest {
+
+    @Test
+    fun simpleFileToLinuxLineFeed(jp: JavaParser) {
+        val style = GeneralFormatStyle(false)
+        val before =
+            "class Test {\r\n" +
+                    "    // some comment\r\n" +
+                    "    public void test() {\n" +
+                    "        System.out.println();\n" +
+                    "    }\r\n" +
+                    "}\n"
+        val expected =
+            "class Test {\n" +
+                    "    // some comment\n" +
+                    "    public void test() {\n" +
+                    "        System.out.println();\n" +
+                    "    }\n" +
+                    "}\n"
+        val after = NormalizeLineBreaksVisitor<ExecutionContext>(style).visit(jp.parse(before)[0], InMemoryExecutionContext())!!.print()
+        Assertions.assertThat(after.toCharArray()).isEqualTo(expected.toCharArray())
+    }
+
+    @Test
+    fun simpleFileToWindowsLineEnd(jp: JavaParser) {
+        val style = GeneralFormatStyle(true)
+        val before =
+            "class Test {\r\n" +
+                    "    // some comment\r\n" +
+                    "    public void test() {\n" +
+                    "        System.out.println();\n" +
+                    "    }\r\n" +
+                    "}\n"
+        val expected =
+            "class Test {\r\n" +
+                    "    // some comment\r\n" +
+                    "    public void test() {\r\n" +
+                    "        System.out.println();\r\n" +
+                    "    }\r\n" +
+                    "}\r\n"
+
+        val after = NormalizeLineBreaksVisitor<ExecutionContext>(style).visit(jp.parse(before)[0], InMemoryExecutionContext())!!.print()
+        Assertions.assertThat(after.toCharArray()).isEqualTo(expected.toCharArray())
+    }
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/style/AutodetectTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/style/AutodetectTest.kt
@@ -18,6 +18,7 @@ package org.openrewrite.java.style
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.openrewrite.java.JavaParser
+import org.openrewrite.style.GeneralFormatStyle
 import org.openrewrite.style.NamedStyles
 
 interface AutodetectTest {
@@ -259,5 +260,39 @@ interface AutodetectTest {
 
         assertThat(importLayout.classCountToUseStarImport).isEqualTo(2147483647)
         assertThat(importLayout.nameCountToUseStarImport).isEqualTo(2147483647)
+    }
+
+    @Test
+    fun detectClrfLineFormat(jp: JavaParser) {
+        val cus = jp.parse(
+            "class Test {\r\n" +
+                    "    // some comment\r\n" +
+                    "    public void test() {\n" +
+                    "        System.out.println();\n" +
+                    "    }\r\n" +
+                    "}\r\n"
+        )
+
+        val styles = Autodetect.detect(cus)
+        val lineFormatStyle = NamedStyles.merge(GeneralFormatStyle::class.java, listOf(styles))
+
+        assertThat(lineFormatStyle!!.useCRLFNewLines).isTrue
+    }
+
+    @Test
+    fun detectLfLineFormat(jp: JavaParser) {
+        val cus = jp.parse(
+            "class Test {\n" +
+                    "    // some comment\r\n" +
+                    "    public void test() {\n" +
+                    "        System.out.println();\n" +
+                    "    }\n" +
+                    "}\r\n"
+        )
+
+        val styles = Autodetect.detect(cus)
+        val lineFormatStyle = NamedStyles.merge(GeneralFormatStyle::class.java, listOf(styles))
+
+        assertThat(lineFormatStyle!!.useCRLFNewLines).isFalse
     }
 }


### PR DESCRIPTION
Move `useCLRFNewLines` from `TabsAndIndentsStyle` to new `FormatStyle` and update AutoDetect. Closes #973 