### PR TITLE
JavaPrinter visitTry semicolon fix

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -1029,6 +1029,7 @@ public class JavaPrinter<P> extends JavaVisitor<P> {
             List<JRightPadded<Try.Resource>> resources = tryable.getPadding().getResources().getPadding().getElements();
             for (int i = 0; i < resources.size(); i++) {
                 JRightPadded<Try.Resource> resource = resources.get(i);
+
                 visitSpace(resource.getElement().getPrefix(), Space.Location.TRY_RESOURCE, p);
                 visitMarkers(resource.getElement().getMarkers(), p);
                 visit(resource.getElement().getVariableDeclarations(), p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -1034,7 +1034,8 @@ public class JavaPrinter<P> extends JavaVisitor<P> {
                 visitMarkers(resource.getElement().getMarkers(), p);
                 visit(resource.getElement().getVariableDeclarations(), p);
 
-                if (i < resources.size() - 1 || resource.getElement().isTerminatedWithSemicolon()) {
+                boolean nextResourceIsTerminatedWithSemicolon = i < resources.size() - 2 && resources.get(i + 1).getElement().isTerminatedWithSemicolon();
+                if (!nextResourceIsTerminatedWithSemicolon && (i < resources.size() - 1 || resource.getElement().isTerminatedWithSemicolon())) {
                     acc.append(';');
                 }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -1029,13 +1029,12 @@ public class JavaPrinter<P> extends JavaVisitor<P> {
             List<JRightPadded<Try.Resource>> resources = tryable.getPadding().getResources().getPadding().getElements();
             for (int i = 0; i < resources.size(); i++) {
                 JRightPadded<Try.Resource> resource = resources.get(i);
-
                 visitSpace(resource.getElement().getPrefix(), Space.Location.TRY_RESOURCE, p);
                 visitMarkers(resource.getElement().getMarkers(), p);
                 visit(resource.getElement().getVariableDeclarations(), p);
 
-                boolean nextResourceIsTerminatedWithSemicolon = i < resources.size() - 2 && resources.get(i + 1).getElement().isTerminatedWithSemicolon();
-                if (!nextResourceIsTerminatedWithSemicolon && (i < resources.size() - 1 || resource.getElement().isTerminatedWithSemicolon())) {
+                boolean nextResourceHasSemicolon = i <= resources.size() - 2 && resources.get(i + 1).getElement().getPrefix().getWhitespace().contains(";");
+                if (!nextResourceHasSemicolon && (i < resources.size() - 1 || resource.getElement().isTerminatedWithSemicolon())) {
                     acc.append(';');
                 }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TryCatchTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TryCatchTest.kt
@@ -93,15 +93,18 @@ interface TryCatchTest : JavaTreeTest {
         """, "java.io.*"
     )
 
+    @Disabled("Java 8 does not allow resources as identifiers")
     @Issue("https://github.com/openrewrite/rewrite/issues/1027")
     @Test
-    fun tryWithResourcesIdentifierAndVariables(jp: JavaParser) = assertParsePrintAndProcess(
-        jp, Block, """
-            FileInputStream fis = new FileInputStream(new File("file.txt"));
-            try (fis; Scanner sc = new Scanner("")) {
+    fun tryWithResourcesIdentifierAndVariables(jp: JavaParser) {
+        assertParsePrintAndProcess(
+            jp, Block, """
+            Scanner sc1 = new Scanner("abc");
+            try (sc1; Scanner sc = new Scanner(System.in)) {
             }
-        """, "java.io.*", "java.util.Scanner"
-    )
+        """, "java.util.Scanner"
+        )
+    }
 
     @Test
     fun multiCatch(jp: JavaParser) = assertParsePrintAndProcess(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TryCatchTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TryCatchTest.kt
@@ -93,7 +93,6 @@ interface TryCatchTest : JavaTreeTest {
         """, "java.io.*"
     )
 
-    @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/1027")
     @Test
     fun tryWithResourcesIdentifierAndVariables(jp: JavaParser) = assertParsePrintAndProcess(


### PR DESCRIPTION
JavaPrinter visitTry does not append a semicolon while iterating resources when the next resource is semicolon terminated.  Fixes #1027