### PR TITLE
Add HCL language annotation to HCLRecipeTest

### DIFF
--- a/rewrite-hcl/src/test/kotlin/org/openrewrite/hcl/format/SpacesTest.kt
+++ b/rewrite-hcl/src/test/kotlin/org/openrewrite/hcl/format/SpacesTest.kt
@@ -21,8 +21,6 @@ import org.openrewrite.Tree
 import org.openrewrite.hcl.HclParser
 import org.openrewrite.hcl.HclRecipeTest
 import org.openrewrite.hcl.style.SpacesStyle
-import org.openrewrite.java.style.IntelliJ
-import org.openrewrite.java.style.TabsAndIndentsStyle
 import org.openrewrite.style.NamedStyles
 
 class SpacesTest : HclRecipeTest {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/hcl/HclRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/hcl/HclRecipeTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.hcl
 
+import org.intellij.lang.annotations.Language
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.hcl.tree.Hcl
@@ -30,7 +31,7 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
         recipe: Recipe = this.recipe!!,
         moderneAstLink: String,
         moderneApiBearerToken: String = apiTokenFromUserHome(),
-        after: String,
+        @Language("HCL") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Hcl.ConfigFile) -> Unit = { }
@@ -41,9 +42,9 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
     fun assertChanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        before: String,
-        dependsOn: Array<String> = emptyArray(),
-        after: String,
+        @Language("HCL") before: String,
+        @Language("HCL") dependsOn: Array<String> = emptyArray(),
+        @Language("HCL") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Hcl.ConfigFile) -> Unit = { }
@@ -54,10 +55,10 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
     fun assertChanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        before: File,
+        @Language("HCL") before: File,
         relativeTo: Path? = null,
-        dependsOn: Array<File> = emptyArray(),
-        after: String,
+        @Language("HCL") dependsOn: Array<File> = emptyArray(),
+        @Language("HCL") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Hcl.ConfigFile) -> Unit = { }
@@ -68,8 +69,8 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
     fun assertUnchanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        before: String,
-        dependsOn: Array<String> = emptyArray()
+        @Language("HCL") before: String,
+        @Language("HCL") dependsOn: Array<String> = emptyArray()
     ) {
         super.assertUnchangedBase(parser, recipe, before, dependsOn)
     }
@@ -77,9 +78,9 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
     fun assertUnchanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        before: File,
+        @Language("HCL") before: File,
         relativeTo: Path? = null,
-        dependsOn: Array<File> = emptyArray()
+        @Language("HCL") dependsOn: Array<File> = emptyArray()
     ) {
         super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
     }


### PR DESCRIPTION
When using the JetBrains-sponsored "terraform and HCL" plugin (https://plugins.jetbrains.com/plugin/7808-terraform-and-hcl), the `@Language("HCL")` annotation provides syntax highlighting similar to our other recipe tests. If a user doesn't have the plugin installed, nothing different happens (as in, it's not like you get visible errors or anything). So, it's all good.

Note, the plugin provides both "HCL" and "HCL-Terraform" as language options. I put down "HCL", since it's a slightly more generalized form of HCL vs. some specific details of HCL-Terraform (though I'm not sure about _what_ specifically). It felt like a safer option.

Before/after:

![before](https://user-images.githubusercontent.com/5619476/134251582-2ba264b6-7cef-4f1d-bd60-f9dfde98f96d.png)

![after](https://user-images.githubusercontent.com/5619476/134251589-280df62f-eaa2-4411-96e9-3400ea0be7ce.png)
