### PR TITLE
Preserve whitespace before HTML tags in ReloadableJava8JavadocVisitor.

### DIFF
--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -278,14 +278,12 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
         }
 
         List<? extends DocTree> restOfBody = node.getBody();
-        for (DocTree docTree : restOfBody) {
-            Javadoc.LineBreak lineBreak;
-            while ((lineBreak = lineBreaks.remove(cursor + 1)) != null) {
-                cursor++;
-                body.add(lineBreak);
+        for (int i = 0; i < restOfBody.size(); i++) {
+            DocTree docTree = restOfBody.get(i);
+            if (!(docTree instanceof DCTree.DCText && i > 0)) {
+                body.addAll(whitespaceBefore());
             }
             if (docTree instanceof DCTree.DCText) {
-                body.addAll(whitespaceBefore());
                 body.addAll(visitText(((DCTree.DCText) docTree).getBody()));
             } else {
                 body.add((Javadoc) scan(docTree, whitespaceBefore()));

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1018,13 +1018,30 @@ interface JavadocTest : JavaTreeTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1026")
     @Test
-    fun selfClosingElement(jp: JavaParser) = assertParsePrintAndProcess(
+    fun selfClosingHTMLTag(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
         CompilationUnit,
         """
             /**
              *<p/>
              * text
+             */
+            class Test {
+            }
+        """.trimIndent()
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1047")
+    @Test
+    fun preserveWhitespaceBeforeHTMLTag(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            /**
+             * <p>
+             * <p/>
+             * text <br>
+             * text <br/>
              */
             class Test {
             }


### PR DESCRIPTION
fixes #1047