### PR TITLE
Change default value for HiddenFieldStyle.setterCanReturnItsClass

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -90,7 +90,7 @@ public class Checkstyle extends NamedStyles {
     }
 
     public static HiddenFieldStyle hiddenFieldStyle() {
-        return new HiddenFieldStyle(true, true, false, false);
+        return new HiddenFieldStyle(true, true, true, false);
     }
 
     public static HideUtilityClassConstructorStyle hideUtilityClassConstructorStyle() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/CheckstyleConfigLoader.java
@@ -209,7 +209,7 @@ public class CheckstyleConfigLoader {
                 .map(module -> new HiddenFieldStyle(
                         module.prop("ignoreConstructorParameter", true),
                         module.prop("ignoreSetter", true),
-                        module.prop("setterCanReturnItsClass", false),
+                        module.prop("setterCanReturnItsClass", true),
                         module.prop("ignoreAbstractMethods", false)
                 ))
                 .collect(toSet());

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
@@ -524,6 +524,7 @@ interface HiddenFieldTest : JavaRecipeTest {
     fun ignoreSetter(jp: JavaParser.Builder<*, *>) = assertChanged(
         jp.styles(hiddenFieldStyle {
             withIgnoreSetter(true)
+                .withSetterCanReturnItsClass(false)
         }).build(),
         before = """
             package org.openrewrite;


### PR DESCRIPTION
IMO there's no reason to treat differently classic setters and fluent setters