### PR TITLE
Fixed parsing error while processing multiline javaDoc with CRLF.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -122,9 +122,6 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
                         String prevNewLine = i > 1 && sourceArr[i - 2] == '\r' ? "\r\n" : "\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevNewLine, Markers.EMPTY));
                     }
-                    if (sourceArr[i - 1] == '\r') {
-                        javadocContent.append('\r');
-                    }
                     javadocContent.append(c);
                 }
                 String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -122,9 +122,6 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                         String prevNewLine = i > 1 && sourceArr[i - 2] == '\r' ? "\r\n" : "\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevNewLine, Markers.EMPTY));
                     }
-                    if (sourceArr[i - 1] == '\r') {
-                        javadocContent.append('\r');
-                    }
                     javadocContent.append(c);
                 }
                 String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1008,8 +1008,8 @@ interface JavadocTest : JavaTreeTest {
     @Test
     fun javaDocWithCRLF(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
-        CompilationUnit,
-        "/**\r\n" +
+        CompilationUnit, "" +
+              "/**\r\n" +
               " * JavaDoc.\r\n" +
               " */\r\n" +
               "public class A {\r\n" +
@@ -1046,5 +1046,40 @@ interface JavadocTest : JavaTreeTest {
             class Test {
             }
         """.trimIndent()
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/976")
+    @Test
+    fun multilineJavaDocWithCRLF(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit, "" +
+                "/**\r\n" +
+                " * Line 1.\r\n" +
+                " * Line 2.\r\n" +
+                " */\r\n" +
+                "public class A {\r\n" +
+                "    /**\r\n" +
+                "     * Line 1.\r\n" +
+                "     * Line 2.\r\n" +
+                "     */\r\n" +
+                "    void method() {}\r\n" +
+                "}"
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/976")
+    @Test
+    fun multilineWithThrowsAndCRLF(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit, "" +
+                "import java.io.IOException;\r\n" +
+                "\r\n" +
+                "public class A {\r\n" +
+                "    /**\r\n" +
+                "     * Line 1.\r\n" +
+                "     * Line 2.\r\n" +
+                "     * @throws IOException text.\r\n" +
+                "     */\r\n" +
+                "    void method() throws IOException {}\r\n" +
+                "}"
     )
 }


### PR DESCRIPTION
Removed appending \r on javadocContent in init.
Added multiline javaDoc tests with CRLF.
Tested on Windows and MacOs using CRLF/LF settings in the IDE. fixes #976