### PR TITLE
Enable comparing versions with more-than-3 semver groups

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/ExactVersion.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/ExactVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-core/src/main/java/org/openrewrite/semver/HyphenRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/HyphenRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,22 +25,15 @@ import java.util.regex.Pattern;
  * <a href="https://github.com/npm/node-semver#hyphen-ranges-xyz---abc">Hyphen ranges</a>.
  */
 public class HyphenRange extends LatestRelease {
-    private static final Pattern HYPHEN_RANGE_PATTERN = Pattern.compile("(\\d+(\\.\\d+)?(\\.\\d+)?)\\s*-\\s*(\\d+(\\.\\d+)?(\\.\\d+)?)");
+    private static final Pattern HYPHEN_RANGE_PATTERN = Pattern.compile("(\\d+(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?)\\s*-\\s*(\\d+(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?)");
 
     private final String upper;
     private final String lower;
 
     private HyphenRange(String lower, String upper, @Nullable String metadataPattern) {
         super(metadataPattern);
-        this.lower = fillPartialVersionWithZeroes(lower);
-        this.upper = fillPartialVersionWithZeroes(upper);
-    }
-
-    private static String fillPartialVersionWithZeroes(String version) {
-        if (version.chars().filter(c -> c == '.').count() < 2) {
-            return fillPartialVersionWithZeroes(version + ".0");
-        }
-        return version;
+        this.lower = lower;
+        this.upper = upper;
     }
 
     @Override
@@ -55,6 +48,6 @@ public class HyphenRange extends LatestRelease {
         if (!matcher.matches()) {
             return Validated.invalid("hyphenRange", pattern, "not a hyphen range");
         }
-        return Validated.valid("hyphenRange", new HyphenRange(matcher.group(1), matcher.group(4), metadataPattern));
+        return Validated.valid("hyphenRange", new HyphenRange(matcher.group(1), matcher.group(5), metadataPattern));
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import static java.lang.Integer.parseInt;
  * <a href="https://github.com/npm/node-semver#tilde-ranges-123-12-1">Tilde ranges</a>.
  */
 public class TildeRange extends LatestRelease {
-    private static final Pattern TILDE_RANGE_PATTERN = Pattern.compile("~(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?");
+    private static final Pattern TILDE_RANGE_PATTERN = Pattern.compile("~(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?");
 
     private final String upperExclusive;
     private final String lower;
@@ -55,19 +55,23 @@ public class TildeRange extends LatestRelease {
         String major = matcher.group(1);
         String minor = matcher.group(2);
         String patch = matcher.group(3);
+        String micro = matcher.group(4);
 
         String lower;
         String upper;
 
         if (minor == null) {
-            lower = major + ".0.0";
-            upper = (parseInt(major) + 1) + ".0.0";
+            lower = major;
+            upper = Integer.toString(parseInt(major) + 1);
         } else if (patch == null) {
-            lower = major + "." + minor + ".0";
-            upper = major + "." + (parseInt(minor) + 1) + ".0";
-        } else {
+            lower = major + "." + minor;
+            upper = major + "." + (parseInt(minor) + 1);
+        } else if (micro == null) {
             lower = major + "." + minor + "." + patch;
-            upper = major + "." + (parseInt(minor) + 1) + ".0";
+            upper = major + "." + (parseInt(minor) + 1);
+        } else {
+            lower = major + "." + minor + "." + patch + "." + micro;
+            upper = major + "." + minor + "." + (parseInt(patch) + 1);
         }
 
         return Validated.valid("tildeRange", new TildeRange(lower, upper, metadataPattern));

--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 public interface VersionComparator extends Comparator<String> {
-    Pattern RELEASE_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?([-+].*)?");
+    Pattern RELEASE_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?([-+].*)?");
     Pattern PRE_RELEASE_ENDING = Pattern.compile("[.-](SNAPSHOT|RC|rc|M|m|beta|alpha)[.-]?\\d*$");
 
     @Deprecated

--- a/rewrite-core/src/main/java/org/openrewrite/semver/package-info.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/CaretRangeTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/CaretRangeTest.kt
@@ -19,6 +19,28 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class CaretRangeTest {
+    @Test
+    fun pattern() {
+        assertThat(CaretRange.build("^1", null).isValid).isTrue
+        assertThat(CaretRange.build("^1.2", null).isValid).isTrue
+        assertThat(CaretRange.build("^1.2.3", null).isValid).isTrue
+        assertThat(CaretRange.build("^1.2.3.4", null).isValid).isTrue
+        assertThat(CaretRange.build("^1.2.3.4.5", null).isValid).isFalse
+    }
+
+    @Test
+    fun updateMicro() {
+        val caretRange: CaretRange = CaretRange.build("^1.2.3.4", null).getValue()!!
+
+        assertThat(caretRange.isValid("1.0", "1.2.3.4")).isTrue
+        assertThat(caretRange.isValid("1.0", "1.2.3.4.RELEASE")).isTrue
+        assertThat(caretRange.isValid("1.0", "1.2.3.5")).isTrue
+        assertThat(caretRange.isValid("1.0", "1.2.4")).isTrue
+        assertThat(caretRange.isValid("1.0", "1.9.0")).isTrue
+        assertThat(caretRange.isValid("1.0", "1.2.3.3")).isFalse
+        assertThat(caretRange.isValid("1.0", "2.0.0")).isFalse
+    }
+
     /**
      * ^1.2.3 := >=1.2.3 <2.0.0
      */

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/HyphenRangeTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/HyphenRangeTest.kt
@@ -19,6 +19,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class HyphenRangeTest {
+    @Test
+    fun pattern() {
+        assertThat(HyphenRange.build("1 - 2", null).isValid).isTrue
+        assertThat(HyphenRange.build("1.0.0.0 - 2", null).isValid).isTrue
+        assertThat(HyphenRange.build("1 - 2.0.0.0", null).isValid).isTrue
+        assertThat(HyphenRange.build("1.0.0.0 - 2.0.0.0", null).isValid).isTrue
+        assertThat(HyphenRange.build("1", null).isValid).isFalse
+        assertThat(HyphenRange.build("1 - 2.x", null).isValid).isFalse
+        assertThat(HyphenRange.build("1.0.0.0.0 - 2", null).isValid).isFalse
+    }
+
     /**
      * 1.2.3 - 2.3.4 := >=1.2.3 <=2.3.4
      */
@@ -27,10 +38,17 @@ class HyphenRangeTest {
         val hyphenRange: HyphenRange = HyphenRange.build("1.2.3 - 2.3.4", null).getValue()!!
 
         assertThat(hyphenRange.isValid("1.0", "1.2.2")).isFalse
+        assertThat(hyphenRange.isValid("1.0", "1.2.2.0")).isFalse
         assertThat(hyphenRange.isValid("1.0", "1.2.3.RELEASE")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "1.2.3.0.RELEASE")).isTrue
         assertThat(hyphenRange.isValid("1.0", "1.2.3")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "1.2.3.0")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "1.2.3.0.0")).isFalse
         assertThat(hyphenRange.isValid("1.0", "2.3.4")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "2.3.4.0")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "2.3.4.1")).isFalse
         assertThat(hyphenRange.isValid("1.0", "2.3.5")).isFalse
+        assertThat(hyphenRange.isValid("1.0", "2.3.5.0")).isFalse
     }
 
     /**
@@ -41,8 +59,13 @@ class HyphenRangeTest {
         val hyphenRange: HyphenRange = HyphenRange.build("1.2 - 2", null).getValue()!!
 
         assertThat(hyphenRange.isValid("1.0", "1.1.9")).isFalse
+        assertThat(hyphenRange.isValid("1.0", "1.1.9.9")).isFalse
         assertThat(hyphenRange.isValid("1.0", "1.2.0")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "1.2.0.0")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "1.2.0.0.0")).isFalse
         assertThat(hyphenRange.isValid("1.0", "2.0.0")).isTrue
+        assertThat(hyphenRange.isValid("1.0", "2.0.0.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.0.1")).isFalse
+        assertThat(hyphenRange.isValid("1.0", "2.0.0.1")).isFalse
     }
 }

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestPatchTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestPatchTest.kt
@@ -24,6 +24,7 @@ class LatestPatchTest {
     @Test
     fun isValid() {
         assertThat(latestPatch.isValid("1.0.0", "1.0.0")).isTrue
+        assertThat(latestPatch.isValid("1.0.0", "1.0.0.1")).isTrue
         assertThat(latestPatch.isValid("1.0.0", "1.0.1")).isTrue
         assertThat(latestPatch.isValid("1.0", "1.0.1")).isTrue
         assertThat(latestPatch.isValid("1.0.0", "1.1.0")).isFalse
@@ -33,5 +34,6 @@ class LatestPatchTest {
     @Test
     fun compare() {
         assertThat(latestPatch.compare("1.0", "1.0.1", "1.0.2")).isLessThan(0)
+        assertThat(latestPatch.compare("1.0", "1.0.0.1", "1.0.1")).isLessThan(0)
     }
 }

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
@@ -25,27 +25,41 @@ class LatestReleaseTest {
     @Test
     fun onlyNumericPartsValid() {
         assertAll(
+            { assertThat(latestRelease.isValid("1.0", "1.1.1.1")).isTrue },
             { assertThat(latestRelease.isValid("1.0", "1.1.1")).isTrue },
             { assertThat(latestRelease.isValid("1.0", "1.1")).isTrue },
             { assertThat(latestRelease.isValid("1.0", "1")).isTrue },
             { assertThat(latestRelease.isValid("1.0", "1.1.a")).isFalse },
+            { assertThat(latestRelease.isValid("1.0", "1.1.1.1.a")).isFalse },
+            { assertThat(latestRelease.isValid("1.0", "1.1.1.1.1")).isFalse },
+            { assertThat(latestRelease.isValid("1.0", "1.1.1.1.1-SNAPSHOT")).isFalse },
             { assertThat(latestRelease.isValid("1.0", "1.1.0-SNAPSHOT")).isFalse }
         )
     }
 
     @Test
+    fun differentMicroVersions() {
+        assertThat(latestRelease.compare("1.0", "1.1.1.1", "1.1.1.2")).isLessThan(0)
+        assertThat(latestRelease.compare("1.0", "1", "1.1.1.1")).isLessThan(0)
+        assertThat(latestRelease.compare("1.0", "1.1.1.1", "2")).isLessThan(0)
+    }
+
+    @Test
     fun differentPatchVersions() {
+        assertThat(latestRelease.compare("1.0", "1.1.1.1", "1.1.2.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1.1.1", "1.1.2")).isLessThan(0)
     }
 
     @Test
     fun differentMinorVersions() {
+        assertThat(latestRelease.compare("1.0", "1.1.1.1", "1.2.1.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1.1.1", "1.2.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1.1", "1.2")).isLessThan(0)
     }
 
     @Test
     fun differentMajorVersions() {
+        assertThat(latestRelease.compare("1.0", "1.1.1.1", "2.1.1.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1.1.1", "2.1.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1.1", "2.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1", "2")).isLessThan(0)
@@ -53,6 +67,7 @@ class LatestReleaseTest {
 
     @Test
     fun differentNumberOfParts() {
+        assertThat(latestRelease.compare("1.0", "1.1.1", "1.1.1.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1.1", "1.1.1")).isLessThan(0)
         assertThat(latestRelease.compare("1.0", "1", "1.1")).isLessThan(0)
     }
@@ -64,6 +79,7 @@ class LatestReleaseTest {
 
     @Test
     fun matchMetadata() {
+        assertThat(LatestRelease("-jre").isValid("1.0", "29.0.0.0-jre")).isTrue
         assertThat(LatestRelease("-jre").isValid("1.0", "29.0-jre")).isTrue
         assertThat(LatestRelease("-jre").isValid("1.0", "29.0")).isFalse
         assertThat(LatestRelease("-jre").isValid("1.0", "29.0-android")).isFalse
@@ -71,6 +87,7 @@ class LatestReleaseTest {
 
     @Test
     fun normalizeVersionStripReleaseSuffix() {
+        assertThat(LatestRelease.normalizeVersion("1.5.1.2.RELEASE")).isEqualTo("1.5.1.2")
         assertThat(LatestRelease.normalizeVersion("1.5.1.RELEASE")).isEqualTo("1.5.1")
         assertThat(LatestRelease.normalizeVersion("1.5.1.FINAL")).isEqualTo("1.5.1")
         assertThat(LatestRelease.normalizeVersion("1.5.1.Final")).isEqualTo("1.5.1")

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/TildeRangeTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/TildeRangeTest.kt
@@ -19,6 +19,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class TildeRangeTest {
+    @Test
+    fun pattern() {
+        assertThat(TildeRange.build("~1", null).isValid).isTrue
+        assertThat(TildeRange.build("~1.2", null).isValid).isTrue
+        assertThat(TildeRange.build("~1.2.3", null).isValid).isTrue
+        assertThat(TildeRange.build("~1.2.3.4", null).isValid).isTrue
+        assertThat(TildeRange.build("~1.2.3.4.5", null).isValid).isFalse
+    }
+
     /**
      * ~1.2.3 := >=1.2.3 <1.(2+1).0 := >=1.2.3 <1.3.0
      */
@@ -26,9 +35,24 @@ class TildeRangeTest {
     fun updatePatch() {
         val tildeRange: TildeRange = TildeRange.build("~1.2.3", null).getValue()!!
 
+        assertThat(tildeRange.isValid("1.0", "1.2.3.0")).isTrue
+        assertThat(tildeRange.isValid("1.0", "1.2.3.1")).isTrue
         assertThat(tildeRange.isValid("1.0", "1.2.3")).isTrue
         assertThat(tildeRange.isValid("1.0", "1.2.3.RELEASE")).isTrue
         assertThat(tildeRange.isValid("1.0", "1.2.4")).isTrue
+        assertThat(tildeRange.isValid("1.0", "1.3.0")).isFalse
+    }
+
+    @Test
+    fun updateMicro() {
+        val tildeRange: TildeRange = TildeRange.build("~1.2.3.4", null).getValue()!!
+
+        assertThat(tildeRange.isValid("1.0", "1.2.3.5")).isTrue
+        assertThat(tildeRange.isValid("1.0", "1.2.3.0")).isFalse
+        assertThat(tildeRange.isValid("1.0", "1.2.3.5.0")).isFalse
+        assertThat(tildeRange.isValid("1.0", "1.2.3")).isFalse
+        assertThat(tildeRange.isValid("1.0", "1.2.4")).isFalse
+        assertThat(tildeRange.isValid("1.0", "1.2.4.0")).isFalse
         assertThat(tildeRange.isValid("1.0", "1.3.0")).isFalse
     }
 

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/XRangeTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/XRangeTest.kt
@@ -26,6 +26,9 @@ class XRangeTest {
         assertThat(XRange.build("1.x", null).isValid).isTrue
         assertThat(XRange.build("1.x.0", null).isValid).isFalse
         assertThat(XRange.build("1.1.X", null).isValid).isTrue
+        assertThat(XRange.build("1.1.1.X", null).isValid).isTrue
+        assertThat(XRange.build("1.1.1.1.X", null).isValid).isFalse
+        assertThat(XRange.build("1.1.x.1", null).isValid).isFalse
         assertThat(XRange.build("a", null).isValid).isFalse
     }
 
@@ -41,6 +44,7 @@ class XRangeTest {
     fun anyVersion() {
         val xRange: XRange = XRange.build("X", null).getValue()!!
 
+        assertThat(xRange.isValid("1.0", "0.0.0.0")).isTrue
         assertThat(xRange.isValid("1.0", "0.0.0")).isTrue
     }
 
@@ -52,6 +56,7 @@ class XRangeTest {
         val xRange: XRange = XRange.build("1.*", null).getValue()!!
 
         assertThat(xRange.isValid("1.0", "1.0.0")).isTrue
+        assertThat(xRange.isValid("1.0", "1.0.0.1")).isTrue
         assertThat(xRange.isValid("1.0", "1.2.3.RELEASE")).isTrue
         assertThat(xRange.isValid("1.0", "1.9.9")).isTrue
         assertThat(xRange.isValid("1.0", "2.0.0")).isFalse
@@ -66,6 +71,16 @@ class XRangeTest {
 
         assertThat(xRange.isValid("1.0", "1.2.0")).isTrue
         assertThat(xRange.isValid("1.0", "1.3.0")).isFalse
+    }
+
+    @Test
+    fun matchingMicroVersions() {
+        val xRange: XRange = XRange.build("1.2.3.X", null).getValue()!!
+
+        assertThat(xRange.isValid("1.0", "1.2.3.0")).isTrue
+        assertThat(xRange.isValid("1.0", "1.2.3")).isTrue
+        assertThat(xRange.isValid("1.0", "1.2.4.0")).isFalse
+        assertThat(xRange.isValid("1.0", "1.2.4")).isFalse
     }
 
     @Test


### PR DESCRIPTION
Accepts between 1 and up to four version places demarcated by ".", as in, "x.y.z" or "x.y.z.n", but not "x.y.z.n.q". 

Of note:
- Decided to keep it at a 4-tuple rather than "n-tuple". This is because we use a regex to validate pattern strings in subclasses of `LatestVersion`, and also use those regexes to extract capture groups for `major`.`minor`.`patch`.`additional`, etc. If using a regex, trying to specify repeating a captured group captures only the _last iteration_ of that group. We could instead capture the repeated group to capture all iterations as it's own group, and then split out each version subcomponent... But, instead, just kept it straightforward for the moment, because I kept getting myself turned around and too enmeshed in the possibility of having a "comparable version" class.
- Subclasses of `LatestVersion` having their own logic to pad out version strings with `+ .0.0` operations is no longer necessary. When comparing `1.2` to `1.3.0.0`, for example, the padding out of `1.2` to meet `1.2.0.0` is now handled in `compare`.