### PR TITLE
RemoveUnusedImports handles Parameterized types

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -81,6 +81,17 @@ public class RemoveUnusedImports extends Recipe {
                         methodsAndFieldsByTypeName.computeIfAbsent(method.getDeclaringType().getFullyQualifiedName(), t -> new HashSet<>())
                                 .add(method.getName());
                     }
+                } else if (javaType instanceof JavaType.Parameterized) {
+                    JavaType.Parameterized parameterized = (JavaType.Parameterized)javaType;
+                    typesByPackage.computeIfAbsent(packageKey(parameterized.getType().getPackageName(), parameterized.getType().getClassName()), f -> new HashSet<>())
+                            .add(parameterized.getType());
+                    for (JavaType typeParameter : parameterized.getTypeParameters()) {
+                        JavaType.FullyQualified fq = TypeUtils.asFullyQualified(typeParameter);
+                        if (fq != null) {
+                            typesByPackage.computeIfAbsent(packageKey(fq.getPackageName(), fq.getClassName()), f -> new HashSet<>())
+                                    .add(fq);
+                        }
+                    }
                 } else if (javaType instanceof JavaType.FullyQualified) {
                     JavaType.FullyQualified fullyQualified = (JavaType.FullyQualified) javaType;
                     typesByPackage.computeIfAbsent(packageKey(fullyQualified.getPackageName(), fullyQualified.getClassName()), f -> new HashSet<>())

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveUnusedImportsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveUnusedImportsTest.kt
@@ -141,13 +141,35 @@ interface RemoveUnusedImportsTest : JavaRecipeTest {
     )
 
     @Test
-    fun leaveStarImportInPlaceIfThreeOrMoreTypesStillReferredTo(jp: JavaParser) = assertUnchanged(
+    fun unfoldIfLessThanStarCount(jp: JavaParser) = assertChanged(
         jp,
         before = """
             import java.util.*;
             class A {
                Collection<Integer> c;
                Set<Integer> s = new HashSet<>();
+            }
+        """,
+        after = """
+            import java.util.Collection;
+            import java.util.HashSet;
+            import java.util.Set;
+            class A {
+               Collection<Integer> c;
+               Set<Integer> s = new HashSet<>();
+            }
+        """
+    )
+
+    @Test
+    fun leaveStarImportInPlaceIfMoreThanStarCount(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            import java.util.*;
+            class A {
+               Collection<Integer> c;
+               Set<Integer> s = new HashSet<>();
+               List<String> l = Arrays.asList("a","b","c");
             }
         """
     )


### PR DESCRIPTION
RemoveUnusedImports handles Parameterized types when building the `typesByPackage` map. Fixes #1128