### PR TITLE
Do not left-shift yaml prefix comments following previous element on the same line

### DIFF
--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/CoalescePropertiesTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/CoalescePropertiesTest.kt
@@ -203,18 +203,25 @@ class CoalescePropertiesTest : YamlRecipeTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1142")
-    @Disabled
-    fun doNotOverWrapYamlKeyPrefixComments() = assertChanged(
+    fun doNotShiftYamlCommentsInPrefixFollowingPreviousYamlObject() = assertChanged(
         before = """
           a:
             b:
               c: c-value  # c-comment
-              d: d-value
+              d: d-value # d-comment
+              e: e-value   # e-comment
+              f: f-value
+
+              g: g-value
         """,
         after = """
             a.b:
               c: c-value  # c-comment
-              d: d-value
+              d: d-value # d-comment
+              e: e-value   # e-comment
+              f: f-value
+
+              g: g-value
         """
     )
 


### PR DESCRIPTION
Do not shift yaml comments in prefix if the comment is following the previous element on the same line

Closes https://github.com/openrewrite/rewrite/issues/1142