### PR TITLE
Upgrade dependency adds an overridden version property

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyValue.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyValue.java
@@ -82,14 +82,15 @@ public class ChangePropertyValue extends Recipe {
                 Xml.Tag root = m.getRoot();
                 Optional<Xml.Tag> properties = root.getChild("properties");
                 if (!properties.isPresent()) {
-                    doAfterVisit(new AddToTagVisitor<>(root, Xml.Tag.build("<properties>\n<" + key + ">" + newValue + "</" + key + ">\n</properties>"),
-                            new MavenTagInsertionComparator(root.getChildren())));
-                    doAfterVisit(new AutoFormatVisitor<>(root));
+                    Xml.Tag propertiesTag = Xml.Tag.build("<properties>\n<" + key + ">" + newValue + "</" + key + ">\n</properties>");
+                    doAfterVisit(new AddToTagVisitor<>(root, propertiesTag, new MavenTagInsertionComparator(root.getChildren())));
+                    doAfterVisit(new AutoFormatVisitor<>(propertiesTag));
 
                 } else if (!properties.get().getChildValue(key).isPresent()) {
-                    doAfterVisit(new AddToTagVisitor<>(properties.get(), Xml.Tag.build("<" + key + ">" + newValue + "</" + key + ">"),
+                    Xml.Tag propertyTag = Xml.Tag.build("<" + key + ">" + newValue + "</" + key + ">");
+                    doAfterVisit(new AddToTagVisitor<>(properties.get(), propertyTag,
                             new MavenTagInsertionComparator(properties.get().getChildren())));
-                    doAfterVisit(new AutoFormatVisitor<>(properties.get()));
+                    doAfterVisit(new AutoFormatVisitor<>(propertyTag));
                 }
 
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyValue.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyValue.java
@@ -17,12 +17,15 @@ package org.openrewrite.maven;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.tree.Maven;
+import org.openrewrite.xml.AddToTagVisitor;
+import org.openrewrite.xml.AutoFormatVisitor;
 import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
+
+import java.util.Optional;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -37,6 +40,12 @@ public class ChangePropertyValue extends Recipe {
             description = "Value to apply to the matching property.",
             example = "4.13")
     String newValue;
+
+    @Option(displayName = "Add If Missing",
+            description = "Add the property if it is missing from the pom file.",
+            required = false,
+            example = "false")
+    Boolean addIfMissing;
 
     @Override
     public String getDisplayName() {
@@ -53,7 +62,7 @@ public class ChangePropertyValue extends Recipe {
         return new ChangePropertyValueVisitor();
     }
 
-    public ChangePropertyValue(String key, String newValue) {
+    public ChangePropertyValue(String key, String newValue, @Nullable Boolean addIfMissing) {
         //Customizing lombok constructor to replace the property markers.
         //noinspection ConstantConditions
         if (key != null) {
@@ -61,9 +70,31 @@ public class ChangePropertyValue extends Recipe {
         }
         this.key = key;
         this.newValue = newValue;
+        this.addIfMissing = addIfMissing != null && addIfMissing;
     }
 
     private class ChangePropertyValueVisitor extends MavenVisitor {
+
+        public Maven visitMaven(Maven maven, ExecutionContext ctx) {
+            Maven m = super.visitMaven(maven, ctx);
+
+            if (addIfMissing) {
+                Xml.Tag root = m.getRoot();
+                Optional<Xml.Tag> properties = root.getChild("properties");
+                if (!properties.isPresent()) {
+                    doAfterVisit(new AddToTagVisitor<>(root, Xml.Tag.build("<properties>\n<" + key + ">" + newValue + "</" + key + ">\n</properties>"),
+                            new MavenTagInsertionComparator(root.getChildren())));
+                    doAfterVisit(new AutoFormatVisitor<>(root));
+
+                } else if (!properties.get().getChildValue(key).isPresent()) {
+                    doAfterVisit(new AddToTagVisitor<>(properties.get(), Xml.Tag.build("<" + key + ">" + newValue + "</" + key + ">"),
+                            new MavenTagInsertionComparator(properties.get().getChildren())));
+                    doAfterVisit(new AutoFormatVisitor<>(properties.get()));
+                }
+
+            }
+            return m;
+        }
 
         @Override
         public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -180,7 +180,7 @@ public class UpgradePluginVersion extends Recipe {
                     String version = versionTag.get().getValue().orElse(null);
                     if (version != null) {
                         if (version.trim().startsWith("${") && !newVersion.equals(model.getValue(version.trim()))) {
-                            doAfterVisit(new ChangePropertyValue(version, newVersion));
+                            doAfterVisit(new ChangePropertyValue(version, newVersion, false));
                         } else if (!newVersion.equals(version)) {
                             doAfterVisit(new ChangeTagValueVisitor<>(versionTag.get(), newVersion));
                         }

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/ChangePropertyValueTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/ChangePropertyValueTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 class ChangePropertyValueTest : MavenRecipeTest {
     @Test
     fun property() = assertChanged(
-        recipe = ChangePropertyValue("guava.version", "29.0-jre"),
+        recipe = ChangePropertyValue("guava.version", "29.0-jre", false),
         before = """
             <project>
               <modelVersion>4.0.0</modelVersion>
@@ -53,26 +53,26 @@ class ChangePropertyValueTest : MavenRecipeTest {
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @Test
     fun checkValidation() {
-        var recipe = ChangePropertyValue(null, null)
+        var recipe = ChangePropertyValue(null, null, false)
         var valid = recipe.validate()
         assertThat(valid.isValid).isFalse()
         assertThat(valid.failures()).hasSize(2)
         assertThat(valid.failures()[0].property).isEqualTo("key")
         assertThat(valid.failures()[1].property).isEqualTo("newValue")
 
-        recipe = ChangePropertyValue(null, "8")
+        recipe = ChangePropertyValue(null, "8", false)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse()
         assertThat(valid.failures()).hasSize(1)
         assertThat(valid.failures()[0].property).isEqualTo("key")
 
-        recipe = ChangePropertyValue("java.version", null)
+        recipe = ChangePropertyValue("java.version", null, false)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse()
         assertThat(valid.failures()).hasSize(1)
         assertThat(valid.failures()[0].property).isEqualTo("newValue")
 
-        recipe = ChangePropertyValue("java.version", "8")
+        recipe = ChangePropertyValue("java.version", "8", false)
         valid = recipe.validate()
         assertThat(valid.isValid).isTrue()
     }

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/UpgradeDependencyVersionTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/UpgradeDependencyVersionTest.kt
@@ -510,6 +510,124 @@ class UpgradeDependencyVersionTest : MavenRecipeTest {
     }
 
     @Test
+    fun upgradeAddsPropertySectionToOverrideManagedDependencyPropertyVersion() = assertChanged(
+        recipe = UpgradeDependencyVersion(
+            "junit",
+            "junit",
+            "4.x",
+            null,
+            false
+        ),
+        before = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              
+              <parent>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-parent</artifactId>
+                <version>2.12</version>
+              </parent>
+            
+              <groupId>com.mycompany.app</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+            
+              <dependencies>
+                <dependency>
+                  <groupId>junit</groupId>
+                  <artifactId>junit</artifactId>
+                </dependency>
+              </dependencies>
+            </project>
+        """.trimIndent(),
+        after = """            
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              
+              <parent>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-parent</artifactId>
+                <version>2.12</version>
+              </parent>
+            
+              <groupId>com.mycompany.app</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+              <properties>
+                <version.junit>4.13.2</version.junit>
+              </properties>
+            
+              <dependencies>
+                <dependency>
+                  <groupId>junit</groupId>
+                  <artifactId>junit</artifactId>
+                </dependency>
+              </dependencies>
+            </project>
+        """.trimIndent()
+    )
+
+    @Test
+    fun upgradeAddsPropertyToOverrideManagedDependencyPropertyVersion() = assertChanged(
+        recipe = UpgradeDependencyVersion(
+            "junit",
+            "junit",
+            "4.x",
+            null,
+            false
+        ),
+        before = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              
+              <parent>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-parent</artifactId>
+                <version>2.12</version>
+              </parent>
+            
+              <groupId>com.mycompany.app</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+              <properties>
+              </properties>
+            
+              <dependencies>
+                <dependency>
+                  <groupId>junit</groupId>
+                  <artifactId>junit</artifactId>
+                </dependency>
+              </dependencies>
+            </project>
+        """.trimIndent(),
+        after = """            
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              
+              <parent>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-parent</artifactId>
+                <version>2.12</version>
+              </parent>
+            
+              <groupId>com.mycompany.app</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+              <properties>
+                <version.junit>4.13.2</version.junit>
+              </properties>
+
+              <dependencies>
+                <dependency>
+                  <groupId>junit</groupId>
+                  <artifactId>junit</artifactId>
+                </dependency>
+              </dependencies>
+            </project>
+        """.trimIndent()
+    )
+
+    @Test
     fun upgradeDependencyHandlesDependencyManagement() = assertChanged(
         recipe = UpgradeDependencyVersion(
             "io.micronaut",

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/UpgradeDependencyVersionTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/UpgradeDependencyVersionTest.kt
@@ -70,37 +70,69 @@ class UpgradeDependencyVersionTest : MavenRecipeTest {
     )
 
     @Test
-    fun trustParent() = assertUnchanged(
-        recipe = UpgradeDependencyVersion(
-            "junit",
-            "junit",
-            "4.x",
-            null,
-            true
-        ),
-        before = """
-            <project>
-              <modelVersion>4.0.0</modelVersion>
-              
-              <parent>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-parent</artifactId>
-                <version>2.12</version>
-              </parent>
-              
-              <groupId>com.mycompany.app</groupId>
-              <artifactId>my-app</artifactId>
-              <version>1</version>
-              
-              <dependencies>
-                <dependency>
-                  <groupId>junit</groupId>
-                  <artifactId>junit</artifactId>
-                </dependency>
-              </dependencies>
-            </project>
-        """
-    )
+    fun trustParent(@TempDir tempDir: Path) {
+        val parent = tempDir.resolve("pom.xml")
+        val child = tempDir.resolve("server/pom.xml")
+        child.toFile().parentFile.mkdirs()
+
+        parent.toFile().writeText(
+            """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <packaging>pom</packaging>
+                    <groupId>com.mycompany</groupId>
+                    <artifactId>my-parent</artifactId>
+                    <version>1</version>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.google.guava</groupId>
+                                <artifactId>guava</artifactId>
+                                <version>13.0.1</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                </project>
+            """.trimIndent()
+        )
+
+        child.toFile().writeText(
+            """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  
+                  <parent>
+                    <groupId>com.mycompany</groupId>
+                    <artifactId>my-parent</artifactId>
+                    <version>1</version>
+                  </parent>
+                
+                  <groupId>com.mycompany</groupId>
+                  <artifactId>my-child</artifactId>
+                  <version>1</version>
+                  
+                  <dependencies>
+                    <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+            """.trimIndent()
+        )
+
+        assertUnchanged(
+            recipe = UpgradeDependencyVersion(
+                "com.google.guava",
+                "guava",
+                "14.0",
+                "",
+                true
+            ),
+            dependsOn = arrayOf(parent.toFile()),
+            before = child.toFile()
+        )
+    }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/739")


### PR DESCRIPTION
`UpgradeDependencyVersion` should detect if a managed dependency's version is expressed as a property and should either update or add a property to a pom that will override the property value.

`ChangePropertyValue` has been modified to include a flag `addIfMissing` with the default value being `false`

fixes #1157 