### PR TITLE
Update TypeMapping also check for `Type.ForAll` when building JavaType.Method

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/TypeMapping.java
@@ -334,6 +334,11 @@ public class TypeMapping {
                         }
                     }
                 }
+            } else if (selectType instanceof Type.ForAll) {
+                Type.ForAll fa = (Type.ForAll) selectType;
+                if (!fa.argtypes(false).isEmpty()) {
+                    argumentTypeSignatures.add(fa.argtypes(false));
+                }
             }
 
             return typeCache.computeMethod(classfile(symbol.owner.type), signature(symbol.owner.type), methodName, signature(selectType.getReturnType()),

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableTypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableTypeMapping.java
@@ -344,6 +344,11 @@ public class ReloadableTypeMapping {
                         }
                     }
                 }
+            } else if (selectType instanceof Type.ForAll) {
+                Type.ForAll fa = (Type.ForAll) selectType;
+                if (!fa.argtypes(false).isEmpty()) {
+                    argumentTypeSignatures.add(fa.argtypes(false));
+                }
             }
 
             return typeCache.computeMethod(classfile(symbol.owner.type), signature(symbol.owner.type), methodName, signature(selectType.getReturnType()),

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesMethodTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesMethodTest.kt
@@ -65,6 +65,7 @@ interface UsesMethodTest : JavaRecipeTest {
             }
         """
     )
+
     @Test
     fun usesMethodReferences(jp: JavaParser) = assertChanged(
         jp,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesTypeTest.kt
@@ -17,10 +17,37 @@ package org.openrewrite.java.search
 
 import org.junit.jupiter.api.Test
 import org.openrewrite.ExecutionContext
+import org.openrewrite.Issue
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
 
 interface UsesTypeTest : JavaRecipeTest {
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1169")
+    @Test
+    fun emptyConstructor(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = toRecipe {
+            UsesType<ExecutionContext>("java.util.ArrayList")
+        },
+        before = """
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            class Test {
+                List<String> l = new ArrayList<>();
+            }
+        """,
+        after = """
+            /*~~>*/import java.util.ArrayList;
+            import java.util.List;
+            
+            class Test {
+                List<String> l = new ArrayList<>();
+            }
+        """
+    )
+
     @Test
     fun usesTypeFindsImports(jp: JavaParser) = assertChanged(
         jp,


### PR DESCRIPTION
fix: Update TypeMapping also check for `Type.ForAll` when building JavaType.Method. Fixes: #1169 