### PR TITLE
Bump johnrengelman.shadow to 7.1.0, compare performance diff

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     id("nebula.release") version "15.3.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 
-    id("com.github.johnrengelman.shadow") version "6.1.0" apply false
+    id("com.github.johnrengelman.shadow") version "7.1.0" apply false
     id("com.github.hierynomus.license") version "0.16.1" apply false
     id("org.jetbrains.kotlin.jvm") version "1.5.21" apply false
     id("org.gradle.test-retry") version "1.2.1" apply false


### PR DESCRIPTION
Leaving as draft so can future compare before/after in time difference on gradle enterprise

https://ge.openrewrite.org/s/jczdsqtmvplbq/timeline?hide-timeline#xe25cw6cye2km