### PR TITLE
Relaxed binding on yaml and properties

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
@@ -94,6 +94,16 @@ public enum NameCaseConvention {
         return str.matches(format(convention, str));
     }
 
+    /**
+     * Check equality between two inputs using "relaxed binding" rules.
+     * The inputs will be converted to {@link NameCaseConvention#LOWER_CAMEL} before being checked using {@link String#equals}.
+     *
+     * @param str0 The first input to compare.
+     * @param str1 The second input to compare.
+     * @return Whether the inputs are equal.
+     * @see <a href="https://docs.micronaut.io/3.1.0/guide/index.html#_property_value_binding">Micronaut Property Value Binding Normalization</a>
+     * @see <a href="https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding">Spring Boot Relaxed Binding</a>
+     */
     public static boolean equalsRelaxedBinding(String str0, String str1) {
         return LOWER_CAMEL.format(str0).equals(LOWER_CAMEL.format(str1));
     }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -74,7 +74,7 @@ public class AddProperty extends Recipe {
             public Properties visitFile(Properties.File file, ExecutionContext executionContext) {
                 Properties p = super.visitFile(file, executionContext);
                 if (!StringUtils.isBlank(property) && !StringUtils.isBlank(value)) {
-                    Set<Properties.Entry> properties = FindProperties.find(p, property);
+                    Set<Properties.Entry> properties = FindProperties.find(p, property, false);
                     if (properties.isEmpty()) {
                         Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, value);
                         Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, property, "", propertyValue);

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/DeleteProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/DeleteProperty.java
@@ -18,6 +18,7 @@ package org.openrewrite.properties;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.internal.NameCaseConvention;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.properties.tree.Properties;
 
@@ -40,6 +41,14 @@ public class DeleteProperty extends Recipe {
             example = "management.metrics.binders.files.enabled")
     String propertyKey;
 
+    @Incubating(since = "7.17.0")
+    @Option(displayName = "Use relaxed binding",
+            description = "Whether to match the `propertyKey` using [relaxed binding](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding) " +
+                    "rules. Default is `true`. Set to `false`  to use exact matching.",
+            required = false)
+    @Nullable
+    Boolean relaxedBinding;
+
     @Option(displayName = "Optional file matcher",
             description = "Matching files will be modified. This is a glob expression.",
             required = false,
@@ -60,7 +69,7 @@ public class DeleteProperty extends Recipe {
         return new PropertiesVisitor<ExecutionContext>() {
             @Override
             public Properties visitEntry(Properties.Entry entry, ExecutionContext context) {
-                if (entry.getKey().equals(propertyKey)) {
+                if (!Boolean.FALSE.equals(relaxedBinding) ? NameCaseConvention.equalsRelaxedBinding(entry.getKey(), propertyKey) : entry.getKey().equals(propertyKey)) {
                     //noinspection ConstantConditions
                     return null;
                 }

--- a/rewrite-properties/src/test/kotlin/org/openrewrite/properties/ChangePropertyKeyTest.kt
+++ b/rewrite-properties/src/test/kotlin/org/openrewrite/properties/ChangePropertyKeyTest.kt
@@ -18,6 +18,8 @@ package org.openrewrite.properties
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.openrewrite.Issue
 import java.nio.file.Path
 
@@ -26,6 +28,7 @@ class ChangePropertyKeyTest : PropertiesRecipeTest {
     override val recipe = ChangePropertyKey(
         "management.metrics.binders.files.enabled",
         "management.metrics.enable.process.files",
+        null,
         null
     )
 
@@ -48,6 +51,48 @@ class ChangePropertyKeyTest : PropertiesRecipeTest {
         after = "management.metrics.enable.process.files=true"
     )
 
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "acme.my-project.person.first-name",
+            "acme.myProject.person.firstName",
+            "acme.my_project.person.first_name",
+        ]
+    )
+    @Issue("https://github.com/openrewrite/rewrite/issues/1168")
+    fun relaxedBinding(propertyKey: String) = assertChanged(
+        recipe = ChangePropertyKey(propertyKey, "acme.my-project.person.change-to", true, null),
+        before = """
+            acme.my-project.person.first-name=example
+            management.contextPath=/manage
+        """,
+        after = """
+            acme.my-project.person.change-to=example
+            management.contextPath=/manage
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1168")
+    fun exactMatch() = assertChanged(
+        recipe = ChangePropertyKey(
+            "acme.my-project.person.first-name",
+            "acme.my-project.person.change-to",
+            false,
+            null
+        ),
+        before = """
+            acme.my-project.person.first-name=example
+            acme.myProject.person.firstName=example
+            acme.my_project.person.first_name=example
+        """,
+        after = """
+            acme.my-project.person.change-to=example
+            acme.myProject.person.firstName=example
+            acme.my_project.person.first_name=example
+        """
+    )
+
     @Test
     fun changeOnlyMatchingFile(@TempDir tempDir: Path) {
         val matchingFile = tempDir.resolve("a.properties").apply {
@@ -58,7 +103,7 @@ class ChangePropertyKeyTest : PropertiesRecipeTest {
             toFile().parentFile.mkdirs()
             toFile().writeText("management.metrics=true")
         }.toFile()
-        val recipe = ChangePropertyKey("management.metrics", "management.stats", "**/a.properties")
+        val recipe = ChangePropertyKey("management.metrics", "management.stats", null, "**/a.properties")
         assertChanged(recipe = recipe, before = matchingFile, after = "management.stats=true")
         assertUnchanged(recipe = recipe, before = nonMatchingFile)
     }
@@ -66,20 +111,20 @@ class ChangePropertyKeyTest : PropertiesRecipeTest {
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @Test
     fun checkValidation() {
-        var recipe = ChangePropertyKey(null, null, null)
+        var recipe = ChangePropertyKey(null, null, null, null)
         var valid = recipe.validate()
         assertThat(valid.isValid).isFalse
         assertThat(valid.failures()).hasSize(2)
         assertThat(valid.failures()[0].property).isEqualTo("newPropertyKey")
         assertThat(valid.failures()[1].property).isEqualTo("oldPropertyKey")
 
-        recipe = ChangePropertyKey(null, "management.metrics.enable.process.files", null)
+        recipe = ChangePropertyKey(null, "management.metrics.enable.process.files", null, null)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse
         assertThat(valid.failures()).hasSize(1)
         assertThat(valid.failures()[0].property).isEqualTo("oldPropertyKey")
 
-        recipe = ChangePropertyKey("management.metrics.binders.files.enabled", null, null)
+        recipe = ChangePropertyKey("management.metrics.binders.files.enabled", null, null, null)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse
         assertThat(valid.failures()).hasSize(1)
@@ -89,6 +134,7 @@ class ChangePropertyKeyTest : PropertiesRecipeTest {
             ChangePropertyKey(
                 "management.metrics.binders.files.enabled",
                 "management.metrics.enable.process.files",
+                null,
                 null
             )
         valid = recipe.validate()

--- a/rewrite-properties/src/test/kotlin/org/openrewrite/properties/Issue1020.kt
+++ b/rewrite-properties/src/test/kotlin/org/openrewrite/properties/Issue1020.kt
@@ -24,7 +24,7 @@ class Issue1020 : PropertiesRecipeTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1020")
     @Test
     fun removalOfDoublePound() = assertUnchanged(
-        recipe = ChangePropertyKey("server.port", "chassis.name", null),
+        recipe = ChangePropertyKey("server.port", "chassis.name", null, null),
         before = """
             key=**##**chassis.management.metrics.export.cloudwatch.awsAccessKey
         """
@@ -33,7 +33,7 @@ class Issue1020 : PropertiesRecipeTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1020")
     @Test
     fun removalOfSlashPound() = assertUnchanged(
-        recipe = ChangePropertyValue("server.tomcat.accesslog.enabled", "true", null, null),
+        recipe = ChangePropertyValue("server.tomcat.accesslog.enabled", "true", null, null, null),
         before = """
             boot.features=https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle**/#**boot-features-jersey
             server.tomcat.accesslog.enabled=true

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.NameCaseConvention;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -43,6 +44,14 @@ public class DeleteProperty extends Recipe {
             description = "Simplify nested map hierarchies into their simplest dot separated property form.",
             example = "true")
     Boolean coalesce;
+
+    @Incubating(since = "7.17.0")
+    @Option(displayName = "Use relaxed binding",
+            description = "Whether to match the `propertyKey` using [relaxed binding](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding) " +
+                    "rules. Default is `true`. Set to `false`  to use exact matching.",
+            required = false)
+    @Nullable
+    Boolean relaxedBinding;
 
     @Incubating(since = "7.8.0")
     @Option(displayName = "Optional file matcher",
@@ -87,7 +96,7 @@ public class DeleteProperty extends Recipe {
                         .map(e2 -> e2.getKey().getValue())
                         .collect(Collectors.joining("."));
 
-                if (prop.equals(propertyKey)) {
+                if (!Boolean.FALSE.equals(relaxedBinding) ? NameCaseConvention.equalsRelaxedBinding(prop, propertyKey) : prop.equals(propertyKey)) {
                     doAfterVisit(new DeletePropertyVisitor<>(entry));
                     if (coalesce) {
                         maybeCoalesceProperties();
@@ -137,4 +146,5 @@ public class DeleteProperty extends Recipe {
             return m;
         }
     }
+
 }


### PR DESCRIPTION
See https://github.com/openrewrite/rewrite/issues/1168

Changes the default `property` matching to use "relaxed binding". In Micronaut this is referred to as [`property value normalization`](https://docs.micronaut.io/3.1.0/guide/index.html#_property_value_binding), and in Spring it's referred to as... well, [`relaxed binding`](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding).

This changes `rewrite-properties` recipes and `rewrite-yaml` "properties"-related recipes to use relaxed binding by default.

Users can explicitly opt-out of relaxed binding and use _exact_ matching instead by explicitly specifying `relaxedBinding: false` when configuring the recipe.