### PR TITLE
Name case convention utilities

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.internal;
+
+import org.openrewrite.Incubating;
+
+/**
+ * Utilities for standard name case conventions.
+ */
+@Incubating(since = "7.17.0")
+public enum NameCaseConvention {
+    /**
+     * Lowercase and hyphen-separated, e.g., "lower-hyphen".
+     * This is also known as "kebab-case".
+     */
+    LOWER_HYPHEN,
+
+    /**
+     * Lowercase and underscore-separated, e.g., "lower_underscore".
+     * This is also known as "snake_case".
+     */
+    LOWER_UNDERSCORE,
+
+    /**
+     * Camel case with the first letter lowercase, e.g., "lowerCamel".
+     * This is the standard Java variable naming convention.
+     */
+    LOWER_CAMEL,
+
+    /**
+     * Camel case with the first letter uppercase, e.g., "UpperCamel".
+     * This is the standard Java and C++ class naming convention.
+     */
+    UPPER_CAMEL,
+
+    /**
+     * Underscore separated with all letters uppercase, e.g., "UPPER_UNDERSCORE".
+     * This is the standard Java and C++ constant variable naming convention.
+     * This is also known as "SCREAMING_SNAKE_CASE".
+     */
+    UPPER_UNDERSCORE;
+
+    /**
+     * Formats the input to the style of this {@link NameCaseConvention}.
+     *
+     * @param str The input string to format.
+     * @return The string formatted to the style of this convention.
+     */
+    public String format(String str) {
+        return format(this, str);
+    }
+
+    public static String format(NameCaseConvention convention, String str) {
+        switch (convention) {
+            case LOWER_HYPHEN:
+                return lowerHyphen(str);
+            case LOWER_UNDERSCORE:
+                return lowerUnderscore(str);
+            case LOWER_CAMEL:
+                return lowerCamel(str);
+            case UPPER_CAMEL:
+                return upperCamel(str);
+            case UPPER_UNDERSCORE:
+                return upperUnderscore(str);
+            default:
+                return str;
+        }
+    }
+
+    /**
+     * Whether the input matches the formatting style of this {@link NameCaseConvention}.
+     *
+     * @param str The input string to check.
+     * @return Whether the input matches the formatting style of this convention.
+     */
+    public boolean matches(String str) {
+        return matches(this, str);
+    }
+
+    public static boolean matches(NameCaseConvention convention, String str) {
+        return str.matches(format(convention, str));
+    }
+
+    public static boolean equalsRelaxedBinding(String str0, String str1) {
+        return LOWER_CAMEL.format(str0).equals(LOWER_CAMEL.format(str1));
+    }
+
+    private static String lowerHyphen(String str) {
+        return nameCaseJoiner(str.replace('_', '-').replace(' ', '-'), true, '-');
+    }
+
+    private static String lowerUnderscore(String str) {
+        return nameCaseJoiner(str.replace('-', '_'), true, '_')
+                .toLowerCase();
+    }
+
+    /**
+     * Returns input formatted using the Java "camelCase" naming convention. Uses these rules:
+     *
+     * <ul>
+     * <li>The first character will be lowercase.
+     * <li>Preserves other existing capitalized characters.
+     * <li>Special characters `$`, `-`, and `_` will be removed.
+     * <li>If a special character is removed, the following alphanumeric will be capitalized.
+     * </ul>
+     *
+     * @param str The input string to check.
+     * @return The string formatted as {@link NameCaseConvention#LOWER_CAMEL}.
+     */
+    @SuppressWarnings("ContinueStatement")
+    private static String lowerCamel(String str) {
+        StringBuilder builder = new StringBuilder();
+        boolean setCaps = false;
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            switch (c) {
+                case '$':
+                case '-':
+                case '_':
+                    if (builder.length() > 0) {
+                        setCaps = true;
+                    }
+                    continue;
+                default:
+                    break;
+            }
+
+            if (builder.length() == 0) {
+                builder.append(String.valueOf(str.charAt(i)).toLowerCase());
+            } else {
+                if (setCaps) {
+                    builder.append(String.valueOf(str.charAt(i)).toUpperCase());
+                    setCaps = false;
+                } else {
+                    builder.append(str.charAt(i));
+                }
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String upperCamel(String str) {
+        return StringUtils.capitalize(lowerCamel(str));
+    }
+
+    private static String upperUnderscore(String str) {
+        return nameCaseJoiner(str.replace('-', '_').replace('.', '_'), false, '_')
+                .toUpperCase();
+    }
+
+    private static String nameCaseJoiner(String str, boolean lowerCase, char separatorChar) {
+        StringBuilder builder = new StringBuilder();
+        if (lowerCase) {
+            char[] chars = str.toCharArray();
+            boolean first = true;
+            char last = '0';
+            char secondLast = separatorChar;
+            for (int i = 0; i < chars.length; i++) {
+                char c = chars[i];
+                if (Character.isLowerCase(c) || !Character.isLetter(c)) {
+                    first = false;
+                    if (c != separatorChar) {
+                        if (last == separatorChar) {
+                            builder.append(separatorChar);
+                        }
+                        builder.append(c);
+                    }
+                } else {
+                    char lowerCaseChar = Character.toLowerCase(c);
+                    if (first) {
+                        first = false;
+                        builder.append(lowerCaseChar);
+                    } else if (Character.isUpperCase(last) || last == '.') {
+                        builder.append(lowerCaseChar);
+                    } else if (Character.isDigit(last) && (Character.isUpperCase(secondLast) || secondLast == separatorChar)) {
+                        builder.append(lowerCaseChar);
+                    } else {
+                        builder.append(separatorChar).append(lowerCaseChar);
+                    }
+                }
+                if (i > 1) {
+                    secondLast = last;
+                }
+                last = c;
+            }
+        } else {
+            boolean first = true;
+            char last = '0';
+            for (char c : str.toCharArray()) {
+                if (first) {
+                    builder.append(c);
+                    first = false;
+                } else {
+                    if (Character.isUpperCase(c) && !Character.isUpperCase(last)) {
+                        if (c != separatorChar) {
+                            builder.append(separatorChar);
+                        }
+                        builder.append(c);
+                    } else {
+                        if (c == '.') {
+                            first = true;
+                        }
+                        if (c != separatorChar) {
+                            if (last == separatorChar) {
+                                builder.append(separatorChar);
+                            }
+                            builder.append(c);
+                        }
+                    }
+                }
+                last = c;
+            }
+        }
+
+        return builder.toString();
+    }
+
+}

--- a/rewrite-core/src/test/kotlin/org/openrewrite/internal/NameCaseConventionTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/internal/NameCaseConventionTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.internal
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+@Suppress("SpellCheckingInspection")
+class NameCaseConventionTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "foo.config-client.enabled:foo.config-client.enabled",
+            "com.fooBar.FooBar:com.foo-bar.foo-bar",
+            "foo_bar.bar:foo-bar.bar",
+            "FooBar:foo-bar",
+            "com.bar.FooBar:com.bar.foo-bar",
+            "Foo:foo",
+            "FooBBar:foo-bbar",
+            "fooBBar:foo-bbar",
+            "fooBar:foo-bar",
+            "test.Foo bar:test.foo-bar",
+        ], delimiter = ':'
+    )
+    fun lowerHyphen(input: String, expected: String) {
+        assertThat(NameCaseConvention.LOWER_HYPHEN.format(input)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "Foo:foo",
+            "Foo-Bar:foo_bar",
+            "FOO.FOO-BAR:foo.foo_bar"
+        ], delimiter = ':'
+    )
+    fun lowerUnderscore(input: String, expected: String) {
+        assertThat(NameCaseConvention.LOWER_UNDERSCORE.format(input)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "rename_one:renameOne",
+            "RenameTwo:renameTwo",
+            "__rename__three__:renameThree",
+            "_Rename__Four:renameFour",
+            "foo.config-client.enabled:foo.configClient.enabled",
+            "foo-bar:fooBar",
+        ], delimiter = ':'
+    )
+    fun lowerCamel(input: String, expected: String) {
+        assertThat(NameCaseConvention.LOWER_CAMEL.format(input)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "rename_one:RenameOne",
+            "RenameTwo:RenameTwo",
+            "__rename__three__:RenameThree",
+            "_Rename__Four:RenameFour",
+            "foo-bar:FooBar",
+        ], delimiter = ':'
+    )
+    fun upperCamel(input: String, expected: String) {
+        assertThat(NameCaseConvention.UPPER_CAMEL.format(input)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "foo:FOO",
+            "foo-bar:FOO_BAR",
+            "foo_bar:FOO_BAR",
+            "FooBar:FOO_BAR",
+            "Foo.fooBar:FOO_FOO_BAR",
+        ], delimiter = ':'
+    )
+    fun upperUnderscore(input: String, expected: String) {
+        assertThat(NameCaseConvention.UPPER_UNDERSCORE.format(input)).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "foo.fooBar:foo.foo-bar",
+            "foo.foo-bar:foo.fooBar",
+        ], delimiter = ':'
+    )
+    fun equalsRelaxedBinding(input: String, expected: String) {
+        assertThat(NameCaseConvention.equalsRelaxedBinding(input, expected)).isTrue
+    }
+
+}


### PR DESCRIPTION
This is a prelude to https://github.com/openrewrite/rewrite/pull/1182 with downstream implications for https://github.com/openrewrite/rewrite/issues/1168

Name case convention utilities for matching and formatting strings according to a standard pattern. Took inspiration from `RenameLocalVariablesToCamelCase`, and used this as an opportunity to move the `isCamelCase` function into this `NameCaseConvention` util. Implemented the case format options as standard in https://github.com/google/guava/blob/master/guava/src/com/google/common/base/CaseFormat.java as they're fairly ubiquitous.