### PR TITLE
FindProperties in rewrite-properties missing visitMarkers

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
@@ -26,6 +26,7 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
     @Override
     public Properties visitFile(Properties.File file, PrintOutputCapture<P> p) {
         p.out.append(file.getPrefix());
+        visitMarkers(file.getMarkers(), p);
         visit(file.getContent(), p);
         p.out.append(file.getEof());
         return file;
@@ -33,8 +34,9 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
 
     @Override
     public Properties visitEntry(Properties.Entry entry, PrintOutputCapture<P> p) {
-        p.out.append(entry.getPrefix())
-                .append(entry.getKey())
+        p.out.append(entry.getPrefix());
+        visitMarkers(entry.getMarkers(), p);
+        p.out.append(entry.getKey())
                 .append(entry.getBeforeEquals())
                 .append('=')
                 .append(entry.getValue().getPrefix())
@@ -44,8 +46,9 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
 
     @Override
     public Properties visitComment(Properties.Comment comment, PrintOutputCapture<P> p) {
-        p.out.append(comment.getPrefix())
-                .append('#')
+        p.out.append(comment.getPrefix());
+        visitMarkers(comment.getMarkers(), p);
+        p.out.append('#')
                 .append(comment.getMessage());
         return comment;
     }

--- a/rewrite-properties/src/test/kotlin/org/openrewrite/properties/search/FindPropertiesTest.kt
+++ b/rewrite-properties/src/test/kotlin/org/openrewrite/properties/search/FindPropertiesTest.kt
@@ -25,7 +25,7 @@ class FindPropertiesTest : PropertiesRecipeTest {
     fun findProperty() = assertChanged(
         recipe = FindProperties("management.metrics.binders.files.enabled"),
         before = "management.metrics.binders.files.enabled=true",
-        after = "management.metrics.binders.files.enabled=true"
+        after = "~~>management.metrics.binders.files.enabled=true"
     )
 
 }


### PR DESCRIPTION
Ensure `visitMarkers` occurs to allow printing of included markers on `properties`