### PR TITLE
Added serialization and deserialization of sub packages option to ImportLayoutStyle

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -812,10 +812,12 @@ class Deserializer extends JsonDeserializer<ImportLayoutStyle> {
                                 builder.importAllOthers();
                             }
                         } else {
+                            boolean withSubpackages = !block.contains(" without subpackages");
+                            block = withSubpackages ? block : block.substring(0, block.indexOf(" without subpackage"));
                             if (statik) {
-                                builder.staticImportPackage(block);
+                                builder.staticImportPackage(block, withSubpackages);
                             } else {
-                                builder.importPackage(block);
+                                builder.importPackage(block, withSubpackages);
                             }
                         }
                     } else {
@@ -866,10 +868,11 @@ class Serializer extends JsonSerializer<ImportLayoutStyle> {
                                 "all other imports";
                     } else if (block instanceof ImportLayoutStyle.Block.ImportPackage) {
                         ImportLayoutStyle.Block.ImportPackage importPackage = (ImportLayoutStyle.Block.ImportPackage) block;
+                        String withSubpackages = importPackage.getPackageWildcard().pattern().contains("[^.]+") ? " without subpackages" : "";
                         return "import " + (importPackage.isStatic() ? "static " : "") + importPackage.getPackageWildcard().pattern()
                                 .replace("\\.", ".")
                                 .replace(".+", "*")
-                                .replace("[^.]+", "*");
+                                .replace("[^.]+", "*") + withSubpackages;
                     }
                     return new UnsupportedOperationException("Unknown block type " + block.getClass().getName());
                 })

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/ImportLayoutStyleTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/ImportLayoutStyleTest.kt
@@ -36,6 +36,7 @@ class ImportLayoutStyleTest {
         val style = mapper.writeValueAsString(ImportLayoutStyle
             .builder()
             .importPackage("import java.*")
+            .importPackage("import javax.*", false)
             .importAllOthers()
             .importStaticAllOthers()
             .build())
@@ -54,7 +55,7 @@ class ImportLayoutStyleTest {
                 "layout" to listOf(
                         "import java.*",
                         "<blank line>",
-                        "import javax.*",
+                        "import javax.* without subpackages",
                         "<blank line>",
                         "import all other imports",
                         "<blank line>",
@@ -85,7 +86,7 @@ class ImportLayoutStyleTest {
                 assertThat(importLayout.layout[2])
                     .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
                     .matches { b -> !(b as ImportLayoutStyle.Block.ImportPackage).isStatic }
-                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "javax\\..+" }
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "javax\\.[^.]+" }
 
                 assertThat(importLayout.layout[3]).isInstanceOf(ImportLayoutStyle.Block.BlankLines::class.java)
 


### PR DESCRIPTION
Added `without subpackages` if the option is set to false.
IntelliJ defaults to true on imports in the layout.

The builder in changes required in 1191 will follow the same pattern for a cleaner API.

Changes:
Serialize and deserialize withSubpackages option.
Added condition to tests.
fixes #1206 