### PR TITLE
MethodMatcher should only matchOverrides when explicitly opted-in

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
@@ -65,7 +65,7 @@ public class ChangeMethodName extends Recipe {
             @Override
             public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext executionContext) {
                 doAfterVisit(new UsesMethod<>(methodPattern, matchOverrides));
-                doAfterVisit(new DeclaresMethod<>(methodPattern));
+                doAfterVisit(new DeclaresMethod<>(methodPattern, matchOverrides));
                 return cu;
             }
         };

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -195,7 +195,7 @@ public class MethodMatcher {
 
         if (targetTypePattern.matcher(type.getFullyQualifiedName()).matches()) {
             return true;
-        } else if (!type.getFullyQualifiedName().equals("java.lang.Object") && matchesTargetType(type.getSupertype() == null ? JavaType.Class.build("java.lang.Object") : type.getSupertype())) {
+        } else if (!type.getFullyQualifiedName().equals("java.lang.Object") && matchesTargetType(JavaType.Class.build("java.lang.Object"))) {
             return true;
         }
 
@@ -348,7 +348,7 @@ class FormalParameterVisitor extends MethodSignatureParserBaseVisitor<String> {
         return String.join("", argumentPatterns).replace("...", "\\[\\]");
     }
 
-    private static abstract class Argument {
+    private abstract static class Argument {
         abstract String getRegex();
 
         private static final Argument DOT_DOT = new Argument() {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeMethodNameTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeMethodNameTest.kt
@@ -47,7 +47,7 @@ interface ChangeMethodNameTest : JavaRecipeTest {
                 public void singleArg(String s) {}
             }
         """.trimIndent()),
-        recipe = ChangeMethodName("com.abc.B singleArg(String)", "bar", null),
+        recipe = ChangeMethodName("com.abc.B singleArg(String)", "bar", true),
         before = """
             package com.abc;
             class A {
@@ -76,6 +76,41 @@ interface ChangeMethodNameTest : JavaRecipeTest {
             val barRefType = barReference.methodType as Method
             assertThat(barRefType.name).isEqualTo("bar")
         }
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1215")
+    @Suppress("MethodMayBeStatic", "RedundantOperationOnEmptyContainer")
+    fun changeMethodNameDoNotMatchOverriddenMethods() = assertChanged(
+        recipe = ChangeMethodName("com.abc.Parent method(String)", "changed", false),
+        before = """
+            package com.abc;
+
+            class Parent {
+                public void method(String s) {
+                }
+            }
+
+            class Test extends Parent {
+                @Override
+                public void method(String s) {
+                }
+            }
+        """,
+        after = """
+            package com.abc;
+
+            class Parent {
+                public void changed(String s) {
+                }
+            }
+
+            class Test extends Parent {
+                @Override
+                public void method(String s) {
+                }
+            }
+        """
     )
 
     @Test


### PR DESCRIPTION
Do not merge.

For https://github.com/openrewrite/rewrite/issues/1215 

Issues with exact matching.