### PR TITLE
MethodNameCasing should not rename overridden methods

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.ChangeMethodName;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -58,6 +59,7 @@ public class MethodNameCasing extends Recipe {
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
                 if (method.getMethodType() != null &&
                         !method.isConstructor() &&
+                        Boolean.FALSE.equals(TypeUtils.isOverride(method.getMethodType())) &&
                         !standardMethodName.matcher(method.getSimpleName()).matches()) {
                     StringBuilder standardized = new StringBuilder();
 
@@ -85,7 +87,7 @@ public class MethodNameCasing extends Recipe {
                     }
 
                     if (!StringUtils.isBlank(standardized.toString())) {
-                        doNext(new ChangeMethodName(MethodMatcher.methodPattern(method), standardized.toString(), null));
+                        doNext(new ChangeMethodName(MethodMatcher.methodPattern(method), standardized.toString(), true));
                     }
                 }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/MethodNameCasingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/MethodNameCasingTest.kt
@@ -78,4 +78,31 @@ interface MethodNameCasingTest: JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun changeMethodNameWhenOverride() = assertChanged(
+        dependsOn = arrayOf(
+            """
+            class ParentClass {
+                void _method() {
+                }
+            }
+        """
+        ),
+        before = """
+            class Test extends ParentClass {
+                @Override
+                void _method() {
+                }
+            }
+        """,
+        after = """
+            class Test extends ParentClass {
+                @Override
+                void method() {
+                }
+            }
+        """
+    )
+
 }


### PR DESCRIPTION
MethodNameCasing should not rename overridden methods _unless the parent method is being renamed_, in which case, the parent is who should drive the renaming.

Breaking out the MethodMatcher code into a separate PR.

Closes https://github.com/openrewrite/rewrite/issues/1213