### PR TITLE
FindMethods description should explicitly say find method usages

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -54,12 +54,12 @@ public class FindMethods extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Find methods";
+        return "Find method usages";
     }
 
     @Override
     public String getDescription() {
-        return "Find methods by pattern.";
+        return "Find method usages by pattern.";
     }
 
     @Override


### PR DESCRIPTION
"Find Methods" sounds like it should include method declarations as well. Reduce confusion and explicitly say "invocations".