### PR TITLE
MethodMatcher should acknowledge matchOverrides

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
@@ -65,7 +65,7 @@ public class ChangeMethodName extends Recipe {
             @Override
             public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext executionContext) {
                 doAfterVisit(new UsesMethod<>(methodPattern, matchOverrides));
-                doAfterVisit(new DeclaresMethod<>(methodPattern));
+                doAfterVisit(new DeclaresMethod<>(methodPattern, matchOverrides));
                 return cu;
             }
         };

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -195,11 +195,13 @@ public class MethodMatcher {
 
         if (targetTypePattern.matcher(type.getFullyQualifiedName()).matches()) {
             return true;
-        } else if (!type.getFullyQualifiedName().equals("java.lang.Object") && matchesTargetType(type.getSupertype() == null ? JavaType.Class.build("java.lang.Object") : type.getSupertype())) {
-            return true;
         }
 
         if (matchOverrides) {
+            if (!type.getFullyQualifiedName().equals("java.lang.Object") && matchesTargetType(JavaType.Class.build("java.lang.Object"))) {
+                return true;
+            }
+
             if (matchesTargetType(type.getSupertype())) {
                 return true;
             }
@@ -348,7 +350,7 @@ class FormalParameterVisitor extends MethodSignatureParserBaseVisitor<String> {
         return String.join("", argumentPatterns).replace("...", "\\[\\]");
     }
 
-    private static abstract class Argument {
+    private abstract static class Argument {
         abstract String getRegex();
 
         private static final Argument DOT_DOT = new Argument() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoFinalizer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoFinalizer.java
@@ -54,7 +54,7 @@ public class NoFinalizer extends Recipe {
     }
 
     private static class NoFinalizerVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final MethodMatcher FINALIZER = new MethodMatcher("java.lang.Object finalize()");
+        private static final MethodMatcher FINALIZER = new MethodMatcher("java.lang.Object finalize()", true);
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenameMethodsNamedHashcodeEqualOrTostring.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenameMethodsNamedHashcodeEqualOrTostring.java
@@ -33,8 +33,8 @@ import java.util.Collections;
 import java.util.Set;
 
 public class RenameMethodsNamedHashcodeEqualOrTostring extends Recipe {
-    private static final MethodMatcher NO_ARGS = new MethodMatcher("*..* *()");
-    private static final MethodMatcher OBJECT_ARG = new MethodMatcher("*..* *(java.lang.Object)");
+    private static final MethodMatcher NO_ARGS = new MethodMatcher("*..* *()", true);
+    private static final MethodMatcher OBJECT_ARG = new MethodMatcher("*..* *(java.lang.Object)", true);
 
     @Override
     public String getDisplayName() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -60,7 +60,7 @@ public class FindDeprecatedMethods extends Recipe {
 
     @Override
     protected JavaVisitor<ExecutionContext> getSingleSourceApplicableTest() {
-        MethodMatcher methodMatcher = methodPattern == null ? null : new MethodMatcher(methodPattern);
+        MethodMatcher methodMatcher = methodPattern == null ? null : new MethodMatcher(methodPattern, true);
 
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeMethodNameTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/ChangeMethodNameTest.kt
@@ -47,7 +47,7 @@ interface ChangeMethodNameTest : JavaRecipeTest {
                 public void singleArg(String s) {}
             }
         """.trimIndent()),
-        recipe = ChangeMethodName("com.abc.B singleArg(String)", "bar", null),
+        recipe = ChangeMethodName("com.abc.B singleArg(String)", "bar", true),
         before = """
             package com.abc;
             class A {
@@ -76,6 +76,37 @@ interface ChangeMethodNameTest : JavaRecipeTest {
             val barRefType = barReference.methodType as Method
             assertThat(barRefType.name).isEqualTo("bar")
         }
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1215")
+    @Suppress("MethodMayBeStatic", "RedundantOperationOnEmptyContainer")
+    fun changeMethodNameForOverriddenMethodMatchOverridesFalse() = assertChanged(
+        recipe = ChangeMethodName("com.abc.Parent method(String)", "changed", false),
+        before = """
+            package com.abc;
+            class Parent {
+                public void method(String s) {
+                }
+            }
+            class Test extends Parent {
+                @Override
+                public void method(String s) {
+                }
+            }
+        """,
+        after = """
+            package com.abc;
+            class Parent {
+                public void changed(String s) {
+                }
+            }
+            class Test extends Parent {
+                @Override
+                public void method(String s) {
+                }
+            }
+        """
     )
 
     @Test


### PR DESCRIPTION
Closes https://github.com/openrewrite/rewrite/issues/1215

Currently, MethodMatcher will match against supertypes regardless of whether `matchOverrides` is provided. This means you cannot do an exact match.

Regardless of what the expected default is, the current behavior of MethodMatcher is that it will always match on overrides. The current de-facto value of `matchOverride` is `true`, even if `matchOverride` is being passed `null` or `false`. Currently, the only situation where `matchOverride` has an effect is if the target type to match against is an interface.