### PR TITLE
Fix #1210. EmptyBlock recipe should not add throw RuntimeException.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -70,7 +70,7 @@ public class Checkstyle extends NamedStyles {
         return new DefaultComesLastStyle(false);
     }
 
-    public static final EmptyBlockStyle.BlockPolicy defaultBlockPolicy = EmptyBlockStyle.BlockPolicy.STATEMENT;
+    public static final EmptyBlockStyle.BlockPolicy defaultBlockPolicy = EmptyBlockStyle.BlockPolicy.TEXT;
 
     public static EmptyBlockStyle emptyBlock() {
         return new EmptyBlockStyle(defaultBlockPolicy, true, true, true, true,

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EmptyBlockTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EmptyBlockTest.kt
@@ -53,7 +53,6 @@ interface EmptyBlockTest : JavaRecipeTest {
 
     @Test
     fun emptyBlockWithComment(jp: JavaParser) = assertUnchanged(
-        jp,
         before = """
             public class A {
                 {
@@ -63,8 +62,9 @@ interface EmptyBlockTest : JavaRecipeTest {
         """
     )
 
+    @Suppress("EmptySynchronizedStatement")
     @Test
-    fun emptySynchronized(jp: JavaParser) = assertChanged(
+    fun emptySynchronized(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
             public class A {
@@ -72,13 +72,6 @@ interface EmptyBlockTest : JavaRecipeTest {
                     final Object o = new Object();
                     synchronized(o) {
                     }
-                }
-            }
-        """,
-        after = """
-            public class A {
-                {
-                    final Object o = new Object();
                 }
             }
         """
@@ -109,7 +102,7 @@ interface EmptyBlockTest : JavaRecipeTest {
     )
 
     @Test
-    fun emptyCatchBlockWithIOException(jp: JavaParser) = assertChanged(
+    fun emptyCatchBlockWithIOException(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
             import java.io.FileInputStream;
@@ -121,22 +114,6 @@ interface EmptyBlockTest : JavaRecipeTest {
                     try {
                         new FileInputStream(new File("somewhere"));
                     } catch (IOException e) {
-                    }
-                }
-            }
-        """,
-        after = """
-            import java.io.FileInputStream;
-            import java.io.IOException;
-            import java.io.UncheckedIOException;
-            import java.nio.file.*;
-            
-            public class A {
-                public void foo() {
-                    try {
-                        new FileInputStream(new File("somewhere"));
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
                     }
                 }
             }
@@ -167,7 +144,6 @@ interface EmptyBlockTest : JavaRecipeTest {
                     try {
                         new FileInputStream(new File("somewhere"));
                     } catch (Throwable t) {
-                        throw new RuntimeException(t);
                     }
                 }
             }


### PR DESCRIPTION
Fix #1210. EmptyBlock recipe should not add throw RuntimeException.
  - Do not remove empty catch or synchronized blocks.
  - Also check for the `TEXT` Checkstyle#BlockPolicy when removing empty blocks.
  - Set the `TEXT` as the default Checkstyle#BlockPolicy.