### PR TITLE
Refactor UnnecessaryThrows recipe. fixes #1207

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
@@ -59,7 +59,7 @@ public class MethodNameCasing extends Recipe {
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
                 if (method.getMethodType() != null &&
                         !method.isConstructor() &&
-                        Boolean.FALSE.equals(TypeUtils.isOverride(method.getMethodType())) &&
+                        !TypeUtils.isOverride(method.getMethodType()) &&
                         !standardMethodName.matcher(method.getSimpleName()).matches()) {
                     StringBuilder standardized = new StringBuilder();
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MissingOverrideAnnotation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MissingOverrideAnnotation.java
@@ -77,9 +77,10 @@ public class MissingOverrideAnnotation extends Recipe {
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             if (!method.hasModifier(J.Modifier.Type.Static)
                     && method.getAllAnnotations().stream().noneMatch(OVERRIDE_ANNOTATION::matches)
-                    && Boolean.TRUE.equals(TypeUtils.isOverride(method.getMethodType())
-                    && !(Boolean.TRUE.equals(ignoreAnonymousClassMethods) && getCursorToParentScope(getCursor()).getValue() instanceof J.NewClass))
-            ) {
+                    && TypeUtils.isOverride(method.getMethodType())
+                    && !(Boolean.TRUE.equals(ignoreAnonymousClassMethods)
+                    && getCursorToParentScope(getCursor()).getValue() instanceof J.NewClass)) {
+
                 method = method.withTemplate(
                         JavaTemplate.builder(this::getCursor, "@Override").build(),
                         method.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryThrows.java
@@ -42,7 +42,7 @@ public class UnnecessaryThrows extends Recipe {
     public String getDescription() {
         return "Remove unnecessary `throws` declarations. This recipe will only remove unused, checked exception if:\n" +
                 "\n" +
-                "- The declaring class or the method declaration are `final`\n" +
+                "- The declaring class or the method declaration is `final`\n" +
                 "- The method declaration is `static` or `private`\n" +
                 "- If the method overriding a method declaration in a super class and the super does not throw the exception.\n" +
                 "- If the method is `public` or `protected` and the exception is not documented via a JavaDoc as a `@throws` tag.";

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryThrows.java
@@ -22,15 +22,14 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavadocVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 public class UnnecessaryThrows extends Recipe {
 
@@ -41,7 +40,12 @@ public class UnnecessaryThrows extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Remove unnecessary `throws` declarations.";
+        return "Remove unnecessary `throws` declarations. This recipe will only remove unused, checked exception if:\n" +
+                "\n" +
+                "- The declaring class or the method declaration are `final`\n" +
+                "- The method declaration is `static` or `private`\n" +
+                "- If the method overriding a method declaration in a super class and the super does not throw the exception.\n" +
+                "- If the method is `public` or `protected` and the exception is not documented via a JavaDoc as a `@throws` tag.";
     }
 
     @Override
@@ -60,13 +64,9 @@ public class UnnecessaryThrows extends Recipe {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                if (m.getThrows() != null && !m.isAbstract() && Boolean.FALSE.equals(TypeUtils.isOverride(method.getMethodType()))) {
-                    Set<JavaType.FullyQualified> unusedThrows = new TreeSet<>(Comparator.comparing(JavaType.FullyQualified::getFullyQualifiedName));
-                    for (NameTree nameTree : m.getThrows()) {
-                        if (!TypeUtils.isAssignableTo(JavaType.Class.build("java.lang.RuntimeException"), nameTree.getType())) {
-                            unusedThrows.add(TypeUtils.asFullyQualified(nameTree.getType()));
-                        }
-                    }
+                Set<JavaType.FullyQualified> unusedThrows = findExceptionCandidates(method);
+
+                if (!unusedThrows.isEmpty()) {
 
                     new JavaIsoVisitor<ExecutionContext>() {
                         @Nullable
@@ -139,5 +139,68 @@ public class UnnecessaryThrows extends Recipe {
                 return m;
             }
         };
+    }
+
+
+    private Set<JavaType.FullyQualified> findExceptionCandidates(@Nullable J.MethodDeclaration method) {
+
+        if (method == null || method.getMethodType() == null
+                || method.getMethodType().getThrownExceptions() == null || method.isAbstract()) {
+            return Collections.emptySet();
+        }
+
+        //Collect all checked exceptions.
+        Set<JavaType.FullyQualified> candidates = new TreeSet<>(Comparator.comparing(JavaType.FullyQualified::getFullyQualifiedName));
+        for (JavaType.FullyQualified exception : method.getMethodType().getThrownExceptions()) {
+            if (!TypeUtils.isAssignableTo(JavaType.Class.build("java.lang.RuntimeException"), exception)) {
+                candidates.add(exception);
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        if ((method.getMethodType().getDeclaringType() != null && method.getMethodType().getDeclaringType().getFlags().contains(Flag.Final))
+                || method.isAbstract() || method.hasModifier(J.Modifier.Type.Static)
+                || method.hasModifier(J.Modifier.Type.Private)
+                || method.hasModifier(J.Modifier.Type.Final)) {
+            //Consider all checked exceptions as candidates if the type/method are final or the method is private or static.
+            return candidates;
+        }
+
+        //Remove any candidates that are defined in an overridden method.
+        Optional<JavaType.Method> superMethod = TypeUtils.findOverriddenMethod(method.getMethodType());
+        if (superMethod.isPresent()) {
+            JavaType.Method baseMethod = superMethod.get();
+            if (baseMethod.getThrownExceptions() != null) {
+                for (JavaType.FullyQualified baseException : baseMethod.getThrownExceptions()) {
+                    candidates.remove(baseException);
+                }
+            }
+        }
+        if (!candidates.isEmpty()) {
+            //Remove any candidates that are defined in Javadocs for the method.
+            new RemoveJavaDocExceptionCandidates().visit(method, candidates);
+        }
+        return candidates;
+    }
+
+    private static class RemoveJavaDocExceptionCandidates extends JavaVisitor<Set<JavaType.FullyQualified>> {
+        private RemoveJavaDocExceptionCandidates() {
+            super();
+            javadocVisitor = new JavadocVisitor<Set<JavaType.FullyQualified>>() {
+                @Override
+                public Javadoc visitThrows(Javadoc.Throws aThrows, Set<JavaType.FullyQualified> candidates) {
+                    if (aThrows.getExceptionName() instanceof TypeTree) {
+                        JavaType.FullyQualified exceptionType = TypeUtils.asFullyQualified(((TypeTree) aThrows.getExceptionName()).getType());
+                        if (exceptionType != null) {
+                            candidates.remove(exceptionType);
+                        }
+                    }
+                    return super.visitThrows(aThrows, candidates);
+                }
+            };
+        }
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UnnecessaryThrowsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UnnecessaryThrowsTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("RedundantThrows")
+
 package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test
@@ -33,11 +35,10 @@ interface UnnecessaryThrowsTest : JavaRecipeTest {
             import java.io.FileNotFoundException;
             import java.io.IOException;
             import java.io.UncheckedIOException;
-            
             class Test {
-                void test() throws FileNotFoundException, UncheckedIOException {
+                private void test() throws FileNotFoundException, UncheckedIOException {
                 }
-            
+
                 void test() throws IOException, UncheckedIOException {
                     new FileInputStream("test");
                 }
@@ -47,9 +48,8 @@ interface UnnecessaryThrowsTest : JavaRecipeTest {
             import java.io.FileInputStream;
             import java.io.IOException;
             import java.io.UncheckedIOException;
-            
             class Test {
-                void test() throws UncheckedIOException {
+                private void test() throws UncheckedIOException {
                 }
             
                 void test() throws IOException, UncheckedIOException {
@@ -59,6 +59,7 @@ interface UnnecessaryThrowsTest : JavaRecipeTest {
         """
     )
 
+    @Suppress("EmptyTryBlock")
     @Issue("https://github.com/openrewrite/rewrite/issues/631")
     @Test
     fun necessaryThrowsFromCloseable(jp: JavaParser) = assertUnchanged(
@@ -156,6 +157,26 @@ interface UnnecessaryThrowsTest : JavaRecipeTest {
         """),
         before = """
             public class FooImpl implements Foo {
+                public void bar() throws Exception {
+                    // no-op
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotRemoveDocumentedExceptions(jp: JavaParser) = assertUnchanged(
+        before = """
+            public class ParentFoo {
+                /**
+                 * @throws Exception Throws an exception
+                 */
+                public void bar() throws Exception { // this throws should not be removed
+                }
+            }
+            
+            class Foo extends ParentFoo {
+                @Override
                 public void bar() throws Exception {
                     // no-op
                 }


### PR DESCRIPTION
Reworked the rules for the `UnnecessaryThrows` recipe based on[ RSPEC-1130 documentation.](https://jira.sonarsource.com/browse/RSPEC-1130)

This recipe will only remove unused, checked exception if:

- The declaring class or method declaration is final
- The method declaration is static or private
- If the method is an override and a thrown exception is not defined in the overridden method's declaration
- If the method is public or protected and the exception is not documented via a JavaDoc as a @throws tag