### PR TITLE
Add support to ImportLayoutStyle for specific packages to fold.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -31,6 +31,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.java.style.ImportLayoutStyle.isPackageAlwaysFolded;
 
 @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public class RemoveImport<P> extends JavaIsoVisitor<P> {
@@ -127,7 +128,8 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
                     if (methodsAndFieldsUsed.isEmpty() && otherMethodsAndFieldsInTypeUsed.isEmpty()) {
                         spaceForNextImport.set(impoort.getPrefix());
                         return null;
-                    } else if (methodsAndFieldsUsed.size() + otherMethodsAndFieldsInTypeUsed.size() < importLayoutStyle.getNameCountToUseStarImport()) {
+                    } else if (!isPackageAlwaysFolded(importLayoutStyle.getPackagesToFold(), impoort) &&
+                            methodsAndFieldsUsed.size() + otherMethodsAndFieldsInTypeUsed.size() < importLayoutStyle.getNameCountToUseStarImport()) {
                         methodsAndFieldsUsed.addAll(otherMethodsAndFieldsInTypeUsed);
                         return unfoldStarImport(impoort, methodsAndFieldsUsed);
                     }
@@ -143,6 +145,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
                 return null;
             } else if (!keepImport && impoort.getPackageName().equals(owner) &&
                     "*".equals(impoort.getClassName()) &&
+                    !isPackageAlwaysFolded(importLayoutStyle.getPackagesToFold(), impoort) &&
                     otherTypesInPackageUsed.size() < importLayoutStyle.getClassCountToUseStarImport()) {
                 if (otherTypesInPackageUsed.isEmpty()) {
                     spaceForNextImport.set(impoort.getPrefix());

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -32,6 +32,8 @@ import org.openrewrite.marker.Markers;
 import java.time.Duration;
 import java.util.*;
 
+import static org.openrewrite.java.style.ImportLayoutStyle.isPackageAlwaysFolded;
+
 /**
  * This recipe will remove any imports for types that are not referenced within the compilation unit. This recipe
  * is aware of the import layout style and will correctly handle unfolding of wildcard imports if the import counts
@@ -136,7 +138,9 @@ public class RemoveUnusedImports extends Recipe {
                         anImport.used = false;
                         changed = true;
                     } else if ("*".equals(qualid.getSimpleName())) {
-                        if (((methodsAndFields == null ? 0 : methodsAndFields.size()) +
+                        if (isPackageAlwaysFolded(layoutStyle.getPackagesToFold(), elem)) {
+                            anImport.used = true;
+                        } else if (((methodsAndFields == null ? 0 : methodsAndFields.size()) +
                                 (staticClasses == null ? 0 : staticClasses.size())) < layoutStyle.getNameCountToUseStarImport()) {
                             // replacing the star with a series of unfolded imports
                             anImport.imports.clear();
@@ -177,7 +181,9 @@ public class RemoveUnusedImports extends Recipe {
                         anImport.used = false;
                         changed = true;
                     } else if ("*".equals(elem.getQualid().getSimpleName())) {
-                        if (types.size() < layoutStyle.getClassCountToUseStarImport()) {
+                        if (isPackageAlwaysFolded(layoutStyle.getPackagesToFold(), elem)) {
+                            anImport.used = true;
+                        } else if (types.size() < layoutStyle.getClassCountToUseStarImport()) {
                             // replacing the star with a series of unfolded imports
                             anImport.imports.clear();
 

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/ImportLayoutStyleTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/ImportLayoutStyleTest.kt
@@ -35,6 +35,10 @@ class ImportLayoutStyleTest {
     fun roundTripSerialize() {
         val style = mapper.writeValueAsString(ImportLayoutStyle
             .builder()
+            .packageToFold("java.awt.*")
+            .packageToFold("java.swing.*", false)
+            .staticPackageToFold("org.unit.Assert.*")
+            .staticPackageToFold("org.mockito.Matchers.*", false)
             .importPackage("import java.*")
             .importPackage("import javax.*", false)
             .importAllOthers()
@@ -62,6 +66,12 @@ class ImportLayoutStyleTest {
                         "import org.springframework.*",
                         "<blank line>",
                         "import static all other imports"
+                ),
+                "packages to fold" to listOf(
+                    "import java.awt.*",
+                    "import java.swing.* without subpackages",
+                    "import static org.unit.Assert.*",
+                    "import static org.mockito.Matchers.* without subpackages"
                 )
         )
 
@@ -108,6 +118,26 @@ class ImportLayoutStyleTest {
                     .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
                     .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).isStatic }
                     .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == ".+" }
+
+                assertThat(importLayout.packagesToFold[0])
+                    .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
+                    .matches { b -> !(b as ImportLayoutStyle.Block.ImportPackage).isStatic }
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "java\\.awt\\..+" }
+
+                assertThat(importLayout.packagesToFold[1])
+                    .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
+                    .matches { b -> !(b as ImportLayoutStyle.Block.ImportPackage).isStatic }
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "java\\.swing\\.[^.]+" }
+
+                assertThat(importLayout.packagesToFold[2])
+                    .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).isStatic }
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "org\\.unit\\.Assert\\..+" }
+
+                assertThat(importLayout.packagesToFold[3])
+                    .isInstanceOf(ImportLayoutStyle.Block.ImportPackage::class.java)
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).isStatic }
+                    .matches { b -> (b as ImportLayoutStyle.Block.ImportPackage).packageWildcard.toString() == "org\\.mockito\\.Matchers\\.[^.]+" }
             }
         }
     }
@@ -132,6 +162,8 @@ class ImportLayoutStyleTest {
                         .importPackage("org.springframework.*")
                         .blankLine()
                         .importStaticAllOthers()
+                        .packageToFold("java.awt.*")
+                        .packageToFold("java.swing.*")
                         .build()
                 )
         )

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
@@ -17,6 +17,7 @@ package org.openrewrite.java
 
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
+import org.openrewrite.Tree
 import org.openrewrite.Tree.randomId
 import org.openrewrite.java.style.ImportLayoutStyle
 import org.openrewrite.style.NamedStyles
@@ -541,6 +542,30 @@ interface OrderImportsTest : JavaRecipeTest {
             import kotlin.Lazy;
             import kotlin.Pair;
             import kotlin.String;
+        """
+    )
+
+    @Test
+    fun foldPackageWithExistingImports() = assertChanged(
+        JavaParser.fromJavaVersion().styles(
+            listOf(
+                NamedStyles(
+                    randomId(), "test", "test", "test", emptySet(), listOf(
+                        ImportLayoutStyle.builder()
+                            .packageToFold("java.util.*", false)
+                            .importAllOthers()
+                            .importStaticAllOthers()
+                            .build()
+                    )
+                )
+            )
+        ).build(),
+        recipe = OrderImports(false),
+        before = """
+            import java.util.List;
+        """,
+        after = """
+            import java.util.*;
         """
     )
 }


### PR DESCRIPTION
Added blocks in ImportLayoutStyle to specify packages to fold.
Updated builders, constructors, serialization, deserialization, and tests.
Updated RemoveUnusedImports to not unfold specified packages and/or sub-packages if a type is in use.
Updated RemoveImports to not unfold specified packages and/or sub-packages if a type is in use.
Updated AddImport to automatically fold specified packages and/or sub-packages.
Updated OrderImports to automatically fold specified packages and/or sub-packages.

fixes #1191 