### PR TITLE
Converge ChangeDependencyVersion options

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,8 @@ We use [Gradle](https://gradle.org/) to build this project.
 The gradle wrapper checked into this project defines the gradle version to use.  
 When building from the command line invoke the wrapper with `./gradlew build` on unix-style terminals and `gradlew build` on windows-style terminals.
 
+NOTE: windows-style users should ensure that they configure `core.autocrlf = false` as Rewrite requires unix-style line endings. This can be done at clone time by using `git clone -c core.autocrlf=false https://github.com/openrewrite/rewrite.git`.
+
 ### CLI Environment Configuration:
 
 * [JDK](https://adoptopenjdk.net/) version: 11

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -68,11 +68,13 @@ public class GitProvenance implements Marker {
         }
     }
 
-    public static GitProvenance fromProjectDirectory(Path projectDir) {
+    public static @Nullable GitProvenance fromProjectDirectory(Path projectDir) {
         try (Repository repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build()) {
             return new GitProvenance(randomId(), getOrigin(repository), repository.getBranch(), getChangeset(repository));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
 tasks.withType<ShadowJar> {
     configurations = listOf(project.configurations.compileClasspath.get())
     archiveClassifier.set(null as String?)
+    exclude("org/slf4j/impl/**.class")
+    exclude("org/gradle/internal/logging/slf4j/**.class")
     dependencies {
         include(dependency("org.gradle:"))
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
@@ -130,11 +130,11 @@ public class ChangeDependencyArtifactId extends Recipe {
                         if ("group".equals(keyValue)) {
                             groupId = valueValue;
                         } else if ("name".equals(keyValue) && !newArtifactId.equals(valueValue)) {
-                            artifactEntry = arg;
-                            artifactId = valueValue;
                             if (value.getValueSource() != null) {
                                 versionStringDelimiter = value.getValueSource().substring(0, value.getValueSource().indexOf(valueValue));
                             }
+                            artifactEntry = arg;
+                            artifactId = valueValue;
                         } else if("version".equals(keyValue)) {
                             version = valueValue;
                         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyVersion.java
@@ -24,28 +24,23 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.semver.DependencyMatcher;
 
 import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class ChangeDependencyVersion extends Recipe {
-
-    @Option(displayName = "Group",
-            description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
-            example = "com.fasterxml.jackson*")
-    String groupId;
-
-    @Option(displayName = "Artifact",
-            description = "The second part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
-            example = "jackson-module*")
-    @Nullable
-    String artifactId;
+    @Option(displayName = "Dependency pattern",
+            description = "A dependency pattern specifying which dependencies should have their groupId updated. " +
+                    DependencyMatcher.STANDARD_OPTION_DESCRIPTION,
+            example = "com.fasterxml.jackson*:*"
+    )
+    String dependencyPattern;
 
     @Option(displayName = "New Version",
             description = "The version number to update the dependency to",
@@ -76,83 +71,86 @@ public class ChangeDependencyVersion extends Recipe {
 
     @Override
     protected GroovyVisitor<ExecutionContext> getVisitor() {
-        MethodMatcher dependency = new MethodMatcher("DependencyHandlerSpec *(..)");
         return new GroovyVisitor<ExecutionContext>() {
+            final DependencyMatcher depMatcher = DependencyMatcher.build(dependencyPattern).getValue();
+            final MethodMatcher dependencyDsl = new MethodMatcher("DependencyHandlerSpec *(..)");
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, context);
-                if (dependency.matches(m)) {
-                    if (configuration == null || m.getSimpleName().equals(configuration)) {
-                        List<Expression> depArgs = m.getArguments();
-                        String versionStringDelimiter = "'";
-                        if (depArgs.get(0) instanceof J.Literal) {
-                            String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
-                            if (gav != null) {
-                                String[] gavs = gav.split(":");
+                if (!dependencyDsl.matches(m) || !(configuration == null || m.getSimpleName().equals(configuration))) {
+                    return m;
+                }
 
-                                if (gavs.length >= 3 &&
-                                        StringUtils.matchesGlob(gavs[0], groupId) &&
-                                        StringUtils.matchesGlob(gavs[1], artifactId) &&
-                                        !StringUtils.matchesGlob(gavs[2], newVersion)) {
-                                    String valueSource = ((J.Literal) depArgs.get(0)).getValueSource();
-                                    String delimiter = (valueSource == null) ? versionStringDelimiter
-                                            : valueSource.substring(0, valueSource.indexOf(gav));
+                List<Expression> depArgs = m.getArguments();
+                String versionStringDelimiter = "'";
+                if (depArgs.get(0) instanceof J.Literal) {
+                    String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
+                    if (gav != null) {
+                        String[] gavs = gav.split(":");
 
-                                    String newGav = gavs[0] + ":" + gavs[1] + ":" + newVersion;
-                                    m = m.withArguments(ListUtils.map(m.getArguments(), (n, arg) ->
-                                            n == 0 ?
-                                                    ((J.Literal) arg).withValue(newGav).withValueSource(delimiter + newGav + delimiter) :
-                                                    arg
-                                    ));
-                                }
-                            }
-                        } else if(depArgs.get(0) instanceof G.MapEntry) {
-                            G.MapEntry groupEntry = null;
-                            G.MapEntry artifactEntry = null;
-                            G.MapEntry versionEntry = null;
+                        if (gavs.length >= 3 && !newVersion.equals(gavs[2]) && depMatcher.matches(gavs[0], gavs[1], gavs[2])) {
+                            String valueSource = ((J.Literal) depArgs.get(0)).getValueSource();
+                            String delimiter = (valueSource == null) ? versionStringDelimiter
+                                    : valueSource.substring(0, valueSource.indexOf(gav));
 
-                            for(Expression e : depArgs) {
-                                if(!(e instanceof G.MapEntry)) {
-                                    continue;
-                                }
-                                G.MapEntry arg = (G.MapEntry)e;
-                                if(!(arg.getKey() instanceof J.Literal) || !(arg.getValue() instanceof J.Literal)) {
-                                    continue;
-                                }
-                                J.Literal key = (J.Literal) arg.getKey();
-                                J.Literal value = (J.Literal) arg.getValue();
-                                if(!(key.getValue() instanceof String) || !(value.getValue() instanceof String)) {
-                                    continue;
-                                }
-                                String keyValue = (String)key.getValue();
-                                String valueValue = (String)value.getValue();
-                                if("group".equals(keyValue) && StringUtils.matchesGlob(valueValue, groupId)) {
-                                    groupEntry = arg;
-                                } else if("name".equals(keyValue) && StringUtils.matchesGlob(valueValue, artifactId)) {
-                                    artifactEntry = arg;
-                                } else if("version".equals(keyValue) && !valueValue.equals(newVersion)) {
-                                    if(value.getValueSource() != null) {
-                                        versionStringDelimiter = value.getValueSource().substring(0, value.getValueSource().indexOf(valueValue));
-                                    }
-                                    versionEntry = arg;
-                                }
-                            }
-                            if(groupEntry == null || artifactEntry == null || versionEntry == null) {
-                                return m;
-                            }
-                            G.MapEntry finalVersion = versionEntry;
-                            String delimiter = versionStringDelimiter;
-                            m = m.withArguments(ListUtils.map(m.getArguments(), arg -> {
-                                if(arg == finalVersion) {
-                                    return finalVersion.withValue(((J.Literal)finalVersion.getValue())
-                                            .withValue(newVersion)
-                                            .withValueSource(delimiter + newVersion + delimiter));
-                                }
-                                return arg;
-                            }));
+                            String newGav = gavs[0] + ":" + gavs[1] + ":" + newVersion;
+                            m = m.withArguments(ListUtils.map(m.getArguments(), (n, arg) ->
+                                    n == 0 ?
+                                            ((J.Literal) arg).withValue(newGav).withValueSource(delimiter + newGav + delimiter) :
+                                            arg
+                            ));
                         }
                     }
+                } else if(depArgs.get(0) instanceof G.MapEntry) {
+                    G.MapEntry versionEntry = null;
+                    String groupId = null;
+                    String artifactId = null;
+                    String version = null;
+
+                    for(Expression e : depArgs) {
+                        if(!(e instanceof G.MapEntry)) {
+                            continue;
+                        }
+                        G.MapEntry arg = (G.MapEntry) e;
+                        if(!(arg.getKey() instanceof J.Literal) || !(arg.getValue() instanceof J.Literal)) {
+                            continue;
+                        }
+                        J.Literal key = (J.Literal) arg.getKey();
+                        J.Literal value = (J.Literal) arg.getValue();
+                        if(!(key.getValue() instanceof String) || !(value.getValue() instanceof String)) {
+                            continue;
+                        }
+                        String keyValue = (String)key.getValue();
+                        String valueValue = (String)value.getValue();
+                        if("group".equals(keyValue)) {
+                            groupId = valueValue;
+                        } else if("name".equals(keyValue)) {
+                            artifactId = valueValue;
+                        } else if("version".equals(keyValue) && !newVersion.equals(valueValue)) {
+                            if(value.getValueSource() != null) {
+                                versionStringDelimiter = value.getValueSource().substring(0, value.getValueSource().indexOf(valueValue));
+                            }
+                            versionEntry = arg;
+                            version = valueValue;
+                        }
+                    }
+                    if (groupId == null || artifactId == null
+                            || (version == null && !depMatcher.matches(groupId, artifactId))
+                            || (version != null && !depMatcher.matches(groupId, artifactId, version))) {
+                        return m;
+                    }
+                    String delimiter = versionStringDelimiter;
+                    G.MapEntry finalVersion = versionEntry;
+                    m = m.withArguments(ListUtils.map(m.getArguments(), arg -> {
+                        if(arg == finalVersion) {
+                            return finalVersion.withValue(((J.Literal)finalVersion.getValue())
+                                    .withValue(newVersion)
+                                    .withValueSource(delimiter + newVersion + delimiter));
+                        }
+                        return arg;
+                    }));
                 }
+
                 return m;
             }
         };

--- a/rewrite-gradle/src/test/kotlin/org/openrewrite/gradle/ChangeDependencyVersionTest.kt
+++ b/rewrite-gradle/src/test/kotlin/org/openrewrite/gradle/ChangeDependencyVersionTest.kt
@@ -21,13 +21,8 @@ import org.junit.jupiter.params.provider.ValueSource
 class ChangeDependencyVersionTest : GradleRecipeTest {
     @ParameterizedTest
     @ValueSource(strings = ["org.openrewrite:rewrite-core", "*:*"])
-    fun findDependency(ga: String) = assertChanged(
-        recipe = ChangeDependencyVersion(
-            ga.substringBefore(':'),
-            ga.substringAfter(':'),
-            "latest.integration",
-            null
-        ),
+    fun findDependency(gav: String) = assertChanged(
+        recipe = ChangeDependencyVersion(gav, "latest.integration", null),
         before = """
             dependencies {
                 api 'org.openrewrite:rewrite-core:latest.release'
@@ -44,13 +39,8 @@ class ChangeDependencyVersionTest : GradleRecipeTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["org.openrewrite:rewrite-core", "*:*"])
-    fun findMapStyleDependency(ga: String) = assertChanged(
-        recipe = ChangeDependencyVersion(
-            ga.substringBefore(':'),
-            ga.substringAfter(':'),
-            "latest.integration",
-            null
-        ),
+    fun findMapStyleDependency(gav: String) = assertChanged(
+        recipe = ChangeDependencyVersion(gav, "latest.integration", null),
         before = """
             dependencies {
                 api group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release'


### PR DESCRIPTION
The other ChangeDependency* recipes had differing options than those of ChangeDependencyVersion. This PR brings those into alignment.

This PR is based off of the latest release tag because main is missing a pair of classes at this time.