### PR TITLE
Update ChangePropertyKey to prevent moving entries to nonscalar nodes or those nested under a sequence

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -143,11 +143,15 @@ public class ChangePropertyKey extends Recipe {
                 public Yaml.Mapping visitMapping(Yaml.Mapping mapping, P p) {
                     Yaml.Mapping m = super.visitMapping(mapping, p);
                     if (m.getEntries().contains(entry)) {
-                        m.getEntries().stream()
-                                .filter(me -> !(me.getValue() instanceof Yaml.Scalar))
-                                .map(me -> Boolean.TRUE.equals(relaxedBinding) ? NameCaseConvention.format(NameCaseConvention.LOWER_CAMEL,me.getKey().getValue()) : me.getKey().getValue())
-                                .filter(propertyToCheck::startsWith)
-                                .findFirst().ifPresent(existingNonScalarEntry -> exists.set(true));
+                        for (Yaml.Mapping.Entry mEntry : m.getEntries()) {
+                            if (!(mEntry.getValue() instanceof Yaml.Scalar)) {
+                                String mKey = Boolean.TRUE.equals(relaxedBinding) ? NameCaseConvention.format(NameCaseConvention.LOWER_CAMEL, mEntry.getKey().getValue()) : mEntry.getKey().getValue();
+                                if (propertyToCheck.startsWith(mKey)) {
+                                    exists.set(true);
+                                    break;
+                                }
+                            }
+                        }
                     }
                     return m;
                 }

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
@@ -178,17 +178,17 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     @Test
     fun doesNotMergeToSiblingWithCoalescedProperty() = assertUnchanged(
         recipe = ChangePropertyKey(
-            "ii",
-            "a.b.c",
-            false,
+            "old-property",
+            "new-property.sub-property.super-sub",
+            true,
             null
         ),
         before = """
-            a.b:
-                c:
+            newProperty.subProperty:
+                superSub:
                   f0: v0
                   f1: v1
-            ii:
+            oldProperty:
               f0: v0
               f1: v1
         """

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
@@ -155,6 +155,64 @@ class ChangePropertyKeyTest : YamlRecipeTest {
         """
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1249")
+    @Test
+    fun doesNotMergeToSibling() = assertUnchanged(
+        recipe = ChangePropertyKey(
+            "i",
+            "a.b.c",
+            false,
+            null
+        ),
+        before = """
+            a:
+              b:
+                f0: v0
+                f1: v1
+            i:
+              f0: v0
+              f1: v1
+        """
+    )
+
+    @Test
+    fun doesNotMergeToSiblingWithCoalescedProperty() = assertUnchanged(
+        recipe = ChangePropertyKey(
+            "ii",
+            "a.b.c",
+            false,
+            null
+        ),
+        before = """
+            a.b:
+                c:
+                  f0: v0
+                  f1: v1
+            ii:
+              f0: v0
+              f1: v1
+        """
+    )
+
+    @Test
+    fun doesNotChangeKeyWhithSequenceInPath() = assertUnchanged(
+        recipe = ChangePropertyKey(
+            "a.b.c.a0",
+            "a.b.a0",
+            true,
+            null
+        ),
+        before = """
+            a:
+              b:
+                c:
+                  - a0: x
+                    a1: 'y'
+                  - aa1: x
+                    a1: 'y'
+        """
+    )
+
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @Test
     fun checkValidation() {


### PR DESCRIPTION
Update ChangePropertyKey to prevent moving entries to nonscalar nodes or those nested under a sequence. Fixes #1249