### PR TITLE
MavenSettings constructors visibility for building MavenSettings

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -48,9 +48,9 @@ public class MavenSettings {
     @Getter
     Mirrors mirrors;
 
+    @With
     @Nullable
     @Getter
-    @With
     Servers servers;
 
     @Nullable
@@ -81,8 +81,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(level = AccessLevel.PRIVATE)
-    @Getter
-    @Setter
+    @Value
     public static class Profiles {
         @JacksonXmlProperty(localName = "profile")
         @JacksonXmlElementWrapper(useWrapping = false)
@@ -90,8 +89,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(level = AccessLevel.PRIVATE)
-    @Getter
-    @Setter
+    @Value
     public static class ActiveProfiles {
         @JacksonXmlProperty(localName = "activeProfile")
         @JacksonXmlElementWrapper(useWrapping = false)
@@ -99,7 +97,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
-    @Data
+    @Value
     public static class Profile {
         @Nullable
         String id;
@@ -120,8 +118,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(level = AccessLevel.PRIVATE)
-    @Getter
-    @Setter
+    @Value
     public static class Mirrors {
         @JacksonXmlProperty(localName = "mirror")
         @JacksonXmlElementWrapper(useWrapping = false)
@@ -129,7 +126,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
-    @Data
+    @Value
     public static class Mirror {
         @Nullable
         String id;
@@ -148,8 +145,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(level = AccessLevel.PRIVATE)
-    @Getter
-    @Setter
+    @Value
     public static class Servers {
         @JacksonXmlProperty(localName = "server")
         @JacksonXmlElementWrapper(useWrapping = false)
@@ -157,7 +153,7 @@ public class MavenSettings {
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
-    @Data
+    @Value
     public static class Server {
         String id;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
@@ -26,6 +26,8 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
 public class RawRepositories {


### PR DESCRIPTION
Enables a different way of building MavenSettings rather than currently only requiring it be through parsing an actual settings.xml _file_.

See, specifically, for: openrewrite/rewrite-maven-plugin#152