### PR TITLE
Prevent StackOverflow when generic types are chained together.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/TypeMapping.java
@@ -180,7 +180,7 @@ public class TypeMapping {
                 } else {
                     StringJoiner shallowGenericTypeVariables = new StringJoiner(",");
                     for (Type typeParameter : classType.typarams_field) {
-                        String typeParameterSignature = signature(typeParameter);
+                        String typeParameterSignature = typeParameter.toString();
                         if (typeParameterSignature != null) {
                             shallowGenericTypeVariables.add(typeParameterSignature);
                         }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableTypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableTypeMapping.java
@@ -179,7 +179,7 @@ public class ReloadableTypeMapping {
                 } else {
                     StringJoiner shallowGenericTypeVariables = new StringJoiner(",");
                     for (Type typeParameter : classType.typarams_field) {
-                        String typeParameterSignature = signature(typeParameter);
+                        String typeParameterSignature = typeParameter.toString();
                         if (typeParameterSignature != null) {
                             shallowGenericTypeVariables.add(typeParameterSignature);
                         }
@@ -459,7 +459,6 @@ public class ReloadableTypeMapping {
         if (type == null) {
             return null;
         } else if (type instanceof Type.ClassType) {
-            Type.ClassType classType = (Type.ClassType) type;
             Symbol.ClassSymbol sym = (Symbol.ClassSymbol) type.tsym;
             return sym.className();
         } else if (type instanceof Type.TypeVar) {
@@ -485,7 +484,6 @@ public class ReloadableTypeMapping {
 
     private Path classfile(com.sun.tools.javac.code.Type type) {
         if (type instanceof Type.ClassType) {
-            Type.ClassType classType = (Type.ClassType) type;
             Symbol.ClassSymbol sym = (Symbol.ClassSymbol) type.tsym;
             return getClasspathElement(sym);
         } else if (type instanceof Type.ArrayType) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeTest.kt
@@ -42,4 +42,20 @@ interface JavaTypeTest {
             .hasSize(1)
             .contains(JavaType.Class.build("java.lang.FunctionalInterface"))
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1267")
+    @Test
+    fun noStackOverflow(jp: JavaParser.Builder<*, *>) {
+        val cu = jp.build().parse(
+            """
+            import java.util.HashMap;
+            import java.util.Map;
+            class A {
+                Map<String, Map<String, Map<Integer, String>>> overflowMap = new HashMap<>();
+            }
+            """)
+        val foo = cu.find { it.classes[0].name.simpleName == "A" }!!
+        val foundTypes = foo.typesInUse.typesInUse
+        assertThat(foundTypes.isNotEmpty())
+    }
 }


### PR DESCRIPTION
Use typeParameter to construct `shallowGenericTypeVariables` in `TypeMapping`. fixes #1267

Currently, shallowGenericTypeVariables reduces `Map<String, Map<String, Map<Integer, String>>> overflowMap = new HashMap<>()` to "java.lang.Map" -> "java.lang.String,java.util.Map", which happens to occur again.

The changes cause shallowGenericTypeVariables to produce something like:
"java.lang.Map" -> "String, Map<String, Map<Integer, String>>"
"java.lang.Map" -> "String, Map<Integer, String>"
"java.lang.Map" -> "Integer, String"