### PR TITLE
Fix type attribution on references in JavaDocs

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -64,15 +64,14 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
     private String source;
     private int cursor = 0;
 
-    public Java11JavadocVisitor(Context context, TreePath scope, TypeMapping typeMapping, String source) {
+    public Java11JavadocVisitor(Context context, TreePath scope, TypeMapping typeMapping, String source, JCTree tree) {
         this.attr = Attr.instance(context);
         this.typeMapping = typeMapping;
         this.source = source;
 
         if (scope.getLeaf() instanceof JCTree.JCCompilationUnit) {
-            JCTree.JCCompilationUnit cu = (JCTree.JCCompilationUnit) scope.getLeaf();
-            this.enclosingClassType = cu.defs.get(0).type;
-            this.symbol = cu.packge;
+            this.enclosingClassType = tree.type;
+            this.symbol = ((JCTree.JCClassDecl) tree).sym;
         } else {
             com.sun.source.tree.Tree classDecl = scope.getLeaf();
             if (classDecl instanceof JCTree.JCClassDecl) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11ParserVisitor.java
@@ -1447,7 +1447,7 @@ public class Java11ParserVisitor extends TreePathScanner<J, Space> {
         try {
             String prefix = source.substring(cursor, max(((JCTree) t).getStartPosition(), cursor));
             cursor += prefix.length();
-            @SuppressWarnings("unchecked") J2 j = (J2) scan(t, formatWithCommentTree(prefix, docCommentTable.getCommentTree((JCTree) t)));
+            @SuppressWarnings("unchecked") J2 j = (J2) scan(t, formatWithCommentTree(prefix, (JCTree) t, docCommentTable.getCommentTree((JCTree) t)));
             return j;
         } catch (Throwable ex) {
             // this SHOULD never happen, but is here simply as a diagnostic measure in the event of unexpected exceptions
@@ -1934,7 +1934,7 @@ public class Java11ParserVisitor extends TreePathScanner<J, Space> {
         return annotations;
     }
 
-    Space formatWithCommentTree(String prefix, @Nullable DCTree.DCDocComment commentTree) {
+    Space formatWithCommentTree(String prefix, JCTree tree, @Nullable DCTree.DCDocComment commentTree) {
         Space fmt = format(prefix);
         if (commentTree != null) {
             List<Comment> comments = fmt.getComments();
@@ -1955,7 +1955,8 @@ public class Java11ParserVisitor extends TreePathScanner<J, Space> {
                             context,
                             getCurrentPath(),
                             typeMapping,
-                            source.substring(commentCursor, source.indexOf("*/", commentCursor + 1))
+                            source.substring(commentCursor, source.indexOf("*/", commentCursor + 1)),
+                            tree
                     ).scan(commentTree, new ArrayList<>()));
                     break;
                 } else {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -65,15 +65,14 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
     private String source;
     private int cursor = 0;
 
-    public ReloadableJava8JavadocVisitor(Context context, TreePath scope, ReloadableTypeMapping typeMapping, String source) {
+    public ReloadableJava8JavadocVisitor(Context context, TreePath scope, ReloadableTypeMapping typeMapping, String source, JCTree tree) {
         this.attr = Attr.instance(context);
         this.typeMapping = typeMapping;
         this.source = source;
 
         if (scope.getLeaf() instanceof JCTree.JCCompilationUnit) {
-            JCTree.JCCompilationUnit cu = (JCTree.JCCompilationUnit) scope.getLeaf();
-            this.enclosingClassType = cu.defs.get(0).type;
-            this.symbol = cu.packge;
+            this.enclosingClassType = tree.type;
+            this.symbol = ((JCTree.JCClassDecl) tree).sym;
         } else {
             com.sun.source.tree.Tree classDecl = scope.getLeaf();
             if (classDecl instanceof JCTree.JCClassDecl) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1431,7 +1431,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         try {
             String prefix = source.substring(cursor, max(((JCTree) t).getStartPosition(), cursor));
             cursor += prefix.length();
-            @SuppressWarnings("unchecked") J2 j = (J2) scan(t, formatWithCommentTree(prefix, docCommentTable.getCommentTree((JCTree) t)));
+            @SuppressWarnings("unchecked") J2 j = (J2) scan(t, formatWithCommentTree(prefix, (JCTree) t, docCommentTable.getCommentTree((JCTree) t)));
             return j;
         } catch (Throwable ex) {
             // this SHOULD never happen, but is here simply as a diagnostic measure in the event of unexpected exceptions
@@ -1918,7 +1918,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         return annotations;
     }
 
-    Space formatWithCommentTree(String prefix, @Nullable DCTree.DCDocComment commentTree) {
+    Space formatWithCommentTree(String prefix, JCTree tree, @Nullable DCTree.DCDocComment commentTree) {
         Space fmt = format(prefix);
         if (commentTree != null) {
             List<Comment> comments = fmt.getComments();
@@ -1939,7 +1939,8 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                             context,
                             getCurrentPath(),
                             typeMapping,
-                            source.substring(commentCursor, source.indexOf("*/", commentCursor + 1))
+                            source.substring(commentCursor, source.indexOf("*/", commentCursor + 1)),
+                            tree
                     ).scan(commentTree, new ArrayList<>()));
                     break;
                 } else {


### PR DESCRIPTION
Use the appropriate class symbol to fix missing type info on identifiers in JavaDoc references from imports existing in a different package than the compilation unit.

fixes #1255