### PR TITLE
Fix to better re-use Java templates and reduce heap pressure

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -38,6 +38,26 @@ public class AnnotationTemplateGenerator {
 
     private final Set<String> imports;
 
+    public String cacheKey(Cursor cursor, String template) {
+        StringBuilder after = new StringBuilder();
+
+        J j = cursor.getValue();
+        if (j instanceof J.MethodDeclaration) {
+            after.insert(0, " void $method() {}");
+        } else if (j instanceof J.VariableDeclarations) {
+            after.insert(0, " int $variable;");
+        } else if (j instanceof J.ClassDeclaration) {
+            after.insert(0, "static class $Clazz {}");
+        }
+
+        if (cursor.getParentOrThrow().getValue() instanceof J.ClassDeclaration &&
+                cursor.getParentOrThrow().getParentOrThrow().getValue() instanceof JavaSourceFile) {
+            after.append("class $Template {}");
+        }
+
+        return "/*" + TEMPLATE_COMMENT + "*/" + template + "\n" + after;
+    }
+
     public String template(Cursor cursor, String template) {
         //noinspection ConstantConditions
         return Timer.builder("rewrite.template.generate.statement")

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -57,22 +57,6 @@ public class BlockStatementTemplateGenerator {
 
     private final Set<String> imports;
 
-    public String cacheKey(Cursor cursor, String template, Space.Location location) {
-        StringBuilder before = new StringBuilder();
-        StringBuilder after = new StringBuilder();
-
-        // for replaceBody()
-        if (cursor.getValue() instanceof J.MethodDeclaration &&
-                location.equals(Space.Location.BLOCK_PREFIX)) {
-            J.MethodDeclaration method = cursor.getValue();
-            J.MethodDeclaration m = method.withBody(null).withLeadingAnnotations(emptyList()).withPrefix(Space.EMPTY);
-            before.insert(0, m.printTrimmed(cursor).trim() + '{');
-            after.append('}');
-        }
-
-        return before.toString().trim() + "\n/*" + TEMPLATE_COMMENT + "*/" + template + "\n" + after;
-    }
-
     public String template(Cursor cursor, String template, Space.Location location) {
         //noinspection ConstantConditions
         return Timer.builder("rewrite.template.generate.statement")

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -57,6 +57,22 @@ public class BlockStatementTemplateGenerator {
 
     private final Set<String> imports;
 
+    public String cacheKey(Cursor cursor, String template, Space.Location location) {
+        StringBuilder before = new StringBuilder();
+        StringBuilder after = new StringBuilder();
+
+        // for replaceBody()
+        if (cursor.getValue() instanceof J.MethodDeclaration &&
+                location.equals(Space.Location.BLOCK_PREFIX)) {
+            J.MethodDeclaration method = cursor.getValue();
+            J.MethodDeclaration m = method.withBody(null).withLeadingAnnotations(emptyList()).withPrefix(Space.EMPTY);
+            before.insert(0, m.printTrimmed(cursor).trim() + '{');
+            after.append('}');
+        }
+
+        return before.toString().trim() + "\n/*" + TEMPLATE_COMMENT + "*/" + template + "\n" + after;
+    }
+
     public String template(Cursor cursor, String template, Space.Location location) {
         //noinspection ConstantConditions
         return Timer.builder("rewrite.template.generate.statement")

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -157,7 +157,7 @@ public class JavaTemplateParser {
     public <J2 extends J> List<J2> parseBlockStatements(Cursor cursor, Class<J2> expected,
                                                         String template,
                                                         Space.Location location) {
-        String cacheKey = addImports(statementTemplateGenerator.cacheKey(cursor, template, location));
+        String cacheKey = addImports(template);
         return cache(cacheKey, () -> {
             @Language("java") String stub = statementTemplateGenerator.template(cursor, template, location);
             onBeforeParseTemplate.accept(stub);
@@ -175,7 +175,7 @@ public class JavaTemplateParser {
             methodWithReplacedNameAndArgs = method.getSelect().print(cursor) + "." + template + ";";
         }
 
-        String cacheKey = addImports(statementTemplateGenerator.cacheKey(cursor, methodWithReplacedNameAndArgs, location));
+        String cacheKey = addImports(template);
         List<J> invocations = cache(cacheKey, () -> {
             @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacedNameAndArgs, location);
             onBeforeParseTemplate.accept(stub);
@@ -192,7 +192,7 @@ public class JavaTemplateParser {
         String methodWithReplacementArgs = method.withArguments(Collections.emptyList()).printTrimmed(cursor)
                 .replaceAll("\\)$", template + ");");
 
-        String cacheKey = addImports(statementTemplateGenerator.cacheKey(cursor, methodWithReplacementArgs, location));
+        String cacheKey = addImports(template);
         List<J> invocations = cache(cacheKey, () -> {
             @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacementArgs, location);
             onBeforeParseTemplate.accept(stub);

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -157,9 +157,10 @@ public class JavaTemplateParser {
     public <J2 extends J> List<J2> parseBlockStatements(Cursor cursor, Class<J2> expected,
                                                         String template,
                                                         Space.Location location) {
-        @Language("java") String stub = statementTemplateGenerator.template(cursor, template, location);
-        onBeforeParseTemplate.accept(stub);
-        return cache(stub, () -> {
+        String cacheKey = addImports(statementTemplateGenerator.cacheKey(cursor, template, location));
+        return cache(cacheKey, () -> {
+            @Language("java") String stub = statementTemplateGenerator.template(cursor, template, location);
+            onBeforeParseTemplate.accept(stub);
             JavaSourceFile cu = compileTemplate(stub);
             return statementTemplateGenerator.listTemplatedTrees(cu, expected);
         });
@@ -173,9 +174,11 @@ public class JavaTemplateParser {
         } else {
             methodWithReplacedNameAndArgs = method.getSelect().print(cursor) + "." + template + ";";
         }
-        @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacedNameAndArgs, location);
-        onBeforeParseTemplate.accept(stub);
-        List<J> invocations = cache(stub, () -> {
+
+        String cacheKey = addImports(statementTemplateGenerator.cacheKey(cursor, methodWithReplacedNameAndArgs, location));
+        List<J> invocations = cache(cacheKey, () -> {
+            @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacedNameAndArgs, location);
+            onBeforeParseTemplate.accept(stub);
             JavaSourceFile cu = compileTemplate(stub);
             J.MethodInvocation replaced = (J.MethodInvocation) statementTemplateGenerator
                     .listTemplatedTrees(cu, Statement.class).get(0);
@@ -188,9 +191,11 @@ public class JavaTemplateParser {
         J.MethodInvocation method = cursor.getValue();
         String methodWithReplacementArgs = method.withArguments(Collections.emptyList()).printTrimmed(cursor)
                 .replaceAll("\\)$", template + ");");
-        @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacementArgs, location);
-        onBeforeParseTemplate.accept(stub);
-        List<J> invocations = cache(stub, () -> {
+
+        String cacheKey = addImports(statementTemplateGenerator.cacheKey(cursor, methodWithReplacementArgs, location));
+        List<J> invocations = cache(cacheKey, () -> {
+            @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacementArgs, location);
+            onBeforeParseTemplate.accept(stub);
             JavaSourceFile cu = compileTemplate(stub);
             J.MethodInvocation replaced = (J.MethodInvocation) statementTemplateGenerator
                     .listTemplatedTrees(cu, Statement.class).get(0);
@@ -200,9 +205,10 @@ public class JavaTemplateParser {
     }
 
     public List<J.Annotation> parseAnnotations(Cursor cursor, String template) {
-        @Language("java") String stub = annotationTemplateGenerator.template(cursor, template);
-        onBeforeParseTemplate.accept(stub);
-        return cache(stub, () -> {
+        String cacheKey = addImports(annotationTemplateGenerator.cacheKey(cursor, template));
+        return cache(cacheKey, () -> {
+            @Language("java") String stub = annotationTemplateGenerator.template(cursor, template);
+            onBeforeParseTemplate.accept(stub);
             JavaSourceFile cu = compileTemplate(stub);
             return annotationTemplateGenerator.listAnnotations(cu);
         });


### PR DESCRIPTION
Changed the cache keys for those templates using either the statement generator or the annotation generator. In the case of statements, the key consists of any added imports plus the template. (The initially generated stub is used to create/extract the AST representation of the template. Thereafter, the same imports+templates can re-use the generated ASTs.)

Fixes #1228