### PR TITLE
Refactor build scripts to use toolchain instead of javac executable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,20 +60,10 @@ subprojects {
     apply(plugin = "com.github.jk1.dependency-license-report")
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(11))
+        }
     }
-
-    val compiler = javaToolchains.compilerFor {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-
-    val maybeExe = if(getCurrentOperatingSystem().isWindows) {
-        ".exe"
-    } else {
-        ""
-    }
-    val javac = compiler.get().metadata.installationPath.file("bin/javac${maybeExe}")
 
     if(!name.contains("benchmark")) {
         apply(plugin = "maven-publish")
@@ -177,17 +167,8 @@ subprojects {
     }
 
     tasks.named<JavaCompile>("compileJava").configure {
-        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-        targetCompatibility = JavaVersion.VERSION_1_8.toString()
-
         options.isFork = true
-        options.forkOptions.executable = javac.toString()
-        options.compilerArgs.addAll(listOf("--release", "8"))
-    }
-
-    java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        options.release.set(8)
     }
 
     configure<LicenseReportExtension> {

--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_11.toString()
     targetCompatibility = JavaVersion.VERSION_11.toString()
 
-    options.compilerArgs.clear() // remove `--release 8` set in root gradle build
+    options.release.set(null as? Int) // remove `--release 8` set in root gradle build
     options.compilerArgs.addAll(
         listOf(
             "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -5,12 +5,6 @@ val compiler = javaToolchains.compilerFor {
     languageVersion.set(JavaLanguageVersion.of(8))
 }
 
-val maybeExe = if(getCurrentOperatingSystem().isWindows) {
-    ".exe"
-} else {
-    ""
-}
-val javac = compiler.get().metadata.installationPath.file("bin/javac${maybeExe}")
 val tools = compiler.get().metadata.installationPath.file("lib/tools.jar")
 
 dependencies {
@@ -33,8 +27,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 tasks.withType<KotlinCompile>().configureEach {
@@ -48,8 +43,7 @@ tasks.withType<JavaCompile>().configureEach {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
     options.isFork = true
-    options.forkOptions.executable = javac.toString()
-    options.compilerArgs.clear() // remove `--release 8` set in root gradle build
+    options.release.set(null as? Int) // remove `--release 8` set in root gradle build
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
This will make the JavaCompile tasks cacheable and should still retain the target/source compatibility that was configured previously.