### PR TITLE
Updates to handle JavaType.FullyQualified inner and nested class fqns having `$` delimiters

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -62,7 +62,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
 
     public AddImport(String type, @Nullable String statik, boolean onlyIfReferenced) {
         this.type = type;
-        this.classType = JavaType.Class.build(type);
+        this.classType = JavaType.ShallowClass.build(type);
         this.statik = statik;
         this.onlyIfReferenced = onlyIfReferenced;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -84,7 +84,7 @@ public class Substitutions {
                         if (arrayType.getElemType() instanceof JavaType.Primitive) {
                             s += ((JavaType.Primitive) arrayType.getElemType()).getKeyword();
                         } else if (arrayType.getElemType() instanceof JavaType.FullyQualified) {
-                            s += ((JavaType.FullyQualified) arrayType.getElemType()).getFullyQualifiedName();
+                            s += ((JavaType.FullyQualified) arrayType.getElemType()).getFullyQualifiedName().replace("$", ".");
                         }
 
                         s += "[0]" + extraDim + ")";
@@ -101,6 +101,8 @@ public class Substitutions {
                                 fqn = getTypeName(((TypedTree) parameter).getType());
                             }
                         }
+
+                        fqn = fqn.replace("$", ".");
 
                         JavaType.Primitive primitive = JavaType.Primitive.fromKeyword(fqn);
                         s = "__P__." + (primitive == null || primitive.equals(JavaType.Primitive.String) ?

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -64,7 +64,7 @@ public class FindTypes extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
-        JavaType.FullyQualified fullyQualifiedType = JavaType.Class.build(fullyQualifiedTypeName);
+        JavaType.FullyQualified fullyQualifiedType = JavaType.ShallowClass.build(fullyQualifiedTypeName);
 
         return new JavaVisitor<ExecutionContext>() {
             @Override
@@ -115,7 +115,7 @@ public class FindTypes extends Recipe {
     }
 
     private static Set<NameTree> find(boolean checkAssignability, J j, String fullyQualifiedClassName) {
-        JavaType.FullyQualified fullyQualifiedType = JavaType.Class.build(fullyQualifiedClassName);
+        JavaType.FullyQualified fullyQualifiedType = JavaType.ShallowClass.build(fullyQualifiedClassName);
 
         JavaIsoVisitor<Set<NameTree>> findVisitor = new JavaIsoVisitor<Set<NameTree>>() {
             @Override
@@ -161,7 +161,7 @@ public class FindTypes extends Recipe {
                                        @Nullable JavaType.FullyQualified test) {
         return test != null && match != null && (checkAssignability ?
                 match.isAssignableFrom(test) :
-                match.getFullyQualifiedName().equals(test.getFullyQualifiedName())
+                TypeUtils.fullyQualifiedNamesAreEqual(match.getFullyQualifiedName(), test.getFullyQualifiedName())
         );
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -222,7 +222,7 @@ public interface JavaType {
         }
 
         public boolean isAssignableTo(String fullyQualifiedName) {
-            return getFullyQualifiedName().equals(fullyQualifiedName) ||
+            return TypeUtils.fullyQualifiedNamesAreEqual(getFullyQualifiedName(), fullyQualifiedName) ||
                     getInterfaces().stream().anyMatch(anInterface -> anInterface.isAssignableTo(fullyQualifiedName))
                     || (getSupertype() != null && getSupertype().isAssignableTo(fullyQualifiedName));
         }
@@ -230,7 +230,7 @@ public interface JavaType {
         public boolean isAssignableFrom(@Nullable JavaType type) {
             if (type instanceof FullyQualified) {
                 FullyQualified clazz = (FullyQualified) type;
-                return getFullyQualifiedName().equals(clazz.getFullyQualifiedName()) ||
+                return TypeUtils.fullyQualifiedNamesAreEqual(getFullyQualifiedName(), clazz.getFullyQualifiedName()) ||
                         isAssignableFrom(clazz.getSupertype()) ||
                         clazz.getInterfaces().stream().anyMatch(this::isAssignableFrom);
             } else if (type instanceof GenericTypeVariable) {
@@ -409,7 +409,7 @@ public interface JavaType {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Class aClass = (Class) o;
-            return fullyQualifiedName.equals(aClass.fullyQualifiedName);
+            return TypeUtils.fullyQualifiedNamesAreEqual(fullyQualifiedName, aClass.fullyQualifiedName);
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -31,6 +31,13 @@ public class TypeUtils {
                 );
     }
 
+    public static boolean fullyQualifiedNamesAreEqual(@Nullable String fqn1, @Nullable String fqn2) {
+        if (fqn1 != null && fqn2 != null) {
+            return fqn1.replace("$", ".").equals(fqn2.replace("$", "."));
+        }
+        return fqn1 == null && fqn2 == null;
+    }
+
     public static boolean isOfType(@Nullable JavaType type1, @Nullable JavaType type2) {
         if (type1 == type2) {
             return true;
@@ -47,7 +54,8 @@ public class TypeUtils {
             return ((JavaType.Primitive) type1).getKeyword().equals(((JavaType.Primitive) type2).getKeyword());
         }
         if (type1 instanceof JavaType.FullyQualified && type2 instanceof JavaType.FullyQualified) {
-            return ((JavaType.FullyQualified) type1).getFullyQualifiedName().equals(((JavaType.FullyQualified) type2).getFullyQualifiedName());
+            return TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) type1).getFullyQualifiedName(),
+                    ((JavaType.FullyQualified) type2).getFullyQualifiedName());
         }
         if (type1 instanceof JavaType.Array && type2 instanceof JavaType.Array) {
             return isOfType(((JavaType.Array) type1).getElemType(), ((JavaType.Array) type2).getElemType());
@@ -71,7 +79,7 @@ public class TypeUtils {
 
     public static boolean isOfClassType(@Nullable JavaType type, String fqn) {
         if(type instanceof JavaType.FullyQualified) {
-            return ((JavaType.FullyQualified) type).getFullyQualifiedName().equals(fqn);
+            return TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) type).getFullyQualifiedName(), (fqn));
         } else if(type instanceof JavaType.Variable) {
             return isOfClassType(((JavaType.Variable) type).getType(), fqn);
         } else if(type instanceof JavaType.Method) {


### PR DESCRIPTION
Substitutions update to handle JavaType.FullyQualified inner and nested class fqns having `$`
AddImport uses `JavaType.ShallowClass` to build classType.