### PR TITLE
Sync the flags bitmap on methods between Javac and Classgraph TypeMapping

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassgraphTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassgraphTypeMapping.java
@@ -466,6 +466,10 @@ public class ClassgraphTypeMapping implements JavaTypeMapping<ClassInfo> {
         if (methodInfo.isDefault()) {
             flags = flags | Flag.Default.getBitMask();
         }
+        if (methodInfo.getClassInfo().isInterface() && !methodInfo.isAbstract()) {
+            // Javac TypeMapping includes the implicit abstract flag.
+            flags = flags | Flag.Abstract.getBitMask();
+        }
         if (methodInfo.isVarArgs()) {
             //method's overload the transient field to indicate varargs. clear the transient bit and then set the varargs
             //bit.

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassgraphTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassgraphTypeMapping.java
@@ -463,6 +463,9 @@ public class ClassgraphTypeMapping implements JavaTypeMapping<ClassInfo> {
 
     private long getFlagsFromMethod(MethodInfo methodInfo) {
         long flags = methodInfo.getModifiers();
+        if (methodInfo.isDefault()) {
+            flags = flags | Flag.Default.getBitMask();
+        }
         if (methodInfo.isVarArgs()) {
             //method's overload the transient field to indicate varargs. clear the transient bit and then set the varargs
             //bit.


### PR DESCRIPTION
Added missing default flag to bitmap.
Added missing abstract flag to bitmap.
fixes #1321