### PR TITLE
fix(rewrite-java): excluding Enum classess from getting serialVersionUid

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/AddSerialVersionUidToSerializable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/AddSerialVersionUidToSerializable.java
@@ -132,6 +132,8 @@ public class AddSerialVersionUidToSerializable extends Recipe {
                     //All other parameterized types fall through
                 } else if (type instanceof JavaType.FullyQualified) {
                     JavaType.FullyQualified fq = (JavaType.FullyQualified) type;
+                    if (fq.getKind() == JavaType.Class.Kind.Enum) return false;
+
                     if (fq.getKind() != JavaType.Class.Kind.Interface &&
                             !fq.isAssignableTo("java.lang.Throwable")) {
                         return fq.isAssignableTo("java.io.Serializable");


### PR DESCRIPTION
# Changelogs
- Excluding Enum classes from getting serialVersionUid

# Refereces
- https://stackoverflow.com/questions/3057751/how-to-ensure-consistency-of-enums-in-java-serialization/3057790
- https://www.infoworld.com/article/2072870/java-enums-are-inherently-serializable.html