### PR TITLE
Use the supertype_field symbol's type when available in Javac TypeMapping

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
@@ -166,7 +166,12 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
 
             typeCache.put(sym.flatName().toString(), clazz);
 
-            JavaType.FullyQualified supertype = TypeUtils.asFullyQualified(type(symType.supertype_field));
+            JavaType.FullyQualified supertype;
+            if (symType.supertype_field != null && symType.supertype_field.tsym != null && symType.supertype_field.tsym.type != null) {
+                supertype = TypeUtils.asFullyQualified(type(symType.supertype_field.tsym.type));
+            } else {
+                supertype = TypeUtils.asFullyQualified(type(symType.supertype_field));
+            }
 
             JavaType.FullyQualified owner = null;
             if (sym.owner instanceof Symbol.ClassSymbol) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -165,7 +165,12 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
 
             typeCache.put(sym.flatName().toString(), clazz);
 
-            JavaType.FullyQualified supertype = TypeUtils.asFullyQualified(type(symType.supertype_field));
+            JavaType.FullyQualified supertype;
+            if (symType.supertype_field != null && symType.supertype_field.tsym != null && symType.supertype_field.tsym.type != null) {
+                supertype = TypeUtils.asFullyQualified(type(symType.supertype_field.tsym.type));
+            } else {
+                supertype = TypeUtils.asFullyQualified(type(symType.supertype_field));
+            }
 
             JavaType.FullyQualified owner = null;
             if (sym.owner instanceof Symbol.ClassSymbol) {

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
@@ -47,6 +47,7 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract <U> PT<U> genericUnbounded(PT<U> n);
     public abstract void genericArray(PT<C>[] n);
     public abstract void inner(C.Inner n);
+    public abstract <U extends PT<U> & C> void inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat);
     public abstract T genericT(T n); // remove after signatures are common.
 }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
@@ -52,6 +52,14 @@ interface JavaTypeMappingTest {
     }
 
     @Test
+    fun inheritedJavaTypeGoat() {
+        val clazz = firstMethodParameter("inheritedJavaTypeGoat") as JavaType.Parameterized
+        val goat = goatType()
+        assertThat(clazz).isNotNull
+        assertThat(clazz.supertype.toString()).isEqualTo(goat.toString())
+    }
+
+    @Test
     fun extendsJavaLangObject() {
         // even though it is implicit in the source code...
         assertThat(goatType().supertype.fullyQualifiedName).isEqualTo("java.lang.Object")

--- a/rewrite-test/src/main/resources/JavaTypeGoat.java
+++ b/rewrite-test/src/main/resources/JavaTypeGoat.java
@@ -47,6 +47,7 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract <U> PT<U> genericUnbounded(PT<U> n);
     public abstract void genericArray(PT<C>[] n);
     public abstract void inner(C.Inner n);
+    public abstract <U extends PT<U> & C> void inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat);
     public abstract T genericT(T n); // remove after signatures are common.
 }
 


### PR DESCRIPTION
fixes #1349