### PR TITLE
Polish type generation of JavaSourceSet in JavaParsers.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -288,13 +288,13 @@ public class Java11Parser implements JavaParser {
 
     @Override
     public JavaSourceSet getSourceSet(ExecutionContext ctx) {
-        if (ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
-            sourceSetProvenance = new JavaSourceSet(Tree.randomId(), sourceSet, emptyList());
-        }
-
         if (sourceSetProvenance == null) {
-            sourceSetProvenance = JavaSourceSet.build(sourceSet, classpath == null ? emptyList() : classpath,
-                    typeCache, ctx);
+            if (ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
+                sourceSetProvenance = new JavaSourceSet(Tree.randomId(), sourceSet, emptyList());
+            } else {
+                sourceSetProvenance = JavaSourceSet.build(sourceSet, classpath == null ? emptyList() : classpath,
+                        typeCache, ctx);
+            }
         }
         return sourceSetProvenance;
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -29,6 +29,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.MetricsHelper;
 import org.openrewrite.internal.StringUtils;
@@ -191,8 +192,8 @@ public class Java11Parser implements JavaParser {
                 .filter(Objects::nonNull)
                 .collect(toList());
 
-        if (!ctx.getMessage(SKIP_SOURCE_SET_MARKER, false)) {
-            JavaSourceSet sourceSet = getSourceSet(ctx);
+        JavaSourceSet sourceSet = getSourceSet(ctx);
+        if (!ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
             List<JavaType.FullyQualified> classpath = sourceSet.getClasspath();
             for (J.CompilationUnit cu : mappedCus) {
                 for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
@@ -202,11 +203,10 @@ public class Java11Parser implements JavaParser {
                 }
             }
             sourceSetProvenance = sourceSet.withClasspath(classpath);
-            assert sourceSetProvenance != null;
-            return ListUtils.map(mappedCus, cu -> cu.withMarkers(cu.getMarkers().add(sourceSetProvenance)));
         }
 
-        return mappedCus;
+        assert sourceSetProvenance != null;
+        return ListUtils.map(mappedCus, cu -> cu.withMarkers(cu.getMarkers().add(sourceSetProvenance)));
     }
 
     LinkedHashMap<Input, JCTree.JCCompilationUnit> parseInputsToCompilerAst(Iterable<Input> sourceFiles, ExecutionContext ctx) {
@@ -288,6 +288,10 @@ public class Java11Parser implements JavaParser {
 
     @Override
     public JavaSourceSet getSourceSet(ExecutionContext ctx) {
+        if (ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
+            sourceSetProvenance = new JavaSourceSet(Tree.randomId(), sourceSet, emptyList());
+        }
+
         if (sourceSetProvenance == null) {
             sourceSetProvenance = JavaSourceSet.build(sourceSet, classpath == null ? emptyList() : classpath,
                     typeCache, ctx);

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -259,13 +259,13 @@ class ReloadableJava8Parser implements JavaParser {
 
     @Override
     public JavaSourceSet getSourceSet(ExecutionContext ctx) {
-        if (ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
-            sourceSetProvenance = new JavaSourceSet(Tree.randomId(), sourceSet, emptyList());
-        }
-
         if (sourceSetProvenance == null) {
-            sourceSetProvenance = JavaSourceSet.build(sourceSet, classpath == null ? emptyList() : classpath,
-                    typeCache, ctx);
+            if (ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
+                sourceSetProvenance = new JavaSourceSet(Tree.randomId(), sourceSet, emptyList());
+            } else {
+                sourceSetProvenance = JavaSourceSet.build(sourceSet, classpath == null ? emptyList() : classpath,
+                        typeCache, ctx);
+            }
         }
         return sourceSetProvenance;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -41,10 +41,10 @@ import static java.util.stream.Collectors.*;
 
 public interface JavaParser extends Parser<J.CompilationUnit> {
     /**
-     * Set to <code>true</code> on an {@link ExecutionContext} supplied to parsing to skip inclusion of
-     * a {@link JavaSourceSet} marker with type attribution from the classpath.
+     * Set to <code>true</code> on an {@link ExecutionContext} supplied to parsing to skip generation of
+     * type attribution from the class in {@link JavaSourceSet} marker.
      */
-    String SKIP_SOURCE_SET_MARKER = "org.openrewrite.java.skipSourceSetMarker";
+    String SKIP_SOURCE_SET_TYPE_GENERATION = "org.openrewrite.java.skipSourceSetTypeGeneration";
 
     /**
      * @deprecated Won't work in isolated classloaders.

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -240,7 +240,7 @@ public class JavaTemplateParser {
 
     private JavaSourceFile compileTemplate(@Language("java") String stub) {
         ExecutionContext ctx = new InMemoryExecutionContext();
-        ctx.putMessage(JavaParser.SKIP_SOURCE_SET_MARKER, true);
+        ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true);
         return stub.contains("@SubAnnotation") ?
                 parser.get().reset().parse(ctx, stub, SUBSTITUTED_ANNOTATION).get(0) :
                 parser.get().reset().parse(ctx, stub).get(0);

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTreeTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTreeTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.fail;
 public interface JavaTreeTest {
     default ExecutionContext getExecutionContext() {
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> fail("Failed to parse", t));
-        ctx.putMessage(JavaParser.SKIP_SOURCE_SET_MARKER, true);
+        ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true);
         return ctx;
     }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -26,7 +26,7 @@ interface AddImportTest : JavaRecipeTest {
     override val executionContext: ExecutionContext
         get() {
             val ctx = super.executionContext
-            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_MARKER, false)
+            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false)
             return ctx
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
@@ -32,7 +32,7 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
     override val executionContext: ExecutionContext
         get() {
             val ctx = super.executionContext
-            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_MARKER, true)
+            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true)
             return ctx
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeTest.kt
@@ -17,7 +17,6 @@ package org.openrewrite.java
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.openrewrite.ExecutionContext
 import org.openrewrite.InMemoryExecutionContext
@@ -30,7 +29,7 @@ interface JavaTypeTest {
     val executionContext: ExecutionContext
         get() {
             val ctx = InMemoryExecutionContext { t: Throwable? -> fail<Any>("Failed to parse", t) }
-            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_MARKER, true)
+            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true)
             return ctx
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
@@ -30,7 +30,7 @@ interface OrderImportsTest : JavaRecipeTest {
     override val executionContext: ExecutionContext
         get() {
             val ctx = super.executionContext
-            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_MARKER, false)
+            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false)
             return ctx
         }
 


### PR DESCRIPTION
Changes:
- Renamed property `SKIP_SOURCE_SET_MARKER` to `SKIP_SOURCE_SET_TYPE_GENERATION`.
- Changed behavior of the property to add a `JavaSourceSet` with the name of the scope and an empty classpath.
- Prevent the `JavaSourceSet` from being generated with a full classpath if `getSourceSet(ctx)` is called when the property is set.

fixes #1360