### PR TITLE
Add super type to bounds of Generic IntersectionTypes in JavacTypeMapping

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
@@ -123,16 +123,14 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
         List<JavaType> bounds = null;
         if (type.getUpperBound() instanceof Type.IntersectionClassType) {
             Type.IntersectionClassType intersectionBound = (Type.IntersectionClassType) type.getUpperBound();
-            if (intersectionBound.interfaces_field.length() > 0) {
-                bounds = new ArrayList<>(intersectionBound.interfaces_field.length());
-                for (Type bound : intersectionBound.interfaces_field) {
-                    bounds.add(type(bound));
-                }
-            } else if (intersectionBound.supertype_field != null) {
-                JavaType mappedBound = type(intersectionBound.supertype_field);
-                if (!(mappedBound instanceof JavaType.FullyQualified) || !((JavaType.FullyQualified) mappedBound).getFullyQualifiedName().equals("java.lang.Object")) {
-                    bounds = singletonList(mappedBound);
-                }
+            boolean isIntersectionSuperType = !intersectionBound.supertype_field.tsym.getQualifiedName().toString().equals("java.lang.Object");
+            bounds = new ArrayList<>((isIntersectionSuperType ? 1 : 0) + intersectionBound.interfaces_field.length());
+
+            if (isIntersectionSuperType) {
+                bounds.add(type(intersectionBound.supertype_field));
+            }
+            for (Type bound : intersectionBound.interfaces_field) {
+                bounds.add(type(bound));
             }
         } else if (type.getUpperBound() != null) {
             JavaType mappedBound = type(type.getUpperBound());

--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11TypeMappingTest.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11TypeMappingTest.kt
@@ -15,8 +15,7 @@
  */
 package org.openrewrite.java
 
-import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Disabled
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.openrewrite.InMemoryExecutionContext
@@ -62,7 +61,7 @@ class Java11TypeMappingTest : JavaTypeMappingTest {
             .body!!.statements[0] as J.If)
             .ifCondition.tree as J.InstanceOf).expression as J.Identifier)
             .type as JavaType.Parameterized
-        Assertions.assertThat(pt).isNotNull
+        assertThat(pt).isNotNull
     }
 
     @Test
@@ -80,7 +79,7 @@ class Java11TypeMappingTest : JavaTypeMappingTest {
             .logCompilationWarningsAndErrors(false)
             .build()
             .parse(InMemoryExecutionContext { t -> fail(t) }, source)
-        Assertions.assertThat(cu).isNotNull
+        assertThat(cu).isNotNull
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1318")
@@ -115,6 +114,6 @@ class Java11TypeMappingTest : JavaTypeMappingTest {
             .logCompilationWarningsAndErrors(true)
             .build()
             .parse(InMemoryExecutionContext { t -> fail(t) }, source)
-        Assertions.assertThat(cu).isNotNull
+        assertThat(cu).isNotNull
     }
 }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -125,16 +125,14 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
         List<JavaType> bounds = null;
         if (type.getUpperBound() instanceof Type.IntersectionClassType) {
             Type.IntersectionClassType intersectionBound = (Type.IntersectionClassType) type.getUpperBound();
-            if (intersectionBound.interfaces_field.length() > 0) {
-                bounds = new ArrayList<>(intersectionBound.interfaces_field.length());
-                for (Type bound : intersectionBound.interfaces_field) {
-                    bounds.add(type(bound));
-                }
-            } else if (intersectionBound.supertype_field != null) {
-                JavaType mappedBound = type(intersectionBound.supertype_field);
-                if (!(mappedBound instanceof JavaType.FullyQualified) || !((JavaType.FullyQualified) mappedBound).getFullyQualifiedName().equals("java.lang.Object")) {
-                    bounds = singletonList(mappedBound);
-                }
+            boolean isIntersectionSuperType = !intersectionBound.supertype_field.tsym.getQualifiedName().toString().equals("java.lang.Object");
+            bounds = new ArrayList<>((isIntersectionSuperType ? 1 : 0) + intersectionBound.interfaces_field.length());
+
+            if (isIntersectionSuperType) {
+                bounds.add(type(intersectionBound.supertype_field));
+            }
+            for (Type bound : intersectionBound.interfaces_field) {
+                bounds.add(type(bound));
             }
         } else if (type.getUpperBound() != null) {
             JavaType mappedBound = type(type.getUpperBound());

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
@@ -37,8 +37,8 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public enum EnumType {
     }
 
-    public static abstract class ImplementedPT implements PT<Object> {  // explicitly bounded to Object
-    }
+    public static abstract class TypeA {}
+    public static abstract class TypeB {}
 
     @AnnotationWithRuntimeRetention
     @AnnotationWithSourceRetention
@@ -46,7 +46,6 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract void primitive(int n);
     public abstract void array(C[][] n);
     public abstract PT<C> parameterized(PT<C> n);
-    public abstract void implementedPT(ImplementedPT n);
     public abstract PT<PT<C>> parameterizedRecursive(PT<PT<C>> n);
     public abstract PT<? extends C> generic(PT<? extends C> n);
     public abstract PT<? super C> genericContravariant(PT<? super C> n);
@@ -55,7 +54,8 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract void genericArray(PT<C>[] n);
     public abstract void inner(C.Inner n);
     public abstract void enumType(EnumType enumType);
-    public abstract<U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat);
+    public abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat);
+    public abstract <U extends TypeA & PT<U> & C> U genericIntersection(U genericIntersection);
     public abstract T genericT(T n); // remove after signatures are common.
 }
 

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Issue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -148,13 +147,21 @@ public interface JavaTypeSignatureBuilderTest {
                 .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inner,return=void,parameters=[org.openrewrite.java.C$Inner]}");
     }
 
-    @Disabled
-    @Issue("https://github.com/openrewrite/rewrite/issues/1349")
+    @Disabled("Temporarily disabled: ClassGraphTypeMapping does not handle generic intersections with a super type, and the mapping is being removed.")
     @Test
     default void inheritedJavaTypeGoat() {
         assertThat(signatureBuilder().signature(firstMethodParameter("inheritedJavaTypeGoat")))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>");
         assertThat(methodSignature("inheritedJavaTypeGoat"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inheritedJavaTypeGoat,return=org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat,parameters=[org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inheritedJavaTypeGoat,return=org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>,parameters=[org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>]}");
+    }
+
+    @Disabled("Temporarily disabled: ClassGraphTypeMapping does not handle generic intersections with a super type, and the mapping is being removed.")
+    @Test
+    default void genericIntersection() {
+        assertThat(signatureBuilder().signature(firstMethodParameter("genericIntersection")))
+                .isEqualTo("Generic{U extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}");
+        assertThat(methodSignature("genericIntersection"))
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericIntersection,return=Generic{U extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C},parameters=[Generic{U extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}]}");
     }
 }

--- a/rewrite-test/src/main/resources/JavaTypeGoat.java
+++ b/rewrite-test/src/main/resources/JavaTypeGoat.java
@@ -37,8 +37,8 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public enum EnumType {
     }
 
-    public static abstract class ImplementedPT implements PT<Object> { // explicitly bounded to Object
-    }
+    public static abstract class TypeA {}
+    public static abstract class TypeB {}
 
     @AnnotationWithRuntimeRetention
     @AnnotationWithSourceRetention
@@ -46,7 +46,6 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract void primitive(int n);
     public abstract void array(C[][] n);
     public abstract PT<C> parameterized(PT<C> n);
-    public abstract void implementedPT(ImplementedPT n);
     public abstract PT<PT<C>> parameterizedRecursive(PT<PT<C>> n);
     public abstract PT<? extends C> generic(PT<? extends C> n);
     public abstract PT<? super C> genericContravariant(PT<? super C> n);
@@ -55,7 +54,8 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract void genericArray(PT<C>[] n);
     public abstract void inner(C.Inner n);
     public abstract void enumType(EnumType enumType);
-    public abstract<U extends PT<U> & C> void inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat);
+    public abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat);
+    public abstract <U extends TypeA & PT<U> & C> U genericIntersection(U genericIntersection);
     public abstract T genericT(T n); // remove after signatures are common.
 }
 


### PR DESCRIPTION
Changes:
- Added check for a generic type's intersection supertype.
- Added supertype to the `GenericTypeVariable` bounds if it exists.

Code clean up.

fixes #1364