### PR TITLE
Removed name from `JavaType$GenericTypeVariable`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
@@ -165,7 +165,7 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
 
         JavaType.GenericTypeVariable.Variance variance = INVARIANT;
 
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, g.getName(), variance, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, variance, null);
         typeCache.put(signature, gtv);
 
         List<JavaType> bounds = null;

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
@@ -83,7 +83,7 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
     }
 
     private JavaType.GenericTypeVariable generic(Type.WildcardType wildcard, String signature) {
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, "?", INVARIANT, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, INVARIANT, null);
         typeCache.put(signature, gtv);
 
         JavaType.GenericTypeVariable.Variance variance;
@@ -115,9 +115,7 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
     }
 
     private JavaType generic(Type.TypeVar type, String signature) {
-        String name = type.tsym.name.toString();
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null,
-                name, INVARIANT, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, INVARIANT, null);
         typeCache.put(signature, gtv);
 
         List<JavaType> bounds = null;
@@ -590,7 +588,7 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
                     continue;
                 }
                 Retention retention = a.getAnnotationType().asElement().getAnnotation(Retention.class);
-                if(retention != null && retention.value() == RetentionPolicy.SOURCE) {
+                if (retention != null && retention.value() == RetentionPolicy.SOURCE) {
                     continue;
                 }
                 annotations.add(annotType);

--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11TypeMappingTest.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11TypeMappingTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.java
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.openrewrite.InMemoryExecutionContext
@@ -48,6 +49,7 @@ class Java11TypeMappingTest : JavaTypeMappingTest {
         return type.get()!!
     }
 
+    @Disabled("Move to JavaTypeGoat")
     @Issue("https://github.com/openrewrite/rewrite/issues/1318")
     @Test
     fun methodInvocationOnUnknownType() {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -85,7 +85,7 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
     }
 
     private JavaType.GenericTypeVariable generic(Type.WildcardType wildcard, String signature) {
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, "?", INVARIANT, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, INVARIANT, null);
         typeCache.put(signature, gtv);
 
         JavaType.GenericTypeVariable.Variance variance;
@@ -117,9 +117,7 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
     }
 
     private JavaType generic(Type.TypeVar type, String signature) {
-        String name = type.tsym.name.toString();
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null,
-                name, INVARIANT, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, INVARIANT, null);
         typeCache.put(signature, gtv);
 
         List<JavaType> bounds = null;

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -55,12 +55,7 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         } else if (type instanceof Type.ArrayType) {
             return arraySignature(type);
         } else if (type instanceof Type.WildcardType) {
-            Type.WildcardType wildcard = (Type.WildcardType) type;
-            StringBuilder s = new StringBuilder("Generic{" + wildcard.kind.toString());
-            if (!type.isUnbound()) {
-                s.append(signature(wildcard.type));
-            }
-            return s.append("}").toString();
+            return wildcardSignature(type);
         } else if (type instanceof Type.JCNoType) {
             return "{none}";
         } else if(type instanceof Type.AnnotatedType) {
@@ -97,6 +92,16 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         return sym.flatName().toString();
     }
 
+    private String wildcardSignature(Object type) {
+        Type.WildcardType wildcard = (Type.WildcardType) type;
+        String wildcardKind = wildcard.isUnbound() ? "" : wildcard.kind.toString().substring(wildcard.kind.toString().indexOf('?') + 2);
+        StringBuilder s = new StringBuilder("Generic{" + wildcardKind);
+        if (!wildcard.isUnbound()) {
+            s.append(signature(wildcard.type));
+        }
+        return s.append("}").toString();
+    }
+
     @Override
     public String genericSignature(Object type) {
         Type.TypeVar generic = (Type.TypeVar) type;
@@ -107,10 +112,10 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         if (!typeVariableNameStack.add(name)) {
-            return "Generic{" + name + "}";
+            return "Generic{}";
         }
 
-        StringBuilder s = new StringBuilder("Generic{").append(name);
+        StringBuilder s = new StringBuilder("Generic{");
 
         StringJoiner boundSigs = new StringJoiner(" & ");
         if (generic.getUpperBound() instanceof Type.IntersectionClassType) {
@@ -133,7 +138,7 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
 
         String boundSigStr = boundSigs.toString();
         if (!boundSigStr.isEmpty()) {
-            s.append(" extends ").append(boundSigStr);
+            s.append("extends ").append(boundSigStr);
         }
 
         typeVariableNameStack.remove(name);
@@ -187,7 +192,6 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
             s += "{name=<constructor>,return=" + s;
@@ -200,7 +204,6 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
 
         String returnType;

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -335,7 +335,7 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
                                                 }
 
                                                 JavaType.GenericTypeVariable genericType = new JavaType.GenericTypeVariable(
-                                                        null, typeParamIdent.getSimpleName(),
+                                                        null,
                                                         JavaType.GenericTypeVariable.Variance.COVARIANT,
                                                         singletonList(bound));
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypes.java
@@ -98,10 +98,10 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
             // if the type expression is null, it implies the types on the lambda arguments are implicit.
-            if (multiVariable.getTypeExpression() == null && getCursor().dropParentUntil(J.class::isInstance).getValue() instanceof J.Lambda) {
+            if (multiVariable.getTypeExpression() == null && getCursor().dropParentUntil(J.class::isInstance).getValue() instanceof J.Lambda &&
+                    !(multiVariable.getVariables().get(0).getType() instanceof JavaType.GenericTypeVariable)) {
                 J.VariableDeclarations.NamedVariable nv = multiVariable.getVariables().get(0);
-                String name = nv.getType() instanceof JavaType.GenericTypeVariable ?
-                        ((JavaType.GenericTypeVariable) nv.getType()).getName() : buildName(nv.getType());
+                String name = buildName(nv.getType());
                 if (name != null) {
                     multiVariable = multiVariable.withTypeExpression(
                             new J.Identifier(Tree.randomId(),

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassgraphJavaTypeSignatureBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/ClassgraphJavaTypeSignatureBuilder.java
@@ -115,7 +115,7 @@ public class ClassgraphJavaTypeSignatureBuilder implements JavaTypeSignatureBuil
             try {
                 return signature(typeVariableSignature.resolve()); // resolves to a TypeParameter
             } catch (IllegalArgumentException ignored) {
-                return "Generic{" + typeVariableSignature.getName() + "}";
+                return "Generic{}";
             }
         } else if (type instanceof TypeArgument) {
             return generic((TypeArgument) type);
@@ -135,23 +135,23 @@ public class ClassgraphJavaTypeSignatureBuilder implements JavaTypeSignatureBuil
             case EXTENDS: {
                 String bound = signature(typeArgument.getTypeSignature());
                 if (bound.equals("java.lang.Object")) {
-                    s.append("Generic{?}");
+                    s.append("Generic{}");
                 } else {
-                    s.append("Generic{? extends ").append(bound).append('}');
+                    s.append("Generic{extends ").append(bound).append('}');
                 }
                 break;
             }
             case SUPER: {
                 String bound = signature(typeArgument.getTypeSignature());
                 if (bound.equals("java.lang.Object")) {
-                    s.append("Generic{?}");
+                    s.append("Generic{}");
                 } else {
-                    s.append("Generic{? super ").append(bound).append('}');
+                    s.append("Generic{super ").append(bound).append('}');
                 }
                 break;
             }
             case ANY:
-                s.append("Generic{?}");
+                s.append("Generic{}");
         }
 
         return s.toString();
@@ -183,12 +183,12 @@ public class ClassgraphJavaTypeSignatureBuilder implements JavaTypeSignatureBuil
 
             String boundsStr = bounds.toString();
             if (boundsStr.isEmpty()) {
-                return "Generic{" + typeParameter.getName() + "}";
+                return "Generic{}";
             }
-            return "Generic{" + typeParameter.getName() + " extends " + boundsStr + "}";
+            return "Generic{extends " + boundsStr + "}";
         }
 
-        return "Generic{" + name + "}";
+        return "Generic{}";
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -48,7 +48,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         }
 
         String signature = signatureBuilder.signature(type);
-        JavaType existing = (JavaType) typeCache.get(signature);
+        JavaType existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }
@@ -94,7 +94,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         JavaType.FullyQualified mappedClazz = classTypeWithoutParameters(clazz);
 
         if (clazz.getTypeParameters().length > 0) {
-            JavaType existing = (JavaType) typeCache.get(signature);
+            JavaType existing = typeCache.get(signature);
             if (existing != null) {
                 return existing;
             }
@@ -116,7 +116,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
     private JavaType.FullyQualified classTypeWithoutParameters(Class<?> clazz) {
         String className = clazz.getName();
-        JavaType.Class mappedClazz = (JavaType.Class) typeCache.get(className);
+        JavaType.Class mappedClazz = typeCache.get(className);
 
         if (mappedClazz == null) {
             JavaType.Class.Kind kind;
@@ -208,8 +208,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
     }
 
     private JavaType generic(TypeVariable<?> typeParameter, String signature) {
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, typeParameter.getName(),
-                INVARIANT, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, INVARIANT, null);
         typeCache.put(signature, gtv);
 
         List<JavaType> bounds = genericBounds(typeParameter.getBounds());
@@ -218,8 +217,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
     }
 
     private JavaType.GenericTypeVariable generic(WildcardType wildcard, String signature) {
-        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, "?",
-                INVARIANT, null);
+        JavaType.GenericTypeVariable gtv = new JavaType.GenericTypeVariable(null, INVARIANT, null);
         typeCache.put(signature, gtv);
 
         JavaType.GenericTypeVariable.Variance variance = INVARIANT;
@@ -274,7 +272,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
     private JavaType.Variable field(Field field) {
         String signature = signatureBuilder.variableSignature(field);
-        JavaType.Variable existing = (JavaType.Variable) typeCache.get(signature);
+        JavaType.Variable existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }
@@ -311,7 +309,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
     private JavaType.Method method(Constructor<?> method, JavaType.FullyQualified declaringType) {
         String signature = signatureBuilder.methodSignature(method, declaringType.getFullyQualifiedName());
 
-        JavaType.Method existing = (JavaType.Method) typeCache.get(signature);
+        JavaType.Method existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }
@@ -369,7 +367,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
     private JavaType.Method method(Method method, JavaType.FullyQualified declaringType) {
         String signature = signatureBuilder.methodSignature(method, declaringType.getFullyQualifiedName());
 
-        JavaType.Method existing = (JavaType.Method) typeCache.get(signature);
+        JavaType.Method existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeSignatureBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeSignatureBuilder.java
@@ -92,12 +92,12 @@ public class JavaReflectionTypeSignatureBuilder implements JavaTypeSignatureBuil
                 typeVariableNameStack = new HashSet<>();
             }
 
-            StringBuilder s = new StringBuilder("Generic{" + name);
+            StringBuilder s = new StringBuilder("Generic{");
             if (typeVariableNameStack.add(name)) {
                 if (typeVar.getBounds().length > 0) {
                     String boundsStr = genericBounds(typeVar.getBounds());
                     if (!boundsStr.isEmpty()) {
-                        s.append(" extends ").append(boundsStr);
+                        s.append("extends ").append(boundsStr);
                     }
                 }
             }
@@ -108,17 +108,17 @@ public class JavaReflectionTypeSignatureBuilder implements JavaTypeSignatureBuil
             return s.toString();
         } else if (type instanceof WildcardType) {
             WildcardType wildcard = (WildcardType) type;
-            StringBuilder s = new StringBuilder("Generic{?");
+            StringBuilder s = new StringBuilder("Generic{");
 
             if (wildcard.getLowerBounds().length > 0) {
                 String boundsStr = genericBounds(wildcard.getLowerBounds());
                 if (!boundsStr.isEmpty()) {
-                    s.append(" super ").append(boundsStr);
+                    s.append("super ").append(boundsStr);
                 }
             } else if (wildcard.getUpperBounds().length > 0) {
                 String boundsStr = genericBounds(wildcard.getUpperBounds());
                 if (!boundsStr.isEmpty()) {
-                    s.append(" extends ").append(boundsStr);
+                    s.append("extends ").append(boundsStr);
                 }
             }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -603,10 +603,6 @@ public interface JavaType {
         Integer managedReference;
 
         @With
-        @Getter
-        String name;
-
-        @With
         @NonFinal
         @Getter
         Variance variance;
@@ -615,9 +611,8 @@ public interface JavaType {
         @Nullable
         List<JavaType> bounds;
 
-        public GenericTypeVariable(@Nullable Integer managedReference, String name, Variance variance, @Nullable List<JavaType> bounds) {
+        public GenericTypeVariable(@Nullable Integer managedReference, Variance variance, @Nullable List<JavaType> bounds) {
             this.managedReference = managedReference;
-            this.name = name;
             this.variance = variance;
             this.bounds = nullIfEmpty(bounds);
         }
@@ -633,7 +628,7 @@ public interface JavaType {
             if (bounds == this.bounds) {
                 return this;
             }
-            return new GenericTypeVariable(managedReference, name, variance, bounds);
+            return new GenericTypeVariable(managedReference, variance, bounds);
         }
 
         @Override
@@ -654,7 +649,7 @@ public interface JavaType {
             if (o == null || getClass() != o.getClass()) return false;
             GenericTypeVariable that = (GenericTypeVariable) o;
             assert bounds != null;
-            return name.equals(that.name) && variance == that.variance && bounds.equals(that.bounds);
+            return variance == that.variance && bounds.equals(that.bounds);
         }
 
         @Override

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
@@ -43,18 +43,18 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
 
     @AnnotationWithRuntimeRetention
     @AnnotationWithSourceRetention
-    public abstract void clazz(C n);
-    public abstract void primitive(int n);
-    public abstract void array(C[][] n);
+    public abstract C clazz(C n);
+    public abstract int primitive(int n);
+    public abstract C[][] array(C[][] n);
     public abstract PT<C> parameterized(PT<C> n);
     public abstract PT<PT<C>> parameterizedRecursive(PT<PT<C>> n);
     public abstract PT<? extends C> generic(PT<? extends C> n);
     public abstract PT<? super C> genericContravariant(PT<? super C> n);
     public abstract <U extends JavaTypeGoat<U, ?>> JavaTypeGoat<? extends U[], ?> genericRecursive(JavaTypeGoat<? extends U[], ?> n);
     public abstract <U> PT<U> genericUnbounded(PT<U> n);
-    public abstract void genericArray(PT<C>[] n);
-    public abstract void inner(C.Inner n);
-    public abstract void enumType(EnumType n);
+    public abstract PT<C>[] genericArray(PT<C>[] n);
+    public abstract C.Inner inner(C.Inner n);
+    public abstract EnumType enumType(EnumType n);
     public abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> n);
     public abstract <U extends TypeA & PT<U> & C> U genericIntersection(U n);
     public abstract T genericT(T n); // remove after signatures are common.

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
@@ -58,7 +58,7 @@ public interface JavaTypeSignatureBuilderTest {
         assertThat(signatureBuilder().signature(firstMethodParameter("array")))
                 .isEqualTo("org.openrewrite.java.C[][]");
         assertThat(methodSignature("array"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=array,return=void,parameters=[org.openrewrite.java.C[][]]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=array,return=org.openrewrite.java.C[][],parameters=[org.openrewrite.java.C[][]]}");
     }
 
     @Test
@@ -66,7 +66,7 @@ public interface JavaTypeSignatureBuilderTest {
         assertThat(signatureBuilder().signature(firstMethodParameter("clazz")))
                 .isEqualTo("org.openrewrite.java.C");
         assertThat(methodSignature("clazz"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=clazz,return=void,parameters=[org.openrewrite.java.C]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=clazz,return=org.openrewrite.java.C,parameters=[org.openrewrite.java.C]}");
     }
 
     @Test
@@ -74,7 +74,7 @@ public interface JavaTypeSignatureBuilderTest {
         assertThat(signatureBuilder().signature(firstMethodParameter("primitive")))
                 .isEqualTo("int");
         assertThat(methodSignature("primitive"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=primitive,return=void,parameters=[int]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=primitive,return=int,parameters=[int]}");
     }
 
     @Test
@@ -96,9 +96,9 @@ public interface JavaTypeSignatureBuilderTest {
     @Test
     default void generic() {
         assertThat(signatureBuilder().signature(firstMethodParameter("generic")))
-                .isEqualTo("org.openrewrite.java.PT<Generic{? extends org.openrewrite.java.C}>");
+                .isEqualTo("org.openrewrite.java.PT<Generic{extends org.openrewrite.java.C}>");
         assertThat(methodSignature("generic"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=generic,return=org.openrewrite.java.PT<Generic{? extends org.openrewrite.java.C}>,parameters=[org.openrewrite.java.PT<Generic{? extends org.openrewrite.java.C}>]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=generic,return=org.openrewrite.java.PT<Generic{extends org.openrewrite.java.C}>,parameters=[org.openrewrite.java.PT<Generic{extends org.openrewrite.java.C}>]}");
     }
 
     // Remove test after signatures are working.
@@ -106,39 +106,39 @@ public interface JavaTypeSignatureBuilderTest {
     @Test
     default void genericT() {
         assertThat(signatureBuilder().signature(firstMethodParameter("genericT")))
-                .isEqualTo("Generic{T}");
+                .isEqualTo("Generic{}");
         assertThat(methodSignature("genericT"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericT,return=Generic{T},parameters=[Generic{T}]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericT,return=Generic{},parameters=[Generic{}]}");
     }
 
     @Test
     default void genericContravariant() {
         assertThat(signatureBuilder().signature(firstMethodParameter("genericContravariant")))
-            .isEqualTo("org.openrewrite.java.PT<Generic{? super org.openrewrite.java.C}>");
+            .isEqualTo("org.openrewrite.java.PT<Generic{super org.openrewrite.java.C}>");
         assertThat(methodSignature("genericContravariant"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericContravariant,return=org.openrewrite.java.PT<Generic{? super org.openrewrite.java.C}>,parameters=[org.openrewrite.java.PT<Generic{? super org.openrewrite.java.C}>]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericContravariant,return=org.openrewrite.java.PT<Generic{super org.openrewrite.java.C}>,parameters=[org.openrewrite.java.PT<Generic{super org.openrewrite.java.C}>]}");
     }
 
     @Test
     default void genericRecursiveInClassDefinition() {
         assertThat(signatureBuilder().signature(lastClassTypeParameter()))
-                .isEqualTo("Generic{S extends org.openrewrite.java.PT<Generic{S}> & org.openrewrite.java.C}");
+                .isEqualTo("Generic{extends org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}");
     }
 
     @Test
     default void genericRecursiveInMethodDeclaration() {
         assertThat(signatureBuilder().signature(firstMethodParameter("genericRecursive")))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat<Generic{? extends Generic{U extends org.openrewrite.java.JavaTypeGoat<Generic{U}, Generic{?}>}[]}, Generic{?}>");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat<Generic{extends Generic{extends org.openrewrite.java.JavaTypeGoat<Generic{}, Generic{}>}[]}, Generic{}>");
         assertThat(methodSignature("genericRecursive"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericRecursive,return=org.openrewrite.java.JavaTypeGoat<Generic{? extends Generic{U extends org.openrewrite.java.JavaTypeGoat<Generic{U}, Generic{?}>}[]}, Generic{?}>,parameters=[org.openrewrite.java.JavaTypeGoat<Generic{? extends Generic{U extends org.openrewrite.java.JavaTypeGoat<Generic{U}, Generic{?}>}[]}, Generic{?}>]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericRecursive,return=org.openrewrite.java.JavaTypeGoat<Generic{extends Generic{extends org.openrewrite.java.JavaTypeGoat<Generic{}, Generic{}>}[]}, Generic{}>,parameters=[org.openrewrite.java.JavaTypeGoat<Generic{extends Generic{extends org.openrewrite.java.JavaTypeGoat<Generic{}, Generic{}>}[]}, Generic{}>]}");
     }
 
     @Test
     default void genericUnbounded() {
         assertThat(signatureBuilder().signature(firstMethodParameter("genericUnbounded")))
-            .isEqualTo("org.openrewrite.java.PT<Generic{U}>");
+            .isEqualTo("org.openrewrite.java.PT<Generic{}>");
         assertThat(methodSignature("genericUnbounded"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericUnbounded,return=org.openrewrite.java.PT<Generic{U}>,parameters=[org.openrewrite.java.PT<Generic{U}>]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericUnbounded,return=org.openrewrite.java.PT<Generic{}>,parameters=[org.openrewrite.java.PT<Generic{}>]}");
     }
 
     @Test
@@ -146,16 +146,16 @@ public interface JavaTypeSignatureBuilderTest {
         assertThat(signatureBuilder().signature(firstMethodParameter("inner")))
                 .isEqualTo("org.openrewrite.java.C$Inner");
         assertThat(methodSignature("inner"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inner,return=void,parameters=[org.openrewrite.java.C$Inner]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inner,return=org.openrewrite.java.C$Inner,parameters=[org.openrewrite.java.C$Inner]}");
     }
 
     @Disabled("Disabled until Classgraph is removed.")
     @Test
     default void inheritedJavaTypeGoat() {
         assertThat(signatureBuilder().signature(firstMethodParameter("inheritedJavaTypeGoat")))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{}, Generic{extends org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}>");
         assertThat(methodSignature("inheritedJavaTypeGoat"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inheritedJavaTypeGoat,return=org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>,parameters=[org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=inheritedJavaTypeGoat,return=org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{}, Generic{extends org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}>,parameters=[org.openrewrite.java.JavaTypeGoat$InheritedJavaTypeGoat<Generic{}, Generic{extends org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}>]}");
     }
 
     @Disabled("Disabled until Classgraph is removed.")
@@ -169,8 +169,8 @@ public interface JavaTypeSignatureBuilderTest {
     @Test
     default void genericIntersection() {
         assertThat(signatureBuilder().signature(firstMethodParameter("genericIntersection")))
-                .isEqualTo("Generic{U extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}");
+                .isEqualTo("Generic{extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}");
         assertThat(methodSignature("genericIntersection"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericIntersection,return=Generic{U extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C},parameters=[Generic{U extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}]}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=genericIntersection,return=Generic{extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C},parameters=[Generic{extends org.openrewrite.java.JavaTypeGoat$TypeA & org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}]}");
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
@@ -1705,9 +1705,7 @@ interface JavaTemplateTest : JavaRecipeTest {
             assertThat(paramTypes[1])
                 .`as`("The method declaration's type's genericSignature second argument should have type 'U' with bound 'java.lang.Object'")
                 .matches { uType ->
-                    uType is JavaType.GenericTypeVariable &&
-                            uType.name == "U" &&
-                            uType.bounds.isEmpty()
+                    uType is JavaType.GenericTypeVariable && uType.bounds.isEmpty()
                 }
         }
     )

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
@@ -94,7 +94,6 @@ interface JavaTypeMappingTest {
     fun generic() {
         val generic =
             firstMethodParameter("generic").asParameterized()!!.typeParameters[0] as JavaType.GenericTypeVariable
-        assertThat(generic.name).isEqualTo("?")
         assertThat(generic.variance).isEqualTo(COVARIANT)
         assertThat(generic.bounds[0].asFullyQualified()!!.fullyQualifiedName).isEqualTo("org.openrewrite.java.C")
     }
@@ -103,7 +102,6 @@ interface JavaTypeMappingTest {
     fun genericContravariant() {
         val generic =
             firstMethodParameter("genericContravariant").asParameterized()!!.typeParameters[0] as JavaType.GenericTypeVariable
-        assertThat(generic.name).isEqualTo("?")
         assertThat(generic.variance).isEqualTo(CONTRAVARIANT)
         assertThat(generic.bounds[0].asFullyQualified()!!.fullyQualifiedName).isEqualTo("org.openrewrite.java.C")
     }
@@ -111,7 +109,6 @@ interface JavaTypeMappingTest {
     @Test
     fun genericMultipleBounds() {
         val generic = goatType().typeParameters.last().asGeneric()!!
-        assertThat(generic.name).isEqualTo("S")
         assertThat(generic.variance).isEqualTo(COVARIANT)
         assertThat(generic.bounds[0].asFullyQualified()!!.fullyQualifiedName).isEqualTo("org.openrewrite.java.PT")
         assertThat(generic.bounds[1].asFullyQualified()!!.fullyQualifiedName).isEqualTo("org.openrewrite.java.C")
@@ -121,7 +118,6 @@ interface JavaTypeMappingTest {
     fun genericUnbounded() {
         val generic =
             firstMethodParameter("genericUnbounded").asParameterized()!!.typeParameters[0] as JavaType.GenericTypeVariable
-        assertThat(generic.name).isEqualTo("U")
         assertThat(generic.variance).isEqualTo(INVARIANT)
         assertThat(generic.bounds).isEmpty()
     }
@@ -131,12 +127,10 @@ interface JavaTypeMappingTest {
         val param = firstMethodParameter("genericRecursive")
         val typeParam = param.asParameterized()!!.typeParameters[0]
         val generic = typeParam as JavaType.GenericTypeVariable
-        assertThat(generic.name).isEqualTo("?")
         assertThat(generic.variance).isEqualTo(COVARIANT)
         assertThat(generic.bounds[0].asArray()).isNotNull
 
         val elemType = generic.bounds[0].asArray()!!.elemType.asGeneric()!!
-        assertThat(elemType.name).isEqualTo("U")
         assertThat(elemType.variance).isEqualTo(COVARIANT)
         assertThat(elemType.bounds).hasSize(1)
     }
@@ -162,9 +156,9 @@ interface JavaTypeMappingTest {
     @Test
     fun inheritedJavaTypeGoat() {
         val clazz = firstMethodParameter("inheritedJavaTypeGoat") as JavaType.Parameterized
-        assertThat(clazz.typeParameters[0].toString()).isEqualTo("Generic{T}")
-        assertThat(clazz.typeParameters[1].toString()).isEqualTo("Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}")
-        assertThat(clazz.toString()).isEqualTo("org.openrewrite.java.JavaTypeGoat${"$"}InheritedJavaTypeGoat<Generic{T}, Generic{U extends org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}>")
+        assertThat(clazz.typeParameters[0].toString()).isEqualTo("Generic{}")
+        assertThat(clazz.typeParameters[1].toString()).isEqualTo("Generic{extends org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}")
+        assertThat(clazz.toString()).isEqualTo("org.openrewrite.java.JavaTypeGoat${"$"}InheritedJavaTypeGoat<Generic{}, Generic{extends org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}>")
     }
 
     @Disabled("Disabled until Classgraph is removed.")
@@ -173,9 +167,9 @@ interface JavaTypeMappingTest {
     fun genericIntersectionType() {
         val clazz = firstMethodParameter("genericIntersection") as JavaType.GenericTypeVariable
         assertThat(clazz.bounds[0].toString()).isEqualTo("org.openrewrite.java.JavaTypeGoat${"$"}TypeA")
-        assertThat(clazz.bounds[1].toString()).isEqualTo("org.openrewrite.java.PT<Generic{U extends org.openrewrite.java.JavaTypeGoat${"$"}TypeA & org.openrewrite.java.C}>")
+        assertThat(clazz.bounds[1].toString()).isEqualTo("org.openrewrite.java.PT<Generic{extends org.openrewrite.java.JavaTypeGoat${"$"}TypeA & org.openrewrite.java.C}>")
         assertThat(clazz.bounds[2].toString()).isEqualTo("org.openrewrite.java.C")
-        assertThat(clazz.toString()).isEqualTo("Generic{U extends org.openrewrite.java.JavaTypeGoat${"$"}TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}")
+        assertThat(clazz.toString()).isEqualTo("Generic{extends org.openrewrite.java.JavaTypeGoat${"$"}TypeA & org.openrewrite.java.PT<Generic{}> & org.openrewrite.java.C}")
     }
 
     @Disabled("Temporarily disabled: JavaReflection returns the implicit constructor that is added by the compiler, and ClassgraphTypeMapping returns the wrong type.")

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypesTest.kt
@@ -341,43 +341,6 @@ interface ExplicitLambdaArgumentTypesTest : JavaRecipeTest {
     )
 
     @Test
-    fun threeArgumentsWithBlockGeneric(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
-            class Test {
-                static <T> void run(TriConsumer<T> tc) {
-                }
-
-                static void method() {
-                    run((a, b, c) -> {
-                        return a.toString();
-                    });
-                }
-
-                private interface TriConsumer<T> {
-                    T method(T a, T b, T c);
-                }
-            }
-        """,
-        after = """
-            class Test {
-                static <T> void run(TriConsumer<T> tc) {
-                }
-
-                static void method() {
-                    run((Object a, Object b, Object c) -> {
-                        return a.toString();
-                    });
-                }
-
-                private interface TriConsumer<T> {
-                    T method(T a, T b, T c);
-                }
-            }
-        """
-    )
-
-    @Test
     fun noArguments(jp: JavaParser) = assertUnchanged(
         jp,
         before = """
@@ -417,33 +380,6 @@ interface ExplicitLambdaArgumentTypesTest : JavaRecipeTest {
                 static void method(String[] arr) {
                     Arrays.sort(arr, (String a, String b) -> {
                         return a.length() - b.length();
-                    });
-                }
-            }
-        """
-    )
-
-    @Test
-    fun arraysSortExampleWithGeneric(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
-            import java.util.Arrays;
-
-            class Test {
-                static <T> void method(T[] arr) {
-                    Arrays.sort(arr, (a, b) -> {
-                        return a.toString().length() - b.toString().length();
-                    });
-                }
-            }
-        """,
-        after = """
-            import java.util.Arrays;
-
-            class Test {
-                static <T> void method(T[] arr) {
-                    Arrays.sort(arr, (T a, T b) -> {
-                        return a.toString().length() - b.toString().length();
                     });
                 }
             }

--- a/rewrite-test/src/main/resources/JavaTypeGoat.java
+++ b/rewrite-test/src/main/resources/JavaTypeGoat.java
@@ -43,18 +43,18 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
 
     @AnnotationWithRuntimeRetention
     @AnnotationWithSourceRetention
-    public abstract void clazz(C n);
-    public abstract void primitive(int n);
-    public abstract void array(C[][] n);
+    public abstract C clazz(C n);
+    public abstract int primitive(int n);
+    public abstract C[][] array(C[][] n);
     public abstract PT<C> parameterized(PT<C> n);
     public abstract PT<PT<C>> parameterizedRecursive(PT<PT<C>> n);
     public abstract PT<? extends C> generic(PT<? extends C> n);
     public abstract PT<? super C> genericContravariant(PT<? super C> n);
     public abstract <U extends JavaTypeGoat<U, ?>> JavaTypeGoat<? extends U[], ?> genericRecursive(JavaTypeGoat<? extends U[], ?> n);
     public abstract <U> PT<U> genericUnbounded(PT<U> n);
-    public abstract void genericArray(PT<C>[] n);
-    public abstract void inner(C.Inner n);
-    public abstract void enumType(EnumType n);
+    public abstract PT<C>[] genericArray(PT<C>[] n);
+    public abstract C.Inner inner(C.Inner n);
+    public abstract EnumType enumType(EnumType n);
     public abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> n);
     public abstract <U extends TypeA & PT<U> & C> U genericIntersection(U n);
     public abstract T genericT(T n); // remove after signatures are common.


### PR DESCRIPTION
**Changes**
- Removed name field from `JavaType#GenericTypeVariable`.
- Updated `JavaType$GenericTypeVariable` instantiations.
- Updated tests.
- Removed explicit generic variable type names from `ExplicitLambdaArgumentTypesTest`. The `RSPEC` rule does not include generic type variables like `T`.
- Updated tests.
- General code clean up.

**Info:**
Java automatically binds unbound generic type variables like `T` to `java.lang.Object.`
The unbound type variables like `T`, `K`, `V`, etc are each a `java.lang.Object` and aren't different types.

**Contains a minor breaking API change.**
The generic type names `T`, `K`, `V`, `?`, etc. will not be available on `JavaType$GenericTypeVariable`.