### PR TITLE
Fix parsing exception in JavaDocVisitor.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -127,6 +127,11 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
                         String prevNewLine = i > 1 && sourceArr[i - 2] == '\r' ? "\r\n" : "\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevNewLine, Markers.EMPTY));
                     }
+                    if (marginBuilder != null) {
+                        String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
+                        marginBuilder.append(newLine);
+                        continue;
+                    }
                     javadocContent.append(c);
                 }
                 String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -127,6 +127,11 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                         String prevNewLine = i > 1 && sourceArr[i - 2] == '\r' ? "\r\n" : "\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevNewLine, Markers.EMPTY));
                     }
+                    if (marginBuilder != null) {
+                        String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
+                        marginBuilder.append(newLine);
+                        continue;
+                    }
                     javadocContent.append(c);
                 }
                 String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1243,4 +1243,21 @@ interface JavadocTest : JavaTreeTest {
                 "}"
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1374")
+    @Test
+    fun tagAfterBlankLineWithMarginAfterText(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            class Test {
+                /**
+                 * Text
+                 
+                 * @return void
+                 */
+                void method() {
+                }
+            }
+        """.trimIndent()
+    )
 }


### PR DESCRIPTION
Cause:
The cursor isn't set properly, since the init expects the margin to already be null.

Changes:
- Continue to build the margin when a new line is found, but the margin is not null.

Fixes #1374