### PR TITLE
Support origin that has a base path in the URI

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -47,11 +47,21 @@ public class GitProvenance implements Marker {
         if(origin == null) {
             return null;
         }
+        String path;
         if (origin.startsWith("git")) {
-            return origin.substring(origin.indexOf(':') + 1, origin.indexOf('/'));
+            path = origin.substring(origin.indexOf(':') + 1);
         } else {
-            String path = URI.create(origin).getPath();
-            return path.substring(1, path.indexOf('/', 1));
+            path = URI.create(origin).getPath().substring(1);
+        }
+        int firstSlashPos = path.lastIndexOf('/');
+        int secondSlashPos = path.lastIndexOf('/', firstSlashPos - 1);
+
+        if (secondSlashPos > -1) {
+            return path.substring(secondSlashPos + 1, firstSlashPos);
+        } else if (firstSlashPos > -1 ){
+            return path.substring(0, firstSlashPos);
+        } else {
+            return "";
         }
     }
 

--- a/rewrite-core/src/test/kotlin/org/openrewrite/marker/GitProvenanceTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/marker/GitProvenanceTest.kt
@@ -22,12 +22,16 @@ import org.openrewrite.Tree.randomId
 class GitProvenanceTest {
     private val sshRepo = GitProvenance(randomId(), "ssh://git@github.com/openrewrite/rewrite.git", "main", "123")
     private val httpsRepo = GitProvenance(randomId(), "https://github.com/openrewrite/rewrite.git", "main", "123")
+    private val fileRepo = GitProvenance(randomId(), "file:///openrewrite/rewrite.git", "main", "123")
+    private val bitbucketWithBasePath = GitProvenance(randomId(), "http://localhost:7990/scm/openrewrite/rewrite.git", "main", "123")
     private val sshAlternateFormRepo = GitProvenance(randomId(), "git@github.com:openrewrite/rewrite.git", "main", "123")
 
     @Test
     fun getOrganizationName() {
         assertThat(sshRepo.organizationName).isEqualTo("openrewrite")
         assertThat(httpsRepo.organizationName).isEqualTo("openrewrite")
+        assertThat(fileRepo.organizationName).isEqualTo("openrewrite")
+        assertThat(bitbucketWithBasePath.organizationName).isEqualTo("openrewrite")
         assertThat(sshAlternateFormRepo.organizationName).isEqualTo("openrewrite")
     }
 
@@ -35,6 +39,8 @@ class GitProvenanceTest {
     fun getRepositoryName() {
         assertThat(sshRepo.repositoryName).isEqualTo("rewrite")
         assertThat(httpsRepo.repositoryName).isEqualTo("rewrite")
+        assertThat(fileRepo.repositoryName).isEqualTo("rewrite")
+        assertThat(bitbucketWithBasePath.repositoryName).isEqualTo("rewrite")
         assertThat(sshAlternateFormRepo.repositoryName).isEqualTo("rewrite")
     }
 }


### PR DESCRIPTION
Given a bitbucket origin of `http://localhost:7990/scm/organization/spring-demo.git`

The GitProvenance was not correctly reporting the organization (`organization`)