### PR TITLE
Guard against NPE in JavaTypeSignatureBuilders in `methodArgumentSignature`. 

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeSignatureBuilder.java
@@ -226,8 +226,10 @@ class Java11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         StringJoiner genericArgumentTypes = new StringJoiner(",", "[", "]");
-        for (Symbol.VarSymbol parameter : sym.getParameters()) {
-            genericArgumentTypes.add(signature(parameter.type));
+        if (sym.type != null) {
+            for (Symbol.VarSymbol parameter : sym.getParameters()) {
+                genericArgumentTypes.add(signature(parameter.type));
+            }
         }
         return genericArgumentTypes.toString();
     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -226,8 +226,10 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         StringJoiner genericArgumentTypes = new StringJoiner(",", "[", "]");
-        for (Symbol.VarSymbol parameter : sym.getParameters()) {
-            genericArgumentTypes.add(signature(parameter.type));
+        if (sym.type != null) {
+            for (Symbol.VarSymbol parameter : sym.getParameters()) {
+                genericArgumentTypes.add(signature(parameter.type));
+            }
         }
         return genericArgumentTypes.toString();
     }


### PR DESCRIPTION
@jkschneider brought up a great point that java docs may refer to types that don't exist due to drift.
It's possible other symbols are missing types, and we will need a more holistic fix.
But this will guard against the NPE for now.

Note: This will cause the signature to be different than the source.

fixes #1377