### PR TITLE
Add `executionContext` as named parameter in base test classes

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/RecipeTest.kt
@@ -39,6 +39,7 @@ interface RecipeTest<T : SourceFile> {
     fun assertChangedBase(
         parser: Parser<T> = this.parser!!,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         before: String,
         dependsOn: Array<String> = emptyArray(),
         after: String,
@@ -53,13 +54,14 @@ interface RecipeTest<T : SourceFile> {
             .`as`("The parser was provided with ${inputs.size} inputs which it parsed into ${sources.size} SourceFiles. The parser likely encountered an error.")
             .isEqualTo(inputs.size)
 
-        assertChangedBase(recipe, sources, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        assertChangedBase(recipe, executionContext, sources, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     @Suppress("UNCHECKED_CAST")
     fun assertChangedBase(
         parser: Parser<T> = this.parser!!,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         before: File,
         relativeTo: Path? = null,
         dependsOn: Array<File> = emptyArray(),
@@ -78,12 +80,13 @@ interface RecipeTest<T : SourceFile> {
             .`as`("The parser was provided with $inputSize inputs which it parsed into ${sources.size} SourceFiles. The parser likely encountered an error.")
             .isEqualTo(inputSize)
 
-        assertChangedBase(recipe, sources, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        assertChangedBase(recipe, executionContext, sources, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     @Suppress("UNCHECKED_CAST")
     private fun assertChangedBase(
-        recipe: Recipe = this.recipe!!,
+        recipe: Recipe,
+        executionContext: ExecutionContext,
         sources: List<SourceFile>,
         after: String,
         cycles: Int = 2,
@@ -130,6 +133,7 @@ interface RecipeTest<T : SourceFile> {
     fun assertUnchangedBase(
         parser: Parser<T> = this.parser!!,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         before: String,
         dependsOn: Array<String> = emptyArray()
     ) {
@@ -140,12 +144,13 @@ interface RecipeTest<T : SourceFile> {
             .`as`("The parser was provided with ${inputs.size} inputs which it parsed into ${sources.size} SourceFiles. The parser likely encountered an error.")
             .isEqualTo(inputs.size)
 
-        assertUnchangedBase(recipe, sources)
+        assertUnchangedBase(recipe,  executionContext, sources)
     }
 
     fun assertUnchangedBase(
         parser: Parser<T> = this.parser!!,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         before: File,
         relativeTo: Path? = null,
         dependsOn: Array<File> = emptyArray()
@@ -156,11 +161,12 @@ interface RecipeTest<T : SourceFile> {
             executionContext
         )
 
-        assertUnchangedBase(recipe, sources)
+        assertUnchangedBase(recipe, executionContext, sources)
     }
 
     private fun assertUnchangedBase(
-        recipe: Recipe = this.recipe!!,
+        recipe: Recipe,
+        executionContext: ExecutionContext,
         sources: List<SourceFile>,
     ) {
         assertThat(recipe).`as`("A recipe must be specified").isNotNull

--- a/rewrite-test/src/main/kotlin/org/openrewrite/groovy/GroovyRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/groovy/GroovyRecipeTest.kt
@@ -16,9 +16,7 @@
 package org.openrewrite.groovy
 
 import org.intellij.lang.annotations.Language
-import org.openrewrite.Parser
-import org.openrewrite.Recipe
-import org.openrewrite.RecipeTest
+import org.openrewrite.*
 import org.openrewrite.groovy.tree.G
 import java.io.File
 import java.nio.file.Path
@@ -31,6 +29,7 @@ interface GroovyRecipeTest : RecipeTest<G.CompilationUnit> {
     fun assertChanged(
         parser: Parser<G.CompilationUnit> = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("groovy") before: String,
         @Language("groovy") dependsOn: Array<String> = emptyArray(),
         @Language("groovy") after: String,
@@ -38,12 +37,13 @@ interface GroovyRecipeTest : RecipeTest<G.CompilationUnit> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (G.CompilationUnit) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertChanged(
         parser: Parser<G.CompilationUnit> = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("groovy") before: File,
         relativeTo: Path? = null,
         @Language("groovy") dependsOn: Array<File> = emptyArray(),
@@ -52,25 +52,27 @@ interface GroovyRecipeTest : RecipeTest<G.CompilationUnit> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (G.CompilationUnit) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertUnchanged(
         parser: Parser<G.CompilationUnit> = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("groovy") before: String,
         @Language("groovy") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: Parser<G.CompilationUnit> = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("groovy") before: File,
         relativeTo: Path? = null,
         @Language("groovy") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/hcl/HclRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/hcl/HclRecipeTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.hcl
 
 import org.intellij.lang.annotations.Language
+import org.openrewrite.ExecutionContext
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.hcl.tree.Hcl
@@ -30,6 +31,7 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
     fun assertChanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("HCL") before: String,
         @Language("HCL") dependsOn: Array<String> = emptyArray(),
         @Language("HCL") after: String,
@@ -37,12 +39,13 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Hcl.ConfigFile) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertChanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("HCL") before: File,
         relativeTo: Path? = null,
         @Language("HCL") dependsOn: Array<File> = emptyArray(),
@@ -51,25 +54,27 @@ interface HclRecipeTest : RecipeTest<Hcl.ConfigFile> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Hcl.ConfigFile) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertUnchanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("HCL") before: String,
         @Language("HCL") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: HclParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("HCL") before: File,
         relativeTo: Path? = null,
         @Language("HCL") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -23,13 +23,6 @@ import org.openrewrite.style.NamedStyles
 
 interface AddImportTest : JavaRecipeTest {
 
-    override val executionContext: ExecutionContext
-        get() {
-            val ctx = super.executionContext
-            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false)
-            return ctx
-        }
-
     fun addImports(vararg adds: () -> TreeVisitor<*, ExecutionContext>): Recipe = adds
         .map { add -> toRecipe(add) }
         .reduce { r1, r2 -> return r1.doNext(r2) }
@@ -826,6 +819,7 @@ interface AddImportTest : JavaRecipeTest {
     fun doNotFoldNormalImportWithNamespaceConflict(jp: JavaParser) = assertChanged(
         jp,
         recipe = addImports({ AddImport("java.util.List", null, false) }),
+        executionContext = executionContext.apply {putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false)},
         before = """
             import java.awt.*; // contains a List class
             import java.util.Collection;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaRecipeTest.kt
@@ -49,6 +49,7 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
     fun assertChanged(
         parser: JavaParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("java") before: String,
         @Language("java") dependsOn: Array<String> = emptyArray(),
         @Language("java") after: String,
@@ -65,6 +66,7 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
         super.assertChangedBase(
             parser,
             recipe,
+            executionContext,
             before,
             dependsOn,
             after,
@@ -77,6 +79,7 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
     fun assertChanged(
         parser: JavaParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("java") before: File,
         relativeTo: Path? = null,
         @Language("java") dependsOn: Array<File> = emptyArray(),
@@ -93,6 +96,7 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
         super.assertChangedBase(
             parser,
             recipe,
+            executionContext,
             before,
             relativeTo,
             dependsOn,
@@ -106,19 +110,21 @@ interface JavaRecipeTest : RecipeTest<J.CompilationUnit> {
     fun assertUnchanged(
         parser: JavaParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("java") before: String,
         @Language("java") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: JavaParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("java") before: File,
         relativeTo: Path? = null,
         @Language("java") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/OrderImportsTest.kt
@@ -16,7 +16,6 @@
 package org.openrewrite.java
 
 import org.junit.jupiter.api.Test
-import org.openrewrite.ExecutionContext
 import org.openrewrite.Issue
 import org.openrewrite.Tree.randomId
 import org.openrewrite.java.style.ImportLayoutStyle
@@ -26,13 +25,6 @@ import org.openrewrite.style.Style
 interface OrderImportsTest : JavaRecipeTest {
     override val recipe: OrderImports
         get() = OrderImports(false)
-
-    override val executionContext: ExecutionContext
-        get() {
-            val ctx = super.executionContext
-            ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false)
-            return ctx
-        }
 
     @Test
     fun sortInnerAndOuterClassesInTheSamePackage(jp: JavaParser) = assertUnchanged(
@@ -543,6 +535,7 @@ interface OrderImportsTest : JavaRecipeTest {
     fun doNotFoldPackageWithJavaLangClassNames(jp: JavaParser) = assertUnchanged(
         jp,
         recipe = OrderImports(false),
+        executionContext = executionContext.apply {putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false)},
         before = """
             import kotlin.DeepRecursiveFunction;
             import kotlin.Function;

--- a/rewrite-test/src/main/kotlin/org/openrewrite/json/JsonRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/json/JsonRecipeTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.json
 
 import org.intellij.lang.annotations.Language
+import org.openrewrite.ExecutionContext
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.json.tree.Json
@@ -30,6 +31,7 @@ interface JsonRecipeTest : RecipeTest<Json.Document> {
     fun assertChanged(
         parser: JsonParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("json5") before: String,
         @Language("json5") dependsOn: Array<String> = emptyArray(),
         @Language("json5") after: String,
@@ -37,12 +39,13 @@ interface JsonRecipeTest : RecipeTest<Json.Document> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Json.Document) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertChanged(
         parser: JsonParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("json5") before: File,
         relativeTo: Path? = null,
         @Language("json5") dependsOn: Array<File> = emptyArray(),
@@ -51,25 +54,27 @@ interface JsonRecipeTest : RecipeTest<Json.Document> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Json.Document) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertUnchanged(
         parser: JsonParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("json5") before: String,
         @Language("json5") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: JsonParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("json5") before: File,
         relativeTo: Path? = null,
         @Language("json5") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/maven/MavenRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/maven/MavenRecipeTest.kt
@@ -21,6 +21,7 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
+import org.openrewrite.ExecutionContext
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.internal.LoggingMeterRegistry
@@ -61,6 +62,7 @@ interface MavenRecipeTest : RecipeTest<Xml.Document> {
     fun assertChanged(
         parser: MavenParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: String,
         @Language("xml") dependsOn: Array<String> = emptyArray(),
         @Language("xml") after: String,
@@ -71,6 +73,7 @@ interface MavenRecipeTest : RecipeTest<Xml.Document> {
         super.assertChangedBase(
             parser,
             recipe,
+            executionContext,
             before,
             dependsOn,
             after,
@@ -83,6 +86,7 @@ interface MavenRecipeTest : RecipeTest<Xml.Document> {
     fun assertChanged(
         parser: MavenParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: File,
         relativeTo: Path? = null,
         @Language("xml") dependsOn: Array<File> = emptyArray(),
@@ -94,6 +98,7 @@ interface MavenRecipeTest : RecipeTest<Xml.Document> {
         super.assertChangedBase(
             parser,
             recipe,
+            executionContext,
             before,
             relativeTo,
             dependsOn,
@@ -107,19 +112,21 @@ interface MavenRecipeTest : RecipeTest<Xml.Document> {
     fun assertUnchanged(
         parser: MavenParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: String,
         @Language("xml") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: MavenParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: File,
         relativeTo: Path? = null,
         @Language("xml") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/properties/PropertiesRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/properties/PropertiesRecipeTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.properties
 
 import org.intellij.lang.annotations.Language
+import org.openrewrite.ExecutionContext
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.properties.tree.Properties
@@ -30,6 +31,7 @@ interface PropertiesRecipeTest : RecipeTest<Properties.File> {
     fun assertChanged(
         parser: PropertiesParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("properties") before: String,
         @Language("properties") dependsOn: Array<String> = emptyArray(),
         @Language("properties") after: String,
@@ -37,12 +39,13 @@ interface PropertiesRecipeTest : RecipeTest<Properties.File> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Properties.File) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertChanged(
         parser: PropertiesParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("properties") before: File,
         relativeTo: Path? = null,
         @Language("properties") dependsOn: Array<File> = emptyArray(),
@@ -51,25 +54,27 @@ interface PropertiesRecipeTest : RecipeTest<Properties.File> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Properties.File) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertUnchanged(
         parser: PropertiesParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("properties") before: String,
         @Language("properties") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: PropertiesParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("properties") before: File,
         relativeTo: Path? = null,
         @Language("properties") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/xml/XmlRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/xml/XmlRecipeTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.xml
 
 import org.intellij.lang.annotations.Language
+import org.openrewrite.ExecutionContext
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.xml.tree.Xml
@@ -30,6 +31,7 @@ interface XmlRecipeTest : RecipeTest<Xml.Document> {
     fun assertChanged(
         parser: XmlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: String,
         @Language("xml") dependsOn: Array<String> = emptyArray(),
         @Language("xml") after: String,
@@ -37,12 +39,13 @@ interface XmlRecipeTest : RecipeTest<Xml.Document> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Xml.Document) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertChanged(
         parser: XmlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: File,
         relativeTo: Path? = null,
         @Language("xml") dependsOn: Array<File> = emptyArray(),
@@ -51,25 +54,27 @@ interface XmlRecipeTest : RecipeTest<Xml.Document> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Xml.Document) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertUnchanged(
         parser: XmlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: String,
         @Language("xml") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser:XmlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("xml") before: File,
         relativeTo: Path? = null,
         @Language("xml") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/yaml/YamlRecipeTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/yaml/YamlRecipeTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.yaml
 
 import org.intellij.lang.annotations.Language
+import org.openrewrite.ExecutionContext
 import org.openrewrite.Recipe
 import org.openrewrite.RecipeTest
 import org.openrewrite.yaml.tree.Yaml
@@ -30,6 +31,7 @@ interface YamlRecipeTest : RecipeTest<Yaml.Documents> {
     fun assertChanged(
         parser: YamlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("yaml") before: String,
         @Language("yaml") dependsOn: Array<String> = emptyArray(),
         @Language("yaml") after: String,
@@ -37,12 +39,13 @@ interface YamlRecipeTest : RecipeTest<Yaml.Documents> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Yaml.Documents) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertChanged(
         parser: YamlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("yaml") before: File,
         relativeTo: Path? = null,
         @Language("yaml") dependsOn: Array<File> = emptyArray(),
@@ -51,25 +54,27 @@ interface YamlRecipeTest : RecipeTest<Yaml.Documents> {
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Yaml.Documents) -> Unit = { }
     ) {
-        super.assertChangedBase(parser, recipe, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
+        super.assertChangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn, after, cycles, expectedCyclesThatMakeChanges, afterConditions)
     }
 
     fun assertUnchanged(
         parser: YamlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("yaml") before: String,
         @Language("yaml") dependsOn: Array<String> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, dependsOn)
     }
 
     fun assertUnchanged(
         parser: YamlParser = this.parser,
         recipe: Recipe = this.recipe!!,
+        executionContext: ExecutionContext = this.executionContext,
         @Language("yaml") before: File,
         relativeTo: Path? = null,
         @Language("yaml") dependsOn: Array<File> = emptyArray()
     ) {
-        super.assertUnchangedBase(parser, recipe, before, relativeTo, dependsOn)
+        super.assertUnchangedBase(parser, recipe, executionContext, before, relativeTo, dependsOn)
     }
 }


### PR DESCRIPTION
Each test class has the ability to override the executionContext, however, this override is applied to all tests in the class. This change allows an individual test to override the context. This pattern is used in AddImportTest and OrderImportsTest to speed up those suites of tests.

See https://github.com/openrewrite/rewrite/pull/1388/files#diff-f052a9d904f415be4f7c03be4ab8b1d2c8bf92d1cf54932d2cb6433794823a88