### PR TITLE
NPE in Positions visitor with lambda parameters

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/UpdateSourcePositions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UpdateSourcePositions.java
@@ -96,8 +96,11 @@ public class UpdateSourcePositions extends Recipe {
                 }
 
                 Range range = positionMap.get(tree);
-                J t = ((J) tree).withMarkers(((J) tree).getMarkers().add(range));
-                return super.visit(t, ctx);
+                if (range != null) {
+                    J t = ((J) tree).withMarkers(((J) tree).getMarkers().add(range));
+                    return super.visit(t, ctx);
+                }
+                return super.visit(tree, ctx);
             }
         };
     }


### PR DESCRIPTION
There are some nodes on which JavaPrinter visitor does not call `visit(Tree, ExecutionContext)`. Those won't have a range therefore and doesn't look like it's a problem thus lets not fail the visitor with an NPE on adding `null` `Range` marker.