### PR TITLE
`tree.isAcceptable()` should consult the visitor's `isAcceptable` method

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -107,6 +107,7 @@ public interface RecipeScheduler {
                     boolean isChanged = !original.getSourcePath().equals(s.getSourcePath());
                     if (!isChanged) {
                         TreeVisitor<Tree, PrintOutputCapture<ExecutionContext>> markerIdPrinter = new TreeVisitor<Tree, PrintOutputCapture<ExecutionContext>>() {
+
                             @Override
                             public Tree visit(@Nullable Tree tree, PrintOutputCapture<ExecutionContext> p) {
                                 if (tree instanceof Markers) {

--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -69,7 +69,9 @@ public interface Tree {
      * @param <P> the visitor's context argument
      * @return 'true' if the arguments to this function would be valid arguments to accept()
      */
-    <P> boolean isAcceptable(TreeVisitor<?, P> v, P p);
+    default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
+        return v.isAcceptable(this, p);
+    }
 
     default <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
         return cursor.firstEnclosingOrThrow(SourceFile.class).printer(cursor);

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -72,7 +72,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
             .tag("visitor.class", getClass().getName())
             .register(Metrics.globalRegistry);
 
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(Tree tree, P p) {
         return true;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/polyglot/Polyglot.java
+++ b/rewrite-core/src/main/java/org/openrewrite/polyglot/Polyglot.java
@@ -64,7 +64,7 @@ public interface Polyglot extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof PolyglotVisitor;
+        return v instanceof PolyglotVisitor && v.isAcceptable(this, p);
     }
 
     interface Member extends Polyglot {

--- a/rewrite-core/src/main/java/org/openrewrite/polyglot/PolyglotVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/polyglot/PolyglotVisitor.java
@@ -24,6 +24,11 @@ import org.openrewrite.internal.lang.Nullable;
 public class PolyglotVisitor<T> extends TreeVisitor<Polyglot, T> {
 
     @Override
+    public boolean isAcceptable(Tree tree, T t) {
+        return t instanceof Polyglot;
+    }
+
+    @Override
     public @Nullable Polyglot visit(@Nullable Tree tree, T ctx) {
         if (tree instanceof Polyglot.Instantiable) {
             return visitInstantiable((Polyglot.Instantiable) tree, ctx);

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
@@ -41,7 +41,7 @@ public class PlainText implements SourceFile, Tree {
 
     @Override
     public <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof PlainTextVisitor;
+        return v instanceof PlainTextVisitor && v.isAcceptable(this, p);
     }
 
     @SuppressWarnings("unchecked")

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
@@ -15,15 +15,14 @@
  */
 package org.openrewrite.text;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 
 public class PlainTextVisitor<P> extends TreeVisitor<PlainText, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof PlainText;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof PlainText;
     }
 
     public PlainText visitText(PlainText text, P p) {

--- a/rewrite-core/src/test/kotlin/org/openrewrite/RecipeLifecycleTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/RecipeLifecycleTest.kt
@@ -133,19 +133,18 @@ class RecipeLifecycleTest {
             if (tree !is FooSource) {
                 throw RuntimeException("tree is not a FooSource")
             }
-            return tree;
+            return tree
         }
 
         override fun postVisit(tree: FooSource, p: P): FooSource {
             if (tree !is FooSource) {
                 throw RuntimeException("tree is not a FooSource")
             }
-            return tree;
+            return tree
         }
     }
 
     class FooSource : SourceFile {
-        override fun <P : Any?> isAcceptable(v: TreeVisitor<*, P>, p: P) = v is FooVisitor
 
         override fun getMarkers(): Markers = throw NotImplementedError()
         override fun <T : SourceFile?> withMarkers(markers: Markers): T = throw NotImplementedError()
@@ -183,11 +182,11 @@ class RecipeLifecycleTest {
                 override fun getVisitor(): PlainTextVisitor<ExecutionContext> {
                     return object : PlainTextVisitor<ExecutionContext>() {
                         override fun visit(tree: Tree, p: ExecutionContext): PlainText {
-                            var pt = tree as PlainText;
+                            var pt = tree as PlainText
                             if (!pt.printAll().startsWith("Change1")) {
                                 pt = pt.withText("Change1" + pt.printAll())
                             }
-                            return pt;
+                            return pt
                         }
                     }
 
@@ -199,7 +198,7 @@ class RecipeLifecycleTest {
                 override fun toString() = displayName
                 override fun getVisitor(): PlainTextVisitor<ExecutionContext> {
                     return object : PlainTextVisitor<ExecutionContext>() {
-                        override fun visit(tree: Tree, p: ExecutionContext) = tree as PlainText;
+                        override fun visit(tree: Tree, p: ExecutionContext) = tree as PlainText
                     }
 
                 }
@@ -212,11 +211,11 @@ class RecipeLifecycleTest {
                     override fun getVisitor(): PlainTextVisitor<ExecutionContext> {
                         return object : PlainTextVisitor<ExecutionContext>() {
                             override fun visit(tree: Tree, p: ExecutionContext): PlainText {
-                                var pt = tree as PlainText;
+                                var pt = tree as PlainText
                                 if (!pt.printAll().endsWith("Change2")) {
                                     pt = pt.withText(pt.printAll() + "Change2")
                                 }
-                                return pt;
+                                return pt
                             }
                         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.groovy;
 
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.groovy.tree.GContainer;
 import org.openrewrite.groovy.tree.GRightPadded;
@@ -29,8 +29,8 @@ import org.openrewrite.java.tree.*;
 public class GroovyVisitor<P> extends JavaVisitor<P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof G.CompilationUnit;
+    public boolean isAcceptable(Tree tree, P p) {
+        return (tree instanceof SourceFile) ? tree instanceof G.CompilationUnit : tree instanceof G || super.isAcceptable(tree, p);
     }
 
     @Override

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclVisitor.java
@@ -16,8 +16,8 @@
 package org.openrewrite.hcl;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.hcl.format.AutoFormatVisitor;
 import org.openrewrite.hcl.tree.*;
@@ -43,8 +43,8 @@ public class HclVisitor<P> extends TreeVisitor<Hcl, P> {
     }
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof Hcl.ConfigFile;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof Hcl;
     }
 
     @Override

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Hcl.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Hcl.java
@@ -49,7 +49,7 @@ public interface Hcl extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof HclVisitor;
+        return v instanceof HclVisitor && v.isAcceptable(this, p);
     }
 
     Space getPrefix();

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -32,8 +32,8 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
     private JavadocVisitor<P> javadocVisitor;
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof JavaSourceFile;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof J;
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -53,7 +53,7 @@ public interface J extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof JavaVisitor;
+        return v instanceof JavaVisitor && v.isAcceptable(this, p);
     }
 
     @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Javadoc.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Javadoc.java
@@ -39,7 +39,7 @@ public interface Javadoc extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof JavadocVisitor;
+        return v instanceof JavadocVisitor && v.isAcceptable(this, p);
     }
 
     @Nullable

--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonVisitor.java
@@ -16,8 +16,8 @@
 package org.openrewrite.json;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -29,8 +29,8 @@ import org.openrewrite.json.tree.Space;
 public class JsonVisitor<P> extends TreeVisitor<Json, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof Json.Document;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof Json;
     }
 
     @Override

--- a/rewrite-json/src/main/java/org/openrewrite/json/tree/Json.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/tree/Json.java
@@ -45,7 +45,7 @@ public interface Json extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof JsonVisitor;
+        return v instanceof JsonVisitor  && v.isAcceptable(this, p);
     }
 
     Space getPrefix();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.maven;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.tree.MavenMetadata;
@@ -50,9 +51,12 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     }
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return super.isAcceptable(sourceFile, ctx) &&
-                sourceFile.getMarkers().findFirst(MavenResolutionResult.class).isPresent();
+    public boolean isAcceptable(Tree tree, P p) {
+        if (tree instanceof SourceFile) {
+            return super.isAcceptable(tree, p) && ((SourceFile) tree).getMarkers().findFirst(MavenResolutionResult.class).isPresent();
+        } else {
+            return super.isAcceptable(tree, p);
+        }
     }
 
     protected MavenResolutionResult getResolutionResult() {

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
@@ -15,8 +15,7 @@
  */
 package org.openrewrite.properties;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.properties.tree.Properties;
@@ -24,8 +23,8 @@ import org.openrewrite.properties.tree.Properties;
 public class PropertiesVisitor<P> extends TreeVisitor<Properties, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof Properties.File;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof Properties;
     }
 
     @Override

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
@@ -41,7 +41,7 @@ public interface Properties extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof PropertiesVisitor;
+        return v instanceof PropertiesVisitor && v.isAcceptable(this, p);
     }
 
     @Nullable

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
@@ -15,8 +15,7 @@
  */
 package org.openrewrite.xml;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.tree.Xml;
@@ -24,8 +23,8 @@ import org.openrewrite.xml.tree.Xml;
 public class XmlVisitor<P> extends TreeVisitor<Xml, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof Xml.Document;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof Xml;
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -58,7 +58,7 @@ public interface Xml extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof XmlVisitor;
+        return v instanceof XmlVisitor && v.isAcceptable(this, p);
     }
 
     String getPrefix();

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
@@ -16,8 +16,7 @@
 package org.openrewrite.yaml;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -28,8 +27,8 @@ import org.openrewrite.yaml.tree.Yaml;
 public class YamlVisitor<P> extends TreeVisitor<Yaml, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return sourceFile instanceof Yaml.Documents;
+    public boolean isAcceptable(Tree tree, P p) {
+        return tree instanceof Yaml;
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
@@ -44,7 +44,7 @@ public interface Yaml extends Tree {
 
     @Override
     default <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-        return v instanceof YamlVisitor;
+        return v instanceof YamlVisitor && v.isAcceptable(this, p);
     }
 
     @Nullable


### PR DESCRIPTION
This problem manifests in the following issue : https://github.com/openrewrite/rewrite-maven-plugin/issues/297


Previously, a model such as `Maven` extended `Xml.Document` and the `isAcceptable()` was overridden to make certain that it was only accepted by a MavenVisitor.

However, now that a maven is represented as an `Xml.Document` with a specialized marker, there was no way to customize the accept() method of `Xml.Document` such that it would only accept a visitor of type MavenVisitor when the marker was present.

This change introduces a generalized way in which a Tree's `isAcceptable` method can limit acceptability by both checking the visitor is of the correct type AND calling the visitor's `isAcceptable()` method. 