### PR TITLE
Fix TreeVisitor.isApplicable test

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -72,7 +72,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
             .tag("visitor.class", getClass().getName())
             .register(Metrics.globalRegistry);
 
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return true;
     }
 
@@ -190,7 +190,8 @@ public abstract class TreeVisitor<T extends Tree, P> {
         setCursor(new Cursor(cursor, tree));
 
         T t = null;
-        boolean isAcceptable = tree.isAcceptable(this, p);
+        // Do you visitor take tree and do you tree take visitor?
+        boolean isAcceptable = tree.isAcceptable(this, p) && (!(tree instanceof SourceFile) || isAcceptable((SourceFile) tree, p));
         if (isAcceptable) {
             //noinspection unchecked
             t = preVisit((T) tree, p);

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
@@ -15,14 +15,13 @@
  */
 package org.openrewrite.text;
 
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 
 public class PlainTextVisitor<P> extends TreeVisitor<PlainText, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof PlainText;
     }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.groovy;
 
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.groovy.tree.GContainer;
@@ -29,7 +28,7 @@ import org.openrewrite.java.tree.*;
 public class GroovyVisitor<P> extends JavaVisitor<P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof G.CompilationUnit;
     }
 

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclVisitor.java
@@ -16,7 +16,6 @@
 package org.openrewrite.hcl;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.hcl.format.AutoFormatVisitor;
@@ -43,7 +42,7 @@ public class HclVisitor<P> extends TreeVisitor<Hcl, P> {
     }
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof Hcl.ConfigFile;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -32,7 +32,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
     private JavadocVisitor<P> javadocVisitor;
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof JavaSourceFile;
     }
 

--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonVisitor.java
@@ -16,7 +16,6 @@
 package org.openrewrite.json;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
@@ -29,7 +28,7 @@ import org.openrewrite.json.tree.Space;
 public class JsonVisitor<P> extends TreeVisitor<Json, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof Json.Document;
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -50,8 +50,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     }
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-        return super.isAcceptable(sourceFile, ctx) &&
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return super.isAcceptable(sourceFile, p) &&
                 sourceFile.getMarkers().findFirst(MavenResolutionResult.class).isPresent();
     }
 

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.properties;
 
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
@@ -24,7 +23,7 @@ import org.openrewrite.properties.tree.Properties;
 public class PropertiesVisitor<P> extends TreeVisitor<Properties, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof Properties.File;
     }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.xml;
 
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
@@ -24,7 +23,7 @@ import org.openrewrite.xml.tree.Xml;
 public class XmlVisitor<P> extends TreeVisitor<Xml, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof Xml.Document;
     }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
@@ -16,7 +16,6 @@
 package org.openrewrite.yaml;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
@@ -28,7 +27,7 @@ import org.openrewrite.yaml.tree.Yaml;
 public class YamlVisitor<P> extends TreeVisitor<Yaml, P> {
 
     @Override
-    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
         return sourceFile instanceof Yaml.Documents;
     }
 


### PR DESCRIPTION
This problem manifests in the following issue : https://github.com/openrewrite/rewrite-maven-plugin/issues/297

Need to make sure both the Tree accepts the Visitor and the Visitor accepts the Tree.