### PR TITLE
Update JavaDocVisitors to parse new lines that only contain whitespace

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -123,14 +123,13 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
                     firstPrefix = firstPrefixBuilder.toString();
                     inFirstPrefix = false;
                 } else {
-                    if (i > 0 && sourceArr[i - 1] == '\n') {
-                        String prevNewLine = i > 1 && sourceArr[i - 2] == '\r' ? "\r\n" : "\n";
-                        lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevNewLine, Markers.EMPTY));
-                    }
-                    if (marginBuilder != null) {
+                    if ((sourceArr[i - 1] == '\n' || sourceArr[i - 1] == '\r' && sourceArr[i -2] == '\n')) {
+                        String prevLineLine = sourceArr[i - 1] == '\n' ? "\n" : "\r\n";
+                        lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevLineLine, Markers.EMPTY));
+                    } else if (marginBuilder != null) { // Javadoc contains a new line that only contains whitespace.
                         String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
-                        marginBuilder.append(newLine);
-                        continue;
+                        lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), newLine, Markers.EMPTY));
+                        javadocContent.append(marginBuilder.substring(marginBuilder.indexOf("\n") + 1));
                     }
                     javadocContent.append(c);
                 }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -123,14 +123,13 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                     firstPrefix = firstPrefixBuilder.toString();
                     inFirstPrefix = false;
                 } else {
-                    if (i > 0 && sourceArr[i - 1] == '\n') {
-                        String prevNewLine = i > 1 && sourceArr[i - 2] == '\r' ? "\r\n" : "\n";
-                        lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevNewLine, Markers.EMPTY));
-                    }
-                    if (marginBuilder != null) {
+                    if ((sourceArr[i - 1] == '\n' || sourceArr[i - 1] == '\r' && sourceArr[i -2] == '\n')) {
+                        String prevLineLine = sourceArr[i - 1] == '\n' ? "\n" : "\r\n";
+                        lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevLineLine, Markers.EMPTY));
+                    } else if (marginBuilder != null) { // Javadoc contains a new line that only contains whitespace.
                         String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
-                        marginBuilder.append(newLine);
-                        continue;
+                        lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), newLine, Markers.EMPTY));
+                        javadocContent.append(marginBuilder.substring(marginBuilder.indexOf("\n") + 1));
                     }
                     javadocContent.append(c);
                 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1245,18 +1245,37 @@ interface JavadocTest : JavaTreeTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1374")
     @Test
-    fun tagAfterBlankLineWithMarginAfterText(jp: JavaParser) = assertParsePrintAndProcess(
+    fun tagAfterBlankNewLines(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
         CompilationUnit,
         """
             class Test {
                 /**
-                 * Text
+                 * New lines with whitespace followed by a param.
+                 
                  
                  * @return void
                  */
                 void method() {
                 }
+            }
+        """.trimIndent()
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1397")
+    @Test
+    fun textWithBlankNewLines(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            class Test {
+                /**
+                * JavaDocs treats whitespace differently when new lines exist
+                
+                
+                * with whitespace that is contained in pure text.
+                */
+                void method() {}
             }
         """.trimIndent()
     )


### PR DESCRIPTION
The DocTreeScanner parses whitespace differently based on what is being visited. I.E. text or param.

Fix:
Added `linebreaks` and handle whitespace appropriately when a new line is parsed that only contains whitespace.
Updated `javadocContent` so that indexes are set correctly.
Updated previous newline detection to account for CRLF.

Note:
The whitespace will be added as `JavaDoc$Text` rather than added in the margin of the linebreak if it's represented in the node as ` Text followed by a new line with only whitespace\n  {whitespace here}  \n ...`.

fixes #1397