### PR TITLE
Updated AddToTagVisitor to preserve non-tag content.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -32,6 +32,8 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Comparator;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.emptyList;
+
 @RequiredArgsConstructor
 public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
     private static final XPathMatcher DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencies");
@@ -79,7 +81,7 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
         Xml.Tag root = maven.getRoot();
         if (!root.getChild("dependencies").isPresent()) {
             doAfterVisit(new AddToTagVisitor<>(root, Xml.Tag.build("<dependencies/>"),
-                    new MavenTagInsertionComparator(root.getChildren())));
+                    new MavenTagInsertionComparator(root.getContent() == null ? emptyList() : root.getContent())));
         }
 
         doAfterVisit(new InsertDependencyInOrder(scope));
@@ -125,7 +127,7 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
                 );
 
                 doAfterVisit(new AddToTagVisitor<>(tag, dependencyTag,
-                        new InsertDependencyComparator(tag.getChildren(), dependencyTag)));
+                        new InsertDependencyComparator(tag.getContent() == null ? emptyList() : tag.getContent(), dependencyTag)));
                 maybeUpdateModel();
 
                 return tag;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeProperty.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeProperty.java
@@ -17,13 +17,9 @@ package org.openrewrite.maven;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.xml.AddToTagVisitor;
-import org.openrewrite.xml.ChangeTagValueVisitor;
-import org.openrewrite.xml.XmlParser;
-import org.openrewrite.xml.XmlVisitor;
+import org.openrewrite.xml.*;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.Comparator;
 import java.util.Optional;
 
 @Value
@@ -46,13 +42,13 @@ public class ChangeProperty<P> extends XmlVisitor<P> {
                     new MavenTagInsertionComparator(document.getRoot().getChildren())
             ).visitNonNull(document, p);
         } else {
-            if(!props.get().getChild(key).isPresent()) {
+            if (!props.get().getChild(key).isPresent()) {
                 Xml.Tag prop = new XmlParser().parse("<" + key + ">" + value + "</" + key + ">")
                         .get(0).getRoot();
                 document = (Xml.Document) new AddToTagVisitor<P>(
                         props.get(),
                         prop,
-                        Comparator.comparing(Xml.Tag::getName)
+                        new TagNameComparator()
                 ).visitNonNull(document, p);
             } else {
                 document = (Xml.Document) new ChangeTagValueVisitor<P>(props.get().getChild(key).get(), value)

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -111,7 +112,7 @@ public class ManageDependencies extends Recipe {
                         Xml.Tag root = document.getRoot();
                         if (!root.getChild("dependencyManagement").isPresent()) {
                             doAfterVisit(new AddToTagVisitor<>(root, Xml.Tag.build("<dependencyManagement>\n<dependencies/>\n</dependencyManagement>"),
-                                    new MavenTagInsertionComparator(root.getChildren())));
+                                    new MavenTagInsertionComparator(root.getContent())));
                         }
 
                         for (GroupArtifact ga : requiresDependencyManagement) {
@@ -165,7 +166,7 @@ public class ManageDependencies extends Recipe {
                 );
 
                 doAfterVisit(new AddToTagVisitor<>(tag, dependencyTag,
-                        new InsertDependencyComparator(tag.getChildren(), dependencyTag)));
+                        new InsertDependencyComparator(tag.getContent() == null ? emptyList() : tag.getContent(), dependencyTag)));
 
                 return tag;
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenTagInsertionComparator.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenTagInsertionComparator.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.maven;
 
+import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.*;
@@ -28,7 +29,7 @@ import java.util.*;
  * GAV coordinates, SCM, properties, but before plugins.
  * "After" ordering preference takes priority over "before".
  */
-public class MavenTagInsertionComparator implements Comparator<Xml.Tag> {
+public class MavenTagInsertionComparator implements Comparator<Content> {
     private static final List<String> canonicalOrdering = Arrays.asList(
             "modelVersion",
             "parent",
@@ -62,16 +63,22 @@ public class MavenTagInsertionComparator implements Comparator<Xml.Tag> {
             "profiles"
     );
 
-    private final Map<Xml.Tag, Integer> existingIndices = new IdentityHashMap<>();
+    private final Map<Content, Integer> existingIndices = new IdentityHashMap<>();
 
-    public MavenTagInsertionComparator(List<Xml.Tag> existingTags) {
+    public MavenTagInsertionComparator(List<? extends Content> existingTags) {
         for (int i = 0; i < existingTags.size(); i++) {
             existingIndices.put(existingTags.get(i), i);
         }
     }
 
     @Override
-    public int compare(Xml.Tag t1, Xml.Tag t2) {
+    public int compare(Content c1,Content c2) {
+        if (!(c1 instanceof Xml.Tag) || !(c2 instanceof Xml.Tag)) {
+            return 1;
+        }
+
+        Xml.Tag t1 = (Xml.Tag) c1;
+        Xml.Tag t2 = (Xml.Tag) c2;
         int i1 = existingIndices.getOrDefault(t1, -1);
         int i2 = existingIndices.getOrDefault(t2, -1);
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
@@ -19,6 +19,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.ArrayList;
@@ -30,13 +31,13 @@ public class AddToTagVisitor<P> extends XmlVisitor<P> {
     private final Xml.Tag tagToAdd;
 
     @Nullable
-    private final Comparator<Xml.Tag> tagComparator;
+    private final Comparator<Content> tagComparator;
 
     public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd) {
         this(scope, tagToAdd, null);
     }
 
-    public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd, @Nullable Comparator<Xml.Tag> tagComparator) {
+    public AddToTagVisitor(Xml.Tag scope, Xml.Tag tagToAdd, @Nullable Comparator<Content> tagComparator) {
         this.scope = scope;
         this.tagToAdd = tagToAdd;
         this.tagComparator = tagComparator;
@@ -64,7 +65,7 @@ public class AddToTagVisitor<P> extends XmlVisitor<P> {
                 formattedTagToAdd = formattedTagToAdd.withPrefix("\n");
             }
 
-            List<Xml.Tag> content = t.getContent() == null ? new ArrayList<>() : new ArrayList<>(t.getChildren());
+            List<Content> content = t.getContent() == null ? new ArrayList<>() : new ArrayList<>(t.getContent());
             content.add(formattedTagToAdd);
 
             if (tagComparator != null) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/TagNameComparator.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/TagNameComparator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import org.openrewrite.xml.tree.Content;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.Comparator;
+
+/**
+ * Helps to add a {@link Xml.Tag} in alphabetical order while preserving the position of non-tag {@link Content}.
+ * I.E. {@link Xml.Comment} or {@link Xml.ProcessingInstruction}
+ */
+public class TagNameComparator implements Comparator<Content> {
+
+    @Override
+    public int compare(Content c1, Content c2) {
+        if (!(c1 instanceof Xml.Tag) || !(c2 instanceof Xml.Tag)) {
+            return 1;
+        }
+
+        return ((Xml.Tag) c1).getName().compareTo(((Xml.Tag) c2).getName());
+    }
+}


### PR DESCRIPTION
**Issue**
`AddToTagVisitor` filters out non-tag content like comments, processing instructions, cdata, and entity references.

**Changes:
_contains breaking changes_**
- `InsertDependencyComparator` and `MavenTagInsertionComparator` implement `Comparator<Content>` instead of `Xml.Tag`. 
- Updated instantiations of `InsertDependencyComparator` and `MavenTagInsertionComparator` to use `Xml.Tag#getContent()` instead of `Xml.Tag#getChildren()`
- Added `TagNameComparator` to replace `Comparator.comparing(Xml.Tag::getName)`.

Note:
- Added executionContext to `AddDependencyTest` to reduce runtime by preventing the `JavaSourceSet` from being generated.



fixes #1392