### PR TITLE
Update MavenResolutionResult after changes in ChangeParentPom

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -155,16 +155,22 @@ public class ChangeParentPom extends Recipe {
                         tag.getChildValue("version")
                                 .flatMap(parentVersion -> findNewerDependencyVersion(targetGroupId, targetArtifactId, parentVersion, ctx))
                                 .ifPresent(newVersion -> {
-                                    if (!oldGroupId.equals(targetGroupId)) {
+                                    boolean isGroupIdChanged = !oldGroupId.equals(targetGroupId);
+                                    if (isGroupIdChanged) {
                                         doAfterVisit(new ChangeTagValueVisitor<>(tag.getChild("groupId").get(), targetGroupId));
                                     }
-                                    if (!oldArtifactId.equals(targetArtifactId)) {
+                                    boolean isArtifactIdChanged = !oldArtifactId.equals(targetArtifactId);
+                                    if (isArtifactIdChanged) {
                                         doAfterVisit(new ChangeTagValueVisitor<>(tag.getChild("artifactId").get(), targetArtifactId));
                                     }
-                                    if (!newVersion.equals(tag.getChildValue("version").orElse(null))) {
+                                    boolean isVersionChanged = !newVersion.equals(tag.getChildValue("version").orElse(null));
+                                    if (isVersionChanged) {
                                         doAfterVisit(new ChangeTagValueVisitor<>(tag.getChild("version").get(), newVersion));
                                     }
                                     doAfterVisit(new RemoveRedundantDependencyVersions());
+                                    if (isGroupIdChanged || isArtifactIdChanged || isVersionChanged) {
+                                        maybeUpdateModel();
+                                    }
                                 });
                     }
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -39,6 +39,16 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
         d = d.withMarkers(d.getMarkers().computeByType(getResolutionResult(), (resolutionResult, ignored) -> {
             Pom requested = resolutionResult.getPom().getRequested();
 
+            Optional<Xml.Tag> parent = document.getRoot().getChild("parent");
+            if (parent.isPresent()) {
+                Parent updatedParent = new Parent(new GroupArtifactVersion(
+                        parent.get().getChildValue("groupId").orElse(null),
+                        parent.get().getChildValue("artifactId").orElseThrow(() -> new IllegalStateException("GAV must have artifactId")),
+                        parent.get().getChildValue("version").orElse(null)
+                ), parent.get().getChildValue("relativePath").orElse(null));
+                requested = requested.withParent(updatedParent);
+            }
+
             Optional<Xml.Tag> dependencies = document.getRoot().getChild("dependencies");
             if (dependencies.isPresent()) {
                 List<Xml.Tag> eachDependency = dependencies.get().getChildren("dependency");


### PR DESCRIPTION
Changes:
- Added `maybeUpdateModel()` in `ChangeParentPom` after changes.
- Update parent of `MavenResolutionResult` in `UpdateMavenModel`.

fixes #1402