### PR TITLE
Fix for new lines without '*' ending with CRLF in Javadoc Visitors

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -124,10 +124,11 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
                     inFirstPrefix = false;
                 } else {
                     // Handle consecutive new lines.
-                    if ((sourceArr[i - 1] == '\n' || sourceArr[i - 1] == '\r' && sourceArr[i -2] == '\n')) {
+                    if ((sourceArr[i - 1] == '\n' ||
+                            sourceArr[i - 1] == '\r' && sourceArr[i - 2] == '\n')) {
                         String prevLineLine = sourceArr[i - 1] == '\n' ? "\n" : "\r\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevLineLine, Markers.EMPTY));
-                    } else if (marginBuilder != null) { // A new line that only contains whitespace.
+                    } else if (marginBuilder != null) { // A new line with no '*' that only contains whitespace.
                         String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), newLine, Markers.EMPTY));
                         javadocContent.append(marginBuilder.substring(marginBuilder.indexOf("\n") + 1));
@@ -152,7 +153,7 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
                                     marginBuilder.toString(), Markers.EMPTY));
                             javadocContent.append(c);
                         } else {
-                            String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
+                            String newLine = marginBuilder.toString().startsWith("\r") ? "\r\n" : "\n";
                             lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(),
                                     newLine, Markers.EMPTY));
                             String margin = marginBuilder.toString();

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -124,10 +124,11 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                     inFirstPrefix = false;
                 } else {
                     // Handle consecutive new lines.
-                    if ((sourceArr[i - 1] == '\n' || sourceArr[i - 1] == '\r' && sourceArr[i -2] == '\n')) {
+                    if ((sourceArr[i - 1] == '\n' ||
+                            sourceArr[i - 1] == '\r' && sourceArr[i -2] == '\n')) {
                         String prevLineLine = sourceArr[i - 1] == '\n' ? "\n" : "\r\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevLineLine, Markers.EMPTY));
-                    } else if (marginBuilder != null) { // A new line that only contains whitespace.
+                    } else if (marginBuilder != null) { // A new line with no '*' that only contains whitespace.
                         String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), newLine, Markers.EMPTY));
                         javadocContent.append(marginBuilder.substring(marginBuilder.indexOf("\n") + 1));
@@ -152,7 +153,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                                     marginBuilder.toString(), Markers.EMPTY));
                             javadocContent.append(c);
                         } else {
-                            String newLine = sourceArr[i - 1] == '\r' ? "\r\n" : "\n";
+                            String newLine = marginBuilder.toString().startsWith("\r") ? "\r\n" : "\n";
                             lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(),
                                     newLine, Markers.EMPTY));
                             String margin = marginBuilder.toString();

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1191,6 +1191,34 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1411")
+    @Test
+    fun noMarginWithCRLF(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit, "" +
+                "/**\r\n" +
+                " * Line 1.\r\n" +
+                "   Text with no margin.\r\n" +
+                " */\r\n" +
+                "public class A {\r\n" +
+                "}"
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1411")
+    @Test
+    fun emptyLinesWithCRLF(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit, "" +
+                "public class A {\r\n" +
+                "  /** Text \r\n" +
+                "         \r\n" +
+                "         \r\n" +
+                "     @param arg0 desc\r\n" +
+                "   */\r\n" +
+                "  void method(int arg0) {}\r\n" +
+                "}"
+    )
+
     @Issue("https://github.com/openrewrite/rewrite/issues/976")
     @Test
     fun multilineJavaDocWithCRLF(jp: JavaParser) = assertParsePrintAndProcess(


### PR DESCRIPTION
Updated detection of a newline character in JavadocVisitors for new lines without a '*'.

fixes #1411