### PR TITLE
Add trailing whitespace to body in JavaDocVisitors.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -335,14 +335,12 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
             body.add((Javadoc) scan(blockTag, body));
         }
 
-        if (lineBreaks.isEmpty()) {
-            if (cursor < source.length()) {
-                String trailingWhitespace = source.substring(cursor);
-                if (!trailingWhitespace.isEmpty()) {
-                    body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
-                }
-            }
-        } else {
+        if (cursor < source.length() && source.substring(cursor).contains(" ")) {
+            String trailingWhitespace = source.substring(cursor);
+            body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
+        }
+
+        if (!lineBreaks.isEmpty()) {
             body.addAll(lineBreaks.values());
         }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -348,14 +348,12 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
             body.addAll(convertMultiline(singletonList(blockTag)));
         }
 
-        if (lineBreaks.isEmpty()) {
-            if (cursor < source.length()) {
-                String trailingWhitespace = source.substring(cursor);
-                if (!trailingWhitespace.isEmpty()) {
-                    body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
-                }
-            }
-        } else {
+        if (cursor < source.length() && source.substring(cursor).contains(" ")) {
+            String trailingWhitespace = source.substring(cursor);
+            body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
+        }
+
+        if (!lineBreaks.isEmpty()) {
             body.addAll(lineBreaks.values());
         }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1091,7 +1091,6 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
-    @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/1094")
     @Test
     fun trailingWhitespaceAfterText(jp: JavaParser) = assertParsePrintAndProcess(
@@ -1109,7 +1108,6 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
-    @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/1094")
     @Test
     fun trailingWhitespaceAfterAnnotation(jp: JavaParser) = assertParsePrintAndProcess(


### PR DESCRIPTION
- Updated conditions to always add trailing whitespace if it exists in JavaDocVisitors.

fixes #1094