### PR TITLE
Add whitespace before equals of attributes in javadoc visitors.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11JavadocVisitor.java
@@ -205,6 +205,9 @@ public class Java11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
                 cursor++;
                 beforeEqual.add(lineBreak);
             }
+            String whitespaceBeforeEqual = whitespaceBeforeAsString();
+            beforeEqual.add(new Javadoc.Text(randomId(), Markers.EMPTY, whitespaceBeforeEqual));
+
             sourceBefore("=");
 
             while ((lineBreak = lineBreaks.remove(cursor + 1)) != null) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -205,6 +205,9 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                 cursor++;
                 beforeEqual.add(lineBreak);
             }
+            String whitespaceBeforeEqual = whitespaceBeforeAsString();
+            beforeEqual.add(new Javadoc.Text(randomId(), Markers.EMPTY, whitespaceBeforeEqual));
+
             sourceBefore("=");
 
             while ((lineBreak = lineBreaks.remove(cursor + 1)) != null) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -754,7 +754,7 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1409")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1412")
     @Test
     fun paramWithMultilineHtmlAttributeNewLineBeforeEquals(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
@@ -763,7 +763,7 @@ interface JavadocTest : JavaTreeTest {
             interface Test {
                 /**
                  * @param contentType <a href
-                 *= "https://www..."> label</a>
+                 *    = "https://www..."> label</a>
                  */
                 boolean test(int contentType);
             }


### PR DESCRIPTION
fixes #1412