### PR TITLE
Prevent infinite recursion in JsonPathMatcher.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
@@ -17,6 +17,7 @@ package org.openrewrite.yaml;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
@@ -148,7 +149,7 @@ public class JsonPathMatcher {
             for (Tree path : cursorPath) {
                 JsonPathYamlVisitor v = new JsonPathYamlVisitor(cursorPath, path);
                 for (int i = 1, len = ctx.getParent().getChildCount(); i < len; i++) {
-                    result = v.visit(ctx.getParent().getChild(i));
+                    result = ctx == ctx.getParent().getChild(i) ? v.visit(ctx.getChild(i)) : v.visit(ctx.getParent().getChild(i));
                     if (result == null) {
                         break;
                     }
@@ -159,7 +160,6 @@ public class JsonPathMatcher {
             }
             return result;
         }
-
 
         @Override
         public Object visitWildcardExpression(JsonPath.WildcardExpressionContext ctx) {

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
@@ -78,6 +78,7 @@ class JsonPathMatcherTest {
     private val appLabel = "$.metadata.labels.app"
     private val appLabelBracket = "$.metadata.labels['app']"
     private val recurseSpecContainers = "..spec.containers"
+    private val recurseForContainer = "$..containers"
     private val firstContainerSlice = "$.spec.template.spec.containers[:1]"
     private val allContainerSlices = "$.spec.template.spec.containers[*]"
     private val allSpecChildren = "$.spec.template.spec.*"
@@ -103,6 +104,12 @@ class JsonPathMatcherTest {
     @Test
     fun `must recurse to find elements`() {
         val results = visit(recurseSpecContainers, source)
+        assertThat(results).hasSize(3)
+    }
+
+    @Test
+    fun `must recurse to find sub-elements`() {
+        val results = visit(recurseForContainer, source)
         assertThat(results).hasSize(3)
     }
 


### PR DESCRIPTION
- Added check to prevent the ParseTree to recurse back to itself on `ctx.getParent().getChild(i)` in JsonPathMatcher.

fixes #1420