### PR TITLE
Alter xml attribute

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeXMLAttribute.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeXMLAttribute.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangeXMLAttribute extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Change XML Attribute";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Alters XML Attribute value within specified element.";
+    }
+
+    @Option(displayName = "element name",
+            description = "The name of the element whose attribute's value is to be changed.",
+            example = "property")
+    String elementName;
+
+    @Option(displayName = "Attribute name",
+            description = "The name of the attribute whose value is to be changed.",
+            example = "name")
+    String attributeName;
+
+    @Option(displayName = "New value",
+            description = "The new value to be used for key specified by `attributeName`.",
+            example = "newfoo.bar.attribute.value.string")
+    String newValue;
+
+    @Option(displayName = "Old value",
+            example = "foo.bar.attribute.value.string",
+            required = false,
+            description = "Only change the property value if it matches the configured `oldValue`.")
+    @Nullable
+    String oldValue;
+
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "'**/application-*.xml'")
+    @Nullable
+    String fileMatcher;
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new ChangeXMLAttributeVisitor<>(elementName, attributeName, oldValue, newValue);
+    }
+}

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeXMLAttributeVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeXMLAttributeVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import org.openrewrite.xml.tree.Xml;
+
+public class ChangeXMLAttributeVisitor<P> extends XmlVisitor<P> {
+
+    private final String elementName;
+    private final String attributeName;
+    private final String oldValue;
+    private final String newValue;
+
+    public ChangeXMLAttributeVisitor(String elementName, String attributeName, String oldValue, String newValue) {
+        this.elementName = elementName;
+        this.attributeName = attributeName;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    @Override
+    public Xml visitTag(Xml.Tag tag, P p) {
+        Xml.Tag t = tag;
+        if (tag.getName().equals(elementName)) {
+            t.getAttributes().forEach( a -> this.visitAttribute(a, p));
+        }
+        t = (Xml.Tag)super.visitTag(t, p);
+        return t;
+    }
+
+    @Override
+    public Xml visitAttribute(Xml.Attribute attribute, P p) {
+
+        if(!attribute.getKeyAsString().equals(attributeName)) {
+            return attribute;
+        }
+        if(!attribute.getValueAsString().startsWith(oldValue)) {
+            return attribute;
+        }
+        String changedValue = attribute.getValueAsString().replace(oldValue, newValue);
+        Xml.Attribute a = attribute;
+        return a.withValue(
+                new Xml.Attribute.Value(attribute.getId(),
+                                        "",
+                                        attribute.getMarkers(),
+                                        attribute.getValue().getQuote(),
+                                        changedValue));
+    }
+}

--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/ChangeXMLAttributeTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/ChangeXMLAttributeTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.xml.tree.Xml
+
+class ChangeXMLAttributeTest: XmlRecipeTest {
+
+    @Test
+    fun alterAttribute() = assertChanged(
+            recipe = toRecipe {
+                object : XmlVisitor<ExecutionContext>() {
+                    override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
+
+                            doAfterVisit(ChangeXMLAttributeVisitor("bean","id","myBean.subpackage","myBean2.subpackage"))
+
+                        return super.visitDocument(x, p)
+                    }
+                }
+            },
+            before = """
+            <beans>
+                <bean id='myBean.subpackage.subpackage2'/>
+            </beans>
+        """,
+            after = """
+            <beans>
+                <bean id='myBean2.subpackage.subpackage2'/>
+            </beans>
+        """,
+            cycles = 2
+    )
+}

--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/ChangeXMLAttributeTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/ChangeXMLAttributeTest.kt
@@ -22,27 +22,54 @@ import org.openrewrite.xml.tree.Xml
 class ChangeXMLAttributeTest: XmlRecipeTest {
 
     @Test
-    fun alterAttribute() = assertChanged(
-            recipe = toRecipe {
-                object : XmlVisitor<ExecutionContext>() {
-                    override fun visitDocument(x: Xml.Document, p: ExecutionContext): Xml {
-
-                            doAfterVisit(ChangeXMLAttributeVisitor("bean","id","myBean.subpackage","myBean2.subpackage"))
-
-                        return super.visitDocument(x, p)
-                    }
-                }
-            },
+    fun alterAttributeWhenElementAndAttributeMatch() = assertChanged(
+            recipe = ChangeXMLAttribute("bean","id","myBean2.subpackage","myBean.subpackage",null)
+            ,
             before = """
             <beans>
                 <bean id='myBean.subpackage.subpackage2'/>
+                <other id='myBean.subpackage.subpackage2'/>
             </beans>
         """,
             after = """
             <beans>
                 <bean id='myBean2.subpackage.subpackage2'/>
+                <other id='myBean.subpackage.subpackage2'/>
+            </beans>
+        """
+
+    )
+
+    @Test
+    fun alterAttributeWithNullOldValue() = assertChanged(
+            recipe = ChangeXMLAttribute("bean","id","myBean2.subpackage",null,null),
+            before = """
+            <beans>
+                <bean id='myBean.subpackage.subpackage2'/>
+                <other id='myBean.subpackage.subpackage2'/>
             </beans>
         """,
-            cycles = 2
+            after = """
+            <beans>
+                <bean id='myBean2.subpackage'/>
+                <other id='myBean.subpackage.subpackage2'/>
+            </beans>
+        """,
+            cycles = 1,
+            expectedCyclesThatMakeChanges = 1
+    )
+
+
+
+    @Test
+    fun attributeNotMatched() = assertUnchanged(
+
+            recipe = ChangeXMLAttribute("bean","id","myBean2.subpackage","not.matched",null),
+            before = """
+            <beans>
+                <bean id='myBean.subpackage.subpackage2'/>
+                <other id='myBean.subpackage.subpackage2'/>
+            </beans>
+        """
     )
 }


### PR DESCRIPTION
This PR is meant to provide the ability to alter the value of a named Xml attribute within a specified element, and can also be restricted to operate only on matched file names.

The recipe parameters are:
`elementName` the name of the element to look for matching attributes
`attributeName` the name of the attribute whose value should be altered
`newValue`        the value to replace the old value of the attribute if found
`oldValue`         the value of the attribute to search for. This is an optional parameter. If supplied, the starting part of the attribute value matching this will be replaced by the `newValue`, leaving the trailing part intact. If not supplied, all attributes with a matching name inside a matching element will have their values set to `newValue` overwriting whatever was previously there.
`fileMatcher`     the standard optional glob expression to specify files to be modified.

Te idea behind this came from a wish to migrate persistence.xml files as part of a javax->jakarta migration. It has been tested using https://github.com/ivargrimstad/jakartaee-duke/tree/start-tutorial/complete-duke as a test app to migrate.