### PR TITLE
Temporarily pin jackson dependencies to 2.13.1

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -9,10 +9,10 @@ dependencies {
     compileOnly("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
     testImplementation("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
 
-    api("com.fasterxml.jackson.core:jackson-databind:latest.release")
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:latest.release")
-    api("com.fasterxml.jackson.module:jackson-module-parameter-names:latest.release")
-    api("com.fasterxml.jackson.module:jackson-module-kotlin:latest.release")
+    api("com.fasterxml.jackson.core:jackson-databind:2.13.1")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.1")
+    api("com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.1")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
 
     implementation("org.graalvm.sdk:graal-sdk:latest.release")
     testImplementation("org.graalvm.sdk:graal-sdk:latest.release")

--- a/rewrite-groovy/build.gradle.kts
+++ b/rewrite-groovy/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
     api("org.jetbrains:annotations:latest.release")
 
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     testImplementation(project(":rewrite-test"))
     testRuntimeOnly("org.codehaus.groovy:groovy-all:latest.release")

--- a/rewrite-hcl/build.gradle.kts
+++ b/rewrite-hcl/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("org.antlr:antlr4:latest.release")
     implementation("io.micrometer:micrometer-core:latest.release")

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
     implementation("org.xerial.snappy:snappy-java:1.1.8.4")
 
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("org.ow2.asm:asm:latest.release")
     implementation("org.ow2.asm:asm-util:latest.release")

--- a/rewrite-json/build.gradle.kts
+++ b/rewrite-json/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("org.antlr:antlr4:latest.release")
     implementation("io.micrometer:micrometer-core:latest.release")

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     api(project(":rewrite-xml"))
     api("org.jetbrains:annotations:latest.release")
 
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     // Caffeine 2.x works with Java 8, Caffeine 3.x is Java 11 only.
     implementation("com.github.ben-manes.caffeine:caffeine:2.+")
@@ -21,10 +21,10 @@ dependencies {
     // FIXME: switch to `latest.release`
     // when https://github.com/resilience4j/resilience4j/issues/1472 is resolved
     implementation("io.github.resilience4j:resilience4j-retry:1.7.0")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:latest.release")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:latest.release")
-    implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:latest.release")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:latest.release")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.1")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.1")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.1")
 
     implementation("org.slf4j:slf4j-api:1.7.+")
 

--- a/rewrite-properties/build.gradle.kts
+++ b/rewrite-properties/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("io.micrometer:micrometer-core:latest.release")
 

--- a/rewrite-protobuf/build.gradle.kts
+++ b/rewrite-protobuf/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("org.antlr:antlr4:latest.release")
     implementation("io.micrometer:micrometer-core:latest.release")

--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("org.antlr:antlr4:latest.release")
     implementation("io.micrometer:micrometer-core:latest.release")

--- a/rewrite-yaml/build.gradle.kts
+++ b/rewrite-yaml/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.13.1")
 
     implementation("org.antlr:antlr4:latest.release")
     implementation("org.yaml:snakeyaml:latest.release")


### PR DESCRIPTION
There is an open [issue](https://github.com/FasterXML/jackson-module-kotlin/issues/550) that prevents the release of `jackson-module-kotlin:2.13.2`.

Temporarily pinning back the Jackson dependencies to 2.13.1 until the issue is fixed.