### PR TITLE
Updated Hcl `Space` to add hash style comments.

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -356,7 +356,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
                 expressions.add(new Hcl.Literal(randomId(), prefix, Markers.EMPTY, value, value));
             } else if (part.templateInterpolation() != null) {
                 Space prefix = Space.format(prefix(part.templateInterpolation()));
-                expressions.add((Expression) visit(part.templateInterpolation()).withPrefix(prefix));
+                expressions.add(visit(part.templateInterpolation()).withPrefix(prefix));
             } else {
                 throw new IllegalStateException("Unsupported terminal node");
             }
@@ -557,7 +557,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
                 expressions.add(new Hcl.Literal(randomId(), prefix, Markers.EMPTY, value, value));
             } else if (part.templateInterpolation() != null) {
                 Space prefix = Space.format(prefix(part.templateInterpolation()));
-                expressions.add((Expression) visit(part.templateInterpolation()).withPrefix(prefix));
+                expressions.add(visit(part.templateInterpolation()).withPrefix(prefix));
             } else {
                 throw new IllegalStateException("Unsupported terminal node");
             }

--- a/rewrite-hcl/src/test/kotlin/org/openrewrite/hcl/format/AutoFormatTest.kt
+++ b/rewrite-hcl/src/test/kotlin/org/openrewrite/hcl/format/AutoFormatTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hcl.format
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
+import org.openrewrite.Recipe
+import org.openrewrite.hcl.HclRecipeTest
+
+class AutoFormatTest : HclRecipeTest {
+    override val recipe: Recipe
+        get() = AutoFormat()
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/974")
+    @Test
+    fun lineComments() = assertUnchanged(
+        before = """
+            # a hash comment with # or // is still 1 line.
+            // a slash comment with # or // is still 1 line.
+            resource {
+            }
+        """
+    )
+}

--- a/rewrite-hcl/src/test/kotlin/org/openrewrite/hcl/format/SpacesTest.kt
+++ b/rewrite-hcl/src/test/kotlin/org/openrewrite/hcl/format/SpacesTest.kt
@@ -15,12 +15,15 @@
  */
 package org.openrewrite.hcl.format
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
 import org.openrewrite.Recipe
 import org.openrewrite.Tree
 import org.openrewrite.hcl.HclParser
 import org.openrewrite.hcl.HclRecipeTest
 import org.openrewrite.hcl.style.SpacesStyle
+import org.openrewrite.hcl.tree.Comment
 import org.openrewrite.style.NamedStyles
 
 class SpacesTest : HclRecipeTest {
@@ -72,6 +75,40 @@ class SpacesTest : HclRecipeTest {
               size = 1
             }
         """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/974")
+    @Test
+    fun lineHashComment() = assertChanged(
+        before = """
+            # a hash comment with inline # or // is still 1 line.
+            resource{}
+        """,
+        after = """
+            # a hash comment with inline # or // is still 1 line.
+            resource {}
+        """,
+        afterConditions = { c ->
+            assertThat(c.prefix.comments.size).isEqualTo(1)
+            assertThat(c.prefix.comments[0].style).isEqualTo(Comment.Style.LINE_HASH)
+        }
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/974")
+    @Test
+    fun lineSlashComment() = assertChanged(
+        before = """
+            // a slash comment with inline # or // is still 1 line.
+            resource{}
+        """,
+        after = """
+            // a slash comment with inline # or // is still 1 line.
+            resource {}
+        """,
+        afterConditions = { c ->
+            assertThat(c.prefix.comments.size).isEqualTo(1)
+            assertThat(c.prefix.comments[0].style).isEqualTo(Comment.Style.LINE_SLASH)
+        }
     )
 
     private fun spaces(style: SpacesStyle) = listOf(


### PR DESCRIPTION
Changes:
- Updated Hcl Space to add hash style comments
- Updated single-line comment to consume all characters until a new line.

fixes #974