### PR TITLE
Only compare the Xml.Tags in InsertDependencyComparator

### DIFF
--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/AddDependencyTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/AddDependencyTest.kt
@@ -327,6 +327,8 @@ class AddDependencyTest {
                                     <artifactId>commons-lang</artifactId>
                                     <version>1.0</version>
                                 </dependency>
+                                <!-- comment 3 -->
+                                <?processing instruction3?>
                             </dependencies>
                         </project>
                     """.trimIndent()
@@ -355,6 +357,8 @@ class AddDependencyTest {
                             <version>29.0-jre</version>
                             <scope>test</scope>
                         </dependency>
+                        <!-- comment 3 -->
+                        <?processing instruction3?>
                     </dependencies>
                 </project>
             """.trimIndent()


### PR DESCRIPTION
Changes:
- Extract the `Xml.Tag`s from `List<? extends Content> existingDependencies` for sorting.
- Only sort `Xml.Tag`s in `InsertDependencyComparator#dependencyComparator`.
- Apply ideally sorted position to the list of content.

Note:
- The bug only occurred on large sets of dependencies. Maven parsing took 10s-15s, so the test has not been added. 

fixes #1442