### PR TITLE
Pin `com.puppycrawl.tools:checkstyle` to 9.+

### DIFF
--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
 
     implementation("org.antlr:antlr4:latest.release")
-    compileOnly("com.puppycrawl.tools:checkstyle:latest.release") {
+    compileOnly("com.puppycrawl.tools:checkstyle:9.+") {
         isTransitive = false
     }
     implementation("commons-lang:commons-lang:latest.release")
@@ -32,7 +32,7 @@ dependencies {
     implementation("org.ow2.asm:asm-util:latest.release")
 
     testImplementation("org.yaml:snakeyaml:latest.release")
-    testImplementation("com.puppycrawl.tools:checkstyle:latest.release") {
+    testImplementation("com.puppycrawl.tools:checkstyle:9.+") {
         isTransitive = false
     }
     testImplementation(project(":rewrite-test"))


### PR DESCRIPTION
Per [docs](https://checkstyle.sourceforge.io/#JRE_and_JDK) checkstyle 10.x does not support java 8.
fixes #1451