### PR TITLE
Fix javac and java reflection type mapping for constructors and super-type of enums.

### DIFF
--- a/rewrite-groovy/src/main/resources/GroovyTypeGoat.groovy
+++ b/rewrite-groovy/src/main/resources/GroovyTypeGoat.groovy
@@ -32,7 +32,15 @@ abstract class JavaTypeGoat<T, S extends PT<S> & C> {
         }
     }
 
-    enum EnumType {
+    enum EnumTypeA {
+    }
+
+    enum EnumTypeB {
+        FOO("bar")
+        private String label
+        EnumTypeB(String label) {
+            this.label = label
+        }
     }
 
     abstract class ExtendsJavaTypeGoat extends JavaTypeGoat<T, S> {
@@ -56,7 +64,8 @@ abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     abstract <U> PT<U> genericUnbounded(PT<U> n);
     abstract void genericArray(PT<C>[] n);
     abstract void inner(C.Inner n);
-    abstract void enumType(EnumType n);
+    abstract void enumTypeA(EnumTypeA n);
+    abstract void enumTypeB(EnumTypeB n);
     abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> n);
     abstract <U extends TypeA & PT<U> & C> U genericIntersection(U n);
     abstract T genericT(T n); // remove after signatures are common.

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
@@ -203,8 +203,7 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
                             fields = new ArrayList<>();
                         }
                         fields.add(variableType(elem, clazz));
-                    } else if ((!JavaType.FullyQualified.Kind.Enum.equals(clazz.getKind()) || !"<init>".equals(elem.name.toString())) &&
-                            elem instanceof Symbol.MethodSymbol &&
+                    } else if (elem instanceof Symbol.MethodSymbol &&
                             (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL | Flags.ANONCONSTR)) == 0) {
                         if (methods == null) {
                             methods = new ArrayList<>();

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -202,8 +202,7 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                             fields = new ArrayList<>();
                         }
                         fields.add(variableType(elem, clazz));
-                    } else if ((!JavaType.FullyQualified.Kind.Enum.equals(clazz.getKind()) || !"<init>".equals(elem.name.toString())) &&
-                            elem instanceof Symbol.MethodSymbol &&
+                    } else if (elem instanceof Symbol.MethodSymbol &&
                             (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL | Flags.ANONCONSTR)) == 0) {
                         if (methods == null) {
                             methods = new ArrayList<>();

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -163,7 +163,9 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
 
             typeCache.put(sym.flatName().toString(), clazz);
 
-            JavaType.FullyQualified supertype = TypeUtils.asFullyQualified(type(symType.supertype_field));
+            JavaType.FullyQualified supertype = TypeUtils.asFullyQualified(type(
+                    JavaType.FullyQualified.Kind.Enum.equals(clazz.getKind()) && isTypeAttributedGeneric(symType.supertype_field) ?
+                            symType.supertype_field.tsym.type : symType.supertype_field));
 
             JavaType.FullyQualified owner = null;
             if (sym.owner instanceof Symbol.ClassSymbol) {
@@ -200,9 +202,9 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                             fields = new ArrayList<>();
                         }
                         fields.add(variableType(elem, clazz));
-                    } else if (elem instanceof Symbol.MethodSymbol &&
-                            (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL |
-                                    Flags.ANONCONSTR)) == 0) {
+                    } else if ((!JavaType.FullyQualified.Kind.Enum.equals(clazz.getKind()) || !"<init>".equals(elem.name.toString())) &&
+                            elem instanceof Symbol.MethodSymbol &&
+                            (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL | Flags.ANONCONSTR)) == 0) {
                         if (methods == null) {
                             methods = new ArrayList<>();
                         }
@@ -236,6 +238,14 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
         }
 
         return clazz;
+    }
+
+    private boolean isTypeAttributedGeneric(Type type) {
+        return type.tsym != null && type.tsym.type != null &&
+                type instanceof Type.ClassType &&
+                ((Type.ClassType) type).typarams_field != null && ((Type.ClassType) type).typarams_field.length() > 0 &&
+                signatureBuilder.classSignature(type).equals(signatureBuilder.classSignature(type.tsym.type)) &&
+                !signatureBuilder.parameterizedSignature(type).equals(signatureBuilder.parameterizedSignature(type.tsym.type));
     }
 
     private JavaType.Class.Kind getKind(Symbol.ClassSymbol sym) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -188,7 +188,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
                 }
             }
 
-            if (clazz.getDeclaredConstructors().length > 0 && !mappedClazz.getKind().equals(JavaType.FullyQualified.Kind.Enum)) {
+            if (clazz.getDeclaredConstructors().length > 0) {
                 if (methods == null) {
                     methods = new ArrayList<>(clazz.getDeclaredConstructors().length);
                 }
@@ -319,7 +319,9 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         if (method.getParameters().length > 0) {
             paramNames = new ArrayList<>(method.getParameters().length);
             for (Parameter p : method.getParameters()) {
-                paramNames.add(p.getName());
+                if (!p.isSynthetic()) {
+                    paramNames.add(p.getName());
+                }
             }
         }
 
@@ -356,8 +358,10 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         if (method.getParameters().length > 0) {
             parameterTypes = new ArrayList<>(method.getParameters().length);
             for (Parameter parameter : method.getParameters()) {
-                Type parameterizedType = parameter.getParameterizedType();
-                parameterTypes.add(type(parameterizedType == null ? parameter.getType() : parameterizedType));
+                if (!parameter.isSynthetic()) {
+                    Type parameterizedType = parameter.getParameterizedType();
+                    parameterTypes.add(type(parameterizedType == null ? parameter.getType() : parameterizedType));
+                }
             }
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -48,12 +48,11 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         }
 
         String signature = signatureBuilder.signature(type);
-        JavaType existing = (JavaType) typeCache.get(signature);
+        JavaType existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }
 
-        JavaType mapped;
         if (type instanceof Class) {
             Class<?> clazz = (Class<?>) type;
             if (clazz.isArray()) {
@@ -94,7 +93,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
         JavaType.FullyQualified mappedClazz = classTypeWithoutParameters(clazz);
 
         if (clazz.getTypeParameters().length > 0) {
-            JavaType existing = (JavaType) typeCache.get(signature);
+            JavaType existing = typeCache.get(signature);
             if (existing != null) {
                 return existing;
             }
@@ -116,7 +115,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
     private JavaType.FullyQualified classTypeWithoutParameters(Class<?> clazz) {
         String className = clazz.getName();
-        JavaType.Class mappedClazz = (JavaType.Class) typeCache.get(className);
+        JavaType.Class mappedClazz = typeCache.get(className);
 
         if (mappedClazz == null) {
             JavaType.Class.Kind kind;
@@ -189,12 +188,12 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
                 }
             }
 
-            if(clazz.getDeclaredConstructors().length > 0) {
-                if(methods == null) {
+            if (clazz.getDeclaredConstructors().length > 0 && !mappedClazz.getKind().equals(JavaType.FullyQualified.Kind.Enum)) {
+                if (methods == null) {
                     methods = new ArrayList<>(clazz.getDeclaredConstructors().length);
                 }
                 for (Constructor<?> ctor : clazz.getDeclaredConstructors()) {
-                    if(!ctor.isSynthetic()) {
+                    if (!ctor.isSynthetic()) {
                         methods.add(method(ctor, mappedClazz));
                     }
                 }
@@ -274,7 +273,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
     private JavaType.Variable field(Field field) {
         String signature = signatureBuilder.variableSignature(field);
-        JavaType.Variable existing = (JavaType.Variable) typeCache.get(signature);
+        JavaType.Variable existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }
@@ -302,7 +301,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
 
     public JavaType.Method method(Method method) {
         JavaType.FullyQualified type = (JavaType.FullyQualified) type(method.getDeclaringClass());
-        if(type instanceof JavaType.Parameterized) {
+        if (type instanceof JavaType.Parameterized) {
             type = ((JavaType.Parameterized) type).getType();
         }
         return method(method, type);
@@ -311,7 +310,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
     private JavaType.Method method(Constructor<?> method, JavaType.FullyQualified declaringType) {
         String signature = signatureBuilder.methodSignature(method, declaringType.getFullyQualifiedName());
 
-        JavaType.Method existing = (JavaType.Method) typeCache.get(signature);
+        JavaType.Method existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }
@@ -369,7 +368,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
     private JavaType.Method method(Method method, JavaType.FullyQualified declaringType) {
         String signature = signatureBuilder.methodSignature(method, declaringType.getFullyQualifiedName());
 
-        JavaType.Method existing = (JavaType.Method) typeCache.get(signature);
+        JavaType.Method existing = typeCache.get(signature);
         if (existing != null) {
             return existing;
         }

--- a/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
+++ b/rewrite-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
@@ -32,7 +32,15 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
         }
     }
 
-    public enum EnumType {
+    public enum EnumTypeA {
+    }
+
+    public enum EnumTypeB {
+        FOO("bar");
+        private String label;
+        EnumTypeB(String label) {
+            this.label = label;
+        }
     }
 
     public abstract class ExtendsJavaTypeGoat extends JavaTypeGoat<T, S> {
@@ -56,7 +64,8 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract <U> PT<U> genericUnbounded(PT<U> n);
     public abstract void genericArray(PT<C>[] n);
     public abstract void inner(C.Inner n);
-    public abstract void enumType(EnumType n);
+    public abstract void enumTypeA(EnumTypeA n);
+    public abstract void enumTypeB(EnumTypeB n);
     public abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> n);
     public abstract <U extends TypeA & PT<U> & C> U genericIntersection(U n);
     public abstract T genericT(T n); // remove after signatures are common.

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
@@ -16,7 +16,6 @@
 package org.openrewrite.java
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
 import org.openrewrite.java.tree.Flag
@@ -176,7 +175,6 @@ interface JavaTypeMappingTest {
         assertThat(clazz.toString()).isEqualTo("Generic{U extends org.openrewrite.java.JavaTypeGoat${"$"}TypeA & org.openrewrite.java.PT<Generic{U}> & org.openrewrite.java.C}")
     }
 
-    @Disabled("https://github.com/openrewrite/rewrite/issues/1438")
     @Issue("https://github.com/openrewrite/rewrite/issues/1349")
     @Test
     fun enumType() {
@@ -186,7 +184,7 @@ interface JavaTypeMappingTest {
 
         val supertype = clazz.supertype
         assertThat(supertype).isNotNull
-        assertThat(supertype!!.toString()).isEqualTo("java.lang.Enum<org.openrewrite.java.JavaTypeGoat${"$"}EnumType>")
+        assertThat(supertype!!.toString()).isEqualTo("java.lang.Enum<Generic{E extends }>")
     }
 
     @Test

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaTypeMappingTest.kt
@@ -177,10 +177,22 @@ interface JavaTypeMappingTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1349")
     @Test
-    fun enumType() {
-        val clazz = firstMethodParameter("enumType") as JavaType.Class
+    fun enumTypeA() {
+        val clazz = firstMethodParameter("enumTypeA") as JavaType.Class
         val type = clazz.methods.find { it.name == "<constructor>" }
-        assertThat(type).isNull()
+        assertThat(type.toString()).isEqualTo("org.openrewrite.java.JavaTypeGoat${"$"}EnumTypeA{name=<constructor>,return=org.openrewrite.java.JavaTypeGoat${"$"}EnumTypeA,parameters=[]}")
+
+        val supertype = clazz.supertype
+        assertThat(supertype).isNotNull
+        assertThat(supertype!!.toString()).isEqualTo("java.lang.Enum<Generic{E extends }>")
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/pull/1453")
+    @Test
+    fun enumTypeB() {
+        val clazz = firstMethodParameter("enumTypeB") as JavaType.Class
+        val type = clazz.methods.find { it.name == "<constructor>" }
+        assertThat(type.toString()).isEqualTo("org.openrewrite.java.JavaTypeGoat${"$"}EnumTypeB{name=<constructor>,return=org.openrewrite.java.JavaTypeGoat${"$"}EnumTypeB,parameters=[java.lang.String]}")
 
         val supertype = clazz.supertype
         assertThat(supertype).isNotNull

--- a/rewrite-test/src/main/resources/JavaTypeGoat.java
+++ b/rewrite-test/src/main/resources/JavaTypeGoat.java
@@ -32,7 +32,15 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
         }
     }
 
-    public enum EnumType {
+    public enum EnumTypeA {
+    }
+
+    public enum EnumTypeB {
+        FOO("bar");
+        private String label;
+        EnumTypeB(String label) {
+            this.label = label;
+        }
     }
 
     public abstract class ExtendsJavaTypeGoat extends JavaTypeGoat<T, S> {
@@ -56,7 +64,8 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
     public abstract <U> PT<U> genericUnbounded(PT<U> n);
     public abstract void genericArray(PT<C>[] n);
     public abstract void inner(C.Inner n);
-    public abstract void enumType(EnumType n);
+    public abstract void enumTypeA(EnumTypeA n);
+    public abstract void enumTypeB(EnumTypeB n);
     public abstract <U extends PT<U> & C> InheritedJavaTypeGoat<T, U> inheritedJavaTypeGoat(InheritedJavaTypeGoat<T, U> n);
     public abstract <U extends TypeA & PT<U> & C> U genericIntersection(U n);
     public abstract T genericT(T n); // remove after signatures are common.


### PR DESCRIPTION
Changes:
- Added method to check for type attributed generics. I.E. `List<Integer>` vs `List<E>`
- Updated javac type mapping to set enum super type based on source code when the generic `E` is type attributed.
- Filter out synthetic parameters in `JavaReflectionTypeMapping`.
- Added an Enum with a constructor param to JavaTypeGoat.

fixes #1438