### PR TITLE
Update ManageDependencies

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -132,7 +132,7 @@ public class AddManagedDependency extends Recipe {
     }
 
     @Override
-    protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
+    protected MavenIsoVisitor<ExecutionContext> getApplicableTest() {
         if (!StringUtils.isNullOrEmpty(onlyIfUsing) && onlyIfUsing.contains(":")) {
             String[] ga = onlyIfUsing.split(":");
             return new MavenIsoVisitor<ExecutionContext>() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependencyVisitor.java
@@ -143,7 +143,7 @@ public class AddManagedDependencyVisitor extends MavenIsoVisitor<ExecutionContex
                                 "<version>" + version + "</version>\n" +
                                 (classifier == null ? "" :
                                         "<classifier>" + classifier + "</classifier>\n") +
-                                (type == null ? "" :
+                                (type == null || type.equals("jar") ? "" :
                                         "<type>" + type + "</type>\n") +
                                 (scope == null || "compile".equals(scope) ? "" :
                                         "<scope>" + scope + "</scope>\n") +

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/AddManagedDependencyTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/AddManagedDependencyTest.kt
@@ -40,7 +40,6 @@ class AddManagedDependencyTest {
         assertThat(validated).anyMatch { v ->
             !v.elementAt(0).isValid
         }
-
     }
 
     @Test
@@ -70,7 +69,7 @@ class AddManagedDependencyTest {
     }
 
     @Test
-    fun `Only added when using is define and has dependency`() {
+    fun `Only added when using is defined and has dependency`() {
         val results = addManagedDependency(false, "org.apache.logging.log4j:*")
                 .run(mavenParser.parseWithProvenance(
                         """


### PR DESCRIPTION
Update `ManageDependencies`:
 - New Option `addToRootPom` for adding new managed-dependency tags to the root pom.
 - Use `AddManagedDependencyVisitor` for creating new dependency-management tags.
 - Prefer the `UpgradeDependency` recipe for updating existing managed-dependency versions by removing ability to update existing managed-dependency versions.
Closes: #1457