### PR TITLE
Use comparator to find the best location for xml tag. fixes #1473

### DIFF
--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/UpgradeDependencyVersionTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/UpgradeDependencyVersionTest.kt
@@ -383,6 +383,70 @@ class UpgradeDependencyVersionTest : MavenRecipeTest {
     )
 
     @Test
+    fun addProperty() = assertChanged(
+        recipe = UpgradeDependencyVersion(
+            "junit",
+            "junit",
+            "4.13",
+            null,
+            null
+        ),
+        before = """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.managed.test</groupId>
+                <artifactId>a</artifactId>
+                <version>1.0.0</version>
+                <parent>
+                    <groupId>com.fasterxml.jackson</groupId>
+                    <artifactId>jackson-parent</artifactId>
+                    <version>2.9.1</version>
+                </parent>
+
+                <properties>
+                    <c>hello</c>
+                    <b>there</b>
+                    <a>friends</a>
+                </properties>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </dependency>
+                </dependencies>
+            </project>
+        """,
+        after = """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.managed.test</groupId>
+                <artifactId>a</artifactId>
+                <version>1.0.0</version>
+                <parent>
+                    <groupId>com.fasterxml.jackson</groupId>
+                    <artifactId>jackson-parent</artifactId>
+                    <version>2.9.1</version>
+                </parent>
+
+                <properties>
+                    <c>hello</c>
+                    <b>there</b>
+                    <a>friends</a>
+                    <version.junit>4.13</version.junit>
+                </properties>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </dependency>
+                </dependencies>
+            </project>
+        """
+    )
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1334")
     fun upgradeGuavaWithExplicitBlankVersionPattern() = assertChanged(
             recipe = UpgradeDependencyVersion(

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
@@ -66,10 +66,19 @@ public class AddToTagVisitor<P> extends XmlVisitor<P> {
             }
 
             List<Content> content = t.getContent() == null ? new ArrayList<>() : new ArrayList<>(t.getContent());
-            content.add(formattedTagToAdd);
-
             if (tagComparator != null) {
-                content.sort(tagComparator);
+                int i = 0;
+                for (; i < content.size(); i++) {
+                    if (tagComparator.compare(content.get(i), formattedTagToAdd) > 0) {
+                        content.add(i, formattedTagToAdd);
+                        break;
+                    }
+                }
+                if (i == content.size()) {
+                    content.add(formattedTagToAdd);
+                }
+            } else {
+                content.add(formattedTagToAdd);
             }
 
             t = t.withContent(content);

--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/AddToTagTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/AddToTagTest.kt
@@ -161,9 +161,9 @@ class AddToTagTest : XmlRecipeTest {
         """,
         after = """
             <beans>
+                <apple/>
                 <!-- comment -->
                 <?processing instruction?>
-                <apple/>
                 <banana/>
             </beans>
         """,


### PR DESCRIPTION
Inserting a new tag within an existing list of content tags was causing all children within the parent tag to sort (if a comparator was used with the `AddToTagVisitor`). This change will iterate over the list of existing child tags and find the first place (according to the comparator) in which the new tag will be inserted.