### PR TITLE
chore(ci): enable pull request creation for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,3 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(ci)"
-    open-pull-requests-limit: 0


### PR DESCRIPTION
I assume that the reasoning behind #1342 is that you were looking to avoid noise from the pull requests. There are better ways to do that in my opinion. Labels is one way

The challenge is  that this adds manual work and it is very easy to miss. At the moment these all the prs we're missing : 


![image](https://user-images.githubusercontent.com/8935151/159270701-2cdf25e8-0de7-4c97-913a-fee3fba388bb.png)

I noticed this pattern in our other modules as well. If agree that this a good idea, I can go ahead and send a PR for them as well

There are also some repositories where this is not set so it is sending PRs. For example, the maven plugin https://github.com/openrewrite/rewrite-maven-plugin/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies


@aegershman as maybe you have more context as of why you did this 

See also #1484 