### PR TITLE
Change how indentation is autodetected

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -11,10 +11,10 @@ dependencies {
 
     implementation("de.danielbechler:java-object-diff:latest.release")
 
-    api("com.fasterxml.jackson.core:jackson-databind:latest.release")
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:latest.release")
-    api("com.fasterxml.jackson.module:jackson-module-parameter-names:latest.release")
-    api("com.fasterxml.jackson.module:jackson-module-kotlin:latest.release")
+    api("com.fasterxml.jackson.core:jackson-databind:2.13.1")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.1")
+    api("com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.1")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
 
     implementation("net.java.dev.jna:jna-platform:latest.release")
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAsked.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAsked.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.Validated;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.semver.Semver;
+import org.openrewrite.xml.tree.Xml;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * This recipe will detect the presence of Java types (in Java ASTs) to determine if a dependency should be added
+ * to a maven build file. Java Provenance information is used to filter the type search to only those java ASTs that
+ * have the same coordinates of that of the pom. Additionally, if a "scope" is specified in this recipe, the dependency
+ * will only be added if there are types found in a given source set are transitively within that scope.
+ * <p>
+ * NOTE: IF PROVENANCE INFORMATION IS NOT PRESENT, THIS RECIPE WILL DO NOTHING.
+ */
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class AddDependencyNoQuestionsAsked extends Recipe {
+
+    @Option(displayName = "Group",
+            description = "The first part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
+            example = "com.google.guava")
+    private final String groupId;
+
+    @Option(displayName = "Artifact",
+            description = "The second part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
+            example = "guava")
+    private final String artifactId;
+
+    @Option(displayName = "Version",
+            description = "An exact version number, or node-style semver selector used to select the version number.",
+            example = "29.X",
+            required = false)
+    private final String version;
+
+    @Option(displayName = "Scope",
+            description = "A scope to use when it is not what can be inferred from usage. Most of the time this will be left empty, but " +
+                    "is used when adding a runtime, provided, or import dependency.",
+            example = "runtime",
+            valid = {"import", "runtime", "provided"},
+            required = false)
+    @Nullable
+    private final String scope;
+
+    @Option(displayName = "Type",
+            description = "The type of dependency to add. If omitted Maven defaults to assuming the type is \"jar\".",
+            valid = {"jar", "pom", "war"},
+            example = "jar",
+            required = false)
+    @Nullable
+    private String type;
+
+    @Option(displayName = "Classifier",
+            description = "A Maven classifier to add. Most commonly used to select shaded or test variants of a library",
+            example = "test",
+            required = false)
+    @Nullable
+    private String classifier;
+
+    @Option(displayName = "Optional",
+            description = "Set the value of the `<optional>` tag. No `<optional>` tag will be added when this is `null`.",
+            example = "true",
+            required = false)
+    @Nullable
+    private Boolean optional;
+
+    @Override
+    public Validated validate() {
+        Validated validated = super.validate();
+        //noinspection ConstantConditions
+        if (version != null) {
+            validated = validated.or(Semver.validate(version, null));
+        }
+        return validated;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Add Maven dependency";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add a maven dependency to a `pom.xml` file in the correct scope based on where it is used.";
+    }
+
+    @Override
+    protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
+        return ListUtils.map(before, s -> s.getMarkers().findFirst(JavaProject.class)
+                .map(javaProject -> (Tree) new MavenVisitor<ExecutionContext>() {
+                    @Override
+                    public Xml visitDocument(Xml.Document document, ExecutionContext executionContext) {
+                        Xml maven = super.visitDocument(document, executionContext);
+
+                        doAfterVisit(new AddDependencyNoQuestionsAskedVisitor(
+                                groupId, artifactId, version, scope,
+                                type, classifier, optional));
+
+                        return maven;
+                    }
+                }.visit(s, ctx))
+                .map(SourceFile.class::cast)
+                .orElse(s)
+        );
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAsked.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAsked.java
@@ -25,7 +25,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.Validated;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.xml.tree.Xml;
 
@@ -115,7 +115,7 @@ public class AddDependencyNoQuestionsAsked extends Recipe {
 
     @Override
     protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
-        return ListUtils.map(before, s -> s.getMarkers().findFirst(JavaProject.class)
+        return ListUtils.map(before, s -> s.getMarkers().findFirst(MavenResolutionResult.class)
                 .map(javaProject -> (Tree) new MavenVisitor<ExecutionContext>() {
                     @Override
                     public Xml visitDocument(Xml.Document document, ExecutionContext executionContext) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAskedVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAskedVisitor.java
@@ -88,7 +88,6 @@ public class AddDependencyNoQuestionsAskedVisitor extends MavenIsoVisitor<Execut
 
                 doAfterVisit(new AddToTagVisitor<>(tag, dependencyTag,
                         new InsertDependencyComparator(tag.getContent() == null ? emptyList() : tag.getContent(), dependencyTag)));
-                maybeUpdateModel();
 
                 return tag;
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAskedVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyNoQuestionsAskedVisitor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import static java.util.Collections.emptyList;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.internal.InsertDependencyComparator;
+import org.openrewrite.xml.AddToTagVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AddDependencyNoQuestionsAskedVisitor extends MavenIsoVisitor<ExecutionContext> {
+    private static final XPathMatcher DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencies");
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    @Nullable
+    private final String scope;
+
+    @Nullable
+    private final String type;
+
+    @Nullable
+    private final String classifier;
+
+    @Nullable
+    private final Boolean optional;
+
+    @Override
+    public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
+        Xml.Document maven = super.visitDocument(document, executionContext);
+
+        Xml.Tag root = maven.getRoot();
+        if (!root.getChild("dependencies").isPresent()) {
+            doAfterVisit(new AddToTagVisitor<>(root, Xml.Tag.build("<dependencies/>"),
+                    new MavenTagInsertionComparator(root.getContent() == null ? emptyList() : root.getContent())));
+        }
+
+        doAfterVisit(new InsertDependencyInOrder(scope));
+
+        return maven;
+    }
+
+    @RequiredArgsConstructor
+    private class InsertDependencyInOrder extends MavenVisitor<ExecutionContext> {
+
+        @Nullable
+        private final String scope;
+
+        @Override
+        public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            if (DEPENDENCIES_MATCHER.matches(getCursor())) {
+                String versionToUse = null;
+
+                Xml.Tag dependencyTag = Xml.Tag.build(
+                        "\n<dependency>\n" +
+                                "<groupId>" + groupId + "</groupId>\n" +
+                                "<artifactId>" + artifactId + "</artifactId>\n" +
+                                (version == null ? "" :
+                                        "<version>" + version + "</version>\n") +
+                                (classifier == null ? "" :
+                                        "<classifier>" + classifier + "</classifier>\n") +
+                                (scope == null || "compile".equals(scope) ? "" :
+                                        "<scope>" + scope + "</scope>\n") +
+                                (Boolean.TRUE.equals(optional) ? "<optional>true</optional>\n" : "") +
+                                "</dependency>"
+                );
+
+                doAfterVisit(new AddToTagVisitor<>(tag, dependencyTag,
+                        new InsertDependencyComparator(tag.getContent() == null ? emptyList() : tag.getContent(), dependencyTag)));
+                maybeUpdateModel();
+
+                return tag;
+            }
+
+            return super.visitTag(tag, ctx);
+        }
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -15,16 +15,18 @@
  */
 package org.openrewrite.maven;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
+import java.util.Optional;
+
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -49,14 +51,21 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
             example = "rewrite-testing-frameworks")
     String newArtifactId;
 
+    @Option(displayName = "New version",
+            description = "The new version to use.",
+            example = "2.0.0",
+            required = false)
+    @Nullable
+    String newVersion;
+
     @Override
     public String getDisplayName() {
-        return "Change Maven dependency groupId and artifactId";
+        return "Change Maven dependency groupId, artifactId and optionally the version";
     }
 
     @Override
     public String getDescription() {
-        return "Change the groupId and artifactId of a specified Maven dependency.";
+        return "Change the groupId, artifactId and optionally the version of a specified Maven dependency.";
     }
 
     @Override
@@ -72,6 +81,12 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                     Optional<Xml.Tag> artifactIdTag = tag.getChild("artifactId");
                     if (artifactIdTag.isPresent() && !newArtifactId.equals(artifactIdTag.get().getValue().orElse(null))) {
                         doAfterVisit(new ChangeTagValueVisitor<>(artifactIdTag.get(), newArtifactId));
+                    }
+                    if (newVersion != null) {
+                        Optional<Xml.Tag> versionTag = tag.getChild("version");
+                        if (versionTag.isPresent() && !newVersion.equals(versionTag.get().getValue().orElse(null))) {
+                            doAfterVisit(new ChangeTagValueVisitor<>(versionTag.get(), newVersion));
+                        }
                     }
                 }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.Validated;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.tree.ResolvedManagedDependency;
+import org.openrewrite.maven.tree.Scope;
+import org.openrewrite.xml.RemoveContentVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class RemoveManagedDependency extends Recipe {
+
+    @Option(displayName = "Group",
+            description = "The first part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
+            example = "com.google.guava")
+    String groupId;
+
+    @Option(displayName = "Artifact",
+            description = "The second part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
+            example = "guava")
+    String artifactId;
+
+    @Option(displayName = "Scope",
+            description = "Only remove dependencies if they are in this scope. If 'runtime', this will" +
+                    "also remove dependencies in the 'compile' scope because 'compile' dependencies are part of the runtime dependency set",
+            valid = {"compile", "test", "runtime", "provided"},
+            example = "compile",
+            required = false)
+    @Nullable
+    String scope;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Maven managed dependency";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes a single dependency from the <dependencyManagement><dependencies> section of the pom.xml.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RemoveManagedDependencyVisitor();
+    }
+
+    @Override
+    public Validated validate() {
+        return super.validate().and(Validated.test("scope", "Scope must be one of compile, runtime, test, or provided",
+                scope, s -> !Scope.Invalid.equals(Scope.fromName(s))));
+    }
+
+    private class RemoveManagedDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
+        @Override
+        public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            if (isManagedDependencyTag(groupId, artifactId)) {
+                Scope checkScope = scope != null ? Scope.fromName(scope) : null;
+                ResolvedManagedDependency dependency = findManagedDependency(tag, checkScope);
+                if (dependency != null) {
+                    doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                    maybeUpdateModel();
+                }
+            }
+
+            return super.visitTag(tag, ctx);
+        }
+    }
+}


### PR DESCRIPTION
This is a proposal to fix #1498 . I think it will lead to far better results as it's not a good idea to just consider the indent that is the most used (you can have more lines indented with 12 spaces than 4 in a file indented with 4 spaces). It definitely fixes my case and my guess is that it should work relatively well for all sorts of files.

Note that I have only adjusted the XML one as it's the one I use. Let's discuss the approach and if you find it OK, I can generalize it to Java.

====

For each indent value detected, we count all the lines whose indent is a
multiple of the current one. So typically, for 4 spaces, we will count as indented with 4 spaces lines with 4/8/12/16/... leading spaces.
This way, each potential candidate is evaluated together with the other
lines.

Also we don't count spaces and tabs in the same way and we don't count
lines that mix both formats.