### PR TITLE
Fixed a handful of binary operator mappings in GroovyParserVisitor.

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -627,12 +627,15 @@ public class GroovyParserVisitor {
                     assignOp = J.AssignmentOperation.Type.Addition;
                     break;
                 case "-=":
-                    assignOp = J.AssignmentOperation.Type.BitAnd;
+                    assignOp = J.AssignmentOperation.Type.Subtraction;
                     break;
                 case "&=":
-                    assignOp = J.AssignmentOperation.Type.BitOr;
+                    assignOp = J.AssignmentOperation.Type.BitAnd;
                     break;
                 case "|=":
+                    assignOp = J.AssignmentOperation.Type.BitOr;
+                    break;
+                case "^=":
                     assignOp = J.AssignmentOperation.Type.BitXor;
                     break;
                 case "/=":
@@ -649,9 +652,6 @@ public class GroovyParserVisitor {
                     break;
                 case ">>=":
                     assignOp = J.AssignmentOperation.Type.RightShift;
-                    break;
-                case "^=":
-                    assignOp = J.AssignmentOperation.Type.Subtraction;
                     break;
                 case ">>>=":
                     assignOp = J.AssignmentOperation.Type.UnsignedRightShift;

--- a/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/BinaryTest.kt
+++ b/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/BinaryTest.kt
@@ -17,6 +17,7 @@ package org.openrewrite.groovy.tree
 
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
 
 class BinaryTest : GroovyTreeTest {
 
@@ -32,26 +33,54 @@ class BinaryTest : GroovyTreeTest {
     @Test
     fun regexMatches() = assertParsePrintAndProcess(
         """
-            def UNSTABLE = /^([\d.-]+(alpha|beta|rc|m)[\d.-]+(groovy[\d.-]+)?|20030203.000550|20031129.200437|2004-03-19)${'$'}/
-            tasks.named("dependencyUpdates")?.configure {
-            gradleReleaseChannel = 'current'
-                rejectVersionIf {
-                    !(it.currentVersion.toLowerCase() ==~ UNSTABLE) && it.candidate.version.toLowerCase() ==~ UNSTABLE
-                }
-            }
-        """.trimIndent()
+            def REGEX = /\d+/
+            def text = "123"
+            def result = text =~ REGEX
+        """
     )
 
-    @Disabled
+    @Issue("https://github.com/openrewrite/rewrite/issues/1520")
     @Test
-    fun notOperatorAndBinaryExpression() = assertParsePrintAndProcess(
+    fun minusEquals() = assertParsePrintAndProcess(
         """
-            tasks.named("dependencyUpdates")?.configure {
-            gradleReleaseChannel = 'current'
-                rejectVersionIf {
-                    !(it.currentVersion.toLowerCase() == false) && it.candidate.version.toLowerCase() == false
-                }
-            }
-        """.trimIndent()
+            def a = 5
+            a -= 5
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1520")
+    @Test
+    fun divisionEquals() = assertParsePrintAndProcess(
+        """
+            def a = 5
+            a /= 5
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1520")
+    @Test
+    fun bitwiseAnd() = assertParsePrintAndProcess(
+        """
+            def a = 4
+            a &= 1
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1520")
+    @Test
+    fun bitwiseOr() = assertParsePrintAndProcess(
+        """
+            def a = 4
+            a |= 1
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1520")
+    @Test
+    fun bitwiseXOr() = assertParsePrintAndProcess(
+        """
+            def a = 4
+            a ^= 1
+        """
     )
 }

--- a/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/UnaryTest.kt
+++ b/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/UnaryTest.kt
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.groovy.tree
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class UnaryTest : GroovyTreeTest {
@@ -38,6 +39,29 @@ class UnaryTest : GroovyTreeTest {
     fun prefix() = assertParsePrintAndProcess(
         """
             int k = ++i;
+        """
+    )
+
+    @Disabled
+    @Test
+    fun unaryPlus() = assertParsePrintAndProcess(
+        """
+            int k = +10
+        """
+    )
+
+    @Test
+    fun unaryMinus() = assertParsePrintAndProcess(
+        """
+            int k = -10
+        """
+    )
+
+    @Disabled
+    @Test
+    fun negation() = assertParsePrintAndProcess(
+        """
+            def a = !true
         """
     )
 }


### PR DESCRIPTION
Changes:
- fixed `-=` mapping.
- fixed `&=` mapping.
- fixed `|=` mapping.
- fixed `^=` mapping.

Added disabled tests for negation and unary plus operators.

fixes #1520