### PR TITLE
Fixed unary not operator in GroovyParserVisitor.

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -872,6 +872,14 @@ public class GroovyParserVisitor {
         }
 
         @Override
+        public void visitNotExpression(NotExpression expression) {
+            Space fmt = sourceBefore("!");
+            JLeftPadded<J.Unary.Type> op = padLeft(EMPTY, J.Unary.Type.Not);
+            Expression expr = visit(expression.getExpression());
+            queue.add(new J.Unary(randomId(), fmt, Markers.EMPTY, op, expr, typeMapping.type(expression.getType())));
+        }
+
+        @Override
         public void visitDeclarationExpression(DeclarationExpression expression) {
             TypeTree typeExpr = visitVariableExpressionType(expression.getVariableExpression());
 

--- a/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/UnaryTest.kt
+++ b/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/UnaryTest.kt
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.groovy.tree
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
 
 class UnaryTest : GroovyTreeTest {
     @Test
@@ -42,7 +42,7 @@ class UnaryTest : GroovyTreeTest {
         """
     )
 
-    @Disabled
+    @Issue("https://github.com/openrewrite/rewrite/issues/1524")
     @Test
     fun negation() = assertParsePrintAndProcess(
         """


### PR DESCRIPTION
Changes:
- `!` operators will not be removed during Groovy parsing.
- Added visitNotExpression in GroovyParserVisitor.

fixes #1524