### PR TITLE
Change how indentation is autodetected

### DIFF
--- a/rewrite-xml/src/test/kotlin/org/openrewrite/xml/format/AutoDetectTest.kt
+++ b/rewrite-xml/src/test/kotlin/org/openrewrite/xml/format/AutoDetectTest.kt
@@ -53,7 +53,6 @@ class AutoDetectTest  {
         assertThat(tabsAndIndents.useTabCharacter).isFalse
     }
 
-    @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/1498")
     @Test
     fun autoDetectQuarkus() {


### PR DESCRIPTION
For each indent value detected, we count all the lines whose indent is a
multiple of the current one.
This way, each potential candidate is evaluated together with the other
lines.

Also we don't count spaces and tabs in the same way and we don't count
lines that mix both formats.

Finally, enables the previously failing test.

/cc @pway99 