### PR TITLE
Allow defining newVersion for ChangeDependencyGroupIdAndArtifactId

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -21,6 +21,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
 
@@ -49,14 +50,21 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
             example = "rewrite-testing-frameworks")
     String newArtifactId;
 
+    @Option(displayName = "New version",
+            description = "The new version to use.",
+            example = "2.0.0",
+            required = false)
+    @Nullable
+    String newVersion;
+
     @Override
     public String getDisplayName() {
-        return "Change Maven dependency groupId and artifactId";
+        return "Change Maven dependency groupId, artifactId and optionally the version";
     }
 
     @Override
     public String getDescription() {
-        return "Change the groupId and artifactId of a specified Maven dependency.";
+        return "Change the groupId, artifactId and optionally the version of a specified Maven dependency.";
     }
 
     @Override
@@ -75,6 +83,13 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                     if (artifactIdTag.isPresent() && !newArtifactId.equals(artifactIdTag.get().getValue().orElse(null))) {
                         doAfterVisit(new ChangeTagValueVisitor<>(artifactIdTag.get(), newArtifactId));
                         changed = true;
+                    }
+                    if (newVersion != null) {
+                        Optional<Xml.Tag> versionTag = tag.getChild("version");
+                        if (versionTag.isPresent() && !newVersion.equals(versionTag.get().getValue().orElse(null))) {
+                            doAfterVisit(new ChangeTagValueVisitor<>(versionTag.get(), newVersion));
+                            changed = true;
+                        }
                     }
                     if (changed) {
                         maybeUpdateModel();

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.kt
@@ -24,7 +24,8 @@ class ChangeDependencyGroupIdAndArtifactIdTest : MavenRecipeTest {
             "org.openrewrite.recipe",
             "rewrite-testing-frameworks",
             "org.openrewrite.recipe",
-            "rewrite-migrate-java"
+            "rewrite-migrate-java",
+            null
         )
 
     @Test
@@ -33,7 +34,8 @@ class ChangeDependencyGroupIdAndArtifactIdTest : MavenRecipeTest {
             "javax.activation",
             "javax.activation-api",
             "jakarta.activation",
-            "jakarta.activation-api"
+            "jakarta.activation-api",
+            null
         ),
         before = """
             <project>
@@ -99,7 +101,8 @@ class ChangeDependencyGroupIdAndArtifactIdTest : MavenRecipeTest {
             "org.openrewrite",
             "rewrite-java-8",
             "org.openrewrite",
-            "rewrite-java-11"
+            "rewrite-java-11",
+            null
         ),
         before = """
             <project>
@@ -152,4 +155,44 @@ class ChangeDependencyGroupIdAndArtifactIdTest : MavenRecipeTest {
         """
     )
 
+    @Test
+    fun changeDependencyGroupIdAndArtifactIdAndVersion() = assertChanged(
+        recipe =  ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "2.1.0"
+        ),
+        before = """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
+                        <version>1.2.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """,
+        after = """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                        <version>2.1.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """
+    )
 }


### PR DESCRIPTION
More often than not, when changing a groupId and artifactId, you will
have to adjust the version.
Of course, you can use UpgradeDependencyVersion to do so but having a
shortcut is really useful in practice.