### PR TITLE
Fix base-n conversion in GradleParser.

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -834,6 +834,13 @@ public class GroovyParserVisitor {
                 jType = JavaType.Primitive.Float;
             } else if (type == ClassHelper.int_TYPE || "java.lang.Integer".equals(type.getName())) {
                 jType = JavaType.Primitive.Int;
+                if (expression.getNodeMetaData().get("_INTEGER_LITERAL_TEXT") instanceof String) {
+                    String literalText = (String) expression.getNodeMetaData().get("_INTEGER_LITERAL_TEXT");
+                    // Groovy automatically converts numbers that start with 0 from base-n to an int.
+                    if (literalText.startsWith("0")) {
+                        text = literalText;
+                    }
+                }
             } else if (type == ClassHelper.long_TYPE || "java.lang.Long".equals(type.getName())) {
                 jType = JavaType.Primitive.Long;
             } else if (type == ClassHelper.short_TYPE || "java.lang.Short".equals(type.getName())) {

--- a/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/AssignmentTest.kt
+++ b/rewrite-groovy/src/test/kotlin/org/openrewrite/groovy/tree/AssignmentTest.kt
@@ -55,4 +55,16 @@ class AssignmentTest : GroovyTreeTest {
             int k = +10
         """
     )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1533")
+    @Test
+    fun baseNConversions() = assertParsePrintAndProcess(
+        """
+            def a = 01
+            def b = 001
+            def c = 0001
+            def d = 00001
+            def e = 000001
+        """
+    )
 }


### PR DESCRIPTION
Changes:
- Base-n numbers that start with a 0 will retain their values in the AST.
- Check the metadata for base-n conversion.
fixes #1533