### PR TITLE
Recipe: SimplifyConstantIfBranchExecution

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -632,4 +632,8 @@ class Java11SimplifyConsecutiveAssignmentsTest : Java11Test, SimplifyConsecutive
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11SimplifyConstantIfBranchExecutionTest : Java11Test, SimplifyConstantIfBranchExecutionTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11SimplifyMethodChainTest : Java11Test, SimplifyMethodChainTest

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -627,4 +627,8 @@ class Java8SimplifyConsecutiveAssignmentsTest : Java8Test, SimplifyConsecutiveAs
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8SimplifyConstantIfBranchExecutionTest : Java8Test, SimplifyConstantIfBranchExecutionTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8SimplifyMethodChainTest : Java8Test, SimplifyMethodChainTest

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
@@ -1,0 +1,115 @@
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SimplifyConstantIfBranchExecution extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Simplify constant if branch execution";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks for if expressions that are always `true` or `false` and simplifies them.";
+    }
+
+    @Override
+    protected JavaVisitor<ExecutionContext> getVisitor() {
+        return new SimplifyConstantIfBranchExecutionVisitor();
+    }
+
+    private static class SimplifyConstantIfBranchExecutionVisitor extends JavaVisitor<ExecutionContext> {
+
+        @Override
+        public J visitWhileLoop(J.WhileLoop whileLoop, ExecutionContext executionContext) {
+            return whileLoop;
+        }
+
+        @Override
+        public J visitBlock(J.Block block, ExecutionContext executionContext) {
+            J.Block bl = (J.Block) super.visitBlock(block, executionContext);
+            List<Statement> addStatements = getCursor().pollMessage("statements");
+            J.If removeIf = getCursor().pollMessage("remove-if");
+            if (removeIf != null) {
+                bl = maybeAutoFormat(bl, bl.withStatements(ListUtils.flatMap(bl.getStatements(), stmt -> {
+                    if (stmt == removeIf) {
+                        return addStatements;
+                    }
+                    return stmt;
+                })), executionContext, getCursor().getParent());
+            }
+            return bl;
+        }
+
+        @Override
+        public J visitIf(J.If if_, ExecutionContext context) {
+            J.If if__ = (J.If) super.visitIf(if_, context);
+            AtomicReference<Boolean> b = new AtomicReference<>(null);
+            new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public <T extends J> J.ControlParentheses<T> visitControlParentheses(J.ControlParentheses<T> controlParens, ExecutionContext executionContext) {
+                    J.ControlParentheses cp = super.visitControlParentheses(controlParens, executionContext);
+                    J.ControlParentheses cp2 = (J.ControlParentheses) new SimplifyBooleanExpressionVisitor<ExecutionContext>().visitNonNull(cp, executionContext);
+                    if (isLiteralTrue((Expression) cp2.getTree())) {
+                        b.getAndSet(true);
+                    } else if (isLiteralFalse((Expression) cp2.getTree())) {
+                        b.getAndSet(false);
+                    }
+                    // else leave it as null
+                    return cp;
+                }
+            }.visit(if__, context);
+            // The compile-time constant value of the if condition control parentheses.
+            Boolean compileTimeConstantBoolean = b.get();
+            // The simplification process did not result in resolving to a single 'true' or 'false' value
+            if (compileTimeConstantBoolean == null) {
+                return if__; // Return the original `if` (unmodified)
+            }
+            // True branch
+            if (compileTimeConstantBoolean) {
+                Statement s = if__.getThenPart();
+                if (s instanceof J.Block) {
+                    getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("statements", ((J.Block) s).getStatements());
+                    getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("remove-if", if__);
+                    return if__; // Return the original `if` (unmodified) since this will need to be replaced
+                } else {
+                    return maybeAutoFormat(if__, s, context, getCursor().getParent());
+                }
+            } else { // False branch
+                if (if__.getElsePart() != null) {
+                    // The `else` part needs to be kept
+                    Statement s = if__.getElsePart().getBody();
+                    if (s instanceof J.Block) {
+                        getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("statements", ((J.Block) s).getStatements());
+                        getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("remove-if", if__);
+                        return if__; // Return the original `if` (unmodified) since this will need to be replaced
+                    } else {
+                        return maybeAutoFormat(if__, s, context, getCursor().getParent());
+                    }
+                }
+                // The if statement can be completely removed
+                return null;
+            }
+        }
+
+        private static boolean isLiteralTrue(@Nullable Expression expression) {
+            return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(true);
+        }
+
+        private static boolean isLiteralFalse(@Nullable Expression expression) {
+            return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(false);
+        }
+    }
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -405,6 +405,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class SimplifyConsecutiveAssignmentsTck : SimplifyConsecutiveAssignmentsTest
 
     @Nested
+    inner class SimplifyConstantIfBranchExecutionTck : SimplifyConstantIfBranchExecutionTest
+
+    @Nested
     inner class SimplifyMethodChainTck : SimplifyMethodChainTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
@@ -1,0 +1,183 @@
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = SimplifyConstantIfBranchExecution()
+
+    @Test
+    fun doNotChangeNonIf(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    boolean b = true;
+                    if (!b) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalse(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfElseTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) {
+                    } else {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfElseFalse(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) {
+                    } else {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrueNoBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) System.out.println("hello");
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalseNoBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) System.out.println("hello");
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrueEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) {}
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalseEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) {}
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+}


### PR DESCRIPTION
Simplify `if` statements with constant execution paths.

For example:
```java
if (true) System.out.println("hello");
```
Becomes:
```java
System.out.println("hello");
```