### PR TITLE
Fix SimplifyConstantIfBranchExecution Bugs

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -452,6 +452,10 @@ class Java11RemoveExtraSemicolonsTest : Java11Test, RemoveExtraSemicolonsTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11RemoveUnneededBlockTest : Java11Test, RemoveUnneededBlockTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11RemoveUnusedLocalVariablesTest : Java11Test, RemoveUnusedLocalVariablesTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -432,6 +432,10 @@ class Java8RemoveExtraSemicolonsTest : Java8Test, RemoveExtraSemicolonsTest
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8RemoveUnneededBlockTest : Java8Test, RemoveUnneededBlockTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8RemoveImplementsTest : Java8Test, RemoveImplementsTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlockVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/EmptyBlockVisitor.java
@@ -110,6 +110,12 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     public J.If visitIf(J.If iff, P p) {
         J.If i = super.visitIf(iff, p);
 
+        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralElse()) &&
+            i.getElsePart() != null &&
+            isEmptyBlock(i.getElsePart().getBody())) {
+            i = i.withElsePart(null);
+        }
+
         if (Boolean.FALSE.equals(emptyBlockStyle.getLiteralIf()) || !isEmptyBlock(i.getThenPart())) {
             return i;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
@@ -1,0 +1,39 @@
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+
+public class RemoveUnneededBlock extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Remove unneeded block";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Flatten blocks into inline statements when possible";
+    }
+
+    @Override
+    protected JavaVisitor<ExecutionContext> getVisitor() {
+        return new RemoveUnneededBlockStatementVisitor();
+    }
+
+    static class RemoveUnneededBlockStatementVisitor extends JavaIsoVisitor<ExecutionContext> {
+        public J.Block visitBlock(J.Block block, ExecutionContext executionContext) {
+            J.Block bl = super.visitBlock(block, executionContext);
+            bl = maybeAutoFormat(bl, block.withStatements(ListUtils.flatMap(bl.getStatements(), stmt -> {
+                if (stmt instanceof J.Block) {
+                    return ((J.Block) stmt).getStatements();
+                } else {
+                    return stmt;
+                }
+            })), executionContext, getCursor().getParent());
+            return bl;
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
@@ -1,12 +1,29 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.cleanup;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
 import org.openrewrite.Recipe;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 
+@Incubating(since = "7.21.0")
 public class RemoveUnneededBlock extends Recipe {
     @Override
     public String getDisplayName() {
@@ -31,7 +48,7 @@ public class RemoveUnneededBlock extends Recipe {
             J.NewClass newClass = getCursor().firstEnclosing(J.NewClass.class);
             J.ClassDeclaration classDeclaration = getCursor().firstEnclosing(J.ClassDeclaration.class);
             // Determine the direct parent
-            J directParent = (J) getCursor().dropParentUntil(J.class::isInstance).getValue();
+            J directParent = getCursor().dropParentUntil(J.class::isInstance).getValue();
 
             J.Block bl = super.visitBlock(block, executionContext);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
@@ -18,15 +18,15 @@ package org.openrewrite.java.cleanup;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.style.EmptyBlockStyle;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
 
+import java.util.Collections;
 import java.util.Optional;
 
 public class SimplifyConstantIfBranchExecution extends Recipe {
@@ -135,8 +135,22 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
                  * ```
                  * The above is not valid java and will cause later processing errors.
                  */
-                return J.Block.empty();
+                return emptyJBlock();
             }
+        }
+
+        /**
+         * An empty {@link J.Block} with no contents.
+         */
+        private static J.Block emptyJBlock() {
+            return new J.Block(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                JRightPadded.build(false),
+                Collections.emptyList(),
+                Space.EMPTY
+            );
         }
 
         private static boolean isLiteralTrue(@Nullable Expression expression) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
@@ -17,16 +17,17 @@ package org.openrewrite.java.cleanup;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.internal.ListUtils;
+import org.openrewrite.SourceFile;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.style.Checkstyle;
+import org.openrewrite.java.style.EmptyBlockStyle;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Statement;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Optional;
 
 public class SimplifyConstantIfBranchExecution extends Recipe {
 
@@ -46,6 +47,8 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
     }
 
     private static class SimplifyConstantIfBranchExecutionVisitor extends JavaVisitor<ExecutionContext> {
+        private static final UnnecessaryParenthesesVisitor UNNECESSARY_PARENTHESES_VISITOR =
+            new UnnecessaryParenthesesVisitor(Checkstyle.unnecessaryParentheses());
 
         @Override
         public J visitWhileLoop(J.WhileLoop whileLoop, ExecutionContext executionContext) {
@@ -55,67 +58,88 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
         @Override
         public J visitBlock(J.Block block, ExecutionContext executionContext) {
             J.Block bl = (J.Block) super.visitBlock(block, executionContext);
-            List<Statement> addStatements = getCursor().pollMessage("statements");
-            J.If removeIf = getCursor().pollMessage("remove-if");
-            if (removeIf != null) {
-                bl = maybeAutoFormat(bl, bl.withStatements(ListUtils.flatMap(bl.getStatements(), stmt -> {
-                    if (stmt == removeIf) {
-                        return addStatements;
-                    }
-                    return stmt;
-                })), executionContext, getCursor().getParent());
+            bl = (J.Block) new RemoveUnneededBlock.RemoveUnneededBlockStatementVisitor()
+                .visitNonNull(bl, executionContext, getCursor().getParentOrThrow());
+            EmptyBlockStyle style = ((SourceFile) getCursor().firstEnclosingOrThrow(JavaSourceFile.class))
+                .getStyle(EmptyBlockStyle.class);
+            if (style == null) {
+                style = Checkstyle.emptyBlock();
             }
+            bl = (J.Block) new EmptyBlockVisitor<>(style)
+                .visitNonNull(bl, executionContext, getCursor().getParentOrThrow());
             return bl;
+        }
+
+        @SuppressWarnings("rawtypes")
+        private J.ControlParentheses<Expression> cleanupControlParentheses(
+            J.ControlParentheses<Expression> controlParentheses, ExecutionContext context
+        ) {
+            J.ControlParentheses cp1 =
+                (J.ControlParentheses) UNNECESSARY_PARENTHESES_VISITOR.visitNonNull(controlParentheses, context);
+            J.ControlParentheses cp2 =
+                (J.ControlParentheses) new SimplifyBooleanExpressionVisitor<ExecutionContext>()
+                    .visitNonNull(cp1, context, getCursor().getParentOrThrow());
+            return cp2;
         }
 
         @Override
         public J visitIf(J.If if_, ExecutionContext context) {
             J.If if__ = (J.If) super.visitIf(if_, context);
-            AtomicReference<Boolean> b = new AtomicReference<>(null);
-            new JavaIsoVisitor<ExecutionContext>() {
-                @Override
-                public <T extends J> J.ControlParentheses<T> visitControlParentheses(J.ControlParentheses<T> controlParens, ExecutionContext executionContext) {
-                    J.ControlParentheses cp = super.visitControlParentheses(controlParens, executionContext);
-                    J.ControlParentheses cp2 = (J.ControlParentheses) new SimplifyBooleanExpressionVisitor<ExecutionContext>().visitNonNull(cp, executionContext);
-                    if (isLiteralTrue((Expression) cp2.getTree())) {
-                        b.getAndSet(true);
-                    } else if (isLiteralFalse((Expression) cp2.getTree())) {
-                        b.getAndSet(false);
-                    }
-                    // else leave it as null
-                    return cp;
-                }
-            }.visit(if__, context);
+            J.ControlParentheses<Expression> cp =
+                cleanupControlParentheses(if__.getIfCondition(), context);
             // The compile-time constant value of the if condition control parentheses.
-            Boolean compileTimeConstantBoolean = b.get();
-            // The simplification process did not result in resolving to a single 'true' or 'false' value
-            if (compileTimeConstantBoolean == null) {
-                return if__; // Return the original `if` (unmodified)
+            final Optional<Boolean> compileTimeConstantBoolean;
+            if (isLiteralTrue(cp.getTree())) {
+                compileTimeConstantBoolean = Optional.of(true);
+            } else if (isLiteralFalse(cp.getTree())) {
+                compileTimeConstantBoolean = Optional.of(false);
+            } else {
+                // The condition is not a literal, so we can't simplify it.
+                compileTimeConstantBoolean = Optional.empty();
             }
-            // True branch
-            if (compileTimeConstantBoolean) {
+
+            // The simplification process did not result in resolving to a single 'true' or 'false' value
+            if (!compileTimeConstantBoolean.isPresent()) {
+                return if__; // Return the original `if`
+            } else if (compileTimeConstantBoolean.get()) {
+                // True branch
+                // Only keep the `then` branch, and remove the `else` branch.
                 Statement s = if__.getThenPart();
-                if (s instanceof J.Block) {
-                    getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("statements", ((J.Block) s).getStatements());
-                    getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("remove-if", if__);
-                    return if__; // Return the original `if` (unmodified) since this will need to be replaced
-                } else {
-                    return maybeAutoFormat(if__, s, context, getCursor().getParent());
-                }
-            } else { // False branch
+                return maybeAutoFormat(
+                    if__,
+                    s,
+                    context,
+                    getCursor().getParentOrThrow()
+                );
+            } else {
+                // False branch
+                // Only keep the `else` branch, and remove the `then` branch.
                 if (if__.getElsePart() != null) {
                     // The `else` part needs to be kept
                     Statement s = if__.getElsePart().getBody();
-                    if (s instanceof J.Block) {
-                        getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("statements", ((J.Block) s).getStatements());
-                        getCursor().dropParentUntil(J.Block.class::isInstance).putMessage("remove-if", if__);
-                        return if__; // Return the original `if` (unmodified) since this will need to be replaced
-                    } else {
-                        return maybeAutoFormat(if__, s, context, getCursor().getParent());
-                    }
+                    return maybeAutoFormat(
+                        if__,
+                        s,
+                        context,
+                        getCursor().getParentOrThrow()
+                    );
                 }
-                // The if statement can be completely removed
-                return null;
+                /*
+                 * The `else` branch is not present, therefore, the `if` can be removed.
+                 * Temporarily return an empty block that will (most likely) later be removed.
+                 * We need to return an empty block, in the following cases:
+                 * ```
+                 * if (a) a();
+                 * else if (false) { }
+                 * ```
+                 * Failing to return an empty block here would result in the following code being emitted:
+                 * ```
+                 * if (a) a();
+                 * else
+                 * ```
+                 * The above is not valid java and will cause later processing errors.
+                 */
+                return J.Block.empty();
             }
         }
 
@@ -127,4 +151,6 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
             return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(false);
         }
     }
+
+
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
@@ -47,8 +47,6 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
     }
 
     private static class SimplifyConstantIfBranchExecutionVisitor extends JavaVisitor<ExecutionContext> {
-        private static final UnnecessaryParenthesesVisitor<ExecutionContext> UNNECESSARY_PARENTHESES_VISITOR =
-            new UnnecessaryParenthesesVisitor<>(Checkstyle.unnecessaryParentheses());
 
         @Override
         public J visitBlock(J.Block block, ExecutionContext executionContext) {
@@ -71,10 +69,10 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
         private J.ControlParentheses<Expression> cleanupControlParentheses(
             J.ControlParentheses<Expression> controlParentheses, ExecutionContext context
         ) {
-            J.ControlParentheses cp1 =
-                (J.ControlParentheses) UNNECESSARY_PARENTHESES_VISITOR
+            final J.ControlParentheses cp1 =
+                (J.ControlParentheses) new UnnecessaryParenthesesVisitor<>(Checkstyle.unnecessaryParentheses())
                     .visitNonNull(controlParentheses, context, getCursor().getParentOrThrow());
-            J.ControlParentheses cp2 =
+            final J.ControlParentheses cp2 =
                 (J.ControlParentheses) new SimplifyBooleanExpressionVisitor<ExecutionContext>()
                     .visitNonNull(cp1, context, getCursor().getParentOrThrow());
             return cp2;
@@ -149,6 +147,5 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
             return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(false);
         }
     }
-
 
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -757,20 +757,6 @@ public interface J extends Tree {
                 return t.statements == statements ? t : new Block(t.id, t.prefix, t.markers, t.statik, statements, t.end);
             }
         }
-
-        /**
-         * An empty {@link Block} with no contents.
-         */
-        public static J.Block empty() {
-            return new J.Block(
-                    Tree.randomId(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    JRightPadded.build(false),
-                    Collections.emptyList(),
-                    Space.EMPTY
-            );
-        }
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -757,6 +757,20 @@ public interface J extends Tree {
                 return t.statements == statements ? t : new Block(t.id, t.prefix, t.markers, t.statik, statements, t.end);
             }
         }
+
+        /**
+         * An empty {@link Block} with no contents.
+         */
+        public static J.Block empty() {
+            return new J.Block(
+                    Tree.randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    JRightPadded.build(false),
+                    Collections.emptyList(),
+                    Space.EMPTY
+            );
+        }
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
@@ -2255,7 +2269,7 @@ public interface J extends Tree {
                     JavaType.Class owner = TypeUtils.asClass(qualid.getTarget().getType());
                     if (owner != null && !(qualid.getTarget().getType() instanceof JavaType.ShallowClass)) {
                         Iterator<JavaType.Method> visibleMethods = owner.getVisibleMethods();
-                        while(visibleMethods.hasNext()) {
+                        while (visibleMethods.hasNext()) {
                             JavaType.Method method = visibleMethods.next();
                             if (method.getName().equals(possibleInnerClassName)) {
                                 return possibleInnerClassFqn.substring(0, possibleInnerClassFqn.lastIndexOf('$'));
@@ -2263,7 +2277,7 @@ public interface J extends Tree {
                         }
 
                         Iterator<JavaType.Variable> visibleMembers = owner.getVisibleMembers();
-                        while(visibleMembers.hasNext()) {
+                        while (visibleMembers.hasNext()) {
                             JavaType.Variable member = visibleMembers.next();
                             if (member.getName().equals(possibleInnerClassName)) {
                                 return possibleInnerClassFqn.substring(0, possibleInnerClassFqn.lastIndexOf('$'));

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -354,6 +354,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class RemoveExtraSemicolonsTck : RemoveExtraSemicolonsTest
 
     @Nested
+    inner class RemoveUnneededBlockTck : RemoveUnneededBlockTest
+
+    @Nested
     inner class RemoveImplementsTck : RemoveImplementsTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EmptyBlockTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/EmptyBlockTest.kt
@@ -115,7 +115,7 @@ interface EmptyBlockTest : JavaRecipeTest {
             import java.io.FileInputStream;
             import java.io.IOException;
             import java.nio.file.*;
-            
+
             public class A {
                 public void foo() {
                     try {
@@ -132,7 +132,7 @@ interface EmptyBlockTest : JavaRecipeTest {
         jp,
         before = """
             import java.nio.file.*;
-            
+
             public class A {
                 public void foo() {
                     try {
@@ -145,7 +145,7 @@ interface EmptyBlockTest : JavaRecipeTest {
         """,
         after = """
             import java.nio.file.*;
-            
+
             public class A {
                 public void foo() {
                     try {
@@ -206,15 +206,15 @@ interface EmptyBlockTest : JavaRecipeTest {
         before = """
             public class A {
                 int n = sideEffect();
-            
+
                 int sideEffect() {
                     return new java.util.Random().nextInt();
                 }
-            
+
                 boolean boolSideEffect() {
                     return sideEffect() == 0;
                 }
-            
+
                 public void lotsOfIfs() {
                     if(sideEffect() == 1) {}
                     if(sideEffect() == sideEffect()) {}
@@ -230,15 +230,15 @@ interface EmptyBlockTest : JavaRecipeTest {
         after = """
             public class A {
                 int n = sideEffect();
-            
+
                 int sideEffect() {
                     return new java.util.Random().nextInt();
                 }
-            
+
                 boolean boolSideEffect() {
                     return sideEffect() == 0;
                 }
-            
+
                 public void lotsOfIfs() {
                     sideEffect();
                     sideEffect();
@@ -304,6 +304,30 @@ interface EmptyBlockTest : JavaRecipeTest {
                         else {
                             System.out.println("this");
                         }
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun emptyElseBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                {
+                    if (true) {
+                        System.out.println("this");
+                    } else {
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                {
+                    if (true) {
+                        System.out.println("this");
                     }
                 }
             }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededBlockTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededBlockTest.kt
@@ -1,0 +1,113 @@
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+interface RemoveUnneededBlockTest : JavaRecipeTest {
+    override val recipe: Recipe
+        get() = RemoveUnneededBlock()
+
+    @Test
+    fun doNotChangeMethod(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class A {
+                void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotChangeLabeledBlock(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class A {
+                void test() {
+                    testLabel: {
+                        System.out.println("hello!");
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotChangeEmptyIfBlock(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class A {
+                void test() {
+                    if(true) { }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyNestedBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                void test() {
+                    {
+                        System.out.println("hello!");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                void test() {
+                    System.out.println("hello!");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyDoublyNestedBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                void test() {
+                    {
+                         { System.out.println("hello!"); }
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                void test() {
+                    System.out.println("hello!");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyBlockNestedInIfBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                void test() {
+                    if (true) {
+                         { System.out.println("hello!"); }
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                void test() {
+                    if (true) {
+                        System.out.println("hello!");
+                    }
+                }
+            }
+        """
+    )
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededBlockTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededBlockTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("StatementWithEmptyBody")
+@file:Suppress("StatementWithEmptyBody", "PointlessBooleanExpression")
 
 package org.openrewrite.java.cleanup
 
@@ -65,6 +65,70 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
     )
 
     @Test
+    fun simplifyConstantIfTrueInParens(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if ((true)) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfNotFalse(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (!false) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    @Suppress("DuplicateCondition")
+    fun simplifyConstantIfTrueOrTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true || true) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
     fun simplifyConstantIfFalse(jp: JavaParser) = assertChanged(
         jp,
         before = """
@@ -85,7 +149,7 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
     )
 
     @Test
-    fun simplifyConstantIfElseTrue(jp: JavaParser) = assertChanged(
+    fun simplifyConstantIfTrueElse(jp: JavaParser) = assertChanged(
         jp,
         before = """
             public class A {
@@ -106,7 +170,7 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
     )
 
     @Test
-    fun simplifyConstantIfElseFalse(jp: JavaParser) = assertChanged(
+    fun simplifyConstantIfFalseElse(jp: JavaParser) = assertChanged(
         jp,
         before = """
             public class A {
@@ -195,6 +259,275 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
         after = """
             public class A {
                 public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrueElseIf(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test(boolean a) {
+                    if (true) {
+                        System.out.println("hello");
+                    } else if (a) {
+                        System.out.println("goodbye");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test(boolean a) {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalseElseIf(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test(boolean a) {
+                    if (false) {
+                        System.out.println("hello");
+                    } else if (a) {
+                        System.out.println("goodbye");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("goodbye");
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrueElseIfFalse(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) {
+                    } else if (false) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalseElseIfTrue(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) {
+                    } else if (true) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrueElseIfFalseNoBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) System.out.println("hello");
+                    else if (false) System.out.println("goodbye");
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("hello");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalseElseIfNoBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) System.out.println("hello");
+                    else if (true) System.out.println("goodbye");
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    System.out.println("goodbye");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfTrueElseIfFalseEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (true) {}
+                    else if (false) {}
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfFalseElseIfTrueEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) {}
+                    else if (true) {}
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfVariableElseIfTrueEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("hello");
+                    } else if (true) {
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfVariableElseIfTruePrint(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("hello");
+                    } else if (true) {
+                        System.out.println("goodbye");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("hello");
+                    } else {
+                        System.out.println("goodbye");
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyConstantIfVariableElseIfFalseEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("hello");
+                    } else if (false) {
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test(boolean a) {
+                    if (a) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    @Suppress("InfiniteLoopStatement")
+    fun simplifyConstantIfFalseElseWhileTrueEmptyBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    if (false) {}
+                    else while (true) {
+                        System.out.println("hello");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    while (true) {
+                        System.out.println("hello");
+                    }
                 }
             }
         """


### PR DESCRIPTION
There were several cases where the `SimplifyConstantIfBranchExecution`
recipie was incorrect.

This fixes those cases and simplifies removing unneeded blocks into
it's own visitor.
