### PR TITLE
Return all matches from binaryExpression in JsonPathMatches.

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonPathMatcher.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonPathMatcher.java
@@ -485,9 +485,11 @@ public class JsonPathMatcher {
 
                 scope = scopeOfLogicalOp;
                 rhs = getBinaryExpressionResult(rhs);
-                if ("&&".equals(operator) && lhs != null && rhs != null) {
+                if ("&&".equals(operator) &&
+                        ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) && (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {
                     return scopeOfLogicalOp;
-                } else if ("||".equals(operator) && (lhs != null || rhs != null)) {
+                } else if ("||".equals(operator) &&
+                        ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) || (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {
                     return scopeOfLogicalOp;
                 }
             } else if (ctx.EQUALITY_OPERATOR() != null) {
@@ -507,12 +509,14 @@ public class JsonPathMatcher {
                 }
 
                 if (lhs instanceof List) {
+                    List<Object> matches = new ArrayList<>();
                     for (Object match : ((List<Object>) lhs)) {
                         Json result = getOperatorResult(match, operator, rhs);
                         if (result != null) {
-                            return match;
+                            matches.add(match);
                         }
                     }
+                    return matches;
                 } else {
                     return getOperatorResult(lhs, operator, rhs);
                 }

--- a/rewrite-json/src/test/kotlin/org/openrewrite/json/JsonPathMatcherTest.kt
+++ b/rewrite-json/src/test/kotlin/org/openrewrite/json/JsonPathMatcherTest.kt
@@ -46,15 +46,15 @@ class JsonPathMatcherTest {
           "list": [
             {
               "item1": "index0",
-              "property": "property1"
+              "property": "property"
             },
             {
               "item2": "index1",
-              "property": "property2"
+              "property": "property"
             },
             {
               "item3": "index2",
-              "property": "property3"
+              "property": "property"
             }
           ]
         }
@@ -260,7 +260,7 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item1": "index0",
-              "property": "property1"
+              "property": "property"
             }
         """.trimIndent())
     )
@@ -272,7 +272,7 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item3": "index2",
-              "property": "property3"
+              "property": "property"
             }
         """.trimIndent())
     )
@@ -284,12 +284,12 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item1": "index0",
-              "property": "property1"
+              "property": "property"
             }
         """.trimIndent(),"""
             {
               "item2": "index1",
-              "property": "property2"
+              "property": "property"
             }
         """.trimIndent())
     )
@@ -301,12 +301,12 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item2": "index1",
-              "property": "property2"
+              "property": "property"
             }
         """.trimIndent(),"""
             {
               "item3": "index2",
-              "property": "property3"
+              "property": "property"
             }
         """.trimIndent())
     )
@@ -318,17 +318,17 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item1": "index0",
-              "property": "property1"
+              "property": "property"
             }
         """.trimIndent(),"""
             {
               "item2": "index1",
-              "property": "property2"
+              "property": "property"
             }
         """.trimIndent(),"""
             {
               "item3": "index2",
-              "property": "property3"
+              "property": "property"
             }
         """.trimIndent())
     )
@@ -359,12 +359,12 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item1": "index0",
-              "property": "property1"
+              "property": "property"
             }
         """.trimIndent(),"""
             {
               "item2": "index1",
-              "property": "property2"
+              "property": "property"
             }
         """.trimIndent())
     )
@@ -415,26 +415,53 @@ class JsonPathMatcherTest {
     )
 
     @Test
-    fun unaryExpression() = assertMatched(
+    fun unaryExpressionByScope() = assertMatched(
         jsonPath = "$.list[?(@.property)]",
         before = sliceList,
         after = arrayOf(
             """
                 {
                   "item1": "index0",
-                  "property": "property1"
+                  "property": "property"
                 }
             """.trimIndent(),
             """
                 {
                   "item2": "index1",
-                  "property": "property2"
+                  "property": "property"
                 }
             """.trimIndent(),
             """
                 {
                   "item3": "index2",
-                  "property": "property3"
+                  "property": "property"
+                }
+            """.trimIndent()
+        )
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1567")
+    @Test
+    fun unaryExpressionByValue() = assertMatched(
+        jsonPath = "$.list[?(@.property == 'property')]",
+        before = sliceList,
+        after = arrayOf(
+            """
+                {
+                  "item1": "index0",
+                  "property": "property"
+                }
+            """.trimIndent(),
+            """
+                {
+                  "item2": "index1",
+                  "property": "property"
+                }
+            """.trimIndent(),
+            """
+                {
+                  "item3": "index2",
+                  "property": "property"
                 }
             """.trimIndent()
         )
@@ -492,7 +519,7 @@ class JsonPathMatcherTest {
         after = arrayOf("""
             {
               "item3": "index2",
-              "property": "property3"
+              "property": "property"
             }
         """.trimIndent())
     )

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
@@ -504,9 +504,11 @@ public class JsonPathMatcher {
 
                 scope = scopeOfLogicalOp;
                 rhs = getBinaryExpressionResult(rhs);
-                if ("&&".equals(operator) && lhs != null && rhs != null) {
+                if ("&&".equals(operator) &&
+                        ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) && (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {
                     return scopeOfLogicalOp;
-                } else if ("||".equals(operator) && (lhs != null || rhs != null)) {
+                } else if ("||".equals(operator) &&
+                        ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) || (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {
                     return scopeOfLogicalOp;
                 }
             } else if (ctx.EQUALITY_OPERATOR() != null) {
@@ -526,12 +528,14 @@ public class JsonPathMatcher {
                 }
 
                 if (lhs instanceof List) {
+                    List<Object> matches = new ArrayList<>();
                     for (Object match : ((List<Object>) lhs)) {
                         Yaml mappingOrEntry = getOperatorResult(match, operator, rhs);
                         if (mappingOrEntry != null) {
-                            return mappingOrEntry;
+                            matches.add(mappingOrEntry);
                         }
                     }
+                    return matches;
                 } else {
                     return getOperatorResult(lhs, operator, rhs);
                 }

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
@@ -41,11 +41,11 @@ class JsonPathMatcherTest {
         ---
         list:
           - item1: index0
-            property: property1
+            property: property
           - item2: index1
-            property: property2
+            property: property
           - item3: index2
-            property: property3
+            property: property
     """.trimIndent())
 
     @Language("yaml")
@@ -216,7 +216,7 @@ class JsonPathMatcherTest {
         after = arrayOf(
             """
                 - item1: index0
-                property: property1
+                property: property
             """.trimIndent())
     )
 
@@ -227,7 +227,7 @@ class JsonPathMatcherTest {
         after = arrayOf(
             """
                 - item3: index2
-                property: property3
+                property: property
             """.trimIndent())
     )
 
@@ -238,11 +238,11 @@ class JsonPathMatcherTest {
         after = arrayOf(
             """
                 - item1: index0
-                property: property1
+                property: property
             """.trimIndent(),
             """
                 - item2: index1
-                property: property2
+                property: property
             """.trimIndent())
     )
 
@@ -253,11 +253,11 @@ class JsonPathMatcherTest {
         after = arrayOf(
             """
                 - item2: index1
-                property: property2
+                property: property
             """.trimIndent(),
             """
                 - item3: index2
-                property: property3
+                property: property
          """.trimIndent())
     )
 
@@ -268,15 +268,15 @@ class JsonPathMatcherTest {
         after = arrayOf(
             """
                 - item1: index0
-                property: property1
+                property: property
             """.trimIndent(),
             """
                 - item2: index1
-                property: property2
+                property: property
             """.trimIndent(),
             """
                 - item3: index2
-                property: property3
+                property: property
             """.trimIndent())
     )
 
@@ -304,10 +304,10 @@ class JsonPathMatcherTest {
         after = arrayOf(
             """
                 - item1: index0
-                property: property1
+                property: property
             """.trimIndent(),"""
                 - item2: index1
-                property: property2
+                property: property
             """.trimIndent())
     )
 
@@ -357,21 +357,42 @@ class JsonPathMatcherTest {
     )
 
     @Test
-    fun unaryExpression() = assertMatched(
+    fun unaryExpressionByScope() = assertMatched(
         jsonPath = "$.list[?(@.property)]",
         before = sliceList,
         after = arrayOf(
             """
                 item1: index0
-                   property: property1
+                   property: property
             """.trimIndent(),
             """
                 item2: index1
-                   property: property2
+                   property: property
             """.trimIndent(),
             """
                 item3: index2
-                   property: property3
+                   property: property
+            """.trimIndent()
+        )
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1567")
+    @Test
+    fun unaryExpressionByValue() = assertMatched(
+        jsonPath = "$.list[?(@.property == 'property')]",
+        before = sliceList,
+        after = arrayOf(
+            """
+                item1: index0
+                   property: property
+            """.trimIndent(),
+            """
+                item2: index1
+                   property: property
+            """.trimIndent(),
+            """
+                item3: index2
+                   property: property
             """.trimIndent()
         )
     )
@@ -422,7 +443,7 @@ class JsonPathMatcherTest {
         before = sliceList,
         after = arrayOf("""
             item3: index2
-               property: property3
+               property: property
             """.trimIndent())
     )
 


### PR DESCRIPTION
Changes:
- Return all matches in `binaryExpression` when a list of potential matches is returned.
- Updated logical operators `&&` and `||` to account for empty lists.

fixes #1567