### PR TITLE
Add Maven Security Recipe Converting HTTP -> HTTPS

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -41,11 +41,6 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     private static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
     private static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/*/plugins/plugin");
     private static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
-    private static final XPathMatcher REPOSITORY_URL_MATCHER = new XPathMatcher("/project/repositories/repository/url");
-    private static final XPathMatcher PLUGIN_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/pluginRepositories/pluginRepository/url");
-    private static final XPathMatcher DISTRIBUTION_MANAGEMENT_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/distributionManagement/repository/url");
-    private static final XPathMatcher DISTRIBUTION_MANAGEMENT_SNAPSHOT_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/distributionManagement/snapshotRepository/url");
-
 
     private transient MavenResolutionResult resolutionResult;
     private transient List<MavenResolutionResult> modules;
@@ -79,13 +74,6 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
 
     public boolean isDependencyTag() {
         return DEPENDENCY_MATCHER.matches(getCursor());
-    }
-
-    public boolean isRepositoryUrlTag() {
-        return REPOSITORY_URL_MATCHER.matches(getCursor()) ||
-                PLUGIN_REPOSITORY_URL_MATCHER.matches(getCursor()) ||
-                DISTRIBUTION_MANAGEMENT_REPOSITORY_URL_MATCHER.matches(getCursor()) ||
-                DISTRIBUTION_MANAGEMENT_SNAPSHOT_REPOSITORY_URL_MATCHER.matches(getCursor());
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -41,6 +41,11 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     private static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
     private static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/*/plugins/plugin");
     private static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
+    private static final XPathMatcher REPOSITORY_URL_MATCHER = new XPathMatcher("/project/repositories/repository/url");
+    private static final XPathMatcher PLUGIN_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/pluginRepositories/pluginRepository/url");
+    private static final XPathMatcher DISTRIBUTION_MANAGEMENT_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/distributionManagement/repository/url");
+    private static final XPathMatcher DISTRIBUTION_MANAGEMENT_SNAPSHOT_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/distributionManagement/snapshotRepository/url");
+
 
     private transient MavenResolutionResult resolutionResult;
     private transient List<MavenResolutionResult> modules;
@@ -74,6 +79,13 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
 
     public boolean isDependencyTag() {
         return DEPENDENCY_MATCHER.matches(getCursor());
+    }
+
+    public boolean isRepositoryUrlTag() {
+        return REPOSITORY_URL_MATCHER.matches(getCursor()) ||
+                PLUGIN_REPOSITORY_URL_MATCHER.matches(getCursor()) ||
+                DISTRIBUTION_MANAGEMENT_REPOSITORY_URL_MATCHER.matches(getCursor()) ||
+                DISTRIBUTION_MANAGEMENT_SNAPSHOT_REPOSITORY_URL_MATCHER.matches(getCursor());
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/security/UseHttpsForRepositories.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/security/UseHttpsForRepositories.java
@@ -21,12 +21,19 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.xml.ChangeTagValueVisitor;
+import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 public class UseHttpsForRepositories extends Recipe {
+    private static final XPathMatcher REPOSITORY_URL_MATCHER = new XPathMatcher("/project/repositories/repository/url");
+    private static final XPathMatcher PLUGIN_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/pluginRepositories/pluginRepository/url");
+    private static final XPathMatcher DISTRIBUTION_MANAGEMENT_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/distributionManagement/repository/url");
+    private static final XPathMatcher DISTRIBUTION_MANAGEMENT_SNAPSHOT_REPOSITORY_URL_MATCHER = new XPathMatcher("/project/distributionManagement/snapshotRepository/url");
+
     @Override
     public String getDisplayName() {
         return "Use HTTPS for repositories";
@@ -39,7 +46,7 @@ public class UseHttpsForRepositories extends Recipe {
 
     @Override
     public Set<String> getTags() {
-        return Collections.singleton("security");
+        return new HashSet<>(Arrays.asList("security", "CWE-829"));
     }
 
     @Override
@@ -61,6 +68,13 @@ public class UseHttpsForRepositories extends Recipe {
                 }
                 return super.visitTag(tag, ctx);
 
+            }
+
+            private boolean isRepositoryUrlTag() {
+                return REPOSITORY_URL_MATCHER.matches(getCursor()) ||
+                    PLUGIN_REPOSITORY_URL_MATCHER.matches(getCursor()) ||
+                    DISTRIBUTION_MANAGEMENT_REPOSITORY_URL_MATCHER.matches(getCursor()) ||
+                    DISTRIBUTION_MANAGEMENT_SNAPSHOT_REPOSITORY_URL_MATCHER.matches(getCursor());
             }
         };
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/security/package-info.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/security/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.maven.security;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/security/UseHttpsForRepositoriesTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/security/UseHttpsForRepositoriesTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("HttpUrlsUsage")
+
+package org.openrewrite.maven.security
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.maven.MavenRecipeTest
+
+class UseHttpsForRepositoriesTest : MavenRecipeTest {
+
+    override val recipe: Recipe
+        get() = UseHttpsForRepositories()
+
+    @Test
+    fun replaceHttpInRepositoryBlock() = assertChanged(
+        before = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+
+              <repositories>
+                <repository>
+                  <id>my-repo</id>
+                  <url>http://repo.example.com/repo</url>
+                </repository>
+              </repositories>
+            </project>
+        """,
+        after = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+
+              <repositories>
+                <repository>
+                  <id>my-repo</id>
+                  <url>https://repo.example.com/repo</url>
+                </repository>
+              </repositories>
+            </project>
+        """
+    )
+
+    @Test
+    fun replaceHttpInDistributionManagementBlock() = assertChanged(
+        before = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+
+              <distributionManagement>
+                <repository>
+                  <id>my-repo</id>
+                  <url>http://repo.example.com/repo</url>
+                </repository>
+                <snapshotRepository>
+                  <id>my-snapshot-repo</id>
+                  <url>http://repo.example.com/repo</url>
+                </snapshotRepository>
+              </distributionManagement>
+            </project>
+        """,
+        after = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+
+              <distributionManagement>
+                <repository>
+                  <id>my-repo</id>
+                  <url>https://repo.example.com/repo</url>
+                </repository>
+                <snapshotRepository>
+                  <id>my-snapshot-repo</id>
+                  <url>https://repo.example.com/repo</url>
+                </snapshotRepository>
+              </distributionManagement>
+            </project>
+        """
+    )
+
+    @Test
+    fun replaceHttpInPluginRepositoriesBlock() = assertChanged(
+        before = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+
+              <pluginRepositories>
+                <pluginRepository>
+                  <id>my-repo</id>
+                  <url>http://repo.example.com/repo</url>
+                </pluginRepository>
+              </pluginRepositories>
+            </project>
+        """,
+        after = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+
+              <pluginRepositories>
+                <pluginRepository>
+                  <id>my-repo</id>
+                  <url>https://repo.example.com/repo</url>
+                </pluginRepository>
+              </pluginRepositories>
+            </project>
+        """
+    )
+
+    @Test
+    fun replaceHttpInRepositoryBlockFromProperties() = assertChanged(
+        before = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+              <properties>
+                <my-repo-url>http://repo.example.com/repo</my-repo-url>
+              </properties>
+
+              <repositories>
+                <repository>
+                  <id>my-repo</id>
+                  <url>${'$'}{my-repo-url}</url>
+                </repository>
+              </repositories>
+            </project>
+        """,
+        after = """
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+
+              <groupId>org.openrewrite.example</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+              <properties>
+                <my-repo-url>https://repo.example.com/repo</my-repo-url>
+              </properties>
+
+              <repositories>
+                <repository>
+                  <id>my-repo</id>
+                  <url>${'$'}{my-repo-url}</url>
+                </repository>
+              </repositories>
+            </project>
+        """
+    )
+}


### PR DESCRIPTION
Finds all `url` tags within Maven POM repositories blocks and rewrites them to use HTTPS instead of HTTP.

Also supports looking up properties and replacing URLS there as well.