### PR TITLE
Add Gradle Security Recipe Converting HTTP -> HTTPS

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/security/UseHttpsForRepositories.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/security/UseHttpsForRepositories.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.security;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.gradle.util.RewriteStringLiteralValueVisitor;
+import org.openrewrite.groovy.GroovyVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class UseHttpsForRepositories extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Use HTTPS for repositories";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Use HTTPS for repository urls";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("security");
+    }
+
+    @Override
+    protected GroovyVisitor<ExecutionContext> getVisitor() {
+        return new RepositoryUrlVisitor();
+    }
+
+    private static class RepositoryUrlVisitor extends GroovyVisitor<ExecutionContext> {
+        MethodMatcher repositories = new MethodMatcher("MavenArtifactRepositorySpec url(..)");
+
+        private void fixupLiteralIfNeeded(J.Literal arg) {
+            String url = (String) arg.getValue();
+            //noinspection HttpUrlsUsage
+            if (url.startsWith("http://")) {
+                String newUrl = url.replaceAll("^http://(.*)", "https://$1");
+                doAfterVisit(new RewriteStringLiteralValueVisitor<>(arg, newUrl));
+            }
+        }
+
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+            if(!repositories.matches(method)) {
+                return m;
+            }
+            List<Expression> args = m.getArguments();
+            if (args.get(0) instanceof J.Literal) {
+                J.Literal arg = (J.Literal) args.get(0);
+                fixupLiteralIfNeeded(arg);
+            } else if (args.get(0) instanceof G.GString) {
+                G.GString arg = (G.GString) args.get(0);
+                if (arg.getStrings().get(0) instanceof J.Literal) {
+                    // Only fixup the first literal in the GString
+                    fixupLiteralIfNeeded((J.Literal) arg.getStrings().get(0));
+                }
+            }
+            return m;
+        }
+    }
+
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/RewriteStringLiteralValueVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/RewriteStringLiteralValueVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.util;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.groovy.GroovyVisitor;
+import org.openrewrite.java.tree.J;
+
+@AllArgsConstructor
+public class RewriteStringLiteralValueVisitor<P> extends GroovyVisitor<P> {
+
+    private final J.Literal target;
+    private final String newValue;
+
+    @Override
+    public J visitLiteral(J.Literal literal, P p) {
+        J.Literal l = (J.Literal) super.visitLiteral(literal, p);
+        if (l == target) {
+            String oldValue = (String) l.getValue();
+            if (oldValue.equals(newValue)) {
+                return l;
+            }
+            String valueSource = l.getValueSource();
+            String delimiter = (valueSource == null) ? "'"
+                : valueSource.substring(0, valueSource.indexOf(oldValue));
+            l = l.withValue(newValue).withValueSource(delimiter + newValue + delimiter);
+        }
+        return l;
+    }
+}

--- a/rewrite-gradle/src/test/kotlin/org/openrewrite/gradle/security/UseHttpsForRepositoriesTest.kt
+++ b/rewrite-gradle/src/test/kotlin/org/openrewrite/gradle/security/UseHttpsForRepositoriesTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.security
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.gradle.GradleRecipeTest
+
+@Suppress("HttpUrlsUsage")
+class UseHttpsForRepositoriesTest : GradleRecipeTest {
+
+    override val recipe: Recipe
+        get() = UseHttpsForRepositories()
+
+    @Test
+    fun unchangedUseOfHttps() = assertUnchanged(
+        before = """
+            repositories {
+                maven { url 'https://repo.spring.example.com/libs-release-local' }
+            }
+        """
+    )
+
+    @Test
+    fun updateUnwrappedInvocationToUseHttpsSingleQuote() = assertChanged(
+        before = """
+            repositories {
+                maven { url 'http://repo.spring.example.com/libs-release-local' }
+            }
+        """,
+        after = """
+            repositories {
+                maven { url 'https://repo.spring.example.com/libs-release-local' }
+            }
+        """
+    )
+
+    @Test
+    fun updateUnwrappedInvocationToUseHttpsDoubleQuote() = assertChanged(
+        before = """
+            repositories {
+                maven { url "http://repo.spring.example.com/libs-release-local" }
+            }
+        """,
+        after = """
+            repositories {
+                maven { url "https://repo.spring.example.com/libs-release-local" }
+            }
+        """
+    )
+
+    @Test
+    fun updateUnwrappedInvocationToUseHttpsGString() = assertChanged(
+        before = """
+            repositories {
+                maven {
+                    def subRepo = properties.snapshot ? 'snapshot' : 'release'
+                    url "http://repo.spring.example.com/libs-release-local/${'$'}subRepo"
+                }
+            }
+        """,
+        after = """
+            repositories {
+                maven {
+                    def subRepo = properties.snapshot ? 'snapshot' : 'release'
+                    url "https://repo.spring.example.com/libs-release-local/${'$'}subRepo"
+                }
+            }
+        """
+    )
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/DelegatingGroovyTypeVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/DelegatingGroovyTypeVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.groovy;
 
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
@@ -63,7 +63,7 @@ public class GroovyVisitor<P> extends JavaVisitor<P> {
         } else {
             g = (G.GString) temp;
         }
-        visit(g.getStrings(), p);
+        g = g.withStrings(ListUtils.map(g.getStrings(), s -> visit(s, p)));
         g = g.withType(gString.getType());
         return g;
     }


### PR DESCRIPTION
```kotlin
@Test
fun updateUnwrappedInvocationToUseHttpsSingleQuote() = assertChanged(
    before = """
        repositories {
            maven { url 'http://repo.spring.example.com/libs-release-local' }
        }
    """,
    after = """
        repositories {
            maven { url 'https://repo.spring.example.com/libs-release-local' }
        }
    """
)
```

Update all  repository declaration sites to use HTTPS