### PR TITLE
Prevent RemoveUnusedPrivateMethods from removing methods with generic types.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnusedPrivateMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnusedPrivateMethods.java
@@ -92,6 +92,14 @@ public class RemoveUnusedPrivateMethods extends Recipe {
                         }
                     }
 
+                    // Temporary stop-gap until we have data flow analysis.
+                    // Do not remove method declarations with generic types since the method invocation in `cu.getTypesInUse` will be bounded with a type.
+                    for (JavaType.Method usedMethodType : cu.getTypesInUse().getDeclaredMethods()) {
+                        if (methodType.getName().equals(usedMethodType.getName()) && methodType.equals(usedMethodType) && m.toString().contains("Generic{")) {
+                            return m;
+                        }
+                    }
+
                     //noinspection ConstantConditions
                     return null;
                 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnusedPrivateMethodsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnusedPrivateMethodsTest.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
 import org.openrewrite.Recipe
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
@@ -80,6 +81,24 @@ interface RemoveUnusedPrivateMethodsTest : JavaRecipeTest {
                 }
                 private Stream<Arguments> sourceExample() {
                     return null;
+                }
+            }
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1536")
+    @Test
+    fun privateMethodWithBoundedGenericTypes() = assertUnchanged(
+        before = """
+            public class TestClass {
+                void method() {
+                    checkMethodInUse("String", "String");
+                }
+
+                private static void checkMethodInUse(String arg0, String arg1) {
+                }
+
+                private static <T> void checkMethodInUse(String arg0, T arg1) {
                 }
             }
         """


### PR DESCRIPTION
Changes:
- RemoveUnusedPrivateMethods will not remove private method declarations with a generic type.

fixes #1536