### PR TITLE
Fix parent/module resolution in MavenParser

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -128,7 +128,7 @@ public class MavenParser implements Parser<Xml.Document> {
             }
 
             if (!modules.isEmpty()) {
-                parsed.set(i, maven.withMarkers(maven.getMarkers().computeByType(resolutionResult.withModules(modules), (old, n) -> n)));
+                resolutionResult.unsafeSetModules(modules);
             }
         }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -45,6 +45,7 @@ public class MavenResolutionResult implements Marker {
      * Resolution results of POMs in this repository that hold this POM as a parent.
      */
     @With
+    @NonFinal
     List<MavenResolutionResult> modules;
 
     @Nullable
@@ -120,6 +121,10 @@ public class MavenResolutionResult implements Marker {
 
     public void unsafeSetParent(MavenResolutionResult parent) {
         this.parent = parent;
+    }
+
+    public void unsafeSetModules(List<MavenResolutionResult> modules) {
+        this.modules = new ArrayList<>(modules);
     }
 
     @Incubating(since = "7.18.0")


### PR DESCRIPTION
@jkschneider @pway99 I had a hard time tracking this one but I think I got to the bottom of it. In this case, I think using the same pattern for the modules as for the parent is safe enough and not creating a copy is the way to go.
In any case, you have a test showing the issue if you think this fix is not correct.

====

Creating a copy is problematic as we are then pointing to stale objects
that do not contain the whole updated information.
In the case of the test, the project in the middle of the hierarchy
loses its parent in the process.
Then when maybeUpdateModel() is called, the pom file cannot be
downloaded and an exception is thrown, resulting in the document not
being updated.
This uses the same pattern for modules as what is currently used to set
the parent.

Related to the issues described in #1582.