### PR TITLE
Updated JsonPathMatchers to cache the scope before evaluating a binaryExpression

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonPathMatcher.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonPathMatcher.java
@@ -484,6 +484,7 @@ public class JsonPathMatcher {
                 }
             } else if (ctx.EQUALITY_OPERATOR() != null) {
                 // Equality operators may resolve the LHS and RHS without caching scope.
+                Object originalScope = scope;
                 lhs = getBinaryExpressionResult(lhs);
                 rhs = getBinaryExpressionResult(rhs);
                 String operator;
@@ -508,7 +509,13 @@ public class JsonPathMatcher {
                     }
                     return matches;
                 } else {
-                    return getOperatorResult(lhs, operator, rhs);
+                    if (originalScope instanceof Json.Member) {
+                        if (getOperatorResult(lhs, operator, rhs) != null) {
+                            return originalScope;
+                        }
+                    } else {
+                        return getOperatorResult(lhs, operator, rhs);
+                    }
                 }
             }
 

--- a/rewrite-json/src/test/kotlin/org/openrewrite/json/JsonPathMatcherTest.kt
+++ b/rewrite-json/src/test/kotlin/org/openrewrite/json/JsonPathMatcherTest.kt
@@ -230,6 +230,27 @@ class JsonPathMatcherTest {
             "\"literal\": \"$.object.list[0]\"")
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1590")
+    @Test
+    fun returnScopeOfMemberOnBinaryEx() = assertMatched(
+        jsonPath = "$.root[?(@.on == 'condition')].list",
+        before = arrayOf("""
+            {
+              "root": {
+                "on": "condition",
+                "list": [
+                  "item"
+                ]
+              }
+            }
+        """.trimIndent()),
+        after = arrayOf("""
+            "list": [
+              "item"
+            ]
+        """.trimIndent())
+    )
+
     @Test
     fun recurseToMatchProperties() = assertMatched(
         jsonPath = "$..object.literal",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
@@ -504,6 +504,7 @@ public class JsonPathMatcher {
                 }
             } else if (ctx.EQUALITY_OPERATOR() != null) {
                 // Equality operators may resolve the LHS and RHS without caching scope.
+                Object originalScope = scope;
                 lhs = getBinaryExpressionResult(lhs);
                 rhs = getBinaryExpressionResult(rhs);
                 String operator;
@@ -528,7 +529,13 @@ public class JsonPathMatcher {
                     }
                     return matches;
                 } else {
-                    return getOperatorResult(lhs, operator, rhs);
+                    if (originalScope instanceof Yaml.Mapping.Entry) {
+                        if (getOperatorResult(lhs, operator, rhs) != null) {
+                            return originalScope;
+                        }
+                    } else {
+                        return getOperatorResult(lhs, operator, rhs);
+                    }
                 }
             }
             return null;

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
@@ -186,6 +186,22 @@ class JsonPathMatcherTest {
         after = arrayOf("literal: $.literal", "literal: $.object.literal", "literal: $.object.list[0]")
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1590")
+    @Test
+    fun returnScopeOfMappingEntryOnBinaryEx() = assertMatched(
+        jsonPath = "$.root[?(@.on == 'condition')].list",
+        before = arrayOf("""
+            root:
+              on: condition
+              list:
+                - item
+        """.trimIndent()),
+        after = arrayOf("""
+            list:
+                - item
+        """.trimIndent())
+    )
+
     @Test
     fun recurseToMatchProperties() = assertMatched(
         jsonPath = "$..object.literal",


### PR DESCRIPTION
Changes:

- JsonPathMatcher will return the correct scope when a binary expression is used on a model object with a key-value pair.

fixes #1590