### PR TITLE
rename fieldAccess when variable is renamed

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
@@ -89,8 +89,16 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
         public J.Identifier visitIdentifier(J.Identifier ident, P p) {
             // The size of the stack will be 1 if the identifier is in the right scope.
             if (ident.getSimpleName().equals(variable.getSimpleName()) && isInSameNameScope(scope, getCursor()) && currentNameScope.size() == 1) {
-                if (!(getCursor().dropParentUntil(J.class::isInstance).getValue() instanceof J.FieldAccess)) {
+                J parent  = getCursor().dropParentUntil(J.class::isInstance).getValue();
+                if (!(parent instanceof J.FieldAccess)) {
                     return ident.withSimpleName(toName);
+                } else if (parent instanceof J.FieldAccess && ((J.FieldAccess) parent).getTarget() instanceof J.Identifier) {
+                    J.FieldAccess fieldAccess =  ((J.FieldAccess) parent);
+                    J.Identifier fieldAccessTarget = (J.Identifier) fieldAccess.getTarget();
+                    if (fieldAccessTarget.getFieldType().equals(variable.getName().getFieldType())
+                            || fieldAccessTarget.getFieldType().getType().equals(variable.getName().getFieldType().getOwner())){
+                        return ident.withSimpleName(toName);
+                    }
                 }
             }
             return super.visitIdentifier(ident, p);

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RenameVariableTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RenameVariableTest.kt
@@ -536,6 +536,67 @@ interface RenameVariableTest : JavaRecipeTest {
         """
     )
 
+    @Suppress("UnnecessaryLocalVariable")
+    @Test
+    fun renameFieldAccessVariables(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = renameVariableTest("A", "val", "VALUE"),
+        dependsOn =  arrayOf("""
+            class ClassWithPublicField {
+                public int publicField = 10;
+            }
+        """),
+        before = """
+            public class A {
+                public ClassWithPublicField val = new ClassWithPublicField();
+
+                int getNumberTwice() {
+                    val.publicField = this.val.publicField + 10;
+                    return val.publicField;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public ClassWithPublicField VALUE = new ClassWithPublicField();
+
+                int getNumberTwice() {
+                    VALUE.publicField = this.VALUE.publicField + 10;
+                    return VALUE.publicField;
+                }
+            }
+        """
+    )
+
+    @Suppress("UnnecessaryLocalVariable")
+    @Test
+    fun renameLocalFieldAccessInStaticMethod(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = renameVariableTest("A", "val", "VALUE"),
+        before = """
+            public class A {
+                private int val;
+
+                static A getInstance() {
+                    A a = new A();
+                    a.val = 12;
+                    return a;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                private int VALUE;
+
+                static A getInstance() {
+                    A a = new A();
+                    a.VALUE = 12;
+                    return a;
+                }
+            }
+        """
+    )
+
     @Suppress("StatementWithEmptyBody", "ConstantConditions", "UnusedAssignment")
     @Test
     fun renameVariable(jp: JavaParser) = assertChanged(


### PR DESCRIPTION
Currently there is a compilation error, when a variable with field access is renamed.

With this pull request the variables with field access will be renamed as expected.