### PR TITLE
introduce RenamePrivateFieldsToCamelCase recipe

### DIFF
--- a/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
+++ b/rewrite-java-11/src/test/kotlin/org/openrewrite/java/Java11VisitorDebugTests.kt
@@ -480,6 +480,10 @@ class Java11RenameLocalVariablesToCamelCaseTest : Java11Test, RenameLocalVariabl
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java11RenamePrivateFieldsToCamelCaseTest : Java11Test, RenamePrivateFieldsToCamelCaseTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java11RenameMethodsNamedHashcodeEqualOrTostringTest : Java11Test, RenameMethodsNamedHashcodeEqualOrTostringTest
 
 @DebugOnly

--- a/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
+++ b/rewrite-java-8/src/test/kotlin/org/openrewrite/java/Java8VisitorDebugTest.kt
@@ -464,6 +464,10 @@ class Java8RenameLocalVariablesToCamelCaseTest : Java8Test, RenameLocalVariables
 
 @DebugOnly
 @ExtendWith(JavaParserResolver::class)
+class Java8RenamePrivateFieldsToCamelCaseTest : Java8Test, RenamePrivateFieldsToCamelCaseTest
+
+@DebugOnly
+@ExtendWith(JavaParserResolver::class)
 class Java8RenameMethodsNamedHashcodeEqualOrTostringTest : Java8Test, RenameMethodsNamedHashcodeEqualOrTostringTest
 
 @DebugOnly

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCase.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCase.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RenameVariable;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+
+import java.time.Duration;
+import java.util.*;
+
+import static org.openrewrite.internal.NameCaseConvention.LOWER_CAMEL;
+
+/**
+ * This recipe converts private fields to camel case convention.
+ * <p>
+ * The first character is set to lower case and existing capital letters are preserved.
+ * Special characters that are allowed in java field names `$` and `_` are removed.
+ * If a special character is removed the next valid alpha-numeric will be capitalized.
+ * <p>
+ * Currently, unsupported:
+ * - The recipe will not rename fields if the result already exists in a class or the result will be a java reserved keyword.
+ */
+public class RenamePrivateFieldsToCamelCase extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Reformat private field names to camelCase";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Reformat private field names to camelCase to comply with Java naming convention. " +
+                "The recipe will not rename fields with default, protected or public access modifiers." +
+                "The recipe will not rename private constants." +
+                "The first character is set to lower case and existing capital letters are preserved. " +
+                "Special characters that are allowed in java field names `$` and `_` are removed. " +
+                "If a special character is removed the next valid alphanumeric will be capitalized. " +
+                "The recipe will not rename a field if the result already exists in the class, conflicts with a java reserved keyword, or the result is blank.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return new LinkedHashSet<>(Arrays.asList("RSPEC-116", "RSPEC-3008"));
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RenameNonCompliantNames();
+    }
+
+    private static class RenameNonCompliantNames extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext ctx) {
+            Map<J.VariableDeclarations.NamedVariable, String> renameVariablesMap = new LinkedHashMap<>();
+            Set<String> hasNameSet = new HashSet<>();
+
+            getCursor().putMessage("RENAME_VARIABLES_KEY", renameVariablesMap);
+            getCursor().putMessage("HAS_NAME_KEY", hasNameSet);
+            super.visitJavaSourceFile(cu, ctx);
+
+            renameVariablesMap.forEach((key, value) -> {
+                if (!hasNameSet.contains(value) && !hasNameSet.contains(key.getSimpleName())) {
+                    doAfterVisit(new RenameVariable<>(key, value));
+                    hasNameSet.add(value);
+                }
+            });
+            return cu;
+        }
+
+        @SuppressWarnings("all")
+        @Override
+        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
+            Cursor parentScope = getCursorToParentScope(getCursor());
+
+            // Does support renaming private fields in a J.ClassDeclaration.
+            if ((parentScope.getParent() != null && parentScope.getParent().getValue() instanceof J.ClassDeclaration && variable.getVariableType().hasFlags(Flag.Private) &&
+                    //do not rename constants
+                    !(variable.getVariableType().hasFlags(Flag.Static, Flag.Final)) &&
+                    // Does not apply for instance variables of inner classes
+                    !((J.ClassDeclaration) parentScope.getParent().getValue()).getType().getFullyQualifiedName().contains("$") &&
+                    // Name does not match camelCase pattern.
+                    !LOWER_CAMEL.matches(variable.getSimpleName()))) {
+                String toName = LOWER_CAMEL.format(variable.getSimpleName());
+                ((Map<J.VariableDeclarations.NamedVariable, String>) getCursor().getNearestMessage("RENAME_VARIABLES_KEY")).put(variable, toName);
+            } else {
+                ((Set<String>) getCursor().getNearestMessage("HAS_NAME_KEY")).add(variable.getSimpleName());
+            }
+
+            return variable;
+        }
+
+        @SuppressWarnings("all")
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+            Map<J.VariableDeclarations.NamedVariable, String> renameVariablesMap = (Map<J.VariableDeclarations.NamedVariable, String>) getCursor().getNearestMessage("RENAME_VARIABLES_KEY");
+            for (J.VariableDeclarations.NamedVariable variableToRename : renameVariablesMap.keySet()) {
+                if (variableToRename.getSimpleName().equals(identifier.getSimpleName())) {
+                    return identifier;
+                }
+            }
+            if(identifier.getType() == null) {
+                ((Set<String>) getCursor().getNearestMessage("HAS_NAME_KEY")).add(identifier.getSimpleName());
+            }
+            return identifier;
+        }
+
+        /**
+         * Returns either the current block or a J.Type that may create a reference to a variable.
+         * I.E. for(int target = 0; target < N; target++) creates a new name scope for `target`.
+         * The name scope in the next J.Block `{}` cannot create new variables with the name `target`.
+         * <p>
+         * J.* types that may only reference an existing name and do not create a new name scope are excluded.
+         */
+        private static Cursor getCursorToParentScope(Cursor cursor) {
+            return cursor.dropParentUntil(is -> is instanceof J.Block);
+        }
+    }
+
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -381,6 +381,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class RenameLocalVariablesToCamelCaseTck : RenameLocalVariablesToCamelCaseTest
 
     @Nested
+    inner class RenamePrivateFieldsToCamelCaseTck : RenamePrivateFieldsToCamelCaseTest
+
+    @Nested
     inner class RenameMethodsNamedHashcodeEqualOrTostringTck : RenameMethodsNamedHashcodeEqualOrTostringTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCaseTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCaseTest.kt
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+interface RenamePrivateFieldsToCamelCaseTest : JavaRecipeTest {
+    override val recipe: Recipe?
+        get() = RenamePrivateFieldsToCamelCase()
+
+    @Test
+    fun doNotChangeStaticImports(jp: JavaParser) = assertUnchanged(
+        jp,
+        dependsOn = arrayOf("""
+            class B {
+                public static int _staticImport_ = 0;
+            }
+        """),
+        before = """
+            import static B._staticImport_;
+
+            class Test {
+                private int member = _staticImport_;
+            }
+        """
+    )
+
+    @Test
+    fun doNotChangeInheritedFields(jp: JavaParser) = assertChanged(
+        jp,
+        dependsOn = arrayOf("""
+            class A {
+                public int _inheritedField_ = 0;
+            }
+        """),
+        before = """
+            class Test extends A {
+                private int _inheritedField_ = super._inheritedField_;
+            }
+        """,
+        after = """
+            class Test extends A {
+                private int inheritedField = super._inheritedField_;
+            }
+        """
+    )
+
+    @Test
+    fun doNotChangeIfToNameExists(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                int test_value;
+
+                public int addTen(int testValue) {
+                    return test_value + testValue;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotChangeExistsInOnlyOneMethod(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                private int DoNoTChange;
+                
+                public int addTwenty(String doNoTChange) {
+                    return DoNoTChange + 20;
+                }
+                public int addTen(String value) {
+                    return DoNoTChange + 10;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun renamePrivateMembers(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                private int DoChange = 10;
+                public int DoNotChangePublicMember;
+                int DoNotChangeDefaultMember;
+
+                public int getTen() {
+                    return DoChange;
+                }
+
+                public int getTwenty() {
+                    return this.DoChange * 2;
+                }
+
+                public int getThirty() {
+                    return DoChange * 3;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                private int doChange = 10;
+                public int DoNotChangePublicMember;
+                int DoNotChangeDefaultMember;
+
+                public int getTen() {
+                    return doChange;
+                }
+
+                public int getTwenty() {
+                    return this.doChange * 2;
+                }
+
+                public int getThirty() {
+                    return doChange * 3;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun renameWithFieldAccess(jp: JavaParser) = assertChanged(
+        jp,
+        dependsOn = arrayOf("""
+            class ClassWithPublicField {
+                public int publicField = 10;
+            }
+        """),
+        before = """
+            class Test {
+                private ClassWithPublicField DoChange = new ClassWithPublicField();
+
+                public int getTen() {
+                    return DoChange.publicField;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                private ClassWithPublicField doChange = new ClassWithPublicField();
+
+                public int getTen() {
+                    return doChange.publicField;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotRenameInnerClassesMembers(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            class Test {
+                private int test = new InnerClass().DoNotChange + new InnerClass().DoNotChange2;
+                
+                private class InnerClass{
+                    public int DoNotChange = 10;
+                    private int DoNotChange2 = 10;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun renameUsageInInnerClasses(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                private int DoChange = 10;
+                
+                private class InnerClass{
+                    private int test = DoChange + 1;
+                }
+            }
+        """,
+        after = """
+            class Test {
+                private int doChange = 10;
+                
+                private class InnerClass{
+                    private int test = doChange + 1;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun doNotRenameAnonymousInnerClasses(jp: JavaParser) = assertUnchanged(
+        jp,
+        dependsOn = arrayOf("""
+                interface Book{}
+            """),
+        before = """
+                class B (){
+                    B(){
+                        new Book() {
+                          private String DoChange;
+
+                          @Override
+                          public String toString() {
+                            return DoChange;
+                          }
+                        };
+                    }
+                }
+        """
+    )
+
+    @Test
+    fun handleStaticMethods(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+                class A (){
+                    private int _variable;
+                    public static A getInstance(){
+                        A a = new A();
+                        a._variable = 12;
+                        return a;
+                    }
+                }
+        """,
+        after = """
+                class A (){
+                    private int variable;
+                    public static A getInstance(){
+                        A a = new A();
+                        a.variable = 12;
+                        return a;
+                    }
+                }
+        """
+    )
+
+    @Test
+    fun renameFinalMembers(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+                class A (){
+                    private final int _final_variable;
+                    private static int _static_variable;
+                    private static final int DO_NOT_CHANGE;
+                }
+        """,
+        after = """
+                class A (){
+                    private final int finalVariable;
+                    private static int staticVariable;
+                    private static final int DO_NOT_CHANGE;
+                }
+        """
+    )
+
+    @Test
+    fun doNotChangeWhenSameMethodParam(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+                class A (){
+                    private int _variable;
+                    public void getInstance(int _variable){
+                        this._variable = _variable;
+                    }
+                }
+        """
+    )
+}


### PR DESCRIPTION
In addition to the RenameLocalVariablesToCamelCase recipe, i created a new recipe called RenamePrivateFieldsToCamelCase. Stated in the name, this receipe will reformat private field names to camelCase to comply with Java naming convention.

Further details see https://jira.sonarsource.com/browse/RSPEC-116 and https://jira.sonarsource.com/browse/RSPEC-3008