### PR TITLE
Updated WatchableExecutionContext to account for `ExecutionContext.CURRENT_RECIPE`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -174,6 +174,9 @@ public interface RecipeScheduler {
         AtomicBoolean thrownErrorOnTimeout = new AtomicBoolean(false);
         Recipe recipe = recipeStack.peek();
         ctx.putCurrentRecipe(recipe);
+        if (ctx instanceof WatchableExecutionContext) {
+            ((WatchableExecutionContext) ctx).resetHasNewMessages();
+        }
 
         if (recipe.getApplicableTest() != null) {
             boolean applicable = false;


### PR DESCRIPTION
Changes

- `WatchableExecutionContext` will not set `hasNewMessages` to true if the message is `ExecutionContext.CURRENT_RECIPE`.

fixes #1617