### PR TITLE
Do not remove unrelated empty entries in `yaml/DeleteKey`.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
@@ -80,7 +80,7 @@ public class DeleteKey extends Recipe {
                         if (i == 0 && getCursor().getParentOrThrow().getValue() instanceof Yaml.Sequence.Entry) {
                             copyFirstPrefix.set(e.getPrefix());
                         }
-                        removeUnused();
+                        removeUnused(getCursor().getParent());
                         return null;
                     }
                     return e;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
@@ -117,9 +117,9 @@ public class YamlVisitor<P> extends TreeVisitor<Yaml, P> {
         }
     }
 
-    public void removeUnused() {
+    public void removeUnused(@Nullable Cursor cursorParent) {
         if (getAfterVisit().stream().noneMatch(RemoveUnusedVisitor.class::isInstance)) {
-            doAfterVisit(new RemoveUnusedVisitor<>());
+            doAfterVisit(new RemoveUnusedVisitor<>(cursorParent));
         }
     }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/cleanup/RemoveUnused.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/cleanup/RemoveUnused.java
@@ -33,6 +33,6 @@ public class RemoveUnused extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new RemoveUnusedVisitor<>();
+        return new RemoveUnusedVisitor<>(null);
     }
 }

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DeleteKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DeleteKeyTest.kt
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.yaml
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.Issue
@@ -143,9 +142,8 @@ class DeleteKeyTest : YamlRecipeTest {
         """
     )
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1175")
-    @Disabled
+    @Test
     fun deleteKeyKeepingUnrelatedUnusedKeys() = assertChanged(
         recipe = DeleteKey("$.jobs.build.strategy.fail-fast", null),
         before = """


### PR DESCRIPTION
Changes:

- Added a nullable Cursor to limit the scope of removed entries in `RemoveUnusedVisitor`.
- Updated `DeleteKey` to only remove empty yaml in the scope of the removed key.

fixes #1175