### PR TITLE
Default `ImportLayoutStyle#layout` to IntelliJ settings if `layout` is empty

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -86,7 +86,7 @@ public class ImportLayoutStyle implements JavaStyle {
     public ImportLayoutStyle(int classCountToUseStarImport, int nameCountToUseStarImport, List<Block> layout, List<Block> packagesToFold) {
         this.classCountToUseStarImport = classCountToUseStarImport;
         this.nameCountToUseStarImport = nameCountToUseStarImport;
-        this.layout = layout;
+        this.layout = layout.isEmpty() ? IntelliJ.importLayout().getLayout() : layout;
         this.packagesToFold = packagesToFold;
 
         // Divide the blocks into those that accept imports from any package ("catchalls") and those that accept imports from only specific packages

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/AddImportTest.kt
@@ -942,6 +942,26 @@ interface AddImportTest : JavaRecipeTest {
         """
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1687")
+    @Test
+    fun noImportLayout() = assertChanged(
+        JavaParser.fromJavaVersion().styles(
+            listOf(
+                NamedStyles(
+                    Tree.randomId(), "test", "test", "test", emptySet(), listOf(
+                        ImportLayoutStyle(999, 999, emptyList(), emptyList())
+                    )
+                )
+            )
+        ).build(),
+        recipe = addImports({ AddImport("java.util.List", null, false) }),
+        before = """
+        """,
+        after = """
+            import java.util.List;
+        """
+    )
+
     @Test
     fun foldStaticSubPackageWithExistingImports() = assertChanged(
         JavaParser.fromJavaVersion().styles(


### PR DESCRIPTION
Changes:

- Set `ImportLayoutStyle#layout` to IntelliJ default settings if an ImportLayoutStyle is provided without a `layout`.

fixes #1687