### PR TITLE
Updated encoding detection in `EncodingDetectingInputStream`.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/EncodingDetectingInputStream.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/EncodingDetectingInputStream.java
@@ -24,6 +24,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class EncodingDetectingInputStream extends InputStream {
+    private static final Charset WINDOWS_1252 = Charset.forName("Windows-1252");
+
     private final InputStream inputStream;
 
     @Nullable
@@ -37,6 +39,10 @@ public class EncodingDetectingInputStream extends InputStream {
     private int prev;
     private int prev2;
     private int prev3;
+
+    boolean maybeTwoByteSequence = false;
+    boolean maybeThreeByteSequence = false;
+    boolean maybeFourByteSequence = false;
 
     public EncodingDetectingInputStream(InputStream inputStream) {
         this.inputStream = inputStream;
@@ -55,17 +61,61 @@ public class EncodingDetectingInputStream extends InputStream {
         int aByte = inputStream.read();
 
         // if we haven't yet determined a charset...
-        if (charset == null && aByte != -1) {
+        if (charset == null) {
             if (prev3 == 0xC3 && prev2 == 0xAF && prev == 0xC2) {
                 charsetBomMarked = true;
                 charset = StandardCharsets.UTF_8;
             } else {
-                if (aByte >= 0x80 && notUtfHighByte(aByte)) {
-                    if (notUtfHighByte(prev)) {
-                        charset = Charset.forName("Windows-1252");
+                if (aByte == -1 || !(prev2 == 0 && prev == 0xC3 || prev3 == 0 && prev2 == 0xC3)) {
+                    if (maybeTwoByteSequence) {
+                        if (aByte == -1 && !utf8SequenceEnd(prev) || aByte != -1 && !(utf8SequenceEnd(aByte))) {
+                            charset = WINDOWS_1252;
+                        } else {
+                            maybeTwoByteSequence = false;
+                            prev2 = -1;
+                            prev = -1;
+                        }
+                    } else if (maybeThreeByteSequence) {
+                        if (aByte == -1 ||
+                                utf8SequenceEnd(prev) && !(utf8SequenceEnd(aByte)) ||
+                                !utf8SequenceEnd(aByte)) {
+                            charset = WINDOWS_1252;
+                        }
+
+                        if (utf8SequenceEnd(prev) && utf8SequenceEnd(aByte)) {
+                            maybeThreeByteSequence = false;
+                            prev2 = -1;
+                            prev = -1;
+                        }
+                    } else if (maybeFourByteSequence) {
+                        if (aByte == -1 ||
+                                utf8SequenceEnd(prev2) && utf8SequenceEnd(prev) && !utf8SequenceEnd(aByte) ||
+                                utf8SequenceEnd(prev) && !utf8SequenceEnd(aByte) ||
+                                !(utf8SequenceEnd(aByte))) {
+                            charset = WINDOWS_1252;
+                        }
+
+                        if (utf8SequenceEnd(prev2) && utf8SequenceEnd(prev) && utf8SequenceEnd(aByte)) {
+                            maybeFourByteSequence = false;
+                            prev2 = -1;
+                            prev = -1;
+                        }
+                    } else if (utf8TwoByteSequence(aByte)) {
+                        maybeTwoByteSequence = true;
+                    } else if (utf8ThreeByteSequence(aByte)) {
+                        maybeThreeByteSequence = true;
+                    } else if (utf8FourByteSequence(aByte)) {
+                        maybeFourByteSequence = true;
+                    } else if (!utf8TwoByteSequence(prev) && utf8SequenceEnd(aByte)) {
+                        charset = WINDOWS_1252;
                     }
                 }
+
+                if (aByte == -1 && charset == null) {
+                    charset = StandardCharsets.UTF_8;
+                }
             }
+
             prev3 = prev2;
             prev2 = prev;
             prev = aByte;
@@ -89,7 +139,23 @@ public class EncodingDetectingInputStream extends InputStream {
         }
     }
 
-    private boolean notUtfHighByte(int b) {
-        return b < 0xC2 || b > 0xD0;
+    // The first byte of a UTF-8 two byte sequence is between 0xC0 - 0xDF.
+    private boolean utf8TwoByteSequence(int b) {
+        return 0xC0 <= b && b <= 0xDF;
+    }
+
+    // The first byte of a UTF-8 three byte sequence is between 0xE0 - 0xEF.
+    private boolean utf8ThreeByteSequence(int b) {
+        return 0xE0 <= b && b <= 0xEF;
+    }
+
+    // The first byte of a UTF-8 four byte sequence is between 0xF0 - 0xF7.
+    private boolean utf8FourByteSequence(int b) {
+        return 0xF0 <= b && b <= 0xF7;
+    }
+
+    // A UTF-8 byte sequence must end between 0x80 - 0xBF.
+    private boolean utf8SequenceEnd(int b) {
+        return 0x80 <= b && b <= 0xBF;
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/internal/EncodingDetectingInputStreamTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/EncodingDetectingInputStreamTest.java
@@ -53,13 +53,16 @@ public class EncodingDetectingInputStreamTest {
     }
 
     @Test
-    void oddPairInWINDOWS_1252() {
-        assertThat(read("ÂÂ", WINDOWS_1252).getCharset()).isEqualTo(UTF_8);
+    void oddPairInWindows1252() {
+        // Range 1: 0xC0 - 0xDF == "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß"
+        // Range 2: 0x80 - 0xBF == "€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”·–—˜™š›œžŸ¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿"
+        // A character in range 1 followed by a character in range 2 encoded in Windows-1252 will be detected as UTF-8.
+        assertThat(read("À€", WINDOWS_1252).getCharset()).isEqualTo(UTF_8);
     }
 
     @Test
     void utf8Characters() {
-        for (int i = 0; i < 1024; i++) {
+        for (int i = 192; i < 2048; i++) {
             String c = Character.toString((char) i);
             assertThat(read(c, UTF_8).getCharset()).isEqualTo(UTF_8);
         }


### PR DESCRIPTION
Changes:

- Detects characters in a range of a UTF-8 2, 3, or 4-byte sequence.
- Sets the encoding to Windows-1252 if the previous bytes do not match a valid UTF-8 sequence.