### PR TITLE
Cleanups: Add Tests

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/DeleteStatementTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/DeleteStatementTest.kt
@@ -46,4 +46,83 @@ interface DeleteStatementTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun deleteSecondStatement(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = object: TestRecipe() {
+            override fun getVisitor(): TreeVisitor<*, ExecutionContext> {
+                return object: JavaIsoVisitor<ExecutionContext>() {
+                    override fun visitBlock(block: J.Block, p: ExecutionContext): J.Block {
+                        val b = super.visitBlock(block, p)
+                        if (b.statements.size != 4) return b
+                        b.statements.forEachIndexed { i, s ->
+                            if (i == 1) {
+                                doAfterVisit(DeleteStatement(s))
+                            }
+                        }
+                        return b
+                    }
+                }
+            }
+        },
+        before = """
+            public class A {
+               {
+                  String s = "";
+                  s.toString();
+                  s = "hello";
+                  s.toString();
+               }
+            }
+        """,
+        after = """
+            public class A {
+               {
+                  String s = "";
+                  s = "hello";
+                  s.toString();
+               }
+            }
+        """
+    )
+
+    @Test
+    fun deleteSecondAndFourthStatement(jp: JavaParser) = assertChanged(
+        jp,
+        recipe = object: TestRecipe() {
+            override fun getVisitor(): TreeVisitor<*, ExecutionContext> {
+                return object: JavaIsoVisitor<ExecutionContext>() {
+                    override fun visitBlock(block: J.Block, p: ExecutionContext): J.Block {
+                        val b = super.visitBlock(block, p)
+                        if (b.statements.size != 4) return b
+                        b.statements.forEachIndexed { i, s ->
+                            if (i == 1 || i == 3) {
+                                doAfterVisit(DeleteStatement(s))
+                            }
+                        }
+                        return b
+                    }
+                }
+            }
+        },
+        before = """
+            public class A {
+               {
+                  String s = "";
+                  s.toString();
+                  s = "hello";
+                  s.toString();
+               }
+            }
+        """,
+        after = """
+            public class A {
+               {
+                  String s = "";
+                  s = "hello";
+               }
+            }
+        """
+    )
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
@@ -532,4 +532,24 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun simplifyConstantIfTrueBlockInWhile(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    while (true)
+                        if (true) break;
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    while (true) break;
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
I need a non-iso version of `DeleteStatement`. I figure that instead of having another copy of the code, it would be better to make `DeleteStatement` non-iso:

https://github.com/openrewrite/rewrite-java-security/pull/19/files#diff-9398f78788834295d06b2a0c3b37ebd41b70fb4f8d67b2581d02d8235b3ce16aR288