### PR TITLE
Fix RemoveUnneededBlock formatting more than is strictly required

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
@@ -58,13 +58,18 @@ public class RemoveUnneededBlock extends Recipe {
             }
 
             // Else perform the flattening on this block.
-            return maybeAutoFormat(bl, block.withStatements(ListUtils.flatMap(bl.getStatements(), stmt -> {
+            return block.withStatements(ListUtils.flatMap(bl.getStatements(), stmt -> {
                 if (!(stmt instanceof J.Block)) {
                     return stmt;
                 }
                 J.Block nested = (J.Block) stmt;
-                return nested.getStatements();
-            })), executionContext, getCursor().getParentOrThrow());
+                return ListUtils.map(nested.getStatements(), inlinedStmt -> maybeAutoFormat(
+                        stmt,
+                        inlinedStmt,
+                        executionContext,
+                        getCursor()
+                ));
+            }));
         }
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededBlockTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededBlockTest.kt
@@ -287,4 +287,56 @@ interface RemoveUnneededBlockTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun simplifyDoesNotFormatSurroundingCode(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                static {
+                    int[] a = new int[] { 1, 2, 3 };
+                    int[] b = new int[] {4,5,6};
+                    {
+                        System.out.println("hello static!");
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                static {
+                    int[] a = new int[] { 1, 2, 3 };
+                    int[] b = new int[] {4,5,6};
+                    System.out.println("hello static!");
+                }
+            }
+        """
+    )
+
+    @Test
+    fun simplifyDoesNotFormatInternalCode(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                static {
+                    int[] a = new int[] { 1, 2, 3 };
+                    int[] b = new int[] {4,5,6};
+                    {
+                        System.out.println("hello!");
+                        System.out.println( "world!" );
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                static {
+                    int[] a = new int[] { 1, 2, 3 };
+                    int[] b = new int[] {4,5,6};
+                    System.out.println("hello!");
+                    System.out.println("world!");
+                }
+            }
+        """
+    )
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
@@ -552,4 +552,34 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
             }
         """
     )
+
+
+    @Test
+    fun doNotFormatCodeOutsideRemovedBlock(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            public class A {
+                public void test() {
+                    int[] a = new int[] { 1, 2, 3 };
+                    int[] b = new int[] {4,5,6};
+                    if (true) {
+                        System.out.println("hello");
+                    }
+                    int[] c = new int[] { 1, 2, 3 };
+                    int[] d = new int[] {4,5,6};
+                }
+            }
+        """,
+        after = """
+            public class A {
+                public void test() {
+                    int[] a = new int[] { 1, 2, 3 };
+                    int[] b = new int[] {4,5,6};
+                    System.out.println("hello");
+                    int[] c = new int[] { 1, 2, 3 };
+                    int[] d = new int[] {4,5,6};
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
`RemoveUnneededBlock` was reformatting the entire block instead of only formatting the lines of code changed.