### PR TITLE
Prevent cast class exception if the symbol.type is `Type.Unknown`

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11TypeMapping.java
@@ -372,7 +372,7 @@ class Java11TypeMapping implements JavaTypeMapping<Tree> {
      */
     @Nullable
     public JavaType.Method methodInvocationType(@Nullable com.sun.tools.javac.code.Type selectType, @Nullable Symbol symbol) {
-        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR) {
+        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR || symbol.type instanceof Type.UnknownType) {
             return null;
         }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -373,7 +373,7 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
      */
     @Nullable
     public JavaType.Method methodInvocationType(@Nullable com.sun.tools.javac.code.Type selectType, @Nullable Symbol symbol) {
-        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.ERR) {
+        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.ERR || symbol.type instanceof Type.UnknownType) {
             return null;
         }
 


### PR DESCRIPTION
Changes:

- Prevent ClassCastException in `TypeMapping#methodInvocationType`.

Note: The cause is similar to commit [c36ef805](https://github.com/openrewrite/rewrite/commit/c36ef8058760f17b3a6f5ff16937fe2f182dd1c1). The commit ensures type attribution is on the classpath because Java 8 is more strict about missing type attribution.

Similarly, in the users reported case, type attribution is missing, which caused a lambda variable, o in `stream().map(o -> ...)` to have an unknown type. 


fixes #1762