### PR TITLE
Do not change var from Java 10 in UseCollectionInterfaces.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseCollectionInterfaces.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseCollectionInterfaces.java
@@ -146,6 +146,9 @@ public class UseCollectionInterfaces extends Recipe {
                 JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(mv.getType());
                 if ((mv.hasModifier(J.Modifier.Type.Public) || mv.hasModifier(J.Modifier.Type.Private) || mv.getModifiers().isEmpty()) &&
                         originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
+                    if (mv.getTypeExpression() instanceof J.Identifier && "var".equals(((J.Identifier) mv.getTypeExpression()).getSimpleName())) {
+                        return mv;
+                    }
 
                     JavaType.FullyQualified newType = TypeUtils.asFullyQualified(
                             JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UseCollectionInterfacesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/UseCollectionInterfacesTest.kt
@@ -15,10 +15,13 @@
  */
 package org.openrewrite.java.cleanup
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
 import org.openrewrite.Recipe
 import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.java.marker.JavaVersion
+import java.util.*
 
 interface UseCollectionInterfacesTest : JavaRecipeTest {
     override val recipe: Recipe
@@ -713,4 +716,23 @@ interface UseCollectionInterfacesTest : JavaRecipeTest {
             }
         """
     )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1771")
+    @Test
+    fun variableWithVar() {
+        val javaRuntimeVersion = System.getProperty("java.runtime.version")
+        val javaVendor = System.getProperty("java.vm.vendor")
+        if (JavaVersion(UUID.randomUUID(), javaRuntimeVersion, javaVendor, javaRuntimeVersion, javaRuntimeVersion).majorVersion >= 10) {
+            assertUnchanged(parser, recipe, executionContext,
+            """
+            import java.util.ArrayList;
+            
+            class Test {
+                public void method() {
+                    var list = new ArrayList<>();
+                }
+            }
+            """.trimIndent())
+        }
+    }
 }


### PR DESCRIPTION
Changes:

- UseCollectionInterfaces will not change variable declarations with type `var`.

fixes #1771