### PR TITLE
Updated `TypeUtils` with model changes from type mapping enhancements.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDelegatesToGradleApi.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDelegatesToGradleApi.java
@@ -72,7 +72,7 @@ public class AddDelegatesToGradleApi extends Recipe {
                         return it;
                     }
                     J.VariableDeclarations param = (J.VariableDeclarations) it;
-                    if (!(TypeUtils.isOfType(CLOSURE_TYPE, param.getType()) && FindAnnotations.find(param, "@groovy.lang.DelegatesTo").isEmpty())) {
+                    if (!(TypeUtils.isOfType(param.getType(), param.getType()) && FindAnnotations.find(param, "@groovy.lang.DelegatesTo").isEmpty())) {
                         return param;
                     }
                     if (method.getMethodType() == null || !(method.getMethodType().getDeclaringType() instanceof JavaType.Class)) {
@@ -81,7 +81,7 @@ public class AddDelegatesToGradleApi extends Recipe {
                     // Construct a matcher that will identify methods identical to this one except they accept Action instead of Closure
                     MethodMatcher matcher = new MethodMatcher(method.getMethodType().withParameterTypes(
                             ListUtils.map(method.getMethodType().getParameterTypes(), p -> {
-                                if (TypeUtils.isOfType(CLOSURE_TYPE, p)) {
+                                if (TypeUtils.isOfClassType(p, CLOSURE_TYPE.getFullyQualifiedName())) {
                                     return ACTION_TYPE;
                                 }
                                 return p;
@@ -93,7 +93,7 @@ public class AddDelegatesToGradleApi extends Recipe {
                     Optional<JavaType> maybeDelegateType = declaringClass.getMethods().stream()
                             .filter(matcher::matches)
                             .map(m -> (JavaType.Parameterized) m.getParameterTypes().stream()
-                                    .filter(mp -> TypeUtils.isOfType(ACTION_TYPE, mp))
+                                    .filter(mp -> TypeUtils.isOfClassType(mp, ACTION_TYPE.getFullyQualifiedName()))
                                     .findFirst().get())
                             .filter(m -> m.getTypeParameters().size() == 1)
                             .map(m -> m.getTypeParameters().get(0))
@@ -102,7 +102,7 @@ public class AddDelegatesToGradleApi extends Recipe {
                         return param;
                     }
                     JavaType.FullyQualified delegateType = unwrapGenericTypeVariable(maybeDelegateType.get());
-                    if(delegateType == null) {
+                    if (delegateType == null) {
                         return param;
                     }
                     String simpleName =  delegateType.getFullyQualifiedName().substring( delegateType.getFullyQualifiedName().lastIndexOf('.') + 1);
@@ -127,7 +127,7 @@ public class AddDelegatesToGradleApi extends Recipe {
     private static JavaType.FullyQualified unwrapGenericTypeVariable(JavaType type) {
         if (type instanceof JavaType.GenericTypeVariable) {
             JavaType.GenericTypeVariable genericType = (JavaType.GenericTypeVariable)type;
-            if(genericType.getBounds().size() == 1) {
+            if (genericType.getBounds().size() == 1) {
                 return unwrapGenericTypeVariable(genericType.getBounds().get(0));
             } else {
                 return null;
@@ -144,6 +144,6 @@ public class AddDelegatesToGradleApi extends Recipe {
 
     private static boolean hasClosureParameter(J.MethodDeclaration methodDeclaration) {
         return methodDeclaration.getParameters().stream()
-                .anyMatch(param -> param instanceof J.VariableDeclarations && TypeUtils.isOfType(CLOSURE_TYPE, ((J.VariableDeclarations)param).getType()));
+                .anyMatch(param -> param instanceof J.VariableDeclarations && TypeUtils.isOfClassType(((J.VariableDeclarations)param).getType(), CLOSURE_TYPE.getFullyQualifiedName()));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveRedundantTypeCast.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveRedundantTypeCast.java
@@ -69,7 +69,7 @@ public class RemoveRedundantTypeCast extends Recipe {
                 JavaType expressionType = typeCast.getExpression().getType();
 
                 JavaType namedVariableType = ((J.VariableDeclarations) parent.getValue()).getVariables().get(0).getType();
-                if (TypeUtils.isOfClassType(namedVariableType, "java.lang.Object") ||
+                if (!(namedVariableType instanceof JavaType.Array) && TypeUtils.isOfClassType(namedVariableType, "java.lang.Object") ||
                         (!(typeTree instanceof J.ParameterizedType) && (TypeUtils.isOfType(namedVariableType, expressionType) || TypeUtils.isAssignableTo(namedVariableType, expressionType)))) {
                     return typeCast.getExpression();
                 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TypeUtilsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/TypeUtilsTest.kt
@@ -24,6 +24,7 @@ import org.openrewrite.test.RewriteTest
 
 interface TypeUtilsTest : RewriteTest {
 
+    /* isOverride */
     @Test
     fun isOverrideBasicInterface(jp: JavaParser) = rewriteRun(
         { spec -> spec.parser(jp) },
@@ -121,8 +122,107 @@ interface TypeUtilsTest : RewriteTest {
         }}
     )
 
+    /* isOfType */
     @Test
-    fun arrayIsAssignableTo(jp: JavaParser) = rewriteRun(
+    fun isFullyQualifiedOfType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                Integer integer1;
+                Integer integer2;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable1 = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+            val variable2 = (cu.classes[0].body.statements[1] as J.VariableDeclarations).variables[0]
+            assertThat(variable1.variableType?.type).isInstanceOf(JavaType.Class::class.java)
+            assertThat(variable2.variableType?.type).isInstanceOf(JavaType.Class::class.java)
+            assertThat(TypeUtils.isOfType(variable1.variableType?.type, variable2.variableType?.type)).isTrue
+        }}
+    )
+
+    @Test
+    fun isParameterizedTypeOfType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                java.util.List<Integer> integer1;
+                java.util.List<Integer> integer2;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable1 = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+            val variable2 = (cu.classes[0].body.statements[1] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable1.variableType?.type).isInstanceOf(JavaType.Parameterized::class.java)
+            assertThat(variable2.variableType?.type).isInstanceOf(JavaType.Parameterized::class.java)
+            assertThat(TypeUtils.isOfType(variable1.variableType?.type, variable2.variableType?.type)).isTrue
+        }}
+    )
+
+    @Test
+    fun differentParameterizedTypesIsOfType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                java.util.List<Integer> integers;
+                java.util.List<String> strings;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable1 = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+            val variable2 = (cu.classes[0].body.statements[1] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable1.variableType?.type).isInstanceOf(JavaType.Parameterized::class.java)
+            assertThat(variable2.variableType?.type).isInstanceOf(JavaType.Parameterized::class.java)
+            assertThat(TypeUtils.isOfType(variable1.variableType?.type, variable2.variableType?.type)).isFalse
+        }}
+    )
+
+    @Test
+    fun isGenericTypeOfType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                java.util.List<? super Number> type1;
+                java.util.List<? super Number> type2;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable1 = ((cu.classes[0].body.statements[0] as J.VariableDeclarations)
+                .variables[0]?.type as JavaType.Parameterized)
+                .typeParameters[0]
+            val variable2 = ((cu.classes[0].body.statements[1] as J.VariableDeclarations)
+                .variables[0]?.type as JavaType.Parameterized)
+                .typeParameters[0]
+
+            assertThat(variable1).isInstanceOf(JavaType.GenericTypeVariable::class.java)
+            assertThat(variable2).isInstanceOf(JavaType.GenericTypeVariable::class.java)
+            assertThat(TypeUtils.isOfType(variable1, variable2)).isTrue
+        }}
+    )
+
+    @Test
+    fun differentVarianceOfGenericTypeOfType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                java.util.List<? super Number> type1;
+                java.util.List<? extends Number> type2;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable1 = ((cu.classes[0].body.statements[0] as J.VariableDeclarations)
+                .variables[0]?.type as JavaType.Parameterized)
+                .typeParameters[0]
+            val variable2 = ((cu.classes[0].body.statements[1] as J.VariableDeclarations)
+                .variables[0]?.type as JavaType.Parameterized)
+                .typeParameters[0]
+
+            assertThat(variable1).isInstanceOf(JavaType.GenericTypeVariable::class.java)
+            assertThat(variable2).isInstanceOf(JavaType.GenericTypeVariable::class.java)
+            assertThat(TypeUtils.isOfType(variable1, variable2)).isFalse
+        }}
+    )
+
+    /* isAssignableTo */
+    @Test
+    fun isJavaTypeArrayAssignableTo(jp: JavaParser) = rewriteRun(
         { spec -> spec.parser(jp) },
         java("class Test {}"),
         java("""
@@ -132,6 +232,82 @@ interface TypeUtilsTest : RewriteTest {
         """) { s -> s.beforeRecipe { cu ->
             val variable = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
             assertThat(TypeUtils.isAssignableTo(variable.variableType?.type, ((variable.initializer as J.NewArray).type))).isTrue
+        }}
+    )
+
+    /* isOfClassType */
+    @Test
+    fun isFullyQualifiedTypeOfClassType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                Integer integer;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable.variableType?.type).isInstanceOf(JavaType.Class::class.java)
+            assertThat(TypeUtils.isOfClassType(variable.variableType?.type, "java.lang.Integer")).isTrue
+        }}
+    )
+
+    @Test
+    fun isParameterizedTypeOfClassType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                java.util.List<Integer> list;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable.variableType?.type).isInstanceOf(JavaType.Parameterized::class.java)
+            assertThat(TypeUtils.isOfClassType(variable.variableType?.type, "java.util.List")).isTrue
+        }}
+    )
+
+    @Test
+    fun isVariableTypeOfClassType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                java.util.List<Integer> list;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable.variableType).isInstanceOf(JavaType.Variable::class.java)
+            assertThat(TypeUtils.isOfClassType(variable.variableType, "java.util.List")).isTrue
+        }}
+    )
+
+    @Test
+    fun isArrayTypeOfClassType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                Integer[] integer;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable.variableType?.type).isInstanceOf(JavaType.Array::class.java)
+            assertThat(TypeUtils.isOfClassType(variable.variableType?.type, "java.lang.Integer")).isTrue
+        }}
+    )
+
+    @Test
+    fun isPrimitiveTypeOfClassType(jp: JavaParser) = rewriteRun(
+        { spec -> spec.parser(jp) },
+        java("""
+            class Test {
+                int i;
+            }
+        """) { s -> s.beforeRecipe { cu ->
+            val variable = (cu.classes[0].body.statements[0] as J.VariableDeclarations).variables[0]
+
+            assertThat(variable.variableType?.type).isInstanceOf(JavaType.Primitive::class.java)
+            assertThat(TypeUtils.isOfClassType(variable.variableType?.type, "int")).isTrue
         }}
     )
 }


### PR DESCRIPTION
Changes:

- `TypeUtils#isOfType(..)` will check if each type parameter matches on `JavaType$ParameterizedType`s.
- `TypeUtils#isOffType(..)` will check if `Variance` matches on `JavaType$GenericTypeVariable`s.

- Added support for `JavaType$Array` in `TypeUtils#isOfClassType(..)`.
- Added support for `JavaType$Primitive` in `TypeUtils#isOfClassType(..)`.

fixes #1788