### PR TITLE
Fix: The ability to use a J.MethodInvocation as a flow source

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/ForwardFlow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/ForwardFlow.java
@@ -123,6 +123,11 @@ public class ForwardFlow extends JavaVisitor<Integer> {
 
     @Nullable
     private static String computeVariableAssignment(Iterator<Object> cursorPath) {
+        if (cursorPath.hasNext()) {
+            // Must avoid inspecting the 'current' node to compute the variable assignment.
+            // This is because we perform filtering here, and filtered types may be valid 'source' types.
+            cursorPath.next();
+        }
         while (cursorPath.hasNext()) {
             Object ancestor = cursorPath.next();
             if (ancestor instanceof J.Binary) {


### PR DESCRIPTION
The previous PR broke the ability to use a J.MethodInvocation as a flow source since it was filtered out during the call to computeVariableAssignment.
