### PR TITLE
Remove unused code in MethodMatcher

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -176,8 +176,6 @@ public class MethodMatcher {
     public boolean matches(J.MethodInvocation method) {
         if (method.getMethodType() == null) {
             return false;
-        } else {
-            method.getMethodType().getDeclaringType();
         }
 
         if (!matchesTargetType(method.getMethodType().getDeclaringType()) || !methodNamePattern.matcher(method.getSimpleName()).matches()) {


### PR DESCRIPTION
Removes a no-op call in MethodMatcher::matches
