### PR TITLE
ExplicitLambdaArgumentTypes should create correctly-formed type expressions

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypes.java
@@ -18,14 +18,13 @@ package org.openrewrite.java.cleanup;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
-import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class ExplicitLambdaArgumentTypes extends Recipe {
@@ -60,39 +59,84 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
         private static final String ADDED_EXPLICIT_TYPE_KEY = "ADDED_EXPLICIT_TYPE";
 
         @Nullable
-        private static String buildName(@Nullable JavaType type) {
-            if (type != null) {
-                if (type instanceof JavaType.FullyQualified && type != JavaType.Unknown.getInstance()) {
-                    JavaType.FullyQualified asFQN = TypeUtils.asFullyQualified(type);
-                    assert asFQN != null;
-                    return asFQN.getClassName();
-                } else if (type instanceof JavaType.Primitive) {
-                    JavaType.Primitive asPrimitive = TypeUtils.asPrimitive(type);
-                    assert asPrimitive != null;
-                    return asPrimitive.getKeyword();
-                } else if (type instanceof JavaType.Array) {
-                    JavaType.Array arrayType = TypeUtils.asArray(type);
-                    assert arrayType != null;
-                    StringBuilder typeAsString = new StringBuilder();
-                    JavaType elemType = arrayType.getElemType();
-                    if (elemType instanceof JavaType.Primitive) {
-                        typeAsString.append(buildName(elemType));
-                    } else if (elemType instanceof JavaType.FullyQualified) {
-                        typeAsString.append(buildName(elemType));
-                    } else if (elemType instanceof JavaType.Array) {
-                        JavaType typeOfArray = ((JavaType.Array) elemType).getElemType();
-                        typeAsString.append(buildName(typeOfArray));
-                        for (; arrayType.getElemType() instanceof JavaType.Array; arrayType = (JavaType.Array) arrayType.getElemType()) {
-                            typeAsString.append("[]");
-                        }
-                    }
-                    typeAsString.append("[]");
-                    return typeAsString.toString();
-                } else if(type instanceof JavaType.Variable) {
-                    return buildName(((JavaType.Variable) type).getType());
+        private TypeTree buildTypeTree(@Nullable JavaType type) {
+            if (type == null || type instanceof JavaType.Unknown) {
+                return null;
+            } else if (type instanceof JavaType.Primitive) {
+                return new J.Primitive(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        (JavaType.Primitive) type
+                );
+            } else if (type instanceof JavaType.Parameterized) {
+                return new J.ParameterizedType(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        buildTypeTree(((JavaType.Parameterized) type).getType()),
+                        buildTypeParameters(((JavaType.Parameterized) type).getTypeParameters())
+                );
+            } else if (type instanceof JavaType.FullyQualified) {
+                JavaType.FullyQualified fq = (JavaType.FullyQualified) type;
+                maybeAddImport(fq);
+                return new J.Identifier(Tree.randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        fq.getClassName(),
+                        type,
+                        null
+                );
+            } else if (type instanceof JavaType.Array) {
+                return (buildTypeTree(((JavaType.Array) type).getElemType()));
+            } else if(type instanceof JavaType.Variable) {
+                return buildTypeTree(((JavaType.Variable) type).getType());
+            } else if (type instanceof JavaType.GenericTypeVariable) {
+                JavaType.GenericTypeVariable genericType = (JavaType.GenericTypeVariable) type;
+
+                if (!genericType.getName().equals("?")) {
+                    return new J.Identifier(Tree.randomId(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            genericType.getName(),
+                            type,
+                            null
+                    );
                 }
+                JLeftPadded<J.Wildcard.Bound> bound = null;
+                NameTree boundedType = null;
+                if (genericType.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
+                    bound = new JLeftPadded<>(Space.format(" "), J.Wildcard.Bound.Extends, Markers.EMPTY);
+                } else if (genericType.getVariance() == JavaType.GenericTypeVariable.Variance.CONTRAVARIANT) {
+                    bound = new JLeftPadded<>(Space.format(" "), J.Wildcard.Bound.Super, Markers.EMPTY);
+                }
+
+                if (!genericType.getBounds().isEmpty()) {
+                    boundedType = buildTypeTree(genericType.getBounds().get(0));
+                }
+
+                return new J.Wildcard(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        bound,
+                        boundedType
+                );
             }
             return null;
+        }
+
+        private JContainer<Expression> buildTypeParameters(List<JavaType> typeParameters) {
+            List<JRightPadded<Expression>> typeExpressions = new ArrayList<>();
+
+            for (JavaType fred : typeParameters) {
+                typeExpressions.add(new JRightPadded<>(
+                        (Expression) buildTypeTree(fred),
+                        Space.EMPTY,
+                        Markers.EMPTY
+                ));
+            }
+            return JContainer.build(Space.EMPTY, typeExpressions, Markers.EMPTY);
         }
 
         @Override
@@ -100,23 +144,34 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
             // if the type expression is null, it implies the types on the lambda arguments are implicit.
             if (multiVariable.getTypeExpression() == null && getCursor().dropParentUntil(J.class::isInstance).getValue() instanceof J.Lambda) {
                 J.VariableDeclarations.NamedVariable nv = multiVariable.getVariables().get(0);
-                String name = nv.getType() instanceof JavaType.GenericTypeVariable ?
-                        ((JavaType.GenericTypeVariable) nv.getType()).getName() : buildName(nv.getType());
-                if (name != null) {
-                    multiVariable = multiVariable.withTypeExpression(
-                            new J.Identifier(Tree.randomId(),
-                                    Space.EMPTY,
-                                    Markers.EMPTY,
-                                    name,
-                                    nv.getType(),
-                                    null
-                            )
-                    );
-                    maybeAddImport(TypeUtils.asFullyQualified(nv.getType()));
+                TypeTree typeExpression = buildTypeTree(nv.getType());
+                if (typeExpression != null) {
+                    multiVariable = multiVariable.withTypeExpression(typeExpression);
+                    int arrayDimensions = countDimensions(nv.getType());
+                    if (arrayDimensions > 0) {
+                        List<JLeftPadded<Space>> dimensions = new ArrayList<>();
+                        for (int index = 0; index < arrayDimensions; index++) {
+                            dimensions.add(new JLeftPadded<>(Space.EMPTY, Space.EMPTY, Markers.EMPTY));
+                        }
+                        multiVariable = multiVariable.withDimensionsBeforeName(dimensions);
+                    }
                     getCursor().dropParentUntil(J.Lambda.class::isInstance).putMessage(ADDED_EXPLICIT_TYPE_KEY, true);
                 }
             }
             return super.visitVariableDeclarations(multiVariable, ctx);
+        }
+
+        public int countDimensions(JavaType type) {
+            if (!(type instanceof JavaType.Array)) {
+                return 0;
+            }
+
+            int count = 0;
+            while (type instanceof JavaType.Array) {
+                type = ((JavaType.Array) type).getElemType();
+                count++;
+            }
+            return count;
         }
 
         @Override

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypesTest.kt
@@ -58,11 +58,11 @@ interface ExplicitLambdaArgumentTypesTest : JavaRecipeTest {
             import java.util.function.Consumer;
 
             class Test {
-                static void run(Consumer<String> c) {
+                static void run(Consumer<List<String>> c) {
                 }
 
                 static void method() {
-                    run((String a) -> a.length());
+                    run(a -> a.size());
                 }
             }
         """
@@ -470,4 +470,36 @@ interface ExplicitLambdaArgumentTypesTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun parameterizedType(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            import java.util.function.Consumer;
+            import java.util.List;
+
+            class Test {
+                static void run(Consumer<List<String>> c) {
+                }
+
+                static void method() {
+                    run(a -> {a.size();});
+                }
+            }
+        """,
+        after = """
+            import java.util.function.Consumer;
+            import java.util.List;
+
+            class Test {
+                static void run(Consumer<List<String>> c) {
+                }
+        
+                static void method() {
+                    run((List<String> a) -> {a.size();});
+                }
+            }
+        """
+    )
+
 }


### PR DESCRIPTION
This recipe uses Rewrite's type information to construct a type expression for each lambda argument. This is actually quite tricky because the expression may include parameterizes types, wildcards, arrays, primitives, and identifiers.