### PR TITLE
UseLambdaForFunctionalInterface should remove unused imports afterward

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseLambdaForFunctionalInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseLambdaForFunctionalInterface.java
@@ -23,12 +23,14 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.RemoveUnusedImports;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -128,7 +130,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                                             .map(p -> {
                                                 J.VariableDeclarations decl = (J.VariableDeclarations) p;
                                                 decl = decl.withVariables(ListUtils.map(decl.getVariables(), v -> v.withPrefix(Space.EMPTY)));
-                                                return decl.withTypeExpression(null);
+                                                return decl.withTypeExpression(null).withModifiers(Collections.emptyList());
                                             }).collect(Collectors.toList())
                             ));
                         }
@@ -141,6 +143,8 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         lambda = lambda.withBody(lambdaBody.withPrefix(Space.format(" ")));
 
                         lambda = (J.Lambda) new LambdaBlockToExpression().getVisitor().visitNonNull(lambda, ctx);
+
+                        doAfterVisit(new RemoveUnusedImports());
 
                         return autoFormat(lambda, ctx, getCursor().getParentOrThrow());
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/TypesInUse.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/TypesInUse.java
@@ -47,6 +47,7 @@ public class TypesInUse {
                     if (!(tree instanceof J.ClassDeclaration) &&
                             !(tree instanceof J.MethodDeclaration) &&
                             !(tree instanceof J.MethodInvocation) &&
+                            !(tree instanceof J.Lambda) &&
                             !(tree instanceof J.VariableDeclarations)) {
                         types.add(((TypedTree) tree).getType());
                     }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveUnusedImportsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveUnusedImportsTest.kt
@@ -704,4 +704,56 @@ interface RemoveUnusedImportsTest : JavaRecipeTest, RewriteTest {
         """
 
     )
+
+    @Test
+    fun removeImportUsedAsLambdaParameter(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            import java.util.HashMap;
+            import java.util.function.Function;
+
+            public class Test {
+                public static void foo(){
+                    final HashMap<Integer,String> map = new HashMap<>();
+                    map.computeIfAbsent(3, integer -> String.valueOf(integer + 1));
+                }
+            }
+        """,
+        after = """
+            import java.util.HashMap;
+
+            public class Test {
+                public static void foo(){
+                    final HashMap<Integer,String> map = new HashMap<>();
+                    map.computeIfAbsent(3, integer -> String.valueOf(integer + 1));
+                }
+            }
+        """
+    )
+
+    @Test
+    fun removeImportUsedAsMethodParameter(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            import java.util.HashMap;
+            import java.util.ArrayList;
+            import java.util.Set;
+
+            public class Test {
+                public static void foo(){
+                    new ArrayList<>(new HashMap<Integer, String>().keySet());
+                }
+            }
+        """,
+        after = """
+            import java.util.HashMap;
+            import java.util.ArrayList;
+
+            public class Test {
+                public static void foo(){
+                    new ArrayList<>(new HashMap<Integer, String>().keySet());
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
I identified and added a few related details along the way, which the new test cases should explain.

I did touch `TypesInUse`, which I expect has pretty broad reach, but the change didn't cause any test failures.

#1844 