### PR TITLE
Adding add hoc taint tracking support for local flow

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/LocalFlowSpec.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/LocalFlowSpec.java
@@ -45,11 +45,36 @@ public abstract class LocalFlowSpec<Source extends Expression, Sink extends J> {
         return (Class<?>) sinkType;
     }
 
+    /**
+     * The following is always true: {@code  source == cursor.getValue()}.
+     *
+     * @param source The {@link Expression} to check to determine if it should be considered flow-graph source.
+     * @param cursor The current cursor position of the {@code source}.
+     * @return {@code true} if {@code source} and {@code cursor} should be considered the source or root of a flow graph.
+     */
     public abstract boolean isSource(Source source, Cursor cursor);
 
+    /**
+     * The following is always true: {@code  sink == cursor.getValue()}.
+     *
+     * @param sink The {@link Expression} to check to determine if it should be considered a flow-graph sink.
+     * @param cursor The current cursor position of the {@code sink}.
+     * @return {@code true} if {@code sink} and {@code cursor} should be considered the sink or leaf of a flow graph.
+     */
     public abstract boolean isSink(Sink sink, Cursor cursor);
 
-    public boolean isAdditionalFlowStep(Expression startE, Cursor startC, Expression endE, Cursor endC) {
+    /**
+     * Allows for ad-hoc taint tracking by allowing for additional, non-default flow steps to be added to the flow graph.
+     *
+     * The following is always true:
+     * {@code  startExpression == startCursor.getValue() && endExpression == endCursor.getValue()}.
+     */
+    public boolean isAdditionalFlowStep(
+            Expression startExpression,
+            Cursor startCursor,
+            Expression endExpression,
+            Cursor endCursor
+    ) {
         return false;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/LocalFlowSpec.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/LocalFlowSpec.java
@@ -64,6 +64,10 @@ public abstract class LocalFlowSpec<Source extends Expression, Sink extends J> {
     public abstract boolean isSink(Sink sink, Cursor cursor);
 
     /**
+     * takes an existing flow-step in the graph and offers a potential next flow step.
+     * The method can then decide if the offered potential next flow step should be considered a valid next flow step
+     * in the graph.
+     *
      * Allows for ad-hoc taint tracking by allowing for additional, non-default flow steps to be added to the flow graph.
      *
      * The following is always true:

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/LocalFlowSpec.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/LocalFlowSpec.java
@@ -49,6 +49,10 @@ public abstract class LocalFlowSpec<Source extends Expression, Sink extends J> {
 
     public abstract boolean isSink(Sink sink, Cursor cursor);
 
+    public boolean isAdditionalFlowStep(Expression startE, Cursor startC, Expression endE, Cursor endC) {
+        return false;
+    }
+
     public boolean isBarrierGuard(Expression expr) {
         return false;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/FlowGraph.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/FlowGraph.java
@@ -17,16 +17,35 @@ package org.openrewrite.java.dataflow.analysis;
 
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.openrewrite.Cursor;
 
+import javax.annotation.CheckReturnValue;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
 
 @Data
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Setter(AccessLevel.PACKAGE)
 public class FlowGraph {
     private final Cursor cursor;
     private List<FlowGraph> edges = emptyList();
+
+    /**
+     * Add an edge to the graph returning the newly added {@link FlowGraph} leaf.
+     * @param cursor The cursor position of the new leaf.
+     * @return The newly added {@link FlowGraph} leaf.
+     */
+    @CheckReturnValue
+    FlowGraph addEdge(Cursor cursor) {
+        if (edges.isEmpty()) {
+            edges = new ArrayList<>(2);
+        }
+        FlowGraph edge = new FlowGraph(cursor);
+        edges.add(edge);
+        return edge;
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/ForwardFlow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/ForwardFlow.java
@@ -201,6 +201,9 @@ public class ForwardFlow extends JavaVisitor<Integer> {
             Cursor ancestorCursor = cursorPath.next();
             Object ancestor = ancestorCursor.getValue();
             if (ancestor instanceof Expression) {
+                // Offer the cursor of the current flow graph, and a next possible expression to
+                // `isAdditionalFlowStep` to see if it should be added to the flow graph.
+                // This allows the API user to extend what the definition of 'flow' is.
                 Cursor previousCursor = nextFlowGraph.getCursor();
                 if (spec.isAdditionalFlowStep(
                         previousCursor.getValue(),
@@ -222,7 +225,9 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                     // If the method invocation is not `toString` on a `String`, it's not dataflow
                     break;
                 }
-            } else if (ancestor instanceof J.TypeCast || ancestor instanceof J.Parentheses || ancestor instanceof J.ControlParentheses) {
+            } else if (ancestor instanceof J.TypeCast ||
+                    ancestor instanceof J.Parentheses ||
+                    ancestor instanceof J.ControlParentheses) {
                 nextFlowGraph = nextFlowGraph.addEdge(ancestorCursor);
             } else if (ancestor instanceof J.NewClass) {
                 break;

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/SinkFlow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/SinkFlow.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.dataflow.analysis;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.openrewrite.Cursor;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.dataflow.LocalFlowSpec;
@@ -30,6 +32,7 @@ public class SinkFlow<Source extends Expression, Sink extends J> extends FlowGra
     @Nullable
     private final Cursor source;
 
+    @Getter(AccessLevel.PACKAGE)
     private final LocalFlowSpec<Source, Sink> spec;
 
     public SinkFlow(@Nullable Cursor source, LocalFlowSpec<Source, Sink> spec) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UriCreatedWithHttpScheme.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UriCreatedWithHttpScheme.java
@@ -47,6 +47,16 @@ public class UriCreatedWithHttpScheme extends Recipe {
         }
 
         @Override
+        public boolean isAdditionalFlowStep(Expression startE, Cursor startC, Expression endE, Cursor endC) {
+            boolean isAdditionalFlow = endE instanceof J.Binary;
+            if (isAdditionalFlow) {
+                J.Binary endBinary = (J.Binary) endE;
+                return startE == endBinary.getLeft();
+            }
+            return false;
+        }
+
+        @Override
         public boolean isBarrierGuard(Expression expr) {
             return STRING_REPLACE.matches(expr);
         }


### PR DESCRIPTION
@pway99  and I did some pair programming on this one to add support for ad-hoc taint tracking leveraging data flow analysis as a basis.

This adds a new API to `LocalFlowSpec` called `isAdditionalFlowStep`. It takes an existing flow-step in the graph and offers a potential next flow step. The method can then decide if the offered potential next flow step should be considered a valid next flow step in the graph.