### PR TITLE
Guard against NPE from a null type in `Symbol.MethodSymbol` in the TypeSignatureBuilders.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -188,7 +188,6 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
             s += "{name=<constructor>,return=" + s;
@@ -201,11 +200,10 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
 
         String returnType;
-        if(symbol.isStaticOrInstanceInit()) {
+        if (symbol.isStaticOrInstanceInit()) {
             returnType = "void";
         } else {
             returnType = signature(symbol.getReturnType());
@@ -222,13 +220,17 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     private String methodArgumentSignature(Symbol.MethodSymbol sym) {
-        if(sym.isStaticOrInstanceInit()) {
+        if (sym.isStaticOrInstanceInit()) {
             return "[]";
         }
 
         StringJoiner genericArgumentTypes = new StringJoiner(",", "[", "]");
-        for (Symbol.VarSymbol parameter : sym.getParameters()) {
-            genericArgumentTypes.add(signature(parameter.type));
+        if (sym.type == null) {
+            genericArgumentTypes.add("{undefined}");
+        } else {
+            for (Symbol.VarSymbol parameter : sym.getParameters()) {
+                genericArgumentTypes.add(signature(parameter.type));
+            }
         }
         return genericArgumentTypes.toString();
     }
@@ -260,7 +262,7 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             owner = methodSignature((Symbol.MethodSymbol) symbol.owner);
         } else {
             owner = signature(symbol.owner.type);
-            if(owner.contains("<")) {
+            if (owner.contains("<")) {
                 owner = owner.substring(0, owner.indexOf('<'));
             }
         }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -188,7 +188,6 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
             s += "{name=<constructor>,return=" + s;
@@ -201,11 +200,10 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
 
         String returnType;
-        if(symbol.isStaticOrInstanceInit()) {
+        if (symbol.isStaticOrInstanceInit()) {
             returnType = "void";
         } else {
             returnType = signature(symbol.getReturnType());
@@ -222,13 +220,17 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     private String methodArgumentSignature(Symbol.MethodSymbol sym) {
-        if(sym.isStaticOrInstanceInit()) {
+        if (sym.isStaticOrInstanceInit()) {
             return "[]";
         }
 
         StringJoiner genericArgumentTypes = new StringJoiner(",", "[", "]");
-        for (Symbol.VarSymbol parameter : sym.getParameters()) {
-            genericArgumentTypes.add(signature(parameter.type));
+        if (sym.type == null) {
+            genericArgumentTypes.add("{undefined}");
+        } else {
+            for (Symbol.VarSymbol parameter : sym.getParameters()) {
+                genericArgumentTypes.add(signature(parameter.type));
+            }
         }
         return genericArgumentTypes.toString();
     }
@@ -260,7 +262,7 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             owner = methodSignature((Symbol.MethodSymbol) symbol.owner);
         } else {
             owner = signature(symbol.owner.type);
-            if(owner.contains("<")) {
+            if (owner.contains("<")) {
                 owner = owner.substring(0, owner.indexOf('<'));
             }
         }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -63,7 +63,7 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             return s.append("}").toString();
         } else if (type instanceof Type.JCNoType) {
             return "{none}";
-        } else if(type instanceof Type.AnnotatedType) {
+        } else if (type instanceof Type.AnnotatedType) {
             return signature(type.unannotatedType());
         }
 
@@ -187,7 +187,6 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
             s += "{name=<constructor>,return=" + s;
@@ -200,7 +199,6 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
-        Type genericType = symbol.type;
         String s = classSignature(symbol.owner.type);
 
         String returnType;
@@ -226,8 +224,12 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         StringJoiner genericArgumentTypes = new StringJoiner(",", "[", "]");
-        for (Symbol.VarSymbol parameter : sym.getParameters()) {
-            genericArgumentTypes.add(signature(parameter.type));
+        if (sym.type == null) {
+            genericArgumentTypes.add("{undefined}");
+        } else {
+            for (Symbol.VarSymbol parameter : sym.getParameters()) {
+                genericArgumentTypes.add(signature(parameter.type));
+            }
         }
         return genericArgumentTypes.toString();
     }


### PR DESCRIPTION
Changes:

- `TypeSignatureBuilders#methodArgumentSignature()` will not thrown an NPE if the type is null via `sym.getParameters()`.

fixes #1825