### PR TITLE
Completed visitors in SemanticallyEqual

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -16,153 +16,1364 @@
 package org.openrewrite.java.search;
 
 import org.openrewrite.Incubating;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.*;
 
-import java.util.List;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /*
  * Recursively checks the equality of each element of two ASTs to determine if two trees are semantically equal.
  */
-@Incubating(since = "6.0.0")
+@Incubating(since = "7.24.0")
 public class SemanticallyEqual {
 
     private SemanticallyEqual() {
     }
 
     public static boolean areEqual(J firstElem, J secondElem) {
-        SemanticallyEqualVisitor sep = new SemanticallyEqualVisitor();
-        sep.visit(firstElem, secondElem); // returns null, but changes value of class variable isEqual
-        return sep.isEqual;
+        SemanticallyEqualVisitor semanticallyEqualVisitor = new SemanticallyEqualVisitor();
+        semanticallyEqualVisitor.visit(firstElem, secondElem);
+        return semanticallyEqualVisitor.isEqual.get();
     }
 
-    /**
-     * Note: The following visit methods extend JavaVisitor in order to inherit access to the
-     * visitor pattern set up there; however, the necessity to return a J did not fit the purposes of
-     * SemanticallyEqualVisitor, so while the equality is tracked in isEqual, all the visitors return null.
-     */
     @SuppressWarnings("ConstantConditions")
-    private static class SemanticallyEqualVisitor extends JavaVisitor<J> {
-        boolean isEqual = true;
+    private static class SemanticallyEqualVisitor extends JavaIsoVisitor<J> {
+        AtomicBoolean isEqual = new AtomicBoolean(true);
+
+        private boolean nullMissMatch(Object obj1, Object obj2) {
+            return (obj1 == null && obj2 != null || obj1 != null && obj2 == null);
+        }
 
         @Override
-        public J visitAnnotation(J.Annotation firstAnnotation, J second) {
-            if (!(second instanceof J.Annotation)) {
-                isEqual = false;
-                return null;
+        public Expression visitExpression(Expression expression, J j) {
+            if (isEqual.get()) {
+                if (!TypeUtils.isOfType(expression.getType(), ((Expression) j).getType())) {
+                    isEqual.set(false);
+                }
             }
-            J.Annotation secondAnnotation = (J.Annotation) second;
+            return expression;
+        }
 
-            if (firstAnnotation.getArguments() != null && secondAnnotation.getArguments() != null) {
-                if (firstAnnotation.getArguments().size() == secondAnnotation.getArguments().size()) {
+        @Override
+        public J.Annotation visitAnnotation(J.Annotation annotation, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Annotation)) {
+                    isEqual.set(false);
+                    return annotation;
+                }
 
-                    List<Expression> firstArgs = firstAnnotation.getArguments();
-                    List<Expression> secondArgs = secondAnnotation.getArguments();
+                J.Annotation compareTo = (J.Annotation) j;
+                if (!TypeUtils.isOfType(annotation.getType(), compareTo.getType()) ||
+                        nullMissMatch(annotation.getArguments(), compareTo.getArguments()) ||
+                        annotation.getArguments() != null && compareTo.getArguments() != null && annotation.getArguments().size() != compareTo.getArguments().size()) {
+                    isEqual.set(false);
+                    return annotation;
+                }
 
-                    for (int i = 0; i < firstArgs.size(); i++) {
-                        this.visit(firstArgs.get(i), secondArgs.get(i));
+                this.visitTypeName(annotation.getAnnotationType(), compareTo.getAnnotationType());
+                if (annotation.getArguments() != null && compareTo.getArguments() != null) {
+                    for (int i = 0; i < annotation.getArguments().size(); i++) {
+                        this.visit(annotation.getArguments().get(i), compareTo.getArguments().get(i));
                     }
-                } else {
-                    isEqual = false;
-                    return null;
                 }
             }
-            this.visitTypeName(firstAnnotation.getAnnotationType(), secondAnnotation.getAnnotationType());
-            return null;
+            return annotation;
+
         }
 
         @Override
-        public J visitIdentifier(J.Identifier firstIdent, J second) {
-            if (!(second instanceof J.Identifier)) {
-                isEqual = false;
-                return null;
-            }
-            J.Identifier secondIdent = (J.Identifier) second;
+        public J.AnnotatedType visitAnnotatedType(J.AnnotatedType annotatedType, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.AnnotatedType)) {
+                    isEqual.set(false);
+                    return annotatedType;
+                }
 
-            isEqual = isEqual && typeEquals(firstIdent.getType(), secondIdent.getType()) &&
-                    firstIdent.getSimpleName().equals(secondIdent.getSimpleName());
+                J.AnnotatedType compareTo = (J.AnnotatedType) j;
+                if (!TypeUtils.isOfType(annotatedType.getType(), compareTo.getType()) ||
+                        annotatedType.getAnnotations().size() != compareTo.getAnnotations().size()) {
+                    isEqual.set(false);
+                    return annotatedType;
+                }
 
-            return null;
-        }
-
-        @Override
-        public J visitFieldAccess(J.FieldAccess firstFieldAccess, J second) {
-            if (!(second instanceof J.FieldAccess)) {
-                isEqual = false;
-                return null;
-            }
-            J.FieldAccess secondFieldAccess = (J.FieldAccess) second;
-
-            // Class literals are the only kind of FieldAccess which can appear within annotations
-            // Functionality to correctly determine semantic equality of other kinds of field access will come later
-            if ("class".equals(firstFieldAccess.getSimpleName())) {
-                if (!"class".equals(secondFieldAccess.getSimpleName())) {
-                    isEqual = false;
-                    return null;
-                } else {
-                    isEqual = isEqual &&
-                            typeEquals(firstFieldAccess.getType(), secondFieldAccess.getType()) &&
-                            typeEquals(firstFieldAccess.getTarget().getType(), secondFieldAccess.getTarget().getType());
+                this.visitTypeName(annotatedType.getTypeExpression(), compareTo.getTypeExpression());
+                for (int i = 0; i < annotatedType.getAnnotations().size(); i++) {
+                    this.visit(annotatedType.getAnnotations().get(i), compareTo.getAnnotations().get(i));
                 }
             }
-
-            return null;
+            return annotatedType;
         }
 
         @Override
-        public J visitAssignment(J.Assignment firstAssignment, J second) {
-            if (!(second instanceof J.Assignment)) {
-                isEqual = false;
-                return null;
+        public J.ArrayAccess visitArrayAccess(J.ArrayAccess arrayAccess, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ArrayAccess)) {
+                    isEqual.set(false);
+                    return arrayAccess;
+                }
+
+                J.ArrayAccess compareTo = (J.ArrayAccess) j;
+                if (nullMissMatch(arrayAccess.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(arrayAccess.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return arrayAccess;
+                }
+
+                this.visit(arrayAccess.getIndexed(), compareTo.getIndexed());
+                this.visit(arrayAccess.getDimension(), compareTo.getDimension());
             }
-            J.Assignment secondAssignment = (J.Assignment) second;
-
-            isEqual = isEqual &&
-                    typeEquals(firstAssignment.getType(), secondAssignment.getType()) &&
-                    SemanticallyEqual.areEqual(firstAssignment.getVariable(), secondAssignment.getVariable()) &&
-                    SemanticallyEqual.areEqual(firstAssignment.getAssignment(), secondAssignment.getAssignment());
-
-            return null;
+            return arrayAccess;
         }
 
         @Override
-        public J visitLiteral(J.Literal firstLiteral, J second) {
-            if (!(second instanceof J.Literal)) {
-                isEqual = false;
-                return null;
-            }
-            J.Literal secondLiteral = (J.Literal) second;
+        public J.ArrayDimension visitArrayDimension(J.ArrayDimension arrayDimension, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ArrayDimension)) {
+                    isEqual.set(false);
+                    return arrayDimension;
+                }
 
-            isEqual = isEqual && Objects.equals(firstLiteral.getValue(), secondLiteral.getValue());
-            return null;
+                J.ArrayDimension compareTo = (J.ArrayDimension) j;
+                this.visit(arrayDimension.getIndex(), compareTo.getIndex());
+            }
+            return arrayDimension;
         }
 
         @Override
-        public <N extends NameTree> N visitTypeName(N firstTypeName, J second) {
-            if (!(second instanceof NameTree)) {
-                isEqual = false;
-                return null;
+        public J.ArrayType visitArrayType(J.ArrayType arrayType, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ArrayType)) {
+                    isEqual.set(false);
+                    return arrayType;
+                }
+
+                J.ArrayType compareTo = (J.ArrayType) j;
+                if (!TypeUtils.isOfType(arrayType.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return arrayType;
+                }
+
+                this.visitTypeName(arrayType.getElementType(), compareTo.getElementType());
             }
-            isEqual = isEqual && typeEquals(firstTypeName.getType(), ((NameTree) second).getType());
-            return null;
+            return arrayType;
         }
 
-        private static boolean typeEquals(JavaType thisType, JavaType otherType) {
-            if (thisType == null) {
-                return otherType == null;
+        @Override
+        public J.Assert visitAssert(J.Assert _assert, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Assert)) {
+                    isEqual.set(false);
+                    return _assert;
+                }
+
+                J.Assert compareTo = (J.Assert) j;
+                if (nullMissMatch(_assert.getDetail(), compareTo.getDetail())) {
+                    isEqual.set(false);
+                    return _assert;
+                }
+
+                this.visit(_assert.getCondition(), compareTo.getCondition());
+                if (_assert.getDetail() != null && compareTo.getDetail() != null) {
+                    this.visit(_assert.getDetail().getElement(), compareTo.getDetail().getElement());
+                }
             }
-            if (thisType instanceof JavaType.FullyQualified) {
-                if (!(otherType instanceof JavaType.FullyQualified)) {
+            return _assert;
+        }
+
+        @Override
+        public J.Assignment visitAssignment(J.Assignment assignment, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Assignment)) {
+                    isEqual.set(false);
+                    return assignment;
+                }
+
+                J.Assignment compareTo = (J.Assignment) j;
+                if (nullMissMatch(assignment.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(assignment.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return assignment;
+                }
+
+                this.visit(assignment.getAssignment(), compareTo.getAssignment());
+                this.visit(assignment.getVariable(), compareTo.getVariable());
+            }
+            return assignment;
+        }
+
+        @Override
+        public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.AssignmentOperation)) {
+                    isEqual.set(false);
+                    return assignOp;
+                }
+
+                J.AssignmentOperation compareTo = (J.AssignmentOperation) j;
+                if (nullMissMatch(assignOp.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(assignOp.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return assignOp;
+                }
+
+                this.visit(assignOp.getAssignment(), compareTo.getAssignment());
+                this.visit(assignOp.getVariable(), compareTo.getVariable());
+            }
+            return assignOp;
+        }
+
+        @Override
+        public J.Binary visitBinary(J.Binary binary, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Binary)) {
+                    isEqual.set(false);
+                    return binary;
+                }
+
+                J.Binary compareTo = (J.Binary) j;
+                if (nullMissMatch(binary.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(binary.getType(), compareTo.getType()) ||
+                        binary.getOperator() != compareTo.getOperator()) {
+                    isEqual.set(false);
+                    return binary;
+                }
+
+                this.visit(binary.getLeft(), compareTo.getLeft());
+                this.visit(binary.getRight(), compareTo.getRight());
+            }
+            return binary;
+        }
+
+        @Override
+        public J.Block visitBlock(J.Block block, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Block)) {
+                    isEqual.set(false);
+                    return block;
+                }
+
+                J.Block compareTo = (J.Block) j;
+                if (block.getStatements().size() != compareTo.getStatements().size()) {
+                    isEqual.set(false);
+                    return block;
+                }
+
+                for (int i = 0; i < block.getStatements().size(); i++) {
+                    this.visit(block.getStatements().get(i), compareTo.getStatements().get(i));
+                }
+            }
+            return block;
+        }
+
+        @Override
+        public J.Break visitBreak(J.Break breakStatement, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Break)) {
+                    isEqual.set(false);
+                    return breakStatement;
+                }
+
+                J.Break compareTo = (J.Break) j;
+                if (nullMissMatch(breakStatement.getLabel(), compareTo.getLabel())) {
+                    isEqual.set(false);
+                    return breakStatement;
+                }
+                if (breakStatement.getLabel() != null && compareTo.getLabel() != null) {
+                    this.visit(breakStatement.getLabel(), compareTo.getLabel());
+                }
+            }
+            return breakStatement;
+        }
+
+        @Override
+        public J.Case visitCase(J.Case _case, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Case)) {
+                    isEqual.set(false);
+                    return _case;
+                }
+
+                J.Case compareTo = (J.Case) j;
+                if (_case.getStatements().size() != compareTo.getStatements().size()) {
+                    isEqual.set(false);
+                    return _case;
+                }
+
+                this.visit(_case.getPattern(), compareTo.getPattern());
+                for (int i = 0; i < _case.getStatements().size(); i++) {
+                    this.visit(_case.getStatements().get(i), compareTo.getStatements().get(i));
+                }
+            }
+            return _case;
+        }
+
+        @Override
+        public J.Try.Catch visitCatch(J.Try.Catch _catch, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Try.Catch)) {
+                    isEqual.set(false);
+                    return _catch;
+                }
+
+                J.Try.Catch compareTo = (J.Try.Catch) j;
+                this.visit(_catch.getParameter(), compareTo.getParameter());
+                this.visit(_catch.getBody(), compareTo.getBody());
+            }
+            return _catch;
+        }
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ClassDeclaration)) {
+                    isEqual.set(false);
+                    return classDecl;
+                }
+
+                J.ClassDeclaration compareTo = (J.ClassDeclaration) j;
+                if (!classDecl.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !TypeUtils.isOfType(classDecl.getType(), compareTo.getType()) ||
+                        classDecl.getModifiers().size() != compareTo.getModifiers().size() ||
+                        !new HashSet<>(classDecl.getModifiers()).containsAll(compareTo.getModifiers()) ||
+                        classDecl.getKind() != compareTo.getKind() ||
+                        classDecl.getLeadingAnnotations().size() != compareTo.getLeadingAnnotations().size() ||
+
+                        nullMissMatch(classDecl.getExtends(), compareTo.getExtends()) ||
+
+                        nullMissMatch(classDecl.getTypeParameters(), compareTo.getTypeParameters()) ||
+                        classDecl.getTypeParameters() != null && compareTo.getTypeParameters() != null && classDecl.getTypeParameters().size() != compareTo.getTypeParameters().size() ||
+
+                        nullMissMatch(classDecl.getImplements(), compareTo.getImplements()) ||
+                        classDecl.getImplements() != null && compareTo.getImplements() != null && classDecl.getImplements().size() != compareTo.getImplements().size()) {
+                    isEqual.set(false);
+                    return classDecl;
+                }
+
+                for (int i = 0; i < classDecl.getLeadingAnnotations().size(); i++) {
+                    this.visit(classDecl.getLeadingAnnotations().get(i), compareTo.getLeadingAnnotations().get(i));
+                }
+
+                if (classDecl.getExtends() != null && compareTo.getExtends() != null) {
+                    this.visit(classDecl.getExtends(), compareTo.getExtends());
+                }
+
+                if (classDecl.getTypeParameters() != null && compareTo.getTypeParameters() != null) {
+                    for (int i = 0; i < classDecl.getTypeParameters().size(); i++) {
+                        this.visit(classDecl.getTypeParameters().get(i), compareTo.getTypeParameters().get(i));
+                    }
+                }
+
+                if (classDecl.getImplements() != null && compareTo.getImplements() != null) {
+                    for (int i = 0; i < classDecl.getImplements().size(); i++) {
+                        this.visit(classDecl.getImplements().get(i), compareTo.getImplements().get(i));
+                    }
+                }
+
+                this.visit(classDecl.getBody(), compareTo.getBody());
+
+            }
+            return classDecl;
+        }
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.CompilationUnit)) {
+                    isEqual.set(false);
+                    return cu;
+                }
+
+                J.CompilationUnit compareTo = (J.CompilationUnit) j;
+                if (nullMissMatch(cu.getPackageDeclaration(), compareTo.getPackageDeclaration()) ||
+                        cu.getImports().size() != compareTo.getImports().size() ||
+                        cu.getClasses().size() != compareTo.getClasses().size()) {
+                    isEqual.set(false);
+                    return cu;
+                }
+
+                this.visit(cu.getPackageDeclaration(), compareTo.getPackageDeclaration());
+                for (int i = 0; i < cu.getImports().size(); i++) {
+                    this.visit(cu.getImports().get(i), compareTo.getImports().get(i));
+                }
+                for (int i = 0; i < cu.getClasses().size(); i++) {
+                    this.visit(cu.getClasses().get(i), compareTo.getClasses().get(i));
+                }
+            }
+            return cu;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends J> J.ControlParentheses<T> visitControlParentheses(J.ControlParentheses<T> controlParens, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ControlParentheses)) {
+                    isEqual.set(false);
+                    return controlParens;
+                }
+
+                J.ControlParentheses<T> compareTo = (J.ControlParentheses<T>) j;
+                if (!TypeUtils.isOfType(controlParens.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return controlParens;
+                }
+                this.visit(controlParens.getTree(), compareTo.getTree());
+            }
+            return controlParens;
+        }
+
+        @Override
+        public J.Continue visitContinue(J.Continue continueStatement, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Continue)) {
+                    isEqual.set(false);
+                    return continueStatement;
+                }
+
+                J.Continue compareTo = (J.Continue) j;
+                if (nullMissMatch(continueStatement.getLabel(), compareTo.getLabel())) {
+                    isEqual.set(false);
+                    return continueStatement;
+                }
+                this.visit(continueStatement.getLabel(), compareTo.getLabel());
+            }
+            return continueStatement;
+        }
+
+        @Override
+        public J.DoWhileLoop visitDoWhileLoop(J.DoWhileLoop doWhileLoop, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.DoWhileLoop)) {
+                    isEqual.set(false);
+                    return doWhileLoop;
+                }
+
+                J.DoWhileLoop compareTo = (J.DoWhileLoop) j;
+                this.visit(doWhileLoop.getWhileCondition(), compareTo.getWhileCondition());
+                this.visit(doWhileLoop.getBody(), compareTo.getBody());
+            }
+            return doWhileLoop;
+        }
+
+        @Override
+        public J.If.Else visitElse(J.If.Else elze, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.If.Else)) {
+                    isEqual.set(false);
+                    return elze;
+                }
+
+                J.If.Else compareTo = (J.If.Else) j;
+                this.visit(elze.getBody(), compareTo.getBody());
+            }
+            return elze;
+        }
+
+        @Override
+        public J.Empty visitEmpty(J.Empty empty, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Empty)) {
+                    isEqual.set(false);
+                    return empty;
+                }
+
+                J.Empty compareTo = (J.Empty) j;
+                if (empty.getType() == null && compareTo.getType() != null ||
+                        empty.getType() != null && compareTo.getType() == null) {
+                    isEqual.set(false);
+                    return empty;
+                }
+            }
+            return empty;
+        }
+
+        @Override
+        public J.EnumValue visitEnumValue(J.EnumValue _enum, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.EnumValue)) {
+                    isEqual.set(false);
+                    return _enum;
+                }
+
+                J.EnumValue compareTo = (J.EnumValue) j;
+                if (!_enum.getName().getSimpleName().equals(compareTo.getName().getSimpleName()) ||
+                        !TypeUtils.isOfType(_enum.getName().getType(), compareTo.getName().getType()) ||
+                        nullMissMatch(_enum.getAnnotations(), compareTo.getAnnotations()) ||
+                        _enum.getAnnotations().size() != compareTo.getAnnotations().size()) {
+                    isEqual.set(false);
+                    return _enum;
+                }
+
+                for (int i = 0; i < _enum.getAnnotations().size(); i++) {
+                    this.visit(_enum.getAnnotations().get(i), compareTo.getAnnotations().get(i));
+                }
+                if (_enum.getInitializer() != null && compareTo.getInitializer() != null) {
+                    this.visit(_enum.getInitializer(), compareTo.getInitializer());
+                }
+            }
+            return _enum;
+        }
+
+        @Override
+        public J.EnumValueSet visitEnumValueSet(J.EnumValueSet enums, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.EnumValueSet)) {
+                    isEqual.set(false);
+                    return enums;
+                }
+
+                J.EnumValueSet compareTo = (J.EnumValueSet) j;
+                if (enums.getEnums().size() != compareTo.getEnums().size()) {
+                    isEqual.set(false);
+                    return enums;
+                }
+
+                for (int i = 0; i < enums.getEnums().size(); i++) {
+                    this.visit(enums.getEnums().get(i), compareTo.getEnums().get(i));
+                }
+            }
+            return enums;
+        }
+
+        @Override
+        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.FieldAccess)) {
+                    isEqual.set(false);
+                    return fieldAccess;
+                }
+
+                J.FieldAccess compareTo = (J.FieldAccess) j;
+                if (!fieldAccess.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !TypeUtils.isOfType(fieldAccess.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(fieldAccess.getTarget().getType(), compareTo.getTarget().getType())) {
+                    isEqual.set(false);
+                    return fieldAccess;
+                }
+            }
+            return fieldAccess;
+        }
+
+        @Override
+        public J.ForEachLoop visitForEachLoop(J.ForEachLoop forLoop, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ForEachLoop)) {
+                    isEqual.set(false);
+                    return forLoop;
+                }
+
+                J.ForEachLoop compareTo = (J.ForEachLoop) j;
+                this.visit(forLoop.getControl(), compareTo.getControl());
+                this.visit(forLoop.getBody(), compareTo.getBody());
+            }
+            return forLoop;
+        }
+
+        @Override
+        public J.ForEachLoop.Control visitForEachControl(J.ForEachLoop.Control control, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ForEachLoop.Control)) {
+                    isEqual.set(false);
+                    return control;
+                }
+
+                J.ForEachLoop.Control compareTo = (J.ForEachLoop.Control) j;
+                this.visit(control.getVariable(), compareTo.getVariable());
+                this.visit(control.getIterable(), compareTo.getIterable());
+            }
+            return control;
+        }
+
+        @Override
+        public J.ForLoop visitForLoop(J.ForLoop forLoop, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ForLoop)) {
+                    isEqual.set(false);
+                    return forLoop;
+                }
+
+                J.ForLoop compareTo = (J.ForLoop) j;
+                this.visit(forLoop.getControl(), compareTo.getControl());
+                this.visit(forLoop.getBody(), compareTo.getBody());
+            }
+            return forLoop;
+        }
+
+        @Override
+        public J.ForLoop.Control visitForControl(J.ForLoop.Control control, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ForLoop.Control)) {
+                    isEqual.set(false);
+                    return control;
+                }
+
+                J.ForLoop.Control compareTo = (J.ForLoop.Control) j;
+                if (control.getInit().size() != compareTo.getInit().size() ||
+                        control.getUpdate().size() != compareTo.getUpdate().size()) {
+                    isEqual.set(false);
+                    return control;
+                }
+                this.visit(control.getCondition(), compareTo.getCondition());
+                for (int i = 0; i < control.getInit().size(); i++) {
+                    this.visit(control.getInit().get(i), compareTo.getInit().get(i));
+                }
+                for (int i = 0; i < control.getUpdate().size(); i++) {
+                    this.visit(control.getUpdate().get(i), compareTo.getUpdate().get(i));
+                }
+            }
+            return control;
+        }
+
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Identifier)) {
+                    isEqual.set(false);
+                    return identifier;
+                }
+
+                J.Identifier compareTo = (J.Identifier) j;
+                if (!identifier.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !TypeUtils.isOfType(identifier.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return identifier;
+                }
+            }
+            return identifier;
+        }
+
+        @Override
+        public J.If visitIf(J.If iff, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.If)) {
+                    isEqual.set(false);
+                    return iff;
+                }
+
+                J.If compareTo = (J.If) j;
+                this.visit(iff.getIfCondition(), compareTo.getIfCondition());
+                this.visit(iff.getThenPart(), compareTo.getThenPart());
+                this.visit(iff.getElsePart(), compareTo.getElsePart());
+            }
+            return iff;
+        }
+
+        @Override
+        public J.Import visitImport(J.Import _import, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Import)) {
+                    isEqual.set(false);
+                    return _import;
+                }
+
+                J.Import compareTo = (J.Import) j;
+                if (_import.isStatic() != compareTo.isStatic() ||
+                        !_import.getPackageName().equals(compareTo.getPackageName()) ||
+                        !_import.getClassName().equals(compareTo.getClassName()) ||
+                        !TypeUtils.isOfType(_import.getQualid().getType(), compareTo.getQualid().getType())) {
+                    isEqual.set(false);
+                    return _import;
+                }
+            }
+            return _import;
+        }
+
+        @Override
+        public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.InstanceOf)) {
+                    isEqual.set(false);
+                    return instanceOf;
+                }
+
+                J.InstanceOf compareTo = (J.InstanceOf) j;
+                if (!TypeUtils.isOfType(instanceOf.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return instanceOf;
+                }
+                this.visit(instanceOf.getClazz(), compareTo.getClazz());
+                this.visit(instanceOf.getExpression(), compareTo.getExpression());
+            }
+            return instanceOf;
+        }
+
+        @Override
+        public J.Label visitLabel(J.Label label, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Label)) {
+                    isEqual.set(false);
+                    return label;
+                }
+
+                J.Label compareTo = (J.Label) j;
+                if (!label.getLabel().getSimpleName().equals(compareTo.getLabel().getSimpleName()) ||
+                        !TypeUtils.isOfType(label.getLabel().getType(), compareTo.getLabel().getType())) {
+                    isEqual.set(false);
+                    return label;
+                }
+                this.visit(label.getStatement(), compareTo.getStatement());
+            }
+            return label;
+        }
+
+        @Override
+        public J.Lambda visitLambda(J.Lambda lambda, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Lambda)) {
+                    isEqual.set(false);
+                    return lambda;
+                }
+
+                J.Lambda compareTo = (J.Lambda) j;
+                if (lambda.getParameters().isParenthesized() != compareTo.getParameters().isParenthesized() ||
+                        lambda.getParameters().getParameters().size() != compareTo.getParameters().getParameters().size()) {
+                    isEqual.set(false);
+                    return lambda;
+                }
+                this.visit(lambda.getBody(), compareTo.getBody());
+                for (int i = 0; i < lambda.getParameters().getParameters().size(); i++) {
+                    this.visit(lambda.getParameters().getParameters().get(i), compareTo.getParameters().getParameters().get(i));
+                }
+            }
+            return lambda;
+        }
+
+        @Override
+        public J.Literal visitLiteral(J.Literal literal, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Literal)) {
+                    isEqual.set(false);
+                    return literal;
+                }
+
+                J.Literal compareTo = (J.Literal) j;
+                if (!TypeUtils.isOfType(literal.getType(), compareTo.getType()) ||
+                        !Objects.equals(literal.getValue(), compareTo.getValue())) {
+                    isEqual.set(false);
+                    return literal;
+                }
+            }
+            return literal;
+        }
+
+        @Override
+        public J.MemberReference visitMemberReference(J.MemberReference memberRef, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.MemberReference)) {
+                    isEqual.set(false);
+                    return memberRef;
+                }
+
+                J.MemberReference compareTo = (J.MemberReference) j;
+                if (!memberRef.getReference().getSimpleName().equals(compareTo.getReference().getSimpleName()) ||
+                        !TypeUtils.isOfType(memberRef.getReference().getType(), compareTo.getReference().getType()) ||
+                        !TypeUtils.isOfType(memberRef.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(memberRef.getVariableType(), compareTo.getVariableType()) ||
+                        !isMethodType(memberRef.getMethodType(), compareTo.getMethodType()) ||
+                        nullMissMatch(memberRef.getTypeParameters(), compareTo.getTypeParameters()) ||
+                        memberRef.getTypeParameters() != null && compareTo.getTypeParameters() != null && memberRef.getTypeParameters().size() != compareTo.getTypeParameters().size()) {
+                    isEqual.set(false);
+                    return memberRef;
+                }
+
+                this.visit(memberRef.getContaining(), compareTo.getContaining());
+                if (memberRef.getTypeParameters() != null && compareTo.getTypeParameters() != null) {
+                    for (int i = 0; i < memberRef.getTypeParameters().size(); i++) {
+                        this.visit(memberRef.getTypeParameters().get(i), compareTo.getTypeParameters().get(i));
+                    }
+                }
+            }
+            return memberRef;
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.MethodDeclaration)) {
+                    isEqual.set(false);
+                    return method;
+                }
+
+                J.MethodDeclaration compareTo = (J.MethodDeclaration) j;
+                if (!method.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !isMethodType(method.getMethodType(), compareTo.getMethodType()) ||
+                        method.getModifiers().size() != compareTo.getModifiers().size() ||
+                        !new HashSet<>(method.getModifiers()).containsAll(compareTo.getModifiers()) ||
+
+                        method.getLeadingAnnotations().size() != compareTo.getLeadingAnnotations().size() ||
+                        method.getParameters().size() != compareTo.getParameters().size() ||
+
+                        nullMissMatch(method.getReturnTypeExpression(), compareTo.getReturnTypeExpression()) ||
+
+                        nullMissMatch(method.getTypeParameters(), compareTo.getTypeParameters()) ||
+                        method.getTypeParameters() != null && compareTo.getTypeParameters() != null && method.getTypeParameters().size() != compareTo.getTypeParameters().size() ||
+
+                        nullMissMatch(method.getThrows(), compareTo.getThrows()) ||
+                        method.getThrows() != null && compareTo.getThrows() != null && method.getThrows().size() != compareTo.getThrows().size() ||
+
+                        nullMissMatch(method.getBody(), compareTo.getBody()) ||
+                        method.getBody().getStatements() != null && compareTo.getBody().getStatements() != null && method.getBody().getStatements().size() != compareTo.getBody().getStatements().size()) {
+                    isEqual.set(false);
+                    return method;
+                }
+
+                for (int i = 0; i < method.getLeadingAnnotations().size(); i++) {
+                    this.visit(method.getLeadingAnnotations().get(i), compareTo.getLeadingAnnotations().get(i));
+                }
+
+                for (int i = 0; i < method.getParameters().size(); i++) {
+                    this.visit(method.getParameters().get(i), compareTo.getParameters().get(i));
+                }
+
+                if (method.getReturnTypeExpression() != null && compareTo.getReturnTypeExpression() != null) {
+                    this.visitTypeName(method.getReturnTypeExpression(), compareTo.getReturnTypeExpression());
+                }
+
+                if (method.getTypeParameters() != null && compareTo.getTypeParameters() != null) {
+                    for (int i = 0; i < method.getTypeParameters().size(); i++) {
+                        this.visit(method.getTypeParameters().get(i), compareTo.getTypeParameters().get(i));
+                    }
+                }
+
+                if (method.getThrows() != null && compareTo.getThrows() != null) {
+                    for (int i = 0; i < method.getThrows().size(); i++) {
+                        this.visitTypeName(method.getThrows().get(i), compareTo.getThrows().get(i));
+                    }
+                }
+
+                if (method.getBody() != null && compareTo.getBody() != null) {
+                    this.visit(method.getBody(), compareTo.getBody());
+                }
+            }
+            return method;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.MethodInvocation)) {
+                    isEqual.set(false);
+                    return method;
+                }
+
+                J.MethodInvocation compareTo = (J.MethodInvocation) j;
+                if (!method.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !isMethodType(method.getMethodType(), compareTo.getMethodType()) ||
+                        method.getArguments().size() != compareTo.getArguments().size() ||
+                        method.getTypeParameters() != null && compareTo.getTypeParameters() != null && method.getTypeParameters().size() != compareTo.getTypeParameters().size()) {
+                    isEqual.set(false);
+                    return method;
+                }
+
+                this.visit(method.getSelect(), compareTo.getSelect());
+                for (int i = 0; i < method.getArguments().size(); i++) {
+                    this.visit(method.getArguments().get(i), compareTo.getArguments().get(i));
+                }
+
+                if (method.getTypeParameters() != null && compareTo.getTypeParameters() != null) {
+                    for (int i = 0; i < method.getTypeParameters().size(); i++) {
+                        this.visit(method.getTypeParameters().get(i), compareTo.getTypeParameters().get(i));
+                    }
+                }
+            }
+            return method;
+        }
+
+        @Override
+        public J.MultiCatch visitMultiCatch(J.MultiCatch multiCatch, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.MultiCatch)) {
+                    isEqual.set(false);
+                    return multiCatch;
+                }
+
+                J.MultiCatch compareTo = (J.MultiCatch) j;
+                if (!(multiCatch.getType() instanceof JavaType.MultiCatch) ||
+                        !(compareTo.getType() instanceof JavaType.MultiCatch) ||
+                        ((JavaType.MultiCatch) multiCatch.getType()).getThrowableTypes().size() != ((JavaType.MultiCatch) compareTo.getType()).getThrowableTypes().size() ||
+                        multiCatch.getAlternatives().size() != compareTo.getAlternatives().size()) {
+                    isEqual.set(false);
+                    return multiCatch;
+                }
+
+                for (int i = 0; i < ((JavaType.MultiCatch) multiCatch.getType()).getThrowableTypes().size(); i++) {
+                    JavaType first = ((JavaType.MultiCatch) multiCatch.getType()).getThrowableTypes().get(i);
+                    JavaType second = ((JavaType.MultiCatch) compareTo.getType()).getThrowableTypes().get(i);
+                    if (!TypeUtils.isOfType(first, second)) {
+                        isEqual.set(false);
+                        return multiCatch;
+                    }
+                }
+
+                for (int i = 0; i < multiCatch.getAlternatives().size(); i++) {
+                    this.visit(multiCatch.getAlternatives().get(i), compareTo.getAlternatives().get(i));
+                }
+            }
+            return multiCatch;
+        }
+
+        @Override
+        public J.NewArray visitNewArray(J.NewArray newArray, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.NewArray)) {
+                    isEqual.set(false);
+                    return newArray;
+                }
+
+                J.NewArray compareTo = (J.NewArray) j;
+                if (!TypeUtils.isOfType(newArray.getType(), compareTo.getType()) ||
+                        newArray.getDimensions().size() != compareTo.getDimensions().size() ||
+                        nullMissMatch(newArray.getTypeExpression(), compareTo.getTypeExpression()) ||
+                        nullMissMatch(newArray.getInitializer(), compareTo.getInitializer()) ||
+                        newArray.getInitializer() != null && compareTo.getInitializer() != null && newArray.getInitializer().size() != compareTo.getInitializer().size()) {
+                    isEqual.set(false);
+                    return newArray;
+                }
+
+                for (int i = 0; i < newArray.getDimensions().size(); i++) {
+                    this.visit(newArray.getDimensions().get(i), compareTo.getDimensions().get(i));
+                }
+                if (newArray.getTypeExpression() != null && compareTo.getTypeExpression() != null) {
+                    this.visit(newArray.getTypeExpression(), compareTo.getTypeExpression());
+                }
+                if (newArray.getInitializer() != null && compareTo.getInitializer() != null) {
+                    for (int i = 0; i < newArray.getInitializer().size(); i++) {
+                        this.visit(newArray.getInitializer().get(i), compareTo.getInitializer().get(i));
+                    }
+                }
+            }
+            return newArray;
+        }
+
+        @Override
+        public J.NewClass visitNewClass(J.NewClass newClass, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.NewClass)) {
+                    isEqual.set(false);
+                    return newClass;
+                }
+
+                J.NewClass compareTo = (J.NewClass) j;
+                if (!TypeUtils.isOfType(newClass.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(newClass.getConstructorType(), compareTo.getConstructorType()) ||
+                        nullMissMatch(newClass.getEnclosing(), compareTo.getEnclosing()) ||
+                        nullMissMatch(newClass.getClazz(), compareTo.getClazz()) ||
+                        nullMissMatch(newClass.getConstructorType(), compareTo.getConstructorType()) ||
+                        nullMissMatch(newClass.getBody(), compareTo.getBody()) ||
+                        nullMissMatch(newClass.getArguments(), compareTo.getArguments()) ||
+                        newClass.getArguments() != null && compareTo.getArguments() != null && newClass.getArguments().size() != compareTo.getArguments().size()) {
+                    isEqual.set(false);
+                    return newClass;
+                }
+
+                if (newClass.getEnclosing() != null && compareTo.getEnclosing() != null) {
+                    this.visit(newClass.getEnclosing(), compareTo.getEnclosing());
+                }
+                if (newClass.getClazz() != null && compareTo.getClazz() != null) {
+                    this.visit(newClass.getClazz(), compareTo.getClazz());
+                }
+                if (newClass.getBody() != null && compareTo.getBody() != null) {
+                    this.visit(newClass.getBody(), compareTo.getBody());
+                }
+                if (newClass.getArguments() != null && compareTo.getArguments() != null) {
+                    for (int i = 0; i < newClass.getArguments().size(); i++) {
+                        this.visit(newClass.getArguments().get(i), compareTo.getArguments().get(i));
+                    }
+                }
+            }
+            return newClass;
+        }
+
+        @Override
+        public J.Package visitPackage(J.Package pkg, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Package)) {
+                    isEqual.set(false);
+                    return pkg;
+                }
+
+                J.Package compareTo = (J.Package) j;
+                if (pkg.getAnnotations().size() != compareTo.getAnnotations().size()) {
+                    isEqual.set(false);
+                    return pkg;
+                }
+                this.visit(pkg.getExpression(), compareTo.getExpression());
+                for (int i = 0; i < pkg.getAnnotations().size(); i++) {
+                    this.visit(pkg.getAnnotations().get(i), compareTo.getAnnotations().get(i));
+                }
+            }
+            return pkg;
+        }
+
+        @Override
+        public J.ParameterizedType visitParameterizedType(J.ParameterizedType type, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.ParameterizedType)) {
+                    isEqual.set(false);
+                    return type;
+                }
+
+                J.ParameterizedType compareTo = (J.ParameterizedType) j;
+                if (!TypeUtils.isOfType(type.getType(), compareTo.getType()) ||
+                        nullMissMatch(type.getTypeParameters(), compareTo.getTypeParameters()) ||
+                        type.getTypeParameters() != null && compareTo.getTypeParameters() != null && type.getTypeParameters().size() != compareTo.getTypeParameters().size()) {
+                    isEqual.set(false);
+                    return type;
+                }
+
+                if (type.getTypeParameters() != null && compareTo.getTypeParameters() != null) {
+                    for (int i = 0; i < type.getTypeParameters().size(); i++) {
+                        this.visit(type.getTypeParameters().get(i), compareTo.getTypeParameters().get(i));
+                    }
+                }
+            }
+            return type;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends J> J.Parentheses<T> visitParentheses(J.Parentheses<T> parens, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Parentheses)) {
+                    isEqual.set(false);
+                    return parens;
+                }
+
+                J.Parentheses<T> compareTo = (J.Parentheses<T>) j;
+                this.visit(parens.getTree(), compareTo.getTree());
+            }
+            return parens;
+        }
+
+        @Override
+        public J.Primitive visitPrimitive(J.Primitive primitive, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Primitive)) {
+                    isEqual.set(false);
+                    return primitive;
+                }
+
+                J.Primitive compareTo = (J.Primitive) j;
+                if (!TypeUtils.isOfType(primitive.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return primitive;
+                }
+            }
+            return primitive;
+        }
+
+        @Override
+        public J.Return visitReturn(J.Return _return, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Return)) {
+                    isEqual.set(false);
+                    return _return;
+                }
+
+                J.Return compareTo = (J.Return) j;
+                this.visit(_return.getExpression(), compareTo.getExpression());
+            }
+            return _return;
+        }
+
+        @Override
+        public J.Switch visitSwitch(J.Switch _switch, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Switch)) {
+                    isEqual.set(false);
+                    return _switch;
+                }
+
+                J.Switch compareTo = (J.Switch) j;
+                this.visit(_switch.getCases(), compareTo.getCases());
+            }
+            return _switch;
+        }
+
+        @Override
+        public J.Synchronized visitSynchronized(J.Synchronized _sync, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Synchronized)) {
+                    isEqual.set(false);
+                    return _sync;
+                }
+
+                J.Synchronized compareTo = (J.Synchronized) j;
+                this.visit(_sync.getLock(), compareTo.getLock());
+                this.visit(_sync.getBody(), compareTo.getBody());
+            }
+            return _sync;
+        }
+
+        @Override
+        public J.Ternary visitTernary(J.Ternary ternary, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Ternary)) {
+                    isEqual.set(false);
+                    return ternary;
+                }
+
+                J.Ternary compareTo = (J.Ternary) j;
+                if (!TypeUtils.isOfType(ternary.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return ternary;
+                }
+                this.visit(ternary.getCondition(), compareTo.getCondition());
+                this.visit(ternary.getTruePart(), compareTo.getTruePart());
+                this.visit(ternary.getFalsePart(), compareTo.getFalsePart());
+            }
+            return ternary;
+        }
+
+        @Override
+        public J.Throw visitThrow(J.Throw thrown, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Throw)) {
+                    isEqual.set(false);
+                    return thrown;
+                }
+
+                J.Throw compareTo = (J.Throw) j;
+                this.visit(thrown.getException(), compareTo.getException());
+            }
+            return thrown;
+        }
+
+        @Override
+        public J.Try visitTry(J.Try _try, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Try)) {
+                    isEqual.set(false);
+                    return _try;
+                }
+
+                J.Try compareTo = (J.Try) j;
+                if (_try.getCatches().size() != compareTo.getCatches().size() ||
+                        nullMissMatch(_try.getFinally(), compareTo.getFinally()) ||
+                        nullMissMatch(_try.getResources(), compareTo.getResources()) ||
+                        _try.getResources() != null && compareTo.getResources() != null && _try.getResources().size() != compareTo.getResources().size()) {
+                    isEqual.set(false);
+                    return _try;
+                }
+                this.visit(_try.getBody(), compareTo.getBody());
+                for (int i = 0; i < _try.getCatches().size(); i++) {
+                    this.visit(_try.getCatches().get(i), compareTo.getCatches().get(i));
+                }
+                if (_try.getResources() != null && compareTo.getResources() != null) {
+                    for (int i = 0; i < _try.getResources().size(); i++) {
+                        this.visit(_try.getResources().get(i), compareTo.getResources().get(i));
+                    }
+                }
+                if (_try.getFinally() != null && compareTo.getFinally() != null) {
+                    this.visit(_try.getFinally(), compareTo.getFinally());
+                }
+            }
+            return _try;
+        }
+
+        @Override
+        public J.Try.Resource visitTryResource(J.Try.Resource tryResource, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Try.Resource)) {
+                    isEqual.set(false);
+                    return tryResource;
+                }
+
+                J.Try.Resource compareTo = (J.Try.Resource) j;
+                if (tryResource.isTerminatedWithSemicolon() != compareTo.isTerminatedWithSemicolon()) {
+                    isEqual.set(false);
+                    return tryResource;
+                }
+                this.visit(tryResource.getVariableDeclarations(), compareTo.getVariableDeclarations());
+            }
+            return tryResource;
+        }
+
+        @Override
+        public J.TypeCast visitTypeCast(J.TypeCast typeCast, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.TypeCast)) {
+                    isEqual.set(false);
+                    return typeCast;
+                }
+
+                J.TypeCast compareTo = (J.TypeCast) j;
+                this.visit(typeCast.getClazz(), compareTo.getClazz());
+                this.visit(typeCast.getExpression(), compareTo.getExpression());
+            }
+            return typeCast;
+        }
+
+        @Override
+        public J.TypeParameter visitTypeParameter(J.TypeParameter typeParam, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.TypeParameter)) {
+                    isEqual.set(false);
+                    return typeParam;
+                }
+
+                J.TypeParameter compareTo = (J.TypeParameter) j;
+                if (typeParam.getAnnotations().size() != compareTo.getAnnotations().size() ||
+                        nullMissMatch(typeParam.getBounds(), compareTo.getBounds()) ||
+                        typeParam.getBounds().size() != compareTo.getBounds().size()) {
+                    isEqual.set(false);
+                    return typeParam;
+                }
+                this.visit(typeParam.getName(), compareTo.getName());
+                for (int i = 0; i < typeParam.getAnnotations().size(); i++) {
+                    this.visit(typeParam.getAnnotations().get(i), compareTo.getAnnotations().get(i));
+                }
+                if (typeParam.getBounds() != null && compareTo.getBounds() != null) {
+                    for (int i = 0; i < typeParam.getBounds().size(); i++) {
+                        this.visit(typeParam.getBounds().get(i), compareTo.getBounds().get(i));
+                    }
+                }
+            }
+            return typeParam;
+        }
+
+        @Override
+        public J.Unary visitUnary(J.Unary unary, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Unary)) {
+                    isEqual.set(false);
+                    return unary;
+                }
+
+                J.Unary compareTo = (J.Unary) j;
+                if (nullMissMatch(unary.getType(), compareTo.getType()) ||
+                        !TypeUtils.isOfType(unary.getType(), compareTo.getType()) ||
+                        unary.getOperator() != compareTo.getOperator()) {
+                    isEqual.set(false);
+                    return unary;
+                }
+
+                this.visit(unary.getExpression(), compareTo.getExpression());
+            }
+            return unary;
+        }
+
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.VariableDeclarations)) {
+                    isEqual.set(false);
+                    return multiVariable;
+                }
+
+                J.VariableDeclarations compareTo = (J.VariableDeclarations) j;
+                if (!TypeUtils.isOfType(multiVariable.getType(), compareTo.getType()) ||
+                        multiVariable.getVariables().size() != compareTo.getVariables().size() ||
+                        multiVariable.getLeadingAnnotations().size() != compareTo.getLeadingAnnotations().size()) {
+                    isEqual.set(false);
+                    return multiVariable;
+                }
+
+                this.visitTypeName(multiVariable.getTypeExpression(), compareTo.getTypeExpression());
+                for (int i = 0; i < multiVariable.getLeadingAnnotations().size(); i++) {
+                    this.visit(multiVariable.getLeadingAnnotations().get(i), compareTo.getLeadingAnnotations().get(i));
+                }
+                for (int i = 0; i < multiVariable.getVariables().size(); i++) {
+                    this.visit(multiVariable.getVariables().get(i), compareTo.getVariables().get(i));
+                }
+            }
+            return multiVariable;
+        }
+
+        @Override
+        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.VariableDeclarations.NamedVariable)) {
+                    isEqual.set(false);
+                    return variable;
+                }
+
+                J.VariableDeclarations.NamedVariable compareTo = (J.VariableDeclarations.NamedVariable) j;
+                if (!variable.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !TypeUtils.isOfType(variable.getType(), compareTo.getType())) {
+                    isEqual.set(false);
+                    return variable;
+                }
+                this.visit(variable.getInitializer(), compareTo.getInitializer());
+            }
+            return variable;
+        }
+
+        @Override
+        public J.WhileLoop visitWhileLoop(J.WhileLoop whileLoop, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.WhileLoop)) {
+                    isEqual.set(false);
+                    return whileLoop;
+                }
+
+                J.WhileLoop compareTo = (J.WhileLoop) j;
+                this.visit(whileLoop.getBody(), compareTo.getBody());
+                this.visit(whileLoop.getCondition(), compareTo.getCondition());
+            }
+            return whileLoop;
+        }
+
+        @Override
+        public J.Wildcard visitWildcard(J.Wildcard wildcard, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof J.Wildcard)) {
+                    isEqual.set(false);
+                    return wildcard;
+                }
+
+                J.Wildcard compareTo = (J.Wildcard) j;
+                if (wildcard.getBound() != compareTo.getBound() ||
+                        nullMissMatch(wildcard.getBoundedType(), compareTo.getBoundedType())) {
+                    isEqual.set(false);
+                    return wildcard;
+                }
+                this.visitTypeName(wildcard.getBoundedType(), compareTo.getBoundedType());
+            }
+            return wildcard;
+        }
+
+        @Override
+        public <N extends NameTree> N visitTypeName(N firstTypeName, J j) {
+            if (isEqual.get()) {
+                if (!(j instanceof NameTree) && !TypeUtils.isOfType(firstTypeName.getType(), ((NameTree) j).getType())) {
+                    isEqual.set(false);
+                    return firstTypeName;
+                }
+            }
+            return firstTypeName;
+        }
+
+        @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+        private boolean isMethodType(JavaType.Method method1, JavaType.Method method2) {
+            if (!method1.getName().equals(method2.getName()) ||
+                    method1.getFlags().size() != method2.getFlags().size() ||
+                    !method1.getFlags().containsAll(method2.getFlags()) ||
+                    !TypeUtils.isOfType(method1.getDeclaringType(), method2.getDeclaringType()) ||
+                    !TypeUtils.isOfType(method1.getReturnType(), method2.getReturnType()) ||
+                    method1.getAnnotations().size() != method2.getAnnotations().size() ||
+                    method1.getThrownExceptions().size() != method2.getThrownExceptions().size() ||
+                    method1.getParameterTypes().size() != method2.getParameterTypes().size()) {
+                return false;
+            }
+
+            for (int index = 0; index < method1.getParameterTypes().size(); index++) {
+                if (!TypeUtils.isOfType(method1.getParameterTypes().get(index), method2.getParameterTypes().get(index))) {
                     return false;
                 }
-                return ((JavaType.FullyQualified) thisType).getFullyQualifiedName().equals(((JavaType.FullyQualified) otherType).getFullyQualifiedName());
             }
-
-            return thisType.equals(otherType);
+            for (int index = 0; index < method1.getThrownExceptions().size(); index++) {
+                if (!TypeUtils.isOfType(method1.getThrownExceptions().get(index), method2.getThrownExceptions().get(index))) {
+                    return false;
+                }
+            }
+            for (int index = 0; index < method1.getAnnotations().size(); index++) {
+                if (!TypeUtils.isOfType(method1.getAnnotations().get(index), method2.getAnnotations().get(index))) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
@@ -16,21 +16,26 @@
 package org.openrewrite.java.search
 
 import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.openrewrite.InMemoryExecutionContext
 import org.openrewrite.Issue
-import org.openrewrite.Parser
 import org.openrewrite.Tree.randomId
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.tree.J
-import org.openrewrite.java.tree.JLeftPadded
 import org.openrewrite.java.tree.JavaType
 import org.openrewrite.java.tree.Space
 import org.openrewrite.marker.Markers
-import java.util.*
 
 interface SemanticallyEqualTest {
 
     companion object {
+        val jp: JavaParser = JavaParser
+            .fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .build()
+
         private const val annotInterface = """
             @interface MyAnnotation { 
                 boolean value();
@@ -41,69 +46,65 @@ interface SemanticallyEqualTest {
         """
     }
 
-    @Issue("#345")
+    private fun parseSources(@Language("java") sources: Array<String>): List<J.CompilationUnit> {
+        jp.reset();
+        return jp.parse(InMemoryExecutionContext { t -> fail(t) }, *sources)
+    }
+
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/345")
     @Test
-    fun fullyQualifiedReference(jp: JavaParser) {
-        val mcAnnoClass =
+    fun fullyQualifiedReference() {
+        val cu = parseSources(arrayOf(
             """
                 package org.mco.anno;
                 public @interface McAnno {}
-            """
-        val j = JavaParser.fromJavaVersion().dependsOn(Collections.singletonList(Parser.Input.fromString(mcAnnoClass))).build()
-        val cu1 = j.parse(
+            """,
             """
                 import org.mco.anno.McAnno;
                 @McAnno
                 class M {}
                 @org.mco.anno.McAnno
                 class N {}
-            """)
-        val c1Anno = cu1[0].classes[0].leadingAnnotations[0]
-        val c2Anno = cu1[0].classes[1].leadingAnnotations[0]
+            """
+        ))[1]
+        val c1Anno = cu.classes[0].leadingAnnotations[0]
+        val c2Anno = cu.classes[1].leadingAnnotations[0]
 
         assertThat(SemanticallyEqual.areEqual(c2Anno, c2Anno)).isTrue
         assertThat(SemanticallyEqual.areEqual(c1Anno, c2Anno)).isTrue
     }
 
     @Test
-    fun noArgumentsTest(jp: JavaParser) {
-        val cu = jp.parse(
-            """
+    fun noArgumentsTest() {
+        val cus = parseSources(
+            arrayOf(
+                """
                 @NoArgAnnotation1
                 class A {}
             """,
-            annotInterface
-        )
-
-        val firstAnnot = cu[0].classes[0].leadingAnnotations[0]
-
-        jp.reset()
-
-        val secondAnnot = jp.parse(
-            """
-                @NoArgAnnotation2
+                """
+                @NoArgAnnotation1
                 class B {}
             """,
-            annotInterface
-        )[0].classes[0].leadingAnnotations[0]
-
-        jp.reset()
-
-        val thirdAnnot = jp.parse(
-            """
+                """
                 @NoArgAnnotation2
-                class B {}
+                class C {}
             """,
-            annotInterface
-        )[0].classes[0].leadingAnnotations[0]
+                annotInterface
+            ))
 
-        assertThat(SemanticallyEqual.areEqual(firstAnnot, secondAnnot)).isFalse
-        assertThat(SemanticallyEqual.areEqual(secondAnnot,thirdAnnot)).isTrue
+        val firstAnnot = cus[0].classes[0].leadingAnnotations[0]
+        val secondAnnot = cus[1].classes[0].leadingAnnotations[0]
+        assertThat(SemanticallyEqual.areEqual(firstAnnot, secondAnnot)).isTrue
+
+        val thirdAnnot = cus[2].classes[0].leadingAnnotations[0]
+        assertThat(SemanticallyEqual.areEqual(secondAnnot,thirdAnnot)).isFalse
     }
 
     @Test
-    fun tagAnnotationEquality(jp: JavaParser) {
-        val cu = jp.parse(
+    fun tagAnnotationEquality() {
+        val clazz = parseSources(arrayOf(
             """
                 @Tag(FastTests.class)
                 @Tag(FastTests.class)
@@ -123,59 +124,53 @@ interface SemanticallyEqualTest {
             """,
             "public interface FastTests {}",
             "public interface SlowTests {}"
-        )
+        ))[0].classes[0]
 
-        val fastTest = cu[0].classes[0].leadingAnnotations[0]
-        val fastTest2 = cu[0].classes[0].leadingAnnotations[1]
-        val slowTest = cu[0].classes[0].leadingAnnotations[2]
-
+        val fastTest = clazz.leadingAnnotations[0]
+        val fastTest2 = clazz.leadingAnnotations[1]
         assertThat(SemanticallyEqual.areEqual(fastTest, fastTest2)).isTrue
+
+        val slowTest = clazz.leadingAnnotations[2]
         assertThat(SemanticallyEqual.areEqual(fastTest, slowTest)).isFalse
     }
 
     @Test
-    fun annotationEquality(jp: JavaParser) {
-        val cu = jp.parse(
+    fun annotationEquality() {
+        val cus = parseSources(arrayOf(
             """
                 @MyAnnotation(value = true, srcValue = "true")
                 class A {}
             """,
-            annotInterface
-        )
-
-        val firstAnnot = cu[0].classes[0].leadingAnnotations[0]
-
-        jp.reset()
-
-        val secondAnnot = jp.parse(
             """
                 @MyAnnotation(value = true, srcValue = "true")
                 class B {}
             """,
             annotInterface
-        )[0].classes[0].leadingAnnotations[0]
+        ))
 
+        val firstAnnot = cus[0].classes[0].leadingAnnotations[0]
+        val secondAnnot = cus[1].classes[0].leadingAnnotations[0]
         assertThat(SemanticallyEqual.areEqual(firstAnnot, secondAnnot)).isTrue
     }
 
     @Test
-    fun identEquality(jp: JavaParser) {
-        val cu = jp.parse(
+    fun identEquality() {
+        val cus = parseSources(arrayOf(
             """
                 @MyAnnotation(value = true)
                 class A {}
             """,
+            """
+                @MyAnnotation(value = true)
+                class B {}
+            """,
             "@interface MyAnnotation { boolean value(); }"
-        )
+        ))
 
-        val firstIdent = cu[0].classes[0].leadingAnnotations[0].annotationType
-        val secondIdent = J.Identifier(
-            randomId(),
-            Space.EMPTY,
-            Markers.EMPTY,
-            "MyAnnotation",
-            JavaType.buildType("MyAnnotation"), null
-        )
+        val firstIdent = cus[0].classes[0].leadingAnnotations[0].annotationType
+        val secondIdent = cus[1].classes[0].leadingAnnotations[0].annotationType
+        assertThat(SemanticallyEqual.areEqual(firstIdent, secondIdent)).isTrue
+
         val thirdIdent = J.Identifier(
             randomId(),
             Space.EMPTY,
@@ -183,19 +178,22 @@ interface SemanticallyEqualTest {
             "YourAnnotation",
             JavaType.buildType("YourAnnotation"), null
         )
-
-        assertThat(SemanticallyEqual.areEqual(firstIdent, secondIdent)).isTrue
-
         assertThat(SemanticallyEqual.areEqual(firstIdent, thirdIdent)).isFalse
     }
 
     @Test
-    fun fieldAccessEquality(jp: JavaParser) {
-        val cu = jp.parse(
+    fun fieldAccessEquality() {
+        val cus = parseSources(arrayOf(
             """
                 @Category(FastTest.class)
                 @Category(SlowTest.class)
                 class A {
+                }
+            """,
+            """
+                @Category(FastTest.class)
+                @Category(SlowTest.class)
+                class B {
                 }
             """,
             """
@@ -211,199 +209,1921 @@ interface SemanticallyEqualTest {
             """,
             "class FastTest {}",
             "class SlowTest {}"
-        )
+        ))
 
-        val firstFieldAccess = cu[0].classes[0].leadingAnnotations[0].arguments!!.first()
-        val secondFieldAccess = J.FieldAccess(
-            randomId(),
-            Space.EMPTY,
-            Markers.EMPTY,
-            J.Identifier(
-                randomId(),
-                Space.EMPTY,
-                Markers.EMPTY,
-                "FastTest",
-                JavaType.ShallowClass.build("FastTest"), null
-            ),
-            JLeftPadded(
-                Space.EMPTY,
-                J.Identifier(
-                    randomId(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    "class",
-                    null, null
-                ),
-                Markers.EMPTY
-            ),
-            JavaType.ShallowClass.build("java.lang.Class")
-        )
-        val thirdFieldAccess = cu[0].classes[0].leadingAnnotations[1].arguments!!.first()
+        val firstFieldAccess = cus[0].classes[0].leadingAnnotations[0].arguments!!.first()
+        val secondFieldAccess = cus[1].classes[0].leadingAnnotations[0].arguments!!.first()
+        assertThat(SemanticallyEqual.areEqual(firstFieldAccess, secondFieldAccess)).isTrue
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    firstFieldAccess,
-                    secondFieldAccess
-                )
-        ).isTrue
-
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    firstFieldAccess,
-                    thirdFieldAccess
-                )
-        ).isFalse
+        val thirdFieldAccess = cus[0].classes[0].leadingAnnotations[1].arguments!!.first()
+        assertThat(SemanticallyEqual.areEqual(firstFieldAccess, thirdFieldAccess)).isFalse
     }
 
     @Test
-    fun assignEquality(jp: JavaParser) {
-        val cu = jp.parse(
+    fun assignEquality() {
+        val cus = parseSources(arrayOf(
             """
                 @MyAnnotation(value = true)
                 class A {}
             """,
+            """
+                @MyAnnotation(value = true)
+                class B {}
+            """,
             "@interface MyAnnotation { boolean value(); }"
-        )
+        ))
 
-        val firstAssign = cu[0].classes[0].leadingAnnotations[0].arguments!!.first() as J.Assignment
-        val secondAssign = J.Assignment(
-            randomId(),
-            Space.EMPTY,
-            Markers.EMPTY,
-            J.Identifier(
-                randomId(),
-                Space.EMPTY,
-                Markers.EMPTY,
-                "value",
-                firstAssign.variable.type, null
-            ),
-            JLeftPadded(
-                Space.format(" "),
-                J.Literal(
-                    randomId(),
-                    Space.format(" "),
-                    Markers.EMPTY,
-                    true,
-                    "true",
-                    null,
-                    JavaType.Primitive.Boolean
-                ),
-                Markers.EMPTY
-            ),
-            JavaType.Primitive.Boolean
-        )
+        val firstAssign = cus[0].classes[0].leadingAnnotations[0].arguments!!.first() as J.Assignment
+        val secondAssign = cus[1].classes[0].leadingAnnotations[0].arguments!!.first() as J.Assignment
+        assertThat(SemanticallyEqual.areEqual(firstAssign, secondAssign)).isTrue
+
         val thirdAssign = secondAssign.withVariable(
             (secondAssign.variable as J.Identifier).withSimpleName("otherValue")
         )
+        assertThat(SemanticallyEqual.areEqual(firstAssign, thirdAssign)).isFalse
+
         val fourthAssign = secondAssign.withAssignment(
             (secondAssign.assignment as J.Literal).withValue(false)
         )
+        assertThat(SemanticallyEqual.areEqual(firstAssign, fourthAssign)).isFalse
+    }
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    firstAssign,
-                    secondAssign
-                )
-        ).isTrue
+    @Suppress("CStyleArrayDeclaration")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun arrayAccess() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original(String s) {
+                        int n[] = new int[] {0};
+                        int m = n[0];
+                    }
+                    void isEqual(String s) {
+                        int n[] = new int[] {0};
+                        int m = n[0];
+                    }
+                    void notEqual(String s) {
+                        int o[] = new int[] {0};
+                        int m = o[0];
+                    }
+                }
+            """
+        ))[0].classes[0].body
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    firstAssign,
-                    thirdAssign
-                )
-        ).isFalse
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[1] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[1] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    firstAssign,
-                    fourthAssign
-                )
-        ).isFalse
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).body!!.statements[1] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun arrayType() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    String[] original() {
+                        String[] s;
+                    }
+                    String[] isEqual() {
+                        return null;
+                    }
+                    Integer[] notEqual() {
+                        return null;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration).returnTypeExpression)!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).returnTypeExpression)!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).returnTypeExpression)!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun assert() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original(String s) {
+                        assert s != null;
+                    }
+                    void isEqual(String s) {
+                        assert s != null;
+                    }
+                    void notEqual(String s) {
+                        assert s == null;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.Assert
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.Assert
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.Assert
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("UnusedAssignment")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun assignment() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        String s;
+                        s = "foo";
+                    }
+                    void isEqual() {
+                        String s;
+                        s = "foo";
+                    }
+                    void notEqual() {
+                        String s;
+                        s = "bar";
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[1] as J.Assignment
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[1] as J.Assignment
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[1] as J.Assignment
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isTrue
+    }
+
+    @Suppress("PointlessArithmeticExpression")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun binary() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        int n = 0 + 1;
+                    }
+                    void isEqual() {
+                        int n = 0 + 1;
+                    }
+                    void notEqual() {
+                        int n = 1 + 1;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.VariableDeclarations).variables[0].initializer as J.Binary
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.VariableDeclarations).variables[0].initializer as J.Binary
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.VariableDeclarations).variables[0].initializer as J.Binary
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("PointlessArithmeticExpression")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun block() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        int n = 0 + 1;
+                    }
+                    void isEqual() {
+                        int n = 0 + 1;
+                    }
+                    void notEqual() {
+                        int n = 1 + 1;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("LoopStatementThatDoesntLoop", "LoopStatementThatDoesntLoop", "UnnecessaryLabelOnBreakStatement")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun breakNoLabel() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        while (true) {
+                            break;
+                        }
+                    }
+                    void isEqual() {
+                        while (true) {
+                            break;
+                        }
+                    }
+                    void notEqual() {
+                        labeled:
+                        while(true) {
+                            break labeled;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.WhileLoop)
+            .body as J.Block)
+            .statements[0]
+        val isEqual = (((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.WhileLoop)
+            .body as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.WhileLoop)
+            .body as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("LoopStatementThatDoesntLoop", "UnnecessaryLabelOnBreakStatement")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun breakWithLabel() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        labeled:
+                        while(true) {
+                            break labeled;
+                        }
+                    }
+                    void isEqual() {
+                        labeled:
+                        while(true) {
+                            break labeled;
+                        }
+                    }
+                    void notEqual() {
+                        while (true) {
+                            break;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.WhileLoop)
+            .body as J.Block)
+            .statements[0]
+        val isEqual = ((((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.WhileLoop)
+            .body as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.WhileLoop)
+            .body as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("SwitchStatementWithTooFewBranches")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun caseStatement() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original(String s) {
+                        switch (s) {
+                            case "a": {
+                                String statement = "isEqual";
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                    void isEqual(String s) {
+                        switch (s) {
+                            case "a": {
+                                String
+                                    statement =
+                                    "isEqual";
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                    void notEqual(String s) {
+                        switch (s) {
+                            case "a": {
+                                String
+                                    statement =
+                                    "notEqual";
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.Switch).cases.statements[0]
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.Switch).cases.statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.Switch).cases.statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isTrue
+    }
+
+    @Suppress("EmptyTryBlock", "CatchMayIgnoreException")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun catch() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original(String s) {
+                        try {
+                        } catch (Exception e) {
+                            if (e instanceof IllegalStateException) {
+                                e.printStackTrace();
+                            }
+                        }
+                    }
+                    void isEqual(String s) {
+                        try {
+                        } catch (Exception e) {
+                            if (e instanceof IllegalStateException) {
+                                e.printStackTrace();
+                            }
+                        }
+                    }
+                    void notEqual(String s) {
+                        try {
+                        } catch (Exception e) {
+                            if (e instanceof IllegalArgumentException) {
+                                e.printStackTrace();
+                            }
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.Try).catches[0]
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.Try).catches[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.Try).catches[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun classDeclaration() {
+        val cus0 = parseSources(arrayOf(
+            "class A {}",
+            "class B {}"
+        ))
+        val cus1 = parseSources(arrayOf(
+            "class A {}"
+        ))
+        val original = cus0[0].classes[0]
+        val isEqual = cus1[0].classes[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = cus0[1].classes[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun compilationUnit() {
+        val originalCu = parseSources(arrayOf(
+            """
+                package foo;
+                import java.util.ArrayList;
+                import java.util.List;
+                
+                class Test {
+                    List<String> s = new ArrayList<>();
+                }
+            """
+        ))[0]
+        val isEqualCu = parseSources(arrayOf(
+            """
+                package foo;
+                import java.util.ArrayList;
+                import java.util.List;
+                
+                class Test {
+                    List<String> s = new ArrayList<>();
+                }
+            """
+        ))[0]
+        val notEqualCu = parseSources(arrayOf(
+            """
+                package foo;
+                import java.util.ArrayList;
+                import java.util.List;
+                
+                class NotEqual {
+                    List<String> s = new ArrayList<>();
+                }
+            """
+        ))[0]
+        assertThat(SemanticallyEqual.areEqual(originalCu, isEqualCu)).isTrue
+        assertThat(SemanticallyEqual.areEqual(originalCu, notEqualCu)).isFalse
+    }
+
+    @Suppress("StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun controlParentheses() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original(String s) {
+                        if (s.isEmpty()) {
+                        }
+                    }
+                    void isEqual(String s) {
+                        if (s.isEmpty()) {
+                        }
+                    }
+                    void notEqual(String s) {
+                        if (s == null) {
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.If).ifCondition
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.If).ifCondition
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.If).ifCondition
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("UnnecessaryContinue", "UnnecessaryLabelOnContinueStatement")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun continueStatementNoLabel() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.ArrayList;
+                import java.util.List;
+                
+                class A {
+                    void original(List<String> strings) {
+                        for (String s : strings) {
+                            continue;
+                        }
+                    }
+                    void isEqual(List<String> strings) {
+                        for (String s : strings) {
+                            continue;
+                        }
+                    }
+                    void notEqual(List<String> strings) {
+                        outer:
+                        for (String s : strings) {
+                            continue outer;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+        val original = (((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop).body as J.Block)
+            .statements[0]
+        val isEqual = (((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop).body as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.ForEachLoop).body as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun continueStatementWithLabel() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.List;
+                class A {
+                    void original(List<String> strings, List<String> contains) {
+                        equal:
+                        for (String s : strings) {
+                            for (String s2 : contains) {
+                                if (s.equals("")) {
+                                    continue equal;
+                                }
+                            }
+                        }
+                    }
+                    void isEqual(List<String> strings, List<String> contains) {
+                        equal:
+                        for (String s : strings) {
+                            for (String s2 : contains) {
+                                if (s.equals("")) {
+                                    continue equal;
+                                }
+                            }
+                        }
+                    }
+                    void notEqual(List<String> strings, List<String> contains) {
+                        other:
+                        for (String s : strings) {
+                            for (String s2 : contains) {
+                                if (s.equals("")) {
+                                    continue other;
+                                }
+                            }
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+        val original = ((((((((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.ForEachLoop).body as J.Block)
+            .statements[0] as J.ForEachLoop)
+            .body as J.Block).statements[0] as J.If)
+            .thenPart as J.Block)
+            .statements[0]
+        val isEqual = ((((((((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.ForEachLoop).body as J.Block)
+            .statements[0] as J.ForEachLoop)
+            .body as J.Block).statements[0] as J.If)
+            .thenPart as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((((((((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label)
+            .statement as J.ForEachLoop).body as J.Block)
+            .statements[0] as J.ForEachLoop)
+            .body as J.Block).statements[0] as J.If)
+            .thenPart as J.Block)
+            .statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun doWhile() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original(int i) {
+                        do {
+                            i++;
+                        } while (i < 10);
+                    }
+                    void isEqual(int i) {
+                        do {
+                            i++;
+                        } while (i < 10);
+                    }
+                    void notEqual(int i) {
+                        do {
+                            i++;
+                        } while (i < 5);
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.DoWhileLoop
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.DoWhileLoop
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.DoWhileLoop
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("UnusedAssignment", "StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun elseStatement() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original(int i) {
+                        if (i == 0) {
+                        } else {
+                            i++;
+                        }
+                    }
+                    void isEqual(int i) {
+                        if (i == 0) {
+                        } else {
+                            i++;
+                        }
+                    }
+                    void notEqual(int i) {
+                        if (i == 0) {
+                        } else {
+                            i += 1;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.If).elsePart!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.If).elsePart!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.If).elsePart!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("UnusedAssignment", "UnnecessarySemicolon")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun empty() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        ;
+                    }
+                    void isEqual() {
+                        ;
+                    }
+                    void notEqual(int i) {
+                        i++;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.Empty
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.Empty
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.Unary
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun enumValue() {
+        val cus = parseSources(arrayOf(
+            "public enum A { ONE }",
+            "public enum B { ONE }"
+        ))
+        val cus1 = parseSources(arrayOf(
+            "public enum A { ONE }"
+        ))
+
+        val original = (cus[0].classes[0].body.statements[0] as J.EnumValueSet).enums[0] as J.EnumValue
+        val isEqual = (cus1[0].classes[0].body.statements[0] as J.EnumValueSet).enums[0] as J.EnumValue
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (cus[1].classes[0].body.statements[0] as J.EnumValueSet).enums[0] as J.EnumValue
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun enumValueSet() {
+        val cus = parseSources(arrayOf(
+            "public enum A { ONE, TWO }",
+            "public enum B { ONE, TWO }"
+        ))
+        val cus1 = parseSources(arrayOf(
+            "public enum A { ONE, TWO }"
+        ))
+
+        val original = cus[0].classes[0].body.statements[0]
+        val isEqual = cus1[0].classes[0].body.statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = cus[1].classes[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun fieldAccess() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        int val = Inner.field0;
+                    }
+                    void isEqual() {
+                        int val = Inner.field0;
+                    }
+                    void notEqual() {
+                        int val = Inner.field1;
+                    }
+                    class Inner {
+                        public static final int field0 = 0;
+                        public static final int field1 = 0;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun forEachLoop() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.List;
+                class Test {
+                    void original(List<String> strings) {
+                        for (String s : strings) {
+                        }
+                    }
+                    void isEqual(List<String> strings) {
+                        for (String s : strings) {
+                        }
+                    }
+                    void notEqual(List<String> strings) {
+                        for (String a : strings) {
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun forEachControl() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.List;
+                class Test {
+                    void original(List<String> strings) {
+                        for (String s : strings) {
+                        }
+                    }
+                    void isEqual(List<String> strings) {
+                        for (String s : strings) {
+                        }
+                    }
+                    void notEqual(List<String> strings) {
+                        for (String a : strings) {
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop).control
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop).control
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForEachLoop).control
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("ForLoopReplaceableByWhile", "StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun forLoop() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.List;
+                class Test {
+                    void original(List<String> strings) {
+                        for (int i = 0; i < strings.size(); i++) {
+                        }
+                    }
+                    void isEqual(List<String> strings) {
+                        for (int i = 0; i < strings.size(); i++) {
+                        }
+                    }
+                    void notEqual(List<String> strings) {
+                        for (int j = 0; j < strings.size(); j++) {
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForLoop
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForLoop
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForLoop
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun forLoopControl() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.List;
+                class Test {
+                    void original(List<String> strings) {
+                        for (int i = 0; i < strings.size(); i++) {
+                        }
+                    }
+                    void isEqual(List<String> strings) {
+                        for (int i = 0; i < strings.size(); i++) {
+                        }
+                    }
+                    void notEqual(List<String> strings) {
+                        for (int j = 0; j < strings.size(); j++) {
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForLoop).control
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForLoop).control
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.ForLoop).control
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun identifier() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        int val;
+                    }
+                    void isEqual() {
+                        int val;
+                    }
+                    void notEqual() {
+                        int value;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].name
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].name
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].name
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("ConstantConditions", "StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun ifStatement() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        if (true) {}
+                    }
+                    void isEqual() {
+                        if (true) {}
+                    }
+                    void notEqual() {
+                        if (false) {}
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.If
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.If
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.If
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun instanceOf() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.Collection;
+                import java.util.List;
+                import java.util.Set;
+                
+                class Test {
+                    void original(Collection<String> strings) {
+                        if (strings instanceof List) {}
+                    }
+                    void isEqual(Collection<String> strings) {
+                        if (strings instanceof List) {}
+                    }
+                    void notEqual(Collection<String> strings) {
+                        if (strings instanceof Set) {}
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.If).ifCondition.tree
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.If).ifCondition.tree
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.If).ifCondition.tree
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun import() {
+        val cus = parseSources(arrayOf(
+            """
+                import java.util.List;
+                import java.util.ArrayList;
+            """,
+            "import java.util.List;"
+        ))
+
+        val original = cus[0].imports[0]
+        val isEqual = cus[1].imports[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = cus[0].imports[1]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("UnnecessaryLabelOnContinueStatement", "UnnecessaryContinue")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun label() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.Collection;
+                
+                class Test {
+                    void original(Collection<String> strings) {
+                        label:
+                        for (String s : strings) {
+                            continue label;
+                        }
+                    }
+                    void isEqual(Collection<String> strings) {
+                        label:
+                        for (String s : strings) {
+                            continue label;
+                        }
+                    }
+                    void notEqual(Collection<String> strings) {
+                        diff:
+                        for (String s : strings) {
+                            continue diff;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Label
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun lambda() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.function.Function;
+                
+                class Test {
+                    void original() {
+                        Function<String, String> func = (String s) -> "";
+                    }
+                    void isEqual() {
+                        Function<String, String> func = (String s) -> "";
+                    }
+                    void notEqual() {
+                        Function<String, String> func = (String o) -> "";
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
     }
 
     @Test
-    fun literalEquality(jp: JavaParser) {
-        val cu = jp.parse(
+    fun literalEquality() {
+        val body = parseSources(arrayOf(
             """
                 class A {
-                    int i = 0;
-                    String str = "thisString";
-                    String str2 = null;
+                    void original() {
+                        int i = 0;
+                        String str = "thisString";
+                        String str2 = null;
+                    }
+                    void isEqual() {
+                        int i = 0;
+                        String str = "thisString";
+                        String str2 = null;
+                    }
                 }
             """
-        )
+        ))[0].classes[0].body
 
-        val intLiteral = (cu[0].classes[0].body.statements[0] as J.VariableDeclarations).variables[0].initializer
-        val strLiteral = (cu[0].classes[0].body.statements[1] as J.VariableDeclarations).variables[0].initializer
-        val nullLiteral = (cu[0].classes[0].body.statements[2] as J.VariableDeclarations).variables[0].initializer
+        val intLiteral0 = (body.statements[0] as J.MethodDeclaration).body!!.statements[0]
+        val intLiteral1 = (body.statements[1] as J.MethodDeclaration).body!!.statements[0]
+        assertThat(SemanticallyEqual.areEqual(intLiteral0, intLiteral1))
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    intLiteral!!,
-                    J.Literal(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        0,
-                        "0",
-                        null,
-                        JavaType.Primitive.Int
-                    )
-                )
-        ).isTrue
+        val strLiteral0 = (body.statements[0] as J.MethodDeclaration).body!!.statements[1]
+        val strLiteral1 = (body.statements[1] as J.MethodDeclaration).body!!.statements[1]
+        assertThat(SemanticallyEqual.areEqual(strLiteral0, strLiteral1))
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    strLiteral!!,
-                    J.Literal(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        "thisString",
-                        "thisString",
-                        null,
-                        JavaType.Primitive.String
-                    )
-                )
-        ).isTrue
+        val nullLiteral0 = (body.statements[0] as J.MethodDeclaration).body!!.statements[2]
+        val nullLiteral1 = (body.statements[1] as J.MethodDeclaration).body!!.statements[2]
+        assertThat(SemanticallyEqual.areEqual(nullLiteral0, nullLiteral1))
+    }
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    nullLiteral!!,
-                    J.Literal(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        null,
-                        "null",
-                        null,
-                        JavaType.Primitive.String
-                    )
-                )
-        ).isTrue
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun memberReference() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    public static void func0(String s) {}
+                    public static void func1(String s) {}
+                }
+            """,
+            """
+                import java.util.stream.Stream;
 
-        assertThat(
-            SemanticallyEqual
-                .areEqual(
-                    strLiteral,
-                    J.Literal(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        0,
-                        "0",
-                        null,
-                        JavaType.Primitive.Int
-                    )
-                )
-        ).isFalse
+                class Test {
+                    void original() {
+                        Stream.of("s").forEach(A::func0);
+                    }
+                    void isEqual() {
+                        Stream.of("s").forEach(A::func0);
+                    }
+                    void notEqual() {
+                        Stream.of("s").forEach(A::func1);
+                    }
+                }
+            """
+        ))[1].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.MethodInvocation).arguments[0]
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.MethodInvocation).arguments[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.MethodInvocation).arguments[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun methodDeclaration() {
+        val body0 = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        String s = "";
+                    }
+                    void notEqual() {
+                        String s = "notEqual";
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val body1 = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        String s = "";
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = body0.statements[0] as J.MethodDeclaration
+        val isEqual = body1.statements[0] as J.MethodDeclaration
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = body0.statements[1] as J.MethodDeclaration
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun methodInvocation() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    public static void func0(String s) {}
+                    public static void func1(String s) {}
+                }
+            """,
+            """
+                import java.util.stream.Stream;
+
+                class Test {
+                    void original() {
+                        Stream.of("s").forEach(A::func0);
+                    }
+                    void isEqual() {
+                        Stream.of("s").forEach(A::func0);
+                    }
+                    void notEqual() {
+                        Stream.of("s").forEach(A::func1);
+                    }
+                }
+            """
+        ))[1].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.MethodInvocation)
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.MethodInvocation)
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.MethodInvocation)
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("EmptyTryBlock", "CatchMayIgnoreException")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun multiCatch() {
+        val body = parseSources(arrayOf(
+            """
+                import java.io.File;
+                import java.io.FileInputStream;
+                import java.io.FileNotFoundException;
+                
+                class A {
+                    void original() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis = new FileInputStream(f)) {}
+                        catch (FileNotFoundException | RuntimeException e) {}
+                    }
+                    void isEqual() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis = new FileInputStream(f)) {}
+                        catch (FileNotFoundException | RuntimeException e) {}
+                    }
+                    void notEqual() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis = new FileInputStream(f)) {}
+                        catch (FileNotFoundException | NullPointerException e) {}
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try)
+            .catches[0].parameter.tree as J.VariableDeclarations)
+            .typeExpression!!
+        val isEqual = (((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try)
+            .catches[0].parameter.tree as J.VariableDeclarations)
+            .typeExpression!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try)
+            .catches[0].parameter.tree as J.VariableDeclarations)
+            .typeExpression!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun newArray() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original() {
+                        int[] n = new int[0];
+                    }
+                    void isEqual() {
+                        int[] n = new int[0];
+                    }
+                    void notEqual() {
+                        long[] n = new long[0];
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun newClass() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.ArrayList;
+                import java.util.HashSet;
+                import java.util.List;
+                import java.util.Set;
+                
+                class A {
+                    void original() {
+                        List<String> l = new ArrayList<>();
+                    }
+                    void isEqual() {
+                        List<String> l = new ArrayList<>();
+                    }
+                    void notEqual() {
+                        Set<String> l = new HashSet<>();
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun packageStatement() {
+        val cus = parseSources(arrayOf(
+            "package foo;",
+            "package foo;",
+            "package bar;"
+        ))
+
+        val original = cus[0].packageDeclaration as J.Package
+        val isEqual = cus[1].packageDeclaration as J.Package
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = cus[2].packageDeclaration as J.Package
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun parameterizedType() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.ArrayList;
+                import java.util.HashSet;
+                import java.util.List;
+                import java.util.Set;
+                
+                class A {
+                    void original() {
+                        List<String> l = new ArrayList<>();
+                    }
+                    void isEqual() {
+                        List<String> l = new ArrayList<>();
+                    }
+                    void notEqual() {
+                        Set<String> l = new HashSet<>();
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations)
+            .variables[0].initializer!! as J.NewClass).clazz!!
+        val isEqual = (((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations)
+            .variables[0].initializer!! as J.NewClass).clazz!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations)
+            .variables[0].initializer!! as J.NewClass).clazz!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun parentheses() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original() {
+                        int n = (0);
+                    }
+                    void isEqual() {
+                        int n = (0);
+                    }
+                    void notEqual() {
+                        int n = (1);
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations)
+            .variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations)
+            .variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations)
+            .variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun primitive() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original() {
+                        int n = 0;
+                    }
+                    void isEqual() {
+                        int n = 0;
+                    }
+                    void notEqual() {
+                        char c = 'c';
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).typeExpression!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).typeExpression!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).typeExpression!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun returnStatement() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    int original() {
+                        return 0;
+                    }
+                    int isEqual() {
+                        return 0;
+                    }
+                    int notEqual() {
+                        return 1;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Return
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Return
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.Return
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("DuplicateBranchesInSwitch")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun switchStatement() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original(String s) {
+                        switch (s) {
+                            case "a": {
+                                String statement = "isEqual";
+                                break;
+                            }
+                            case "b": {
+                                String statement = "isEqual";
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                    void isEqual(String s) {
+                        switch (s) {
+                            case "a": {
+                                String
+                                    statement =
+                                    "isEqual";
+                                break;
+                            }
+                            case "b": {
+                                String
+                                    statement =
+                                    "isEqual";
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val switch0 = (body.statements[0] as J.MethodDeclaration).body!!.statements[0]
+        val switch1 = (body.statements[1] as J.MethodDeclaration).body!!.statements[0]
+        assertThat(SemanticallyEqual.areEqual(switch0, switch1)).isTrue
+    }
+
+    @Suppress("EmptySynchronizedStatement", "SynchronizationOnLocalVariableOrMethodParameter")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun synchronized() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original() {
+                        Integer n = 0;
+                        synchronized(n) {
+                        }
+                    }
+                    void isEqual() {
+                        Integer n = 0;
+                        synchronized(n) {
+                        }
+                    }
+                    void notEqual() {
+                        Integer m = 0;
+                        synchronized(m) {
+                        }
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Synchronized
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Synchronized
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Synchronized
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun ternary() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original(int n) {
+                        String evenOrOdd = n % 2 == 0 ? "even" : "odd";
+                    }
+                    void isEqual(int n) {
+                        String evenOrOdd = n % 2 == 0 ? "even" : "odd";
+                    }
+                    void notEqual(int n) {
+                        String evenOrOdd = n % 2 == 1 ? "odd" : "even";
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun throws() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original() {
+                        throw new RuntimeException();
+                    }
+                    void isEqual() {
+                        throw new RuntimeException();
+                    }
+                    void notEqual() {
+                        throw new IllegalStateException();
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.Throw
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.Throw
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.Throw
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("EmptyTryBlock", "CatchMayIgnoreException")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun tryStatement() {
+        val body = parseSources(arrayOf(
+            """
+                import java.io.File;
+                import java.io.FileInputStream;
+                import java.io.FileNotFoundException;
+                
+                class A {
+                    void original() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis0 = new FileInputStream(f)) {
+                        }
+                        catch (Exception e) {}
+                    }
+                    void isEqual() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis0 = new FileInputStream(f)) {
+                        }
+                        catch (Exception e) {}
+                    }
+                    void notEqual() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis1 = new FileInputStream(f)) {
+                        }
+                        catch (Exception e) {}
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try
+        val isEqual = (body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("EmptyTryBlock", "CatchMayIgnoreException")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun tryResource() {
+        val body = parseSources(arrayOf(
+            """
+                import java.io.File;
+                import java.io.FileInputStream;
+                import java.io.FileNotFoundException;
+                
+                class A {
+                    void original() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis0 = new FileInputStream(f)) {
+                        }
+                        catch (Exception e) {}
+                    }
+                    void isEqual() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis0 = new FileInputStream(f)) {
+                        }
+                        catch (Exception e) {}
+                    }
+                    void notEqual() {
+                        File f = new File("file.text");
+                        try (FileInputStream fis1 = new FileInputStream(f)) {
+                        }
+                        catch (Exception e) {}
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try).resources!![0]
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try).resources!![0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[1] as J.Try).resources!![0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("RedundantCast", "unchecked")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun typeCast() {
+        val body = parseSources(arrayOf(
+            """
+                class A {
+                    void original() {
+                        Object o = (Class<String>) Class.forName("java.lang.String");
+                    }
+                    void isEqual() {
+                        Object o = (Class<String>) Class.forName("java.lang.String");
+                    }
+                    void notEqual() {
+                        Object o = (Class<Integer>) Class.forName("java.lang.Integer");
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun typeParameter() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    class A<E extends Number> {}
+                    class B<E extends Number> {}
+                    class C<T> {}
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.ClassDeclaration).typeParameters!![0]
+        val isEqual = (body.statements[1] as J.ClassDeclaration).typeParameters!![0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.ClassDeclaration).typeParameters!![0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Suppress("PointlessBooleanExpression")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun unary() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        boolean b = !(1 == 2);
+                    }
+                    void isEqual() {
+                        boolean b = !(1 == 2);
+                    }
+                    void notEqual() {
+                        boolean b = !(2 == 2);
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        val isEqual = ((body.statements[1] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration)
+            .body!!.statements[0] as J.VariableDeclarations).variables[0].initializer!!
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun variableDeclaration() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        Integer i = 0;
+                    }
+                    void isEqual() {
+                        Integer i = 0;
+                    }
+                    void notEqual() {
+                        Integer k = 0;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[0]
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!.statements[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun namedVariable() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        Integer i = 0;
+                    }
+                    void isEqual() {
+                        Integer i = 0;
+                    }
+                    void notEqual() {
+                        Integer k = 0;
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.VariableDeclarations).variables[0]
+        val isEqual = ((body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.VariableDeclarations).variables[0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.VariableDeclarations).variables[0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+    @Suppress("InfiniteLoopStatement", "StatementWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun whileLoop() {
+        val body = parseSources(arrayOf(
+            """
+                class Test {
+                    void original() {
+                        while (true) {}
+                    }
+                    void isEqual() {
+                        while (true) {}
+                    }
+                    void notEqual() {
+                        while (false) {}
+                    }
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = (body.statements[0] as J.MethodDeclaration).body!!.statements[0] as J.WhileLoop
+        val isEqual = (body.statements[1] as J.MethodDeclaration).body!!.statements[0] as J.WhileLoop
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = (body.statements[2] as J.MethodDeclaration).body!!.statements[0] as J.WhileLoop
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1856")
+    @Test
+    fun wildCard() {
+        val body = parseSources(arrayOf(
+            """
+                import java.util.List;
+                
+                class Test {
+                    List<? extends B> original;
+                    List<? extends B> isEqual;
+                    List<? extends C> notEqual;
+                    interface B {}
+                    interface C {}
+                }
+            """
+        ))[0].classes[0].body
+
+        val original = ((body.statements[0] as J.VariableDeclarations).typeExpression!! as J.ParameterizedType).typeParameters!![0]
+        val isEqual = ((body.statements[1] as J.VariableDeclarations).typeExpression!! as J.ParameterizedType).typeParameters!![0]
+        assertThat(SemanticallyEqual.areEqual(original, isEqual)).isTrue
+
+        val notEqual = ((body.statements[2] as J.VariableDeclarations).typeExpression!! as J.ParameterizedType).typeParameters!![0]
+        assertThat(SemanticallyEqual.areEqual(original, notEqual)).isTrue
     }
 }


### PR DESCRIPTION
Changes:

- `SemanticallyEqual` may be used to check for semantically equality on any `J` tree. 

fixes #1856