### PR TITLE
Compare the invoked method when possible in SemanticallyEqual.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -634,7 +634,8 @@ public class SemanticallyEqual {
                 }
 
                 J.Identifier compareTo = (J.Identifier) j;
-                if (!identifier.getSimpleName().equals(compareTo.getSimpleName())) {
+                if (!identifier.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        !TypeUtils.isOfType(identifier.getType(), compareTo.getType())) {
                     isEqual.set(false);
                     return identifier;
                 }
@@ -866,8 +867,15 @@ public class SemanticallyEqual {
                 }
 
                 this.visit(method.getSelect(), compareTo.getSelect());
-                for (int i = 0; i < method.getArguments().size(); i++) {
-                    this.visit(method.getArguments().get(i), compareTo.getArguments().get(i));
+                if (method.getMethodType() != null && compareTo.getMethodType() != null) {
+                    if (!isMethodType(method.getMethodType(), compareTo.getMethodType())) {
+                        isEqual.set(false);
+                        return method;
+                    }
+                } else {
+                    for (int i = 0; i < method.getArguments().size(); i++) {
+                        this.visit(method.getArguments().get(i), compareTo.getArguments().get(i));
+                    }
                 }
 
                 if (method.getTypeParameters() != null && compareTo.getTypeParameters() != null) {
@@ -975,9 +983,16 @@ public class SemanticallyEqual {
                 if (newClass.getBody() != null && compareTo.getBody() != null) {
                     this.visit(newClass.getBody(), compareTo.getBody());
                 }
-                if (newClass.getArguments() != null && compareTo.getArguments() != null) {
-                    for (int i = 0; i < newClass.getArguments().size(); i++) {
-                        this.visit(newClass.getArguments().get(i), compareTo.getArguments().get(i));
+                if (newClass.getConstructorType() != null && compareTo.getConstructorType() != null) {
+                    if (!isMethodType(newClass.getConstructorType(), compareTo.getConstructorType())) {
+                        isEqual.set(false);
+                        return newClass;
+                    }
+                } else {
+                    if (newClass.getArguments() != null && compareTo.getArguments() != null) {
+                        for (int i = 0; i < newClass.getArguments().size(); i++) {
+                            this.visit(newClass.getArguments().get(i), compareTo.getArguments().get(i));
+                        }
                     }
                 }
             }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/SemanticallyEqualTest.kt
@@ -47,7 +47,7 @@ interface SemanticallyEqualTest {
     }
 
     private fun parseSources(@Language("java") sources: Array<String>): List<J.CompilationUnit> {
-        jp.reset();
+        jp.reset()
         return jp.parse(InMemoryExecutionContext { t -> fail(t) }, *sources)
     }
 
@@ -102,6 +102,7 @@ interface SemanticallyEqualTest {
         assertThat(SemanticallyEqual.areEqual(secondAnnot,thirdAnnot)).isFalse
     }
 
+    @Suppress("rawtypes")
     @Test
     fun tagAnnotationEquality() {
         val clazz = parseSources(arrayOf(
@@ -181,6 +182,7 @@ interface SemanticallyEqualTest {
         assertThat(SemanticallyEqual.areEqual(firstIdent, thirdIdent)).isFalse
     }
 
+    @Suppress("rawtypes")
     @Test
     fun fieldAccessEquality() {
         val cus = parseSources(arrayOf(
@@ -1529,20 +1531,17 @@ interface SemanticallyEqualTest {
     fun newClass() {
         val body = parseSources(arrayOf(
             """
-                import java.util.ArrayList;
-                import java.util.HashSet;
-                import java.util.List;
-                import java.util.Set;
+                import java.util.*;
                 
                 class A {
-                    void original() {
-                        List<String> l = new ArrayList<>();
+                    void original(List<String> s) {
+                        List<String> l = new ArrayList<>(s);
                     }
-                    void isEqual() {
-                        List<String> l = new ArrayList<>();
+                    void isEqual(Collection<String> s) {
+                        List<String> l = new ArrayList<>(s);
                     }
-                    void notEqual() {
-                        Set<String> l = new HashSet<>();
+                    void notEqual(List<String> s) {
+                        Set<String> l = new HashSet<>(s);
                     }
                 }
             """
@@ -1828,14 +1827,14 @@ interface SemanticallyEqualTest {
         val body = parseSources(arrayOf(
             """
                 class A {
-                    void original() {
-                        throw new RuntimeException();
+                    void original(IllegalStateException ex) {
+                        throw new RuntimeException(ex);
                     }
-                    void isEqual() {
-                        throw new RuntimeException();
+                    void isEqual(IllegalArgumentException ex) {
+                        throw new RuntimeException(ex);
                     }
-                    void notEqual() {
-                        throw new IllegalStateException();
+                    void notEqual(IllegalStateException ex) {
+                        throw new IllegalStateException(ex);
                     }
                 }
             """
@@ -1989,7 +1988,7 @@ interface SemanticallyEqualTest {
         assertThat(SemanticallyEqual.areEqual(original, notEqual)).isFalse
     }
 
-    @Suppress("PointlessBooleanExpression")
+    @Suppress("PointlessBooleanExpression", "ConstantConditions")
     @Issue("https://github.com/openrewrite/rewrite/issues/1856")
     @Test
     fun unary() {


### PR DESCRIPTION
Changes:

- Semantically equal will compare the invoked method invocation when possible to reduce false negatives.
- Incubating change: added type checks on identifiers back until we know the checks are unnecessary.

fixes #1870