### PR TITLE
Add data flow support for ternary expressions

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/ForwardFlow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/analysis/ForwardFlow.java
@@ -225,6 +225,16 @@ public class ForwardFlow extends JavaVisitor<Integer> {
                     // If the method invocation is not `toString` on a `String`, it's not dataflow
                     break;
                 }
+            } else if (ancestor instanceof J.Ternary) {
+                J.Ternary ternary = (J.Ternary) ancestor;
+                Object previousCursorValue = nextFlowGraph.getCursor().getValue();
+                if (ternary.getTruePart() == previousCursorValue ||
+                        ternary.getFalsePart() == previousCursorValue) {
+                    nextFlowGraph = nextFlowGraph.addEdge(ancestorCursor);
+                } else {
+                    // Data flow does not occur from the ternary conditional part
+                    break;
+                }
             } else if (ancestor instanceof J.TypeCast ||
                     ancestor instanceof J.Parentheses ||
                     ancestor instanceof J.ControlParentheses) {


### PR DESCRIPTION
Data flow now traces data flow through ternary operators

```java
    @Test
    fun `a ternary operator is considered a data flow step`() = rewriteRun(
        { spec -> spec.expectedCyclesThatMakeChanges(1).cycles(1) },
        java(
            """
                class Test {

                    void test(boolean conditional) {
                        String n = conditional ? "42" : "100";
                        System.out.println(n);
                    }
                }
            """,
            """
                class Test {

                    void test(boolean conditional) {
                        String n = /*~~>*/conditional ? /*~~>*/"42" : "100";
                        System.out.println(/*~~>*/n);
                    }
                }
            """
        )
    )

    @Test
    fun `a ternary operator is considered a data flow step 2`() = rewriteRun(
        { spec -> spec.expectedCyclesThatMakeChanges(1).cycles(1) },
        java(
            """
                class Test {

                    void test(boolean conditional) {
                        String n = "42";
                        String m = conditional ? "100" : n;
                        System.out.println(m);
                    }
                }
            """,
            """
                class Test {

                    void test(boolean conditional) {
                        String n = /*~~>*/"42";
                        String m = /*~~>*/conditional ? "100" : /*~~>*/n;
                        System.out.println(/*~~>*/m);
                    }
                }
            """
        )
    )
    
    @Test
    fun `a ternary condition is not considered a data flow step`() = rewriteRun(
        { spec -> spec.expectedCyclesThatMakeChanges(1).cycles(1) },
        java(
            """
                class Test {

                    Boolean source() {
                        return null;
                    }

                    void test(String other) {
                        String n = source() ? "102" : "100";
                        System.out.println(n);
                    }
                }
            """,
            """
                class Test {

                    Boolean source() {
                        return null;
                    }

                    void test(String other) {
                        String n = /*~~>*/source() ? "102" : "100";
                        System.out.println(n);
                    }
                }
            """
        )
    )

```
