### PR TITLE
Add `Call` interface to `J.NewClass` and `J.MethodInvocation`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Call.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Call.java
@@ -5,9 +5,9 @@ import org.openrewrite.internal.lang.Nullable;
 import java.util.List;
 
 /**
- * A callable expression like {@link J.MethodInvocation} or {@link J.NewClass}.
+ * A call expression. Specifically, an instance of {@link J.MethodInvocation} or {@link J.NewClass}.
  */
-public interface JCallable extends Expression {
+public interface Call extends Expression {
     @Nullable
     List<Expression> getArguments();
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3196,7 +3196,7 @@ public interface J extends Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class MethodInvocation implements J, Statement, Expression, JCallable, TypedTree {
+    final class MethodInvocation implements J, Statement, Expression, Call, TypedTree {
         @Nullable
         @NonFinal
         transient WeakReference<Padding> padding;
@@ -3664,7 +3664,7 @@ public interface J extends Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class NewClass implements J, Statement, Expression, JCallable, TypedTree {
+    final class NewClass implements J, Statement, Expression, Call, TypedTree {
         @Nullable
         @NonFinal
         transient WeakReference<Padding> padding;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3196,7 +3196,7 @@ public interface J extends Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class MethodInvocation implements J, Statement, Expression, TypedTree {
+    final class MethodInvocation implements J, Statement, Expression, JCallable, TypedTree {
         @Nullable
         @NonFinal
         transient WeakReference<Padding> padding;
@@ -3254,6 +3254,8 @@ public interface J extends Tree {
 
         JContainer<Expression> arguments;
 
+        @NonNull
+        @Override
         public List<Expression> getArguments() {
             return arguments.getElements();
         }
@@ -3662,7 +3664,7 @@ public interface J extends Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class NewClass implements J, Statement, Expression, TypedTree {
+    final class NewClass implements J, Statement, Expression, JCallable, TypedTree {
         @Nullable
         @NonFinal
         transient WeakReference<Padding> padding;
@@ -3718,6 +3720,7 @@ public interface J extends Tree {
         JContainer<Expression> arguments;
 
         @Nullable
+        @Override
         public List<Expression> getArguments() {
             return arguments == null ? null : arguments.getElements();
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JCallable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JCallable.java
@@ -1,0 +1,13 @@
+package org.openrewrite.java.tree;
+
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.List;
+
+/**
+ * A callable expression like {@link J.MethodInvocation} or {@link J.NewClass}.
+ */
+public interface JCallable extends Expression {
+    @Nullable
+    List<Expression> getArguments();
+}


### PR DESCRIPTION

Allows for walking the type hierarchy efficiently for all `Call` types (`J.NewClass` & `J.MethodInvocation`) by adding a new interface `Call`.

For the latter, here is an example of a use case:
```java
private static final MethodMatcher FILE_CREATE =
        new MethodMatcher("java.io.File <constructor>(.., java.lang.String)");
private static final MethodMatcher FILES_NEW_OUTPUT_STREAM =
        new MethodMatcher("java.nio.file.Files newOutputStream(java.nio.file.Path)");

@Override
public boolean isSink(Expression expression, Cursor cursor) {
    Call maybeEnclosingJCallable = cursor.firstEnclosing(Call.class);
    if (maybeEnclosingJCallable != null &&
            (FILE_CREATE.matches(maybeEnclosingJCallable) || FILES_NEW_OUTPUT_STREAM.matches(maybeEnclosingJCallable))) {
        return Objects.requireNonNull(maybeEnclosingJCallable.getArguments(), "callable arguments")
                .contains(expression);
    } else {
        return false;
    }
}
```

This is the way I have to write the above (desired) code currently due to the two issues listed above.
I argue that the above is far more readable than the code below:

```java
private static final MethodMatcher FILE_CREATE =
        new MethodMatcher("java.io.File <constructor>(.., java.lang.String)");
private static final MethodMatcher FILES_NEW_OUTPUT_STREAM =
        new MethodMatcher("java.nio.file.Files newOutputStream(java.nio.file.Path)");

@Override
public boolean isSink(Expression expression, Cursor cursor) {
    Expression maybeEnclosingJCallable =
            Optional.<Expression>ofNullable(cursor.firstEnclosing(J.NewClass.class))
                    .orElseGet(() -> cursor.firstEnclosing(J.MethodInvocation.class));
    if (maybeEnclosingJCallable != null &&
            (FILES_NEW_OUTPUT_STREAM.matches(maybeEnclosingJCallable) ||
            (maybeEnclosingJCallable instanceof J.NewClass && FILE_CREATE.matches(maybeEnclosingJCallable)))
    ) {
        if (maybeEnclosingJCallable instanceof J.NewClass) {
            J.NewClass newClass = (J.NewClass) maybeEnclosingJCallable;
            return Objects.requireNonNull(newClass.getArguments(), "new File() arguments")
                    .contains(expression);
        } else {
            J.MethodInvocation methodInvocation = (J.MethodInvocation) maybeEnclosingJCallable;
            return methodInvocation.getArguments().contains(expression);
        }
    } else {
        return false;
    }
}
```