### PR TITLE
refactor: validate should allow for execution context

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/HttpSenderExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/HttpSenderExecutionContextView.java
@@ -13,25 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.gradle;
+package org.openrewrite;
 
-import org.openrewrite.DelegatingExecutionContext;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 
-public class GradleExecutionContextView extends DelegatingExecutionContext {
+public class HttpSenderExecutionContextView extends DelegatingExecutionContext {
 
-    private static final String HTTP_SENDER = "httpSender";
+    private static final String HTTP_SENDER = "org.openrewrite.httpSender";
 
-    public GradleExecutionContextView(ExecutionContext delegate) {
+    public HttpSenderExecutionContextView(ExecutionContext delegate) {
         super(delegate);
     }
 
-    public static GradleExecutionContextView view(ExecutionContext ctx) {
-        if(ctx instanceof GradleExecutionContextView) {
-            return (GradleExecutionContextView) ctx;
+    public static HttpSenderExecutionContextView view(ExecutionContext ctx) {
+        if(ctx instanceof HttpSenderExecutionContextView) {
+            return (HttpSenderExecutionContextView) ctx;
         }
-        return new GradleExecutionContextView(ctx);
+        return new HttpSenderExecutionContextView(ctx);
     }
 
     public void setHttpSender(org.openrewrite.ipc.http.HttpSender httpSender) {

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -288,10 +288,13 @@ public abstract class Recipe {
         return recipeScheduler.scheduleRun(this, before, ctx, maxCycles, minCycles);
     }
 
-    @SuppressWarnings("unused")
-    @Incubating(since = "7.0.0")
     public Validated validate(ExecutionContext ctx) {
-        return validate();
+        Validated validated = validate();
+
+        for(Recipe recipe : recipeList) {
+            validated = validated.and(recipe.validate(ctx));
+        }
+        return validated;
     }
 
     /**

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
@@ -73,7 +73,7 @@ public class AddGradleWrapper extends Recipe {
     @Override
     public Validated validate(ExecutionContext ctx) {
         if (gradleWrapper == null) {
-            org.openrewrite.ipc.http.HttpSender httpSender = GradleExecutionContextView.view(ctx).getHttpSender();
+            org.openrewrite.ipc.http.HttpSender httpSender = HttpSenderExecutionContextView.view(ctx).getHttpSender();
             gradleWrapper = super.validate().and(GradleWrapper.validate(version, distribution, httpSender));
         }
         return gradleWrapper;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
@@ -24,14 +24,11 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.LoathingOfOthers;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.ipc.http.HttpSender;
-import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.properties.PropertiesParser;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.text.PlainText;
 
-import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,10 +73,7 @@ public class AddGradleWrapper extends Recipe {
     @Override
     public Validated validate(ExecutionContext ctx) {
         if (gradleWrapper == null) {
-            HttpSender httpSender = ctx.getMessage("httpSender");
-            if (httpSender == null) {
-                httpSender = new HttpUrlConnectionSender(Duration.ofSeconds(3), Duration.ofSeconds(10));
-            }
+            org.openrewrite.ipc.http.HttpSender httpSender = GradleExecutionContextView.view(ctx).getHttpSender();
             gradleWrapper = super.validate().and(GradleWrapper.validate(version, distribution, httpSender));
         }
         return gradleWrapper;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleExecutionContextView.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleExecutionContextView.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.openrewrite.DelegatingExecutionContext;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ipc.http.HttpUrlConnectionSender;
+
+public class GradleExecutionContextView extends DelegatingExecutionContext {
+
+    private static final String HTTP_SENDER = "httpSender";
+
+    public GradleExecutionContextView(ExecutionContext delegate) {
+        super(delegate);
+    }
+
+    public static GradleExecutionContextView view(ExecutionContext ctx) {
+        if(ctx instanceof GradleExecutionContextView) {
+            return (GradleExecutionContextView) ctx;
+        }
+        return new GradleExecutionContextView(ctx);
+    }
+
+    public void setHttpSender(org.openrewrite.ipc.http.HttpSender httpSender) {
+        putMessage(HTTP_SENDER, httpSender);
+    }
+
+    public org.openrewrite.ipc.http.HttpSender getHttpSender() {
+        return getMessage(HTTP_SENDER, new HttpUrlConnectionSender());
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -71,7 +71,7 @@ public class UpdateGradleWrapper extends Recipe {
     @Override
     public Validated validate(ExecutionContext ctx) {
         if (gradleWrapper == null) {
-            org.openrewrite.ipc.http.HttpSender httpSender = GradleExecutionContextView.view(ctx).getHttpSender();
+            org.openrewrite.ipc.http.HttpSender httpSender = HttpSenderExecutionContextView.view(ctx).getHttpSender();
             gradleWrapper = super.validate().and(GradleWrapper.validate(version, distribution, httpSender));
         }
         return gradleWrapper;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -24,6 +24,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.LoathingOfOthers;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
@@ -71,10 +72,13 @@ public class UpdateGradleWrapper extends Recipe {
     Validated gradleWrapper;
 
     @Override
-    public Validated validate() {
+    public Validated validate(ExecutionContext ctx) {
         if (gradleWrapper == null) {
-            gradleWrapper = super.validate().and(GradleWrapper.validate(version, distribution,
-                    new HttpUrlConnectionSender(Duration.ofSeconds(3), Duration.ofSeconds(10))));
+            HttpSender httpSender = ctx.getMessage("httpSender");
+            if (httpSender == null) {
+                httpSender = new HttpUrlConnectionSender(Duration.ofSeconds(3), Duration.ofSeconds(10));
+            }
+            gradleWrapper = super.validate().and(GradleWrapper.validate(version, distribution, httpSender));
         }
         return gradleWrapper;
     }
@@ -90,8 +94,6 @@ public class UpdateGradleWrapper extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
-        GradleWrapper gradleWrapper = validate().getValue();
-        assert gradleWrapper != null;
 
         return new PropertiesVisitor<ExecutionContext>() {
             @Override
@@ -105,6 +107,9 @@ public class UpdateGradleWrapper extends Recipe {
                 if (!"distributionUrl".equals(entry.getKey())) {
                     return entry;
                 }
+
+                GradleWrapper gradleWrapper = validate(context).getValue();
+
                 // Typical example: https://services.gradle.org/distributions/gradle-7.4-all.zip
                 String currentDistributionUrl = entry.getValue().getText();
                 if (!gradleWrapper.getPropertiesFormattedUrl().equals(currentDistributionUrl)) {
@@ -117,7 +122,7 @@ public class UpdateGradleWrapper extends Recipe {
 
     @Override
     protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
-        GradleWrapper gradleWrapper = validate().getValue();
+        GradleWrapper gradleWrapper = validate(ctx).getValue();
         assert gradleWrapper != null;
 
         return ListUtils.map(before, sourceFile -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -24,14 +24,11 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.LoathingOfOthers;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.ipc.http.HttpSender;
-import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.quark.Quark;
 import org.openrewrite.text.PlainText;
 
-import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -74,10 +71,7 @@ public class UpdateGradleWrapper extends Recipe {
     @Override
     public Validated validate(ExecutionContext ctx) {
         if (gradleWrapper == null) {
-            HttpSender httpSender = ctx.getMessage("httpSender");
-            if (httpSender == null) {
-                httpSender = new HttpUrlConnectionSender(Duration.ofSeconds(3), Duration.ofSeconds(10));
-            }
+            org.openrewrite.ipc.http.HttpSender httpSender = GradleExecutionContextView.view(ctx).getHttpSender();
             gradleWrapper = super.validate().and(GradleWrapper.validate(version, distribution, httpSender));
         }
         return gradleWrapper;


### PR DESCRIPTION
Problem: 
Validation doesn't use ExecutionContext on recipes. There is a need to be able to add customizations through the ExecutionContext during recipe validation. 

Solution: 
Enhance base recipe execution to allow for execution context. 

Outcome: 
Ability to use ExecutionContext for recipe validation. 
