### PR TITLE
Added support to auto format multi catch control parens

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -302,6 +302,28 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     @Override
+    public J.MultiCatch visitMultiCatch(J.MultiCatch multiCatch, P p) {
+        J.MultiCatch mc = super.visitMultiCatch(multiCatch, p);
+        final int argsSize = mc.getAlternatives().size();
+        mc = mc.getPadding().withAlternatives(
+                ListUtils.map(mc.getPadding().getAlternatives(),
+                        (index, arg) -> {
+                            if (index > 0) {
+                                arg = arg.withElement(
+                                        spaceBefore(arg.getElement(), style.getAroundOperators().getBitwise())
+                                );
+                            }
+                            if (index != argsSize - 1) {
+                                arg = spaceAfter(arg, style.getAroundOperators().getBitwise());
+                            }
+                            return arg;
+                        }
+                )
+        );
+        return mc;
+    }
+
+    @Override
     public J.If visitIf(J.If iff, P p) {
         J.If i = super.visitIf(iff, p);
         i = i.withIfCondition(spaceBefore(i.getIfCondition(), style.getBeforeParentheses().getIfParentheses()));

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/SpacesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/SpacesTest.kt
@@ -1758,6 +1758,68 @@ interface SpacesTest : JavaRecipeTest {
             """
     )
 
+        @Suppress("CatchMayIgnoreException", "EmptyTryBlock")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1896")
+    @Test
+    fun aroundExceptionDelimiterFalse(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(
+            namedStyles(listOf(IntelliJ.spaces().run {
+                withAroundOperators(aroundOperators.run {
+                    withBitwise(false)
+                })
+            }))
+        ).build(),
+        before = """
+                class Test {
+                    public void foo() {
+                        try {
+                        } catch (IllegalAccessException | IllegalStateException | IllegalArgumentException e) {
+                        }
+                    }
+                }
+            """,
+        after = """
+                class Test {
+                    public void foo() {
+                        try {
+                        } catch (IllegalAccessException|IllegalStateException|IllegalArgumentException e) {
+                        }
+                    }
+                }
+            """
+    )
+
+    @Suppress("CatchMayIgnoreException", "EmptyTryBlock")
+    @Issue("https://github.com/openrewrite/rewrite/issues/1896")
+    @Test
+    fun aroundExceptionDelimiterTrue(jp: JavaParser.Builder<*, *>) = assertChanged(
+        parser = jp.styles(
+            namedStyles(listOf(IntelliJ.spaces().run {
+                withAroundOperators(aroundOperators.run {
+                    withBitwise(true)
+                })
+            }))
+        ).build(),
+        before = """
+                class Test {
+                    public void foo() {
+                        try {
+                        } catch (IllegalAccessException|IllegalStateException|IllegalArgumentException e) {
+                        }
+                    }
+                }
+            """,
+        after = """
+                class Test {
+                    public void foo() {
+                        try {
+                        } catch (IllegalAccessException | IllegalStateException | IllegalArgumentException e) {
+                        }
+                    }
+                }
+            """
+    )
+
     @Test
     fun beforeLeftBraceFinallyLeftBraceFalse(jp: JavaParser.Builder<*, *>) = assertChanged(
             parser = jp.styles(


### PR DESCRIPTION
Changes:

- Auto format will apply spaces style before and after `|` in `J.MultiCatch` control parentheses. The formatting is based on `SpacesStyle$AroundOperators.bitwise`

fixes #1896