### PR TITLE
Align method parameters

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -207,28 +207,25 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                     case METHOD_DECLARATION_PARAMETER: {
                         JContainer<J> container = getCursor().getParentOrThrow().getValue();
                         J firstArg = container.getElements().iterator().next();
-                        if (firstArg.getPrefix().getLastWhitespace().contains("\n")) {
-                            // if the first argument is on its own line, align all arguments to be continuation indented
-                            elem = visitAndCast(elem, p);
-                            after = indentTo(right.getAfter(), indent, loc.getAfterLocation());
-                        } else {
-                            // align to first argument when the first argument isn't on its own line
-                            if (style.getMethodDeclarationParameters().getAlignWhenMultiple()) {
-                                System.out.println();
-                                J.MethodDeclaration method = getCursor().firstEnclosing(J.MethodDeclaration.class);
-                                if (method != null) {
-                                    String source = method.print(getCursor());
-                                    int alignTo = source.indexOf(firstArg.print(getCursor())) - 1;
-                                    getCursor().getParentOrThrow().putMessage("lastIndent", alignTo - style.getContinuationIndent());
-                                    elem = visitAndCast(elem, p);
-                                    after = indentTo(right.getAfter(), alignTo, loc.getAfterLocation());
+                        if (style.getMethodDeclarationParameters().getAlignWhenMultiple()) {
+                            J.MethodDeclaration method = getCursor().firstEnclosing(J.MethodDeclaration.class);
+                            if (method != null) {
+                                int alignTo;
+                                if (firstArg.getPrefix().getLastWhitespace().contains("\n")) {
+                                    alignTo = firstArg.getPrefix().getLastWhitespace().length() - 1;
                                 } else {
-                                    after = right.getAfter();
+                                    String source = method.print(getCursor());
+                                    alignTo = source.indexOf(firstArg.print(getCursor())) - 1;
                                 }
-                            } else {
+                                getCursor().getParentOrThrow().putMessage("lastIndent", alignTo - style.getContinuationIndent());
                                 elem = visitAndCast(elem, p);
-                                after = indentTo(right.getAfter(), style.getContinuationIndent(), loc.getAfterLocation());
+                                after = indentTo(right.getAfter(), alignTo, loc.getAfterLocation());
+                            } else {
+                                after = right.getAfter();
                             }
+                        } else {
+                            elem = visitAndCast(elem, p);
+                            after = indentTo(right.getAfter(), style.getContinuationIndent(), loc.getAfterLocation());
                         }
                         break;
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -21,15 +21,11 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.JavadocVisitor;
 import org.openrewrite.java.style.TabsAndIndentsStyle;
 import org.openrewrite.java.tree.*;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
     @Nullable
@@ -211,19 +207,28 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                     case METHOD_DECLARATION_PARAMETER: {
                         JContainer<J> container = getCursor().getParentOrThrow().getValue();
                         J firstArg = container.getElements().iterator().next();
-                        if (firstArg.getPrefix().getWhitespace().isEmpty()) {
-                            after = right.getAfter();
-                        } else if (firstArg.getPrefix().getLastWhitespace().contains("\n")) {
+                        if (firstArg.getPrefix().getLastWhitespace().contains("\n")) {
                             // if the first argument is on its own line, align all arguments to be continuation indented
                             elem = visitAndCast(elem, p);
                             after = indentTo(right.getAfter(), indent, loc.getAfterLocation());
                         } else {
                             // align to first argument when the first argument isn't on its own line
-                            int firstArgIndent = findIndent(firstArg.getPrefix());
-                            getCursor().getParentOrThrow().putMessage("lastIndent", firstArgIndent);
-                            elem = visitAndCast(elem, p);
-                            getCursor().getParentOrThrow().putMessage("lastIndent", indent);
-                            after = indentTo(right.getAfter(), firstArgIndent, loc.getAfterLocation());
+                            if (style.getMethodDeclarationParameters().getAlignWhenMultiple()) {
+                                System.out.println();
+                                J.MethodDeclaration method = getCursor().firstEnclosing(J.MethodDeclaration.class);
+                                if (method != null) {
+                                    String source = method.print(getCursor());
+                                    int alignTo = source.indexOf(firstArg.print(getCursor())) - 1;
+                                    getCursor().getParentOrThrow().putMessage("lastIndent", alignTo - style.getContinuationIndent());
+                                    elem = visitAndCast(elem, p);
+                                    after = indentTo(right.getAfter(), alignTo, loc.getAfterLocation());
+                                } else {
+                                    after = right.getAfter();
+                                }
+                            } else {
+                                elem = visitAndCast(elem, p);
+                                after = indentTo(right.getAfter(), style.getContinuationIndent(), loc.getAfterLocation());
+                            }
                         }
                         break;
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -145,7 +145,8 @@ public class Autodetect extends NamedStyles {
                     useTabs ? indent : 1,
                     useTabs ? 1 : indent,
                     continuationIndent,
-                    false
+                    false,
+                    new TabsAndIndentsStyle.MethodDeclarationParameters(true)
             );
         }
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/IntelliJ.java
@@ -66,7 +66,8 @@ public class IntelliJ extends NamedStyles {
     }
 
     public static TabsAndIndentsStyle tabsAndIndents() {
-        return new TabsAndIndentsStyle(false, 4, 4, 8, false);
+        return new TabsAndIndentsStyle(false, 4, 4, 8, false,
+                new TabsAndIndentsStyle.MethodDeclarationParameters(true));
     }
 
     public static BlankLinesStyle blankLines() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/TabsAndIndentsStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/TabsAndIndentsStyle.java
@@ -33,6 +33,14 @@ public class TabsAndIndentsStyle implements JavaStyle {
     Integer continuationIndent;
     Boolean indentsRelativeToExpressionStart;
 
+    MethodDeclarationParameters methodDeclarationParameters;
+
+    @Value
+    @With
+    public static class MethodDeclarationParameters {
+        Boolean alignWhenMultiple;
+    }
+
     @Override
     public Style applyDefaults() {
         return StyleHelper.merge(IntelliJ.tabsAndIndents(), this);

--- a/rewrite-java/src/test/kotlin/org/openrewrite/java/style/StyleHelperTest.kt
+++ b/rewrite-java/src/test/kotlin/org/openrewrite/java/style/StyleHelperTest.kt
@@ -23,11 +23,12 @@ class StyleHelperTest {
 
     @Test
     fun mergeTabsAndIndentsStyles() {
-        val merged = StyleHelper.merge(IntelliJ.tabsAndIndents(), TabsAndIndentsStyle(true, 1, 1, 2, true))
+        val merged = StyleHelper.merge(IntelliJ.tabsAndIndents(), TabsAndIndentsStyle(true, 1, 1, 2, true, TabsAndIndentsStyle.MethodDeclarationParameters(true)))
         assertThat(merged.useTabCharacter).isTrue
         assertThat(merged.tabSize).isEqualTo(1)
         assertThat(merged.indentSize).isEqualTo(1)
         assertThat(merged.continuationIndent).isEqualTo(2)
+        assertThat(merged.methodDeclarationParameters.alignWhenMultiple).isTrue
         assertThat(merged.indentsRelativeToExpressionStart).isTrue
     }
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -42,6 +42,51 @@ interface TabsAndIndentsTest : JavaRecipeTest {
         )
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1913")
+    @Test
+    fun alignMethodDeclarationParamsWhenMultiple(jp: JavaParser) = assertChanged(
+        jp,
+        before = """
+            class Test {
+                private void takeBoth(String first,
+                                      int times,
+                     String third) {
+                }
+            }
+        """,
+        after = """
+            class Test {
+                private void takeBoth(String first,
+                                      int times,
+                                      String third) {
+                }
+            }
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1913")
+    @Test
+    fun alignMethodDeclarationParamsWhenContinuationIndent(jp: JavaParser.Builder<*, *>) = assertChanged(
+        jp.styles(tabsAndIndents { withMethodDeclarationParameters(
+            TabsAndIndentsStyle.MethodDeclarationParameters(false)) }).build(),
+        before = """
+            class Test {
+                private void takeBoth(String first,
+                                      int times,
+                                      String third) {
+                }
+            }
+        """,
+        after = """
+            class Test {
+                private void takeBoth(String first,
+                        int times,
+                        String third) {
+                }
+            }
+        """
+    )
+
     // https://rules.sonarsource.com/java/tag/confusing/RSPEC-3973
     @Test
     fun rspec3973(jp: JavaParser) = assertChanged(

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/TabsAndIndentsTest.kt
@@ -48,17 +48,27 @@ interface TabsAndIndentsTest : JavaRecipeTest {
         jp,
         before = """
             class Test {
-                private void takeBoth(String first,
-                                      int times,
+                private void firstArgNoPrefix(String first,
+                                              int times,
+                     String third) {
+                }
+                private void firstArgOnNewLine(
+                        String first,
+                        int times,
                      String third) {
                 }
             }
         """,
         after = """
             class Test {
-                private void takeBoth(String first,
-                                      int times,
-                                      String third) {
+                private void firstArgNoPrefix(String first,
+                                              int times,
+                                              String third) {
+                }
+                private void firstArgOnNewLine(
+                        String first,
+                        int times,
+                        String third) {
                 }
             }
         """
@@ -71,15 +81,25 @@ interface TabsAndIndentsTest : JavaRecipeTest {
             TabsAndIndentsStyle.MethodDeclarationParameters(false)) }).build(),
         before = """
             class Test {
-                private void takeBoth(String first,
-                                      int times,
-                                      String third) {
+                private void firstArgNoPrefix(String first,
+                                              int times,
+                                              String third) {
+                }
+                private void firstArgOnNewLine(
+                                               String first,
+                                               int times,
+                                               String third) {
                 }
             }
         """,
         after = """
             class Test {
-                private void takeBoth(String first,
+                private void firstArgNoPrefix(String first,
+                        int times,
+                        String third) {
+                }
+                private void firstArgOnNewLine(
+                        String first,
                         int times,
                         String third) {
                 }


### PR DESCRIPTION
Changes:

- Added support to align method parameters of multi-line method declaration parameters to the first argument.
- Added `TabsAndIndentStyle$MethodDeclarationParameters#alignWhenMultiple`.
- Added auto-detection for alignment setting. (defaults to true)

fixes #1913