### PR TITLE
Do not change lambda on chained method invocations.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceLambdaWithMethodReference.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceLambdaWithMethodReference.java
@@ -109,7 +109,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     }
                 } else if (body instanceof J.MethodInvocation) {
                     J.MethodInvocation method = (J.MethodInvocation) body;
-                    if (!methodArgumentsMatchLambdaParameters(method, lambda)) {
+                    if (!methodArgumentsMatchLambdaParameters(method, lambda) || multipleMethodInvocations(method)) {
                         return l;
                     }
 
@@ -134,6 +134,10 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                 }
 
                 return l;
+            }
+
+            private boolean multipleMethodInvocations(J.MethodInvocation method) {
+                return method.getSelect() instanceof J.MethodInvocation;
             }
 
             private boolean methodArgumentsMatchLambdaParameters(J.MethodInvocation method, J.Lambda lambda) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/ReplaceLambdaWithMethodReferenceTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/ReplaceLambdaWithMethodReferenceTest.kt
@@ -26,6 +26,25 @@ interface ReplaceLambdaWithMethodReferenceTest : JavaRecipeTest {
     override val recipe: Recipe?
         get() = ReplaceLambdaWithMethodReference()
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1926")
+    @Test
+    fun multipleMethodInvocations() = assertUnchanged(
+        before = """
+            import java.nio.file.Path;
+            import java.nio.file.Paths;
+            import java.util.List;import java.util.stream.Collectors;
+            
+            class Test {
+                Path path = Paths.get("");
+                List<String> method(List<String> l) {
+                    return l.stream()
+                        .filter(s -> path.getFileName().toString().equals(s))
+                        .collect(Collectors.toList());
+                }
+            }
+        """.trimIndent()
+    )
+
     @Test
     fun containsMultipleStatements() = assertUnchanged(
         before = """


### PR DESCRIPTION
Fix:

- `ReplaceLambdaWithMethodReference` will not change lambdas with multiple linked method invocations.

fixes #1926