### PR TITLE
Impossible Control Flow computation fails gracefully

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlowBasicBlockVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlowBasicBlockVisitor.java
@@ -35,24 +35,25 @@ public class ControlFlowBasicBlockVisitor<P> extends JavaIsoVisitor<P> {
         J.MethodDeclaration methodDeclaration = getCursor().firstEnclosing(J.MethodDeclaration.class);
         if (block == methodDeclaration.getBody() &&
                 methodDeclaration.getName().getSimpleName().equals(methodName)) {
-            ControlFlowSummary summary = ControlFlow.startingAt(getCursor()).findControlFlow();
-            Set<J> inBasicBlock = summary.getBasicBlocks().stream().flatMap(b ->
-                    b.getNodeValues().stream()).collect(Collectors.toSet());
-            doAfterVisit(new JavaIsoVisitor<P>() {
+            ControlFlow.startingAt(getCursor()).findControlFlow().ifPresent(summary -> {
+                Set<J> inBasicBlock = summary.getBasicBlocks().stream().flatMap(b ->
+                        b.getNodeValues().stream()).collect(Collectors.toSet());
+                doAfterVisit(new JavaIsoVisitor<P>() {
 
-                @Override
-                public Statement visitStatement(Statement statement, P p) {
-                    return inBasicBlock.contains(statement) ?
-                            statement.withMarkers(statement.getMarkers().searchResult()) :
-                            statement;
-                }
+                    @Override
+                    public Statement visitStatement(Statement statement, P p) {
+                        return inBasicBlock.contains(statement) ?
+                                statement.withMarkers(statement.getMarkers().searchResult()) :
+                                statement;
+                    }
 
-                @Override
-                public Expression visitExpression(Expression expression, P p) {
-                    return inBasicBlock.contains(expression) ?
-                            expression.withMarkers(expression.getMarkers().searchResult()) :
-                            expression;
-                }
+                    @Override
+                    public Expression visitExpression(Expression expression, P p) {
+                        return inBasicBlock.contains(expression) ?
+                                expression.withMarkers(expression.getMarkers().searchResult()) :
+                                expression;
+                    }
+                });
             });
         }
         return super.visitBlock(block, p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/Dataflow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/Dataflow.java
@@ -43,19 +43,20 @@ public class Dataflow {
             if (!spec.isSource(source, start)) {
                 return Optional.empty();
             }
+            return ControlFlow.startingAt(start).findControlFlow().flatMap(summary -> {
+                Set<Expression> reachable = summary.computeReachableExpressions(spec::isBarrierGuard);
 
-            ControlFlowSummary controlFlowSummary = ControlFlow.startingAt(start).findControlFlow();
-            Set<Expression> reachable = controlFlowSummary.computeReachableExpressions(spec::isBarrierGuard);
+                SinkFlow<Source, Sink> flow = new SinkFlow<>(start, spec, reachable);
 
-            SinkFlow<Source, Sink> flow = new SinkFlow<>(start, spec, reachable);
+                ForwardFlow.findSinks(flow);
 
-            ForwardFlow.findSinks(flow);
-
-            if (flow.isNotEmpty()) {
-                return Optional.of(flow);
-            }
+                if (flow.isNotEmpty()) {
+                    return Optional.of(flow);
+                } else {
+                    return Optional.empty();
+                }
+            });
         }
-
         return Optional.empty();
     }
 


### PR DESCRIPTION
Instead of throwing an exception when control flow can't be computed
return `Optional.empty`.
