### PR TITLE
Add remaining linebreaks in numerical order in JavaDocVisitors#visitDocComment.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -348,7 +348,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         }
 
         if (!lineBreaks.isEmpty()) {
-            body.addAll(lineBreaks.values());
+            lineBreaks.keySet().stream().sorted().forEach(o -> body.add(lineBreaks.get(o)));
         }
 
         return new Javadoc.DocComment(randomId(), Markers.EMPTY, body, "");

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -348,7 +348,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         }
 
         if (!lineBreaks.isEmpty()) {
-            body.addAll(lineBreaks.values());
+            lineBreaks.keySet().stream().sorted().forEach(o -> body.add(lineBreaks.get(o)));
         }
 
         return new Javadoc.DocComment(randomId(), Markers.EMPTY, body, "");

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -361,7 +361,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
         }
 
         if (!lineBreaks.isEmpty()) {
-            body.addAll(lineBreaks.values());
+            lineBreaks.keySet().stream().sorted().forEach(o -> body.add(lineBreaks.get(o)));
         }
 
         return new Javadoc.DocComment(randomId(), Markers.EMPTY, body, "");

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -139,6 +139,21 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
+    @Test
+    fun authorPostFixedNumber(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            /**
+             * @author FirstName LastName 42
+             *
+             */
+            public class A {
+                void method() {}
+            }
+        """.trimIndent()
+    )
+
     // code
     @Test
     fun code(jp: JavaParser) = assertParsePrintAndProcess(


### PR DESCRIPTION
Fix:

- The remaining linebreaks will be added to the body in numerical order in each JavaDocVisitor#`visitDocComment`.

fixes #1965