### PR TITLE
Apply `BlankLinesStyle$KeepMaximum.inDeclarations` to format `J.ClassDeclaration` prefix.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
@@ -114,6 +114,11 @@ public class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
                 // Apply `style.getMinimum().getAroundClass()` to classes declared in the SourceFile.
                 (classes.contains(j)) ? minimumLines(j, style.getMinimum().getAroundClass()) : j;
 
+        // style.getKeepMaximum().getInDeclarations() also sets the maximum new lines of class declaration prefixex.
+        j = firstClass ?
+                (hasImports ? keepMaximumLines(j, Math.max(style.getKeepMaximum().getInDeclarations(), style.getMinimum().getAfterImports())) : j) :
+                (classes.contains(j)) ? keepMaximumLines(j, Math.max(style.getKeepMaximum().getInDeclarations(), style.getKeepMaximum().getInDeclarations())) : j;
+
         if (!hasImports && firstClass) {
             if (cu.getPackageDeclaration() == null) {
                 if (!j.getPrefix().getWhitespace().isEmpty()) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/format/BlankLinesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/format/BlankLinesTest.kt
@@ -45,7 +45,7 @@ interface BlankLinesTest : JavaRecipeTest {
         before = """
             public class A {
                 private Long id; // this comment will move to wrong place
-
+            
                 public Long id() {
                     return id;
                 }
@@ -91,6 +91,9 @@ interface BlankLinesTest : JavaRecipeTest {
     fun keepMaximumInDeclarations(jp: JavaParser.Builder<*, *>) = assertChanged(
         jp.styles(blankLines { withKeepMaximum(keepMaximum.withInDeclarations(0)) }).build(),
         before = """
+            import java.util.List;
+            
+            
             public class Test {
             
             
@@ -119,6 +122,8 @@ interface BlankLinesTest : JavaRecipeTest {
             }
         """,
         after = """
+            import java.util.List;
+            
             public class Test {
                 private int field1;
                 private int field2;


### PR DESCRIPTION
Fix:

- `J.ClassDeclaration` prefixes that exceed the `Style` will be appropriately auto-formatted.

fixes #1912