### PR TITLE
Implicily Handle Boolean Literal 'true' & 'false' in control flow

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/controlflow/ControlFlowTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/controlflow/ControlFlowTest.kt
@@ -1149,4 +1149,33 @@ interface ControlFlowTest : RewriteTest {
             """
         )
     )
+
+    /**
+     * TODO: It may be beneficial in the future to represent this as a single basic block with no conditional nodes
+     */
+    @Test
+    fun `literal true`() = rewriteRun(
+        java(
+            """
+            abstract class Test {
+                void test() {
+                    System.out.println("Hello!");
+                    if (true) {
+                        System.out.println("Goodbye!");
+                    }
+                }
+            }
+            """,
+            """
+            abstract class Test {
+                void test() /*~~(BB: 2 CN: 1 EX: 2 | L)~~>*/{
+                    System.out.println("Hello!");
+                    if (true) /*~~(L)~~>*/{
+                        System.out.println("Goodbye!");
+                    }
+                }
+            }
+            """
+        )
+    )
 }

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/dataflow/FindLocalFlowPathsStringTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/dataflow/FindLocalFlowPathsStringTest.kt
@@ -1246,11 +1246,7 @@ interface FindLocalFlowPathsStringTest : RewriteTest {
                 void test() {
                     String n = "42";
                     ArrayList<Integer> numbers = new ArrayList<Integer>();
-                    numbers.add(5);
-                    numbers.add(9);
-                    numbers.add(8);
-                    numbers.add(1);
-                    numbers.forEach( (i) -> { System.out.println(i); } );
+                    numbers.forEach( (i) -> { System.out.println(n); } );
                 }
             }
             """, """
@@ -1260,16 +1256,64 @@ interface FindLocalFlowPathsStringTest : RewriteTest {
                 void test() {
                     String n = /*~~>*/"42";
                     ArrayList<Integer> numbers = new ArrayList<Integer>();
-                    numbers.add(5);
-                    numbers.add(9);
-                    numbers.add(8);
-                    numbers.add(1);
-                    numbers.forEach( (i) -> { System.out.println(i); } );
+                    numbers.forEach( (i) -> { System.out.println(/*~~>*/n); } );
                 }
             }
             """
         )
     )
 
+    @Test
+    fun `true literal guard`() = rewriteRun(
+        java(
+            """
+            abstract class Test {
+                void test() {
+                    String n = "42";
+                    if (true) {
+                        System.out.println(n);
+                    }
+                    System.out.println(n);
+                }
+            }
+            """, """
+            abstract class Test {
+                void test() {
+                    String n = /*~~>*/"42";
+                    if (true) {
+                        System.out.println(/*~~>*/n);
+                    }
+                    System.out.println(/*~~>*/n);
+                }
+            }
+            """
+        )
+    )
 
+    @Test
+    fun `false literal guard`() = rewriteRun(
+        java(
+            """
+            abstract class Test {
+                void test() {
+                    String n = "42";
+                    if (false) {
+                        System.out.println(n);
+                    }
+                    System.out.println(n);
+                }
+            }
+            """, """
+            abstract class Test {
+                void test() {
+                    String n = /*~~>*/"42";
+                    if (false) {
+                        System.out.println(n);
+                    }
+                    System.out.println(/*~~>*/n);
+                }
+            }
+            """
+        )
+    )
 }


### PR DESCRIPTION
Logic like the following will be implicitly handled in the control flow reachability computation: 

```java
if (true)
    System.out.println("This will always run");
if (false)
    System.out.println("This will never run");
````