### PR TITLE
Adjusted ChangeDependencyGroupIdAndArtifactId to allow null newGroupId and newArtifactId…

### DIFF
--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.kt
@@ -646,4 +646,50 @@ class ChangeDependencyGroupIdAndArtifactIdTest : RewriteTest {
             </project>
         """)
     )
+
+    @Test
+    fun changeGroupIdOnWildcardArtifacts() = rewriteRun(
+        { spec ->
+            spec.recipe(
+                ChangeDependencyGroupIdAndArtifactId(
+                    "org.apache.commons",
+                    "*",
+                    "commons-io",
+                    null,
+                    "2.11.0",
+                    null
+                )
+            )
+        },
+        pomXml("""
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>1.3.2</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """,
+            """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.11.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+        """
+        ))
 }


### PR DESCRIPTION
…, enabling flexible new use cases (ie change only group id across wildcard artifacts in an existing group id).

Also some changes to the `Option` annotations to clarify behaviors that were already there (`newVersion` not required, old group/artifact support glob)