### PR TITLE
Only add imported static field names when possible in VariableNameScopeVisitor.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
@@ -195,10 +195,17 @@ public class VariableNameUtils {
                     if (i.isStatic()) {
                         // Note: Currently, adds all statically imported identifiers including method and classes rather than restricting the names to static fields.
                         Set<String> namesAtCursor = nameScopes.computeIfAbsent(classCursor, k -> new HashSet<>());
-                        namesAtCursor.add(i.getQualid().getSimpleName());
+                        if (isValidImportName(i.getQualid().getTarget().getType(), i.getQualid().getSimpleName())) {
+                            namesAtCursor.add(i.getQualid().getSimpleName());
+                        }
                     }
                 });
             }
+        }
+
+        private boolean isValidImportName(@Nullable JavaType targetType, String name) {
+            // Consider the id a valid field if the type is null since it is indistinguishable from a method name or class name.
+            return targetType == null || (targetType instanceof JavaType.FullyQualified && ((JavaType.FullyQualified) targetType).getMembers().stream().anyMatch(o -> o.getName().equals(name)));
         }
 
         private void addInheritedClassFields(@Nullable JavaType.FullyQualified fq, Cursor classCursor) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/VariableNameUtilsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/VariableNameUtilsTest.kt
@@ -64,7 +64,7 @@ interface VariableNameUtilsTest : RewriteTest {
             }
         """.trimIndent())
 
-        baseTest(source, "classBlock", "classBlock, UTF_8, emptyList")
+        baseTest(source, "classBlock", "classBlock, UTF_8")
     }
 
     @Test


### PR DESCRIPTION
Changes:

- VariableNameScopeVisitor will only add static field names to names in scope when type attribution is available.

fixes #1978.