### PR TITLE
Add `UsesAllMethods` visitor

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Marks a {@link JavaSourceFile} as matching if all the passed methods are found.
+ */
+public class UsesAllMethods<P> extends JavaIsoVisitor<P> {
+    private final Set<MethodMatcher> methodMatchers;
+
+    public UsesAllMethods(Set<MethodMatcher> methodMatchers) {
+        this.methodMatchers = Objects.requireNonNull(methodMatchers, "methodMatchers cannot be null");
+    }
+
+    public UsesAllMethods(MethodMatcher... methodMatchers) {
+        this(new HashSet<>(Arrays.asList(methodMatchers)));
+    }
+
+    @Override
+    public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, P p) {
+        Set<MethodMatcher> unmatched = new HashSet<>(methodMatchers);
+        for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
+            unmatched.removeIf(matcher -> matcher.matches(type));
+            if (unmatched.isEmpty()) {
+                break;
+            }
+        }
+        if (unmatched.isEmpty()) {
+            return cu.withMarkers(cu.getMarkers().searchResult());
+        }
+        return cu;
+    }
+}

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -529,6 +529,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class UseStandardCharsetTck : UseStandardCharsetTest
 
     @Nested
+    inner class UsesAllMethodsTck : UsesAllMethodsTest
+
+    @Nested
     inner class UsesMethodTck : UsesMethodTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesAllMethodsTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/search/UsesAllMethodsTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.MethodMatcher
+import org.openrewrite.test.RewriteTest
+
+interface UsesAllMethodsTest : RewriteTest {
+
+    @Test
+    fun usesBothMethods() = rewriteRun(
+        { spec ->
+            spec.recipe(RewriteTest.toRecipe {
+                UsesAllMethods(
+                    MethodMatcher("java.util.Collections emptyList()"),
+                    MethodMatcher("java.util.Collections emptySet()")
+                )
+            })
+        },
+        java(
+            """
+            import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                    Collections.emptySet();
+                }
+            }
+            """,
+            """
+            /*~~>*/import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                    Collections.emptySet();
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun usesNeitherMethods() = rewriteRun(
+        { spec ->
+            spec.recipe(RewriteTest.toRecipe {
+                UsesAllMethods(
+                    MethodMatcher("java.util.Collections emptyList()"),
+                    MethodMatcher("java.util.Collections emptySet()")
+                )
+            })
+        },
+        java(
+            """
+            import java.util.Collections;
+            class Test {
+            }
+            """
+        )
+    )
+
+    @Test
+    fun usesOneMethod() = rewriteRun(
+        { spec ->
+            spec.recipe(RewriteTest.toRecipe {
+                UsesAllMethods(
+                    MethodMatcher("java.util.Collections emptyList()"),
+                    MethodMatcher("java.util.Collections emptySet()")
+                )
+            })
+        },
+        java(
+            """
+            import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun usesBothExitEarlyMethods() = rewriteRun(
+        { spec ->
+            spec.recipe(RewriteTest.toRecipe {
+                UsesAllMethods(
+                    MethodMatcher("java.util.Collections emptyList()"),
+                    MethodMatcher("java.util.Collections emptySet()")
+                )
+            })
+        },
+        java(
+            """
+            import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                    Collections.emptySet();
+                    System.out.println("Hello");
+                }
+            }
+            """,
+            """
+            /*~~>*/import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                    Collections.emptySet();
+                    System.out.println("Hello");
+                }
+            }
+            """
+        )
+    )
+
+    @Test
+    fun matchesMultipleMethods() = rewriteRun(
+        { spec ->
+            spec.recipe(RewriteTest.toRecipe {
+                UsesAllMethods(
+                    MethodMatcher("java.util.Collections emptyList()"),
+                    MethodMatcher("java.util.Collections *()"),
+                    MethodMatcher("java.util.Collections emptySet()")
+                )
+            })
+        },
+        java(
+            """
+            import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                    Collections.emptySet();
+                }
+            }
+            """,
+            """
+            /*~~>*/import java.util.Collections;
+            class Test {
+                {
+                    Collections.emptyList();
+                    Collections.emptySet();
+                }
+            }
+            """
+        )
+    )
+}


### PR DESCRIPTION
Useful when `getSingleSourceApplicableTest()` requires an AND relationship instead of an OR relationship.
