### PR TITLE
Various fixes in `ChangePackage`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -25,6 +25,8 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A recipe that will rename a package name in package statements, imports, and fully-qualified types (see: NOTE).
@@ -97,6 +99,7 @@ public class ChangePackage extends Recipe {
         private static final String RENAME_TO_KEY = "renameTo";
         private static final String RENAME_FROM_KEY = "renameFrom";
 
+        private final Map<String, JavaType> oldNameToChangedType = new HashMap<>();
         private final JavaType.Class newPackageType = JavaType.ShallowClass.build(newPackageName);
 
         @Override
@@ -114,12 +117,80 @@ public class ChangePackage extends Recipe {
                 )));
 
                 for (J.Import anImport : c.getImports()) {
-                    if (anImport.getPackageName().equals(newPackageName)) {
+                    if (anImport.getPackageName().equals(changingTo)) {
                         c = new RemoveImport<ExecutionContext>(anImport.getTypeName(), true).visitJavaSourceFile(c, ctx);
                     }
                 }
             }
             return c;
+        }
+
+        @Override
+        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
+            J.FieldAccess f = super.visitFieldAccess(fieldAccess, ctx);
+
+            if (f.isFullyQualifiedClassReference(oldPackageName)) {
+                Cursor parent = getCursor().getParent();
+                if (parent != null &&
+                        // Ensure the parent isn't a J.FieldAccess OR the parent doesn't match the target package name.
+                        (!(parent.getValue() instanceof J.FieldAccess) ||
+                        (!(((J.FieldAccess) parent.getValue()).isFullyQualifiedClassReference(newPackageName))))) {
+
+                    f = TypeTree.build(((JavaType.FullyQualified) newPackageType).getFullyQualifiedName())
+                            .withPrefix(f.getPrefix());
+                }
+            }
+            return f;
+        }
+
+        @Override
+        public J.Package visitPackage(J.Package pkg, ExecutionContext context) {
+            String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
+            getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, RENAME_FROM_KEY, original);
+
+            if (original.equals(oldPackageName)) {
+                getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, RENAME_TO_KEY, newPackageName);
+
+                if (newPackageName.contains(".")) {
+                    pkg = pkg.withTemplate(JavaTemplate.builder(this::getCursor, newPackageName).build(), pkg.getCoordinates().replace());
+                } else {
+                    // Covers unlikely scenario where the package is removed.
+                    getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, "UPDATE_PREFIX", true);
+                    pkg = null;
+                }
+            } else if (isTargetRecursivePackageName(original)) {
+                String changingTo = getNewPackageName(original);
+                getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, RENAME_TO_KEY, changingTo);
+                pkg = pkg.withTemplate(JavaTemplate.builder(this::getCursor, changingTo).build(), pkg.getCoordinates().replace());
+            }
+            //noinspection ConstantConditions
+            return pkg;
+        }
+
+        @Override
+        public J.Import visitImport(J.Import _import, ExecutionContext executionContext) {
+            // Polls message before calling super to change the prefix of the first import if applicable.
+            Boolean updatePrefix = getCursor().pollNearestMessage("UPDATE_PREFIX");
+            if (updatePrefix != null && updatePrefix) {
+                _import = _import.withPrefix(Space.EMPTY);
+            }
+            return super.visitImport(_import, executionContext);
+        }
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            J.ClassDeclaration c = super.visitClassDeclaration(classDecl, ctx);
+
+            Boolean updatePrefix = getCursor().pollNearestMessage("UPDATE_PREFIX");
+            if (updatePrefix != null && updatePrefix) {
+                c = c.withPrefix(Space.EMPTY);
+            }
+            return c;
+        }
+
+        @Override
+        public @Nullable JavaType visitType(@Nullable JavaType javaType, ExecutionContext executionContext) {
+            return updateType(javaType);
         }
 
         @Override
@@ -140,82 +211,77 @@ public class ChangePackage extends Recipe {
             return j;
         }
 
-        @Override
-        public J.Import visitImport(J.Import _import, ExecutionContext executionContext) {
-            Boolean updatePrefix = getCursor().pollNearestMessage("UPDATE_PREFIX");
-            if (updatePrefix != null && updatePrefix) {
-                _import = _import.withPrefix(Space.EMPTY);
-            }
-            return super.visitImport(_import, executionContext);
-        }
-
-        @Override
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-            J.ClassDeclaration c = super.visitClassDeclaration(classDecl, ctx);
-
-            Boolean updatePrefix = getCursor().pollNearestMessage("UPDATE_PREFIX");
-            if (updatePrefix != null && updatePrefix) {
-                c = c.withPrefix(Space.EMPTY);
-            }
-
-            String changingTo = getCursor().getNearestMessage(RENAME_TO_KEY);
-            if (changingTo != null && classDecl.getType() != null) {
-                JavaType.FullyQualified type = c.getType();
-                if (type != null) {
-                    c = c.withType(type.withFullyQualifiedName(changingTo + "." + c.getType().getClassName()));
-                }
-            }
-            return c;
-        }
-
-        @Override
-        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
-            J.FieldAccess f = super.visitFieldAccess(fieldAccess, ctx);
-
-            if (f.isFullyQualifiedClassReference(oldPackageName)) {
-                if (getCursor().getParent() != null
-                        // Ensure the parent isn't a J.FieldAccess OR the parent doesn't match the target package name.
-                        && (!(getCursor().getParent().getValue() instanceof J.FieldAccess)
-                        || (!(((J.FieldAccess) getCursor().getParent().getValue())
-                        .isFullyQualifiedClassReference(newPackageName))))) {
-
-                    f = TypeTree.build(((JavaType.FullyQualified) newPackageType).getFullyQualifiedName())
-                            .withPrefix(f.getPrefix());
-                }
-            }
-            return f;
-        }
-
-        @Override
-        public J.Package visitPackage(J.Package pkg, ExecutionContext context) {
-            String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
-            getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, RENAME_FROM_KEY, original);
-
-            if (original.equals(oldPackageName)) {
-                getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, RENAME_TO_KEY, newPackageName);
-                if (newPackageName.contains(".")) {
-                    pkg = pkg.withTemplate(JavaTemplate.builder(this::getCursor, newPackageName).build(), pkg.getCoordinates().replace());
-                } else {
-                    getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, "UPDATE_PREFIX", true);
-                    pkg = null;
-                }
-            } else if ((recursive == null || recursive)
-                    && original.startsWith(oldPackageName) && !original.startsWith(newPackageName)) {
-                String changingTo = newPackageName + original.substring(oldPackageName.length());
-                getCursor().putMessageOnFirstEnclosing(J.CompilationUnit.class, RENAME_TO_KEY, changingTo);
-                pkg = pkg.withTemplate(JavaTemplate.builder(this::getCursor, changingTo).build(), pkg.getCoordinates().replace());
-            }
-            //noinspection ConstantConditions
-            return pkg;
-        }
-
         @Nullable
-        private JavaType updateType(@Nullable JavaType javaType) {
-            JavaType.FullyQualified fq = TypeUtils.asFullyQualified(javaType);
-            if (fq != null && fq.getPackageName().equals(oldPackageName) && !fq.getClassName().isEmpty()) {
-                return TypeUtils.asFullyQualified(JavaType.buildType(newPackageName + "." + fq.getClassName()));
+        private JavaType updateType(@Nullable JavaType oldType) {
+            if (oldType == null) {
+                return oldType;
             }
-            return javaType;
+
+            JavaType type = oldNameToChangedType.get(oldType.toString());
+            if (type != null) {
+                return type;
+            }
+
+            if (oldType instanceof JavaType.Parameterized) {
+                JavaType.Parameterized pt = (JavaType.Parameterized) oldType;
+                pt = pt.withTypeParameters(ListUtils.map(pt.getTypeParameters(), tp -> {
+                    if (tp instanceof JavaType.FullyQualified) {
+                        JavaType.FullyQualified tpFq = (JavaType.FullyQualified) tp;
+                        if (isTargetFullyQualifiedType(tpFq)) {
+                            return TypeUtils.asFullyQualified(JavaType.buildType(getNewPackageName(tpFq.getPackageName()) + "." + tpFq.getClassName()));
+                        }
+                    }
+                    return tp;
+                }));
+
+                if (isTargetFullyQualifiedType(pt)) {
+                    pt = pt.withType(pt.getType().withFullyQualifiedName(getNewPackageName(pt.getPackageName()) + "." + pt.getClassName()));
+                }
+
+                // Saves oldType to prevent recomputing type parameters.
+                oldNameToChangedType.put(oldType.toString(), pt);
+                return pt;
+            } else if (oldType instanceof JavaType.FullyQualified) {
+                JavaType.FullyQualified original = TypeUtils.asFullyQualified(oldType);
+                if (isTargetFullyQualifiedType(original)) {
+                    JavaType.FullyQualified fq = TypeUtils.asFullyQualified(JavaType.buildType(getNewPackageName(original.getPackageName()) + "." + original.getClassName()));
+                    oldNameToChangedType.put(oldType.toString(), fq);
+                    return fq;
+                }
+            } else if (oldType instanceof JavaType.GenericTypeVariable) {
+                JavaType.GenericTypeVariable gtv = (JavaType.GenericTypeVariable) oldType;
+                gtv = gtv.withBounds(ListUtils.map(gtv.getBounds(), b -> {
+                    if (b instanceof JavaType.FullyQualified && isTargetFullyQualifiedType((JavaType.FullyQualified) b)) {
+                        return updateType(b);
+                    }
+                    return b;
+                }));
+
+                // Saves oldType to prevent recomputing type bounds.
+                oldNameToChangedType.put(oldType.toString(), gtv);
+                return gtv;
+            } else if (oldType instanceof JavaType.Array) {
+                JavaType.Array array = (JavaType.Array) oldType;
+                array = array.withElemType(updateType(array.getElemType()));
+                oldNameToChangedType.put(oldType.toString(), array);
+                return array;
+            }
+            return oldType;
+        }
+
+        private String getNewPackageName(String packageName) {
+            return (recursive == null || recursive) && !newPackageName.endsWith(packageName.substring(oldPackageName.length()))?
+                    newPackageName + packageName.substring(oldPackageName.length()) : newPackageName;
+        }
+
+        private boolean isTargetFullyQualifiedType(@Nullable JavaType.FullyQualified fq) {
+            return fq != null &&
+                    (fq.getPackageName().equals(oldPackageName) && !fq.getClassName().isEmpty() ||
+                            isTargetRecursivePackageName(fq.getPackageName()));
+        }
+
+        private boolean isTargetRecursivePackageName(String packageName) {
+            return (recursive == null || recursive) && packageName.startsWith(oldPackageName) && !packageName.startsWith(newPackageName);
         }
 
         @Nullable


### PR DESCRIPTION
Fixes in `ChangePackage`:

- Updates type information for bounds of `JavaType$GenericTypeVariable`, type of multi-dimensional `JavaType$Array`, and typeParameters of `JavaType.ParameterizedType`
- Types are updated appropriately for sub-packages when `recursive` is enabled.
- Only creates one new type per FQN.
- Will not remove an import when the package name does not match the package name of an imported class.
- Updated `afterCondition` to prevent regressions.

fixes #1997