### PR TITLE
Added support to replace J.NewArray in JavaTemplate.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -454,6 +454,15 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
             }
 
             @Override
+            public J visitNewArray(J.NewArray newArray, Integer integer) {
+                if (loc.equals(NEW_ARRAY_PREFIX) && newArray.isScope(insertionPoint)) {
+                    return autoFormat(substitutions.unsubstitute(templateParser.parseIdentifier(substitutedTemplate))
+                            .withPrefix(newArray.getPrefix()), integer, getCursor().getParentOrThrow());
+                }
+                return super.visitNewArray(newArray, integer);
+            }
+
+            @Override
             public J visitPackage(J.Package pkg, Integer integer) {
                 if (loc.equals(PACKAGE_PREFIX) && pkg.isScope(insertionPoint)) {
                     return pkg.withExpression(substitutions.unsubstitute(templateParser.parsePackage(substitutedTemplate)));

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/CoordinateBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/CoordinateBuilder.java
@@ -224,6 +224,16 @@ public abstract class CoordinateBuilder {
         }
     }
 
+    public static class NewArray extends CoordinateBuilder {
+        public NewArray(J.NewArray tree) {
+            super(tree);
+        }
+
+        public JavaCoordinates replace() {
+            return replace(Space.Location.NEW_ARRAY_PREFIX);
+        }
+    }
+
     public static class Package extends Statement {
         Package(J.Package tree) {
             super(tree);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3610,6 +3610,10 @@ public interface J extends Tree {
             return v.visitNewArray(this, p);
         }
 
+        public CoordinateBuilder.NewArray getCoordinates() {
+            return new CoordinateBuilder.NewArray(this);
+        }
+
         public Padding getPadding() {
             Padding p;
             if (this.padding == null) {


### PR DESCRIPTION
Changes:

- `JavaTemplate` may be used to replace `J.NewArray`.

fixes #1985