### PR TITLE
Fix control flow when `new int[]{1,2,3}` used in for each

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlow.java
@@ -532,7 +532,9 @@ public final class ControlFlow {
                 fakeConditionalTemplate = JavaTemplate.builder(this::getCursor, "#{any(java.lang.Iterable)}.iterator().hasNext()").build();
             }
             final JavaCoordinates coordinates;
-            if (iterable instanceof Statement) {
+            if (iterable instanceof J.NewArray) {
+                coordinates = ((J.NewArray) iterable).getCoordinates().replace();
+            } else if (iterable instanceof Statement) {
                 coordinates = ((Statement) iterable).getCoordinates().replace();
             } else if (iterable instanceof J.Identifier) {
                 coordinates = ((J.Identifier) iterable).getCoordinates().replace();

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/controlflow/ControlFlowTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/controlflow/ControlFlowTest.kt
@@ -1056,7 +1056,37 @@ interface ControlFlowTest : RewriteTest {
         )
     )
 
-
+    @Test
+    fun `for each loop over new array`() = rewriteRun(
+        java(
+            """
+            abstract class Test {
+                abstract int start();
+                int test() {
+                    int x = start();
+                    x++;
+                    for (int i : new int[]{1, 2, 3, 5}) {
+                        System.out.println(i);
+                    }
+                    return 5;
+                }
+            }
+            """,
+            """
+            abstract class Test {
+                abstract int start();
+                int test() /*~~(BB: 3 CN: 1 EX: 1 | L)~~>*/{
+                    int x = start();
+                    x++;
+                    for (int i : new int[]{1, 2, 3, 5}) /*~~(L)~~>*/{
+                        System.out.println(i);
+                    }
+                    return /*~~(L)~~>*/5;
+                }
+            }
+            """
+        )
+    )
 
     @Test
     fun typecast() = rewriteRun(


### PR DESCRIPTION
Control flow would throw an exception in the following case:

```java
for (int i : new int[]{1,2,3,5}) {
  //...
}
```

This fixes that case

Related https://github.com/openrewrite/rewrite/issues/1985