### PR TITLE
Fix `InvocationMatcher` bug looking too high for a call expression

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/internal/InvocationMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/internal/InvocationMatcher.java
@@ -146,8 +146,13 @@ public interface InvocationMatcher {
         }
 
         private static Optional<Expression> extractCallExpression(Cursor cursor) {
-            J stop = cursor.dropParentUntil(v -> v instanceof J.MethodInvocation || v instanceof J.NewClass || v instanceof J.Block).getValue();
-            if (stop instanceof J.Block) {
+            J stop = cursor.dropParentUntil(v ->
+                    v instanceof J.MethodInvocation || // Valid call expression
+                            v instanceof J.NewClass || // Valid call expression
+                            v instanceof J.Block || // Exit case
+                            v instanceof J.CompilationUnit // Exit case
+            ).getValue();
+            if (stop instanceof J.CompilationUnit || stop instanceof J.Block) {
                 return Optional.empty();
             }
             return Optional.of((Expression) stop);


### PR DESCRIPTION
`InvocationMatcher` was looking too high for a `J.MethodInvocation` or `J.NewClass` when none would be present. For example, if the `Expression` passed was for an import statement.