### PR TITLE
Fix Nullability on J.NewClass#getArguments to make it consistent

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3786,9 +3786,8 @@ public interface J extends Tree {
         @Nullable
         JContainer<Expression> arguments;
 
-        @Nullable
         public List<Expression> getArguments() {
-            return arguments == null ? null : arguments.getElements();
+            return arguments == null ? Collections.emptyList() : arguments.getElements();
         }
 
         public NewClass withArguments(@Nullable List<Expression> arguments) {


### PR DESCRIPTION
Makes it significantly easier to work with this API as end-users don't have to check for null when using `getArguments`.
Brings this API into alignment with `J.MethodInvocation`.

