### PR TITLE
Refactor and Optimize `InvocationMatcher`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/MethodCall.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/MethodCall.java
@@ -21,12 +21,14 @@ import java.util.List;
 
 /**
  * Either a {@link org.openrewrite.java.tree.J.MethodInvocation} or
+ * a {@link org.openrewrite.java.tree.J.MemberReference} or
  * a {@link org.openrewrite.java.tree.J.NewClass}.
  */
-public interface MethodCall extends J {
+public interface MethodCall extends Expression {
     @Nullable
     JavaType getType();
 
+    @Override
     MethodCall withType(@Nullable JavaType type);
 
     @Nullable


### PR DESCRIPTION
Take advantage of the new `MethodCall` interface in `InvocationMatcher`.
