### PR TITLE
Fix DataFlow & ControlFlow not working in doubly nested `doAfterVisit`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -246,7 +246,10 @@ public abstract class TreeVisitor<T extends Tree, P> {
 
             if (t != null) {
                 for (TreeVisitor<T, P> v : afterVisit) {
-                    t = v.visit(t, p);
+                    if (v != null) {
+                        v.setCursor(getCursor());
+                        t = v.visit(t, p);
+                    }
                 }
             }
 


### PR DESCRIPTION
This was because the visitors invoked in `doAfterVisit` did not have the correct cursor passed to them.
