### PR TITLE
Fix Javadoc parsing issue related to trailing whitespace.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -335,16 +335,25 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             body.add((Javadoc) scan(blockTag, body));
         }
 
+        // The javadoc ends with trailing whitespace.
         if (cursor < source.length() && source.substring(cursor).contains(" ")) {
             String trailingWhitespace = source.substring(cursor);
-            // The last line of the javadoc was a new line that only contained whitespace.
             if (trailingWhitespace.contains("\n")) {
-                int pos = Collections.min(lineBreaks.keySet());
-                body.add(lineBreaks.get(pos));
-                lineBreaks.remove(pos);
-                trailingWhitespace = trailingWhitespace.replace("\n", "");
+                // 1 or more newlines.
+                String[] parts = trailingWhitespace.split("\n");
+                for (String part : parts) {
+                    // Add trailing whitespace for each new line.
+                    if (!part.isEmpty()) {
+                        body.add(new Javadoc.Text(randomId(), Markers.EMPTY, part));
+                    }
+                    int pos = Collections.min(lineBreaks.keySet());
+                    body.add(lineBreaks.get(pos));
+                    lineBreaks.remove(pos);
+                }
+            } else {
+                // The Javadoc ends with trailing whitespace.
+                body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
             }
-            body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
         }
 
         if (!lineBreaks.isEmpty()) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -335,16 +335,25 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             body.add((Javadoc) scan(blockTag, body));
         }
 
+        // The javadoc ends with trailing whitespace.
         if (cursor < source.length() && source.substring(cursor).contains(" ")) {
             String trailingWhitespace = source.substring(cursor);
-            // The last line of the javadoc was a new line that only contained whitespace.
             if (trailingWhitespace.contains("\n")) {
-                int pos = Collections.min(lineBreaks.keySet());
-                body.add(lineBreaks.get(pos));
-                lineBreaks.remove(pos);
-                trailingWhitespace = trailingWhitespace.replace("\n", "");
+                // 1 or more newlines.
+                String[] parts = trailingWhitespace.split("\n");
+                for (String part : parts) {
+                    // Add trailing whitespace for each new line.
+                    if (!part.isEmpty()) {
+                        body.add(new Javadoc.Text(randomId(), Markers.EMPTY, part));
+                    }
+                    int pos = Collections.min(lineBreaks.keySet());
+                    body.add(lineBreaks.get(pos));
+                    lineBreaks.remove(pos);
+                }
+            } else {
+                // The Javadoc ends with trailing whitespace.
+                body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
             }
-            body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
         }
 
         if (!lineBreaks.isEmpty()) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -348,16 +348,25 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
             body.addAll(convertMultiline(singletonList(blockTag)));
         }
 
+        // The javadoc ends with trailing whitespace.
         if (cursor < source.length() && source.substring(cursor).contains(" ")) {
             String trailingWhitespace = source.substring(cursor);
-            // The last line of the javadoc was a new line that only contained whitespace.
             if (trailingWhitespace.contains("\n")) {
-                int pos = Collections.min(lineBreaks.keySet());
-                body.add(lineBreaks.get(pos));
-                lineBreaks.remove(pos);
-                trailingWhitespace = trailingWhitespace.replace("\n", "");
+                // 1 or more newlines.
+                String[] parts = trailingWhitespace.split("\n");
+                for (String part : parts) {
+                    // Add trailing whitespace for each new line.
+                    if (!part.isEmpty()) {
+                        body.add(new Javadoc.Text(randomId(), Markers.EMPTY, part));
+                    }
+                    int pos = Collections.min(lineBreaks.keySet());
+                    body.add(lineBreaks.get(pos));
+                    lineBreaks.remove(pos);
+                }
+            } else {
+                // The Javadoc ends with trailing whitespace.
+                body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
             }
-            body.add(new Javadoc.Text(randomId(), Markers.EMPTY, trailingWhitespace));
         }
 
         if (!lineBreaks.isEmpty()) {

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -1259,6 +1259,23 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/2046")
+    @Test
+    fun trailingWhitespaceAndMultilineMargin(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            interface Test {
+                /**
+                 * Text followed by whitespace, and multiple new lines with/without whitespace.        
+                 *
+                 * 
+                 */
+                void method();
+            }
+        """.trimIndent()
+    )
+
     // CRLF
     @Issue("https://github.com/openrewrite/rewrite/issues/980")
     @Test


### PR DESCRIPTION
Fix:

- Javadocs ending with multiple new lines with margins containing trailing whitespace will parse correctly.

fixes #2046