### PR TITLE
Print `JavaDoc.LineBreak` in place of new lines in `Space` for @link and @see

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -485,6 +485,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 Markers.EMPTY,
                 node.getKind() != DocTree.Kind.LINK,
                 spaceBeforeRef,
+                null,
                 reference,
                 label,
                 endBrace()
@@ -541,6 +542,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 randomId(),
                 Markers.EMPTY,
                 spaceBefore,
+                null,
                 reference,
                 convertMultiline(param.getDescription())
         );
@@ -752,7 +754,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             docs = convertMultiline(node.getReference());
         }
 
-        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, reference, docs);
+        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, null, reference, docs);
     }
 
     @Override

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -36,6 +36,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -470,7 +471,13 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         body.addAll(sourceBefore(node.getKind() == DocTree.Kind.LINK ? "{@link" : "{@linkplain"));
 
         List<Javadoc> spaceBeforeRef = whitespaceBefore();
+        Javadoc.Reference reference = null;
         J ref = visitReference(node.getReference(), body);
+        //noinspection ConstantConditions
+        if (ref != null) {
+            reference = new Javadoc.Reference(randomId(), ref, lineBreaksInMultilineJReference());
+        }
+
         List<Javadoc> label = convertMultiline(node.getLabel());
 
         return new Javadoc.Link(
@@ -478,7 +485,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 Markers.EMPTY,
                 node.getKind() != DocTree.Kind.LINK,
                 spaceBeforeRef,
-                ref,
+                reference,
                 label,
                 endBrace()
         );
@@ -504,32 +511,37 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     public Tree visitParam(ParamTree node, List<Javadoc> body) {
         body.addAll(sourceBefore("@param"));
         DCTree.DCParam param = (DCTree.DCParam) node;
+
+        List<Javadoc> spaceBefore;
         J typeName;
 
-        List<Javadoc> beforeName;
         if (param.isTypeParameter) {
-            beforeName = sourceBefore("<");
+            spaceBefore = sourceBefore("<");
+
+            String beforeName = whitespaceBeforeAsString();
+            Space namePrefix = beforeName.isEmpty() ? Space.EMPTY : Space.build(beforeName, emptyList());
             typeName = new J.TypeParameter(
                     randomId(),
                     Space.EMPTY,
                     Markers.EMPTY,
                     emptyList(),
-                    visitIdentifier(node.getName(), whitespaceBefore()),
+                    visitIdentifier(node.getName(), whitespaceBefore()).withPrefix(namePrefix),
                     null
             );
-
-            // FIXME could be space here
+            // The node will not be considered a type parameter if whitespace exists before `>`.
             sourceBefore(">");
         } else {
-            beforeName = whitespaceBefore();
+            spaceBefore = whitespaceBefore();
             typeName = (J) scan(node.getName(), body);
         }
 
+        List<Javadoc> beforeReference = lineBreaksInMultilineJReference();
+        Javadoc.Reference reference = new Javadoc.Reference(randomId(), typeName, beforeReference);
         return new Javadoc.Parameter(
                 randomId(),
                 Markers.EMPTY,
-                beforeName,
-                typeName,
+                spaceBefore,
+                reference,
                 convertMultiline(param.getDescription())
         );
     }
@@ -570,7 +582,6 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             } else {
                 qualifier = null;
             }
-
         }
 
         if (ref.memberName != null) {
@@ -724,17 +735,24 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     @Override
     public Tree visitSee(SeeTree node, List<Javadoc> body) {
         body.addAll(sourceBefore("@see"));
-        J ref = null;
+
+        Javadoc.Reference reference = null;
+
+        J ref;
         List<Javadoc> spaceBeforeTree = whitespaceBefore();
         List<Javadoc> docs;
         if (node.getReference().get(0) instanceof DCTree.DCReference) {
             ref = visitReference((ReferenceTree) node.getReference().get(0), body);
+            //noinspection ConstantConditions
+            if (ref != null) {
+                reference = new Javadoc.Reference(randomId(), ref, lineBreaksInMultilineJReference());
+            }
             docs = convertMultiline(node.getReference().subList(1, node.getReference().size()));
         } else {
             docs = convertMultiline(node.getReference());
         }
 
-        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, ref, docs);
+        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, reference, docs);
     }
 
     @Override
@@ -752,6 +770,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     @Override
     public Tree visitSerialField(SerialFieldTree node, List<Javadoc> body) {
         body.addAll(sourceBefore("@serialField"));
+
         return new Javadoc.SerialField(randomId(), Markers.EMPTY,
                 visitIdentifier(node.getName(), whitespaceBefore()),
                 visitReference(node.getType(), whitespaceBefore()),
@@ -1035,6 +1054,29 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
         return js;
+    }
+
+    /**
+     * A {@link J} may contain new lines in each {@link Space} and each new line will have a corresponding
+     * {@link org.openrewrite.java.tree.Javadoc.LineBreak}.
+     *
+     * This method collects the linebreaks associated to new lines in a Space, and removes the applicable linebreaks
+     * from the map.
+     */
+    private List<Javadoc> lineBreaksInMultilineJReference() {
+        List<Integer> linebreakIndexes = lineBreaks.keySet().stream()
+                .filter(o -> o <= cursor)
+                .collect(Collectors.toList());
+
+        List<Javadoc> referenceLineBreaks = linebreakIndexes.stream()
+                .sorted()
+                .map(lineBreaks::get)
+                .collect(Collectors.toList());
+
+        for (Integer key : linebreakIndexes) {
+            lineBreaks.remove(key);
+        }
+        return referenceLineBreaks;
     }
 
     class JavaVisitor extends TreeScanner<J, Space> {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -485,6 +485,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 Markers.EMPTY,
                 node.getKind() != DocTree.Kind.LINK,
                 spaceBeforeRef,
+                null,
                 reference,
                 label,
                 endBrace()
@@ -541,6 +542,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 randomId(),
                 Markers.EMPTY,
                 spaceBefore,
+                null,
                 reference,
                 convertMultiline(param.getDescription())
         );
@@ -753,7 +755,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             docs = convertMultiline(node.getReference());
         }
 
-        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, reference, docs);
+        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, null, reference, docs);
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -36,6 +36,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -470,7 +471,13 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         body.addAll(sourceBefore(node.getKind() == DocTree.Kind.LINK ? "{@link" : "{@linkplain"));
 
         List<Javadoc> spaceBeforeRef = whitespaceBefore();
+        Javadoc.Reference reference = null;
         J ref = visitReference(node.getReference(), body);
+        //noinspection ConstantConditions
+        if (ref != null) {
+            reference = new Javadoc.Reference(randomId(), ref, lineBreaksInMultilineJReference());
+        }
+
         List<Javadoc> label = convertMultiline(node.getLabel());
 
         return new Javadoc.Link(
@@ -478,7 +485,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 Markers.EMPTY,
                 node.getKind() != DocTree.Kind.LINK,
                 spaceBeforeRef,
-                ref,
+                reference,
                 label,
                 endBrace()
         );
@@ -504,32 +511,37 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     public Tree visitParam(ParamTree node, List<Javadoc> body) {
         body.addAll(sourceBefore("@param"));
         DCTree.DCParam param = (DCTree.DCParam) node;
+
+        List<Javadoc> spaceBefore;
         J typeName;
 
-        List<Javadoc> beforeName;
         if (param.isTypeParameter) {
-            beforeName = sourceBefore("<");
+            spaceBefore = sourceBefore("<");
+
+            String beforeName = whitespaceBeforeAsString();
+            Space namePrefix = beforeName.isEmpty() ? Space.EMPTY : Space.build(beforeName, emptyList());
             typeName = new J.TypeParameter(
                     randomId(),
                     Space.EMPTY,
                     Markers.EMPTY,
                     emptyList(),
-                    visitIdentifier(node.getName(), whitespaceBefore()),
+                    visitIdentifier(node.getName(), whitespaceBefore()).withPrefix(namePrefix),
                     null
             );
-
-            // FIXME could be space here
+            // The node will not be considered a type parameter if whitespace exists before `>`.
             sourceBefore(">");
         } else {
-            beforeName = whitespaceBefore();
+            spaceBefore = whitespaceBefore();
             typeName = (J) scan(node.getName(), body);
         }
 
+        List<Javadoc> beforeReference = lineBreaksInMultilineJReference();
+        Javadoc.Reference reference = new Javadoc.Reference(randomId(), typeName, beforeReference);
         return new Javadoc.Parameter(
                 randomId(),
                 Markers.EMPTY,
-                beforeName,
-                typeName,
+                spaceBefore,
+                reference,
                 convertMultiline(param.getDescription())
         );
     }
@@ -724,17 +736,24 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     @Override
     public Tree visitSee(SeeTree node, List<Javadoc> body) {
         body.addAll(sourceBefore("@see"));
-        J ref = null;
+
+        Javadoc.Reference reference = null;
+
+        J ref;
         List<Javadoc> spaceBeforeTree = whitespaceBefore();
         List<Javadoc> docs;
         if (node.getReference().get(0) instanceof DCTree.DCReference) {
             ref = visitReference((ReferenceTree) node.getReference().get(0), body);
+            //noinspection ConstantConditions
+            if (ref != null) {
+                reference = new Javadoc.Reference(randomId(), ref, lineBreaksInMultilineJReference());
+            }
             docs = convertMultiline(node.getReference().subList(1, node.getReference().size()));
         } else {
             docs = convertMultiline(node.getReference());
         }
 
-        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, ref, docs);
+        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, reference, docs);
     }
 
     @Override
@@ -1035,6 +1054,30 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
         return js;
+    }
+
+    /**
+     * A {@link J} may contain new lines in each {@link Space} and each new line will have a corresponding
+     * {@link org.openrewrite.java.tree.Javadoc.LineBreak}.
+     *
+     * This method collects the linebreaks associated to new lines in a Space, and removes the applicable linebreaks
+     * from the map.
+     */
+    private List<Javadoc> lineBreaksInMultilineJReference() {
+        @SuppressWarnings("SimplifyStreamApiCallChains")
+        List<Integer> linebreakIndexes = lineBreaks.keySet().stream()
+                .filter(o -> o <= cursor)
+                .collect(Collectors.toList());
+
+        List<Javadoc> referenceLineBreaks = linebreakIndexes.stream()
+                .sorted()
+                .map(lineBreaks::get)
+                .collect(Collectors.toList());
+
+        for (Integer key : linebreakIndexes) {
+            lineBreaks.remove(key);
+        }
+        return referenceLineBreaks;
     }
 
     class JavaVisitor extends TreeScanner<J, Space> {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -455,6 +455,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                 Markers.EMPTY,
                 node.getKind() != DocTree.Kind.LINK,
                 spaceBeforeRef,
+                null,
                 reference,
                 label,
                 endBrace()
@@ -511,6 +512,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                 randomId(),
                 Markers.EMPTY,
                 spaceBefore,
+                null,
                 reference,
                 convertMultiline(param.getDescription())
         );
@@ -707,7 +709,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
             docs = convertMultiline(node.getReference());
         }
 
-        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, reference, docs);
+        return new Javadoc.See(randomId(), Markers.EMPTY, spaceBeforeTree, null, reference, docs);
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
@@ -146,7 +146,7 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
         visitMarkers(link.getMarkers(), p);
         p.append(link.isPlain() ? "{@linkplain" : "{@link");
         visit(link.getSpaceBeforeTree(), p);
-        visit(link.getTree(), p);
+        visit(link.getTreeReference(), p);
         visit(link.getLabel(), p);
         visit(link.getEndBrace(), p);
         return link;
@@ -166,7 +166,7 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
         visitMarkers(parameter.getMarkers(), p);
         p.append("@param");
         visit(parameter.getSpaceBeforeName(), p);
-        visit(parameter.getName(), p);
+        visit(parameter.getNameReference(), p);
         visit(parameter.getDescription(), p);
         return parameter;
     }
@@ -194,7 +194,7 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
         visitMarkers(see.getMarkers(), p);
         p.append("@see");
         visit(see.getSpaceBeforeTree(), p);
-        visit(see.getTree(), p);
+        visit(see.getTreeReference(), p);
         visit(see.getReference(), p);
         return see;
     }
@@ -317,8 +317,8 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
 
     @Override
     public Javadoc visitReference(Javadoc.Reference reference, PrintOutputCapture<P> p) {
-        getCursor().putMessageOnFirstEnclosing(Javadoc.DocComment.class, "LINE_BREAKS", reference.getLineBreaks());
-        getCursor().putMessage("INDEX", 0);
+        getCursor().putMessageOnFirstEnclosing(Javadoc.DocComment.class, "JAVADOC_LINE_BREAKS", reference.getLineBreaks());
+        getCursor().putMessage("JAVADOC_LINE_BREAK_INDEX", 0);
         javaVisitor.visit(reference.getTree(), p, getCursor());
         return reference;
     }
@@ -384,8 +384,8 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
 
         @Override
         public Space visitSpace(Space space, Space.Location loc, PrintOutputCapture<P> p) {
-            List<Javadoc.LineBreak> lineBreaks = getCursor().getNearestMessage("LINE_BREAKS");
-            Integer index = getCursor().getNearestMessage("INDEX");
+            List<Javadoc.LineBreak> lineBreaks = getCursor().getNearestMessage("JAVADOC_LINE_BREAKS");
+            Integer index = getCursor().getNearestMessage("JAVADOC_LINE_BREAK_INDEX");
 
             if (lineBreaks != null && index != null && space.getWhitespace().contains("\n")) {
                 for (char c : space.getWhitespace().toCharArray()) {
@@ -399,7 +399,7 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
                         p.append(c);
                     }
                 }
-                getCursor().putMessageOnFirstEnclosing(Javadoc.DocComment.class, "INDEX", index);
+                getCursor().putMessageOnFirstEnclosing(Javadoc.DocComment.class, "JAVADOC_LINE_BREAK_INDEX", index);
             } else {
                 p.append(space.getWhitespace());
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocVisitor.java
@@ -119,9 +119,7 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         Javadoc.Link l = link;
         l = l.withMarkers(visitMarkers(l.getMarkers(), p));
         l = l.withSpaceBeforeTree(ListUtils.map(l.getSpaceBeforeTree(), s -> visit(s, p)));
-        if (l.getTree() != null) {
-            l = l.withTree((Javadoc.Reference) visitReference(l.getTree(), p));
-        }
+        l = l.withTreeReference(visitAndCast(l.getTreeReference() , p));
         l = l.withLabel(ListUtils.map(l.getLabel(), la -> visit(la, p)));
         l = l.withEndBrace(ListUtils.map(l.getEndBrace(), s -> visit(s, p)));
         return l;
@@ -138,9 +136,7 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         Javadoc.Parameter pa = parameter;
         pa = pa.withMarkers(visitMarkers(pa.getMarkers(), p));
         pa = pa.withSpaceBeforeName(ListUtils.map(pa.getSpaceBeforeName(), b -> visit(b, p)));
-        if (pa.getName() != null) {
-            pa = pa.withName((Javadoc.Reference) visit(pa.getName(), p));
-        }
+        pa = pa.withNameReference(visitAndCast(pa.getNameReference(), p));
         pa = pa.withDescription(ListUtils.map(pa.getDescription(), desc -> visit(desc, p)));
         return pa;
     }
@@ -164,9 +160,7 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         Javadoc.See s = see;
         s = s.withMarkers(visitMarkers(s.getMarkers(), p));
         s = s.withSpaceBeforeTree(ListUtils.map(s.getSpaceBeforeTree(), sb -> visit(sb, p)));
-        if (s.getTree() != null) {
-            s = s.withTree((Javadoc.Reference) visitReference(s.getTree(), p));
-        }
+        s = s.withTreeReference(visitAndCast(s.getTreeReference() , p));
         s = s.withReference(ListUtils.map(s.getReference(), desc -> visit(desc, p)));
         return s;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocVisitor.java
@@ -119,7 +119,9 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         Javadoc.Link l = link;
         l = l.withMarkers(visitMarkers(l.getMarkers(), p));
         l = l.withSpaceBeforeTree(ListUtils.map(l.getSpaceBeforeTree(), s -> visit(s, p)));
-        l = l.withTree(javaVisitor.visit(l.getTree(), p));
+        if (l.getTree() != null) {
+            l = l.withTree((Javadoc.Reference) visitReference(l.getTree(), p));
+        }
         l = l.withLabel(ListUtils.map(l.getLabel(), la -> visit(la, p)));
         l = l.withEndBrace(ListUtils.map(l.getEndBrace(), s -> visit(s, p)));
         return l;
@@ -136,7 +138,9 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         Javadoc.Parameter pa = parameter;
         pa = pa.withMarkers(visitMarkers(pa.getMarkers(), p));
         pa = pa.withSpaceBeforeName(ListUtils.map(pa.getSpaceBeforeName(), b -> visit(b, p)));
-        pa = pa.withName(javaVisitor.visit(pa.getName(), p));
+        if (pa.getName() != null) {
+            pa = pa.withName((Javadoc.Reference) visit(pa.getName(), p));
+        }
         pa = pa.withDescription(ListUtils.map(pa.getDescription(), desc -> visit(desc, p)));
         return pa;
     }
@@ -160,7 +164,9 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         Javadoc.See s = see;
         s = s.withMarkers(visitMarkers(s.getMarkers(), p));
         s = s.withSpaceBeforeTree(ListUtils.map(s.getSpaceBeforeTree(), sb -> visit(sb, p)));
-        s = s.withTree(javaVisitor.visit(s.getTree(), p));
+        if (s.getTree() != null) {
+            s = s.withTree((Javadoc.Reference) visitReference(s.getTree(), p));
+        }
         s = s.withReference(ListUtils.map(s.getReference(), desc -> visit(desc, p)));
         return s;
     }
@@ -250,5 +256,12 @@ public class JavadocVisitor<P> extends TreeVisitor<Javadoc, P> {
         v = v.withMarkers(visitMarkers(v.getMarkers(), p));
         v = v.withBody(ListUtils.map(v.getBody(), b -> visit(b, p)));
         return v;
+    }
+
+    public Javadoc visitReference(Javadoc.Reference reference, P p) {
+        Javadoc.Reference r = reference;
+        r = r.withTree(javaVisitor.visit(r.getTree(), p));
+        r = r.withLineBreaks(ListUtils.map(r.getLineBreaks(), l -> visit(l, p)));
+        return r;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Javadoc.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Javadoc.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.JavadocPrinter;
 import org.openrewrite.java.JavadocVisitor;
 import org.openrewrite.marker.Markers;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -329,7 +330,7 @@ public interface Javadoc extends Tree {
         List<Javadoc> spaceBeforeTree;
 
         @Nullable
-        J tree;
+        Reference tree;
 
         List<Javadoc> label;
 
@@ -368,7 +369,7 @@ public interface Javadoc extends Tree {
 
         Markers markers;
         List<Javadoc> spaceBeforeName;
-        J name;
+        Reference name;
         List<Javadoc> description;
 
         @Override
@@ -422,7 +423,7 @@ public interface Javadoc extends Tree {
         List<Javadoc> spaceBeforeTree;
 
         @Nullable
-        J tree;
+        Reference tree;
 
         List<Javadoc> reference;
 
@@ -640,6 +641,29 @@ public interface Javadoc extends Tree {
         @Override
         public <P> Javadoc acceptJavadoc(JavadocVisitor<P> v, P p) {
             return v.visitVersion(this, p);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Reference implements Javadoc {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        @Nullable
+        J tree;
+
+        @Nullable
+        List<Javadoc> lineBreaks;
+
+        public List<Javadoc> getLineBreaks() {
+            return lineBreaks == null ? Collections.emptyList() : lineBreaks;
+        }
+
+        @Override
+        public <P> Javadoc acceptJavadoc(JavadocVisitor<P> v, P p) {
+            return v.visitReference(this, p);
         }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Javadoc.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Javadoc.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.tree;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import lombok.experimental.NonFinal;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
@@ -330,7 +331,20 @@ public interface Javadoc extends Tree {
         List<Javadoc> spaceBeforeTree;
 
         @Nullable
-        Reference tree;
+        J tree;
+
+        @Nullable
+        public Reference getTreeReference() {
+            if (tree != null && treeReference == null) {
+                treeReference = new Reference(Tree.randomId(), tree, null);
+            }
+            return treeReference;
+        }
+
+        // This is non-final to maintain backwards compatibility.
+        @NonFinal
+        @Nullable
+        Reference treeReference;
 
         List<Javadoc> label;
 
@@ -369,7 +383,23 @@ public interface Javadoc extends Tree {
 
         Markers markers;
         List<Javadoc> spaceBeforeName;
-        Reference name;
+
+        @Nullable
+        J name;
+
+        @Nullable
+        public Reference getNameReference() {
+            if (name != null && nameReference == null) {
+                nameReference = new Reference(Tree.randomId(), name, null);
+            }
+            return nameReference;
+        }
+
+        // This is non-final to maintain backwards compatibility.
+        @NonFinal
+        @Nullable
+        Reference nameReference;
+
         List<Javadoc> description;
 
         @Override
@@ -423,7 +453,20 @@ public interface Javadoc extends Tree {
         List<Javadoc> spaceBeforeTree;
 
         @Nullable
-        Reference tree;
+        J tree;
+
+        @Nullable
+        public Reference getTreeReference() {
+            if (tree != null && treeReference == null) {
+                treeReference = new Reference(Tree.randomId(), tree, null);
+            }
+            return treeReference;
+        }
+
+        // This is non-final to maintain backwards compatibility.
+        @NonFinal
+        @Nullable
+        Reference treeReference;
 
         List<Javadoc> reference;
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/tree/JavadocTest.kt
@@ -15,13 +15,13 @@
  */
 package org.openrewrite.java.tree
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaTreeTest
 import org.openrewrite.java.JavaTreeTest.NestingLevel.CompilationUnit
 
+@Suppress("JavadocDeclaration")
 interface JavadocTest : JavaTreeTest {
 
     @Test
@@ -637,6 +637,34 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/963")
+    @Test
+    fun blankLink(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            /**
+             * {@link}
+             */
+            class Test {
+            }
+        """.trimIndent()
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/968")
+    @Test
+    fun missingBracket(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            /**
+             * {@link missing.bracket
+             */
+            class Test {
+            }
+        """.trimIndent()
+    )
+
     @Test
     fun methodReferenceNoParameters(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
@@ -714,6 +742,20 @@ interface JavadocTest : JavaTreeTest {
 
     // param
     @Test
+    fun emptyParam(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            public class A {
+                /**
+                 * @param
+                 */
+                void method(int val) {}
+            }
+        """.trimIndent()
+    )
+
+    @Test
     fun param(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
         CompilationUnit,
@@ -738,23 +780,6 @@ interface JavadocTest : JavaTreeTest {
     )
 
     @Test
-    fun paramWithoutMargin(jp: JavaParser) = assertParsePrintAndProcess(
-        jp,
-        CompilationUnit,
-        """
-            public class Test {
-                /** Text
-                 @return No margin
-                 */
-                public int test() {
-                    return 0;
-                }
-            }
-        """.trimIndent()
-    )
-
-    @Disabled
-    @Test
     fun lineBreakInParam(jp: JavaParser) = assertParsePrintAndProcess(
         jp,
         CompilationUnit,
@@ -763,8 +788,10 @@ interface JavadocTest : JavaTreeTest {
                 /**
                  * @param <
                  *   T> t hi
+                 * @param 
+                 *   val
                  */
-                <T> boolean test();
+                <T> boolean test(int val);
             }
         """.trimIndent()
     )
@@ -818,34 +845,6 @@ interface JavadocTest : JavaTreeTest {
         """.trimIndent()
     )
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/963")
-    @Test
-    fun blankLink(jp: JavaParser) = assertParsePrintAndProcess(
-        jp,
-        CompilationUnit,
-        """
-            /**
-             * {@link}
-             */
-            class Test {
-            }
-        """.trimIndent()
-    )
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/968")
-    @Test
-    fun missingBracket(jp: JavaParser) = assertParsePrintAndProcess(
-        jp,
-        CompilationUnit,
-        """
-            /**
-             * {@link missing.bracket
-             */
-            class Test {
-            }
-        """.trimIndent()
-    )
-
     // provides
     @Test
     fun provide(jp: JavaParser) = assertParsePrintAndProcess(
@@ -872,6 +871,22 @@ interface JavadocTest : JavaTreeTest {
                  * @return id
                  */
                 int method(int val) {}
+            }
+        """.trimIndent()
+    )
+
+    @Test
+    fun returnWithoutMargin(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            public class Test {
+                /** Text
+                 @return No margin
+                 */
+                public int test() {
+                    return 0;
+                }
             }
         """.trimIndent()
     )
@@ -1272,6 +1287,31 @@ interface JavadocTest : JavaTreeTest {
                  * 
                  */
                 void method();
+            }
+        """.trimIndent()
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1078")
+    @Test
+    fun seeWithMultilineMethodInvocation(jp: JavaParser) = assertParsePrintAndProcess(
+        jp,
+        CompilationUnit,
+        """
+            import java.lang.Math;
+            
+            interface Test {
+                /**
+                 * @see Math#pow(
+                 * 
+                 *    double   
+                 * 
+                 *
+                 *    ,    
+                 * double
+                 * 
+                 * )
+                 */
+                boolean test();
             }
         """.trimIndent()
     )


### PR DESCRIPTION
Changes:
- Added `JavaDoc.LineBreak` detection in a `J.*` and applied detection to `@link` and `@see`.
- Added `Javadoc.Reference` to wrap linebreaks associated with a `J`.
- Added `visitLineBreak` in `Javadoc.JavaVisitor`.
- Added support to print multiline `@param`.
- Added `LineBreak` printing in place of new lines in `Space` in the JavaDocJavaPrinter.

fixes #1078