### PR TITLE
Guard against null JavaType$Method declaringType in DataFlow models

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/ExternalFlowModels.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/ExternalFlowModels.java
@@ -215,10 +215,12 @@ final class ExternalFlowModels {
         FlowModels forTypesInUse(TypesInUse typesInUse) {
             Set<FlowModel> value = new HashSet<>();
             Set<FlowModel> taint = new HashSet<>();
+            //noinspection ConstantConditions
             typesInUse
                     .getUsedMethods()
                     .stream()
                     .map(JavaType.Method::getDeclaringType)
+                    .filter(o -> o != null && !(o instanceof JavaType.Unknown))
                     .map(JavaType.FullyQualified::getFullyQualifiedName)
                     .distinct()
                     .forEach(fqn -> {

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/ExternalSinkModels.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/ExternalSinkModels.java
@@ -187,10 +187,12 @@ public final class ExternalSinkModels {
          */
         SinkModels forTypesInUse(TypesInUse typesInUse) {
             Map<String, Set<SinkModel>> sinkModels = new HashMap<>();
+            //noinspection ConstantConditions
             typesInUse
                     .getUsedMethods()
                     .stream()
                     .map(JavaType.Method::getDeclaringType)
+                    .filter(o -> o != null && !(o instanceof JavaType.Unknown))
                     .map(JavaType.FullyQualified::getFullyQualifiedName)
                     .distinct()
                     .flatMap(fqn -> fqnToSinkModels.getOrDefault(


### PR DESCRIPTION
Fix:

- ExternalSinkModels and ExternalFlowModels will not NPE when `JavaType$Method#declaringType` is null.