### PR TITLE
ChangeParentPom now runs RemoveRedundantDependencyVersion both before and after applying the new parent to the maven model

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -138,7 +138,9 @@ public class ChangeParentPom extends Recipe {
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
                 Xml.Document m = super.visitDocument(document, executionContext);
                 if(m != document) {
-                    maybeUpdateModel();
+                    doAfterVisit(new RemoveRedundantDependencyVersions(null, null, true));
+                    doAfterVisit(new UpdateMavenModel<>());
+                    doAfterVisit(new RemoveRedundantDependencyVersions(null, null, true));
                 }
                 return m;
             }
@@ -172,7 +174,6 @@ public class ChangeParentPom extends Recipe {
                             if (!oldVersion.equals(targetVersion.get())) {
                                 t = (Xml.Tag) new ChangeTagValueVisitor<>(t.getChild("version").get(), targetVersion.get()).visitNonNull(t, ctx);
                             }
-                            doAfterVisit(new RemoveRedundantDependencyVersions(null, null, true));
                         }
                     }
                 }


### PR DESCRIPTION
Subjective change, but I think it's a good one. The recipe already has the opinion of removing redundant versions in favor of the managed, and now it'll do it with the new parent's set of managed versions as well. (Previously it only ran the RRDV *before* updating the parent)

Meanwhile, I *believe* `maybeUpdateModel` and `doAfterVisit(new UpdateMavenModel<>())` are equivalent in this context (there's no path for this recipe to call the line more than once per execution), so I switched to `doAfterVisit` for consistent readability with the RRDV calls. But if I missed some detail, that can be switched back. Similarly, moving the original RRDV call over to where it is now should be equivalent but more readable.