### PR TITLE
Yaml ChangePropertyKey enhancements

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -67,6 +67,12 @@ public class ChangePropertyKey extends Recipe {
     @Nullable
     String fileMatcher;
 
+    @Option(displayName = "Except",
+            description = "If any of these property keys exist as direct children of `oldPropertyKey`, then they will not be moved to `newPropertyKey`.",
+            required = false)
+    @Nullable
+    List<String> except;
+
     @Override
     public String getDisplayName() {
         return "Change property key";
@@ -115,7 +121,8 @@ public class ChangePropertyKey extends Recipe {
                     Yaml.Mapping.Entry propertyEntry = propertyEntriesLeftToRight.next();
                     String value = propertyEntry.getKey().getValue() + ".";
 
-                    if (!propertyToTest.startsWith(value ) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext())) {
+                    if ((!propertyToTest.startsWith(value ) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext()))
+                        && hasNonExcludedValues(propertyEntry)) {
                         doAfterVisit(new InsertSubpropertyVisitor<>(
                                 propertyEntry,
                                 propertyToTest,
@@ -128,7 +135,8 @@ public class ChangePropertyKey extends Recipe {
             } else {
                 String parentProp = prop.substring(0, prop.length() - e.getKey().getValue().length()).replaceAll(".$", "");
                 if (matches(prop, oldPropertyKey + ".*") &&
-                        !(matches(parentProp, oldPropertyKey + ".*") || matches(parentProp, oldPropertyKey))) {
+                        !(matches(parentProp, oldPropertyKey + ".*") || matches(parentProp, oldPropertyKey)) &&
+                        noneMatch(prop, oldPropertyKey, excludedSubKeys())) {
                     Iterator<Yaml.Mapping.Entry> propertyEntriesLeftToRight = propertyEntries.descendingIterator();
                     while (propertyEntriesLeftToRight.hasNext()) {
                         Yaml.Mapping.Entry propertyEntry = propertyEntriesLeftToRight.next();
@@ -151,13 +159,71 @@ public class ChangePropertyKey extends Recipe {
         }
     }
 
+    private boolean hasNonExcludedValues(Yaml.Mapping.Entry propertyEntry) {
+        if (!(propertyEntry.getValue() instanceof Yaml.Mapping)) {
+            return true;
+        } else {
+            for (Yaml.Mapping.Entry entry : ((Yaml.Mapping) propertyEntry.getValue()).getEntries()) {
+                if (noneMatch(entry, excludedSubKeys())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private boolean hasExcludedValues(Yaml.Mapping.Entry propertyEntry) {
+        if (propertyEntry.getValue() instanceof Yaml.Mapping) {
+            for (Yaml.Mapping.Entry entry : ((Yaml.Mapping) propertyEntry.getValue()).getEntries()) {
+                if (anyMatch(entry, excludedSubKeys())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean anyMatch(Yaml.Mapping.Entry entry, List<String> subKeys) {
+        for (String subKey : subKeys) {
+            if (entry.getKey().getValue().equals(subKey)
+                    || entry.getKey().getValue().startsWith(subKey + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean noneMatch(Yaml.Mapping.Entry entry, List<String> subKeys) {
+        for (String subKey : subKeys) {
+            if (entry.getKey().getValue().equals(subKey)
+                    || entry.getKey().getValue().startsWith(subKey + ".")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean noneMatch(String key, String basePattern, List<String> excludedSubKeys) {
+        for (String subkey : excludedSubKeys) {
+            String subKeyPattern = basePattern + "." + subkey;
+            if (matches(key, subKeyPattern) || matches(key, subKeyPattern + ".*")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private boolean matches(String string, String pattern) {
         return !Boolean.FALSE.equals(relaxedBinding) ?
                 NameCaseConvention.matchesRelaxedBinding(string, pattern) :
                 StringUtils.matchesGlob(string, pattern);
     }
 
-    private static class InsertSubpropertyVisitor<P> extends YamlIsoVisitor<P> {
+    private List<String> excludedSubKeys() {
+        return except != null ? except : Collections.emptyList();
+    }
+
+    private class InsertSubpropertyVisitor<P> extends YamlIsoVisitor<P> {
         private final Yaml.Mapping.Entry scope;
         private final String subproperty;
         private final Yaml.Mapping.Entry entryToReplace;
@@ -179,24 +245,63 @@ public class ChangePropertyKey extends Recipe {
                         new Yaml.Scalar(randomId(), "", Markers.EMPTY,
                                 Yaml.Scalar.Style.PLAIN, null, subproperty),
                         scope.getBeforeMappingValueIndicator(),
-                        entryToReplace.getValue().copyPaste());
+                        removeExclusions(entryToReplace.getValue().copyPaste()));
 
-                if (m.getEntries().contains(entryToReplace)) {
-                    m = m.withEntries(ListUtils.map(m.getEntries(), e -> {
-                        if (e.equals(entryToReplace)) {
-                            return newEntry.withPrefix(e.getPrefix());
-                        }
-                        return e;
-                    }));
+                if (hasExcludedValues(entryToReplace)) {
+                    m = m.withEntries(ListUtils.concat(m.getEntries(), newEntry));
                 } else {
-                    m = (Yaml.Mapping) new DeletePropertyVisitor<>(entryToReplace).visitNonNull(m, p);
-                    m = maybeAutoFormat(m, m.withEntries(ListUtils.concat(m.getEntries(), newEntry)), p, getCursor().getParentOrThrow());
+                    if (m.getEntries().contains(entryToReplace)) {
+                        m = m.withEntries(ListUtils.map(m.getEntries(), e -> {
+                            if (e.equals(entryToReplace)) {
+                                return newEntry.withPrefix(e.getPrefix());
+                            }
+                            return e;
+                        }));
+                    } else {
+                        m = (Yaml.Mapping) new DeletePropertyVisitor<>(entryToReplace).visitNonNull(m, p);
+                        m = maybeAutoFormat(m, m.withEntries(ListUtils.concat(m.getEntries(), newEntry)), p, getCursor().getParentOrThrow());
+                    }
                 }
             }
 
             return m;
         }
+
+        @Override
+        public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry originalEntry, P p) {
+            final Yaml.Mapping.Entry e = super.visitMappingEntry(originalEntry, p);
+            if (e == entryToReplace && hasNonExcludedValues(entryToReplace) && e.getValue() instanceof Yaml.Mapping) {
+                return e.withValue(onlyExclusions((Yaml.Mapping) e.getValue()));
+            }
+            return e;
+        }
+
+        private Yaml.Mapping onlyExclusions(final Yaml.Mapping mapping) {
+            List<Yaml.Mapping.Entry> list = new ArrayList<>();
+            for (Yaml.Mapping.Entry entry : mapping.getEntries()) {
+                if (!noneMatch(entry, excludedSubKeys())) {
+                    list.add(entry);
+                }
+            }
+            return mapping.withEntries(list);
+        }
+
+        private Yaml.Block removeExclusions(Yaml.Block block) {
+            if (!(block instanceof Yaml.Mapping)) {
+                return block;
+            } else {
+                Yaml.Mapping mapping = (Yaml.Mapping) block;
+                List<Yaml.Mapping.Entry> list = new ArrayList<>();
+                for (Yaml.Mapping.Entry entry : mapping.getEntries()) {
+                    if (noneMatch(entry, excludedSubKeys())) {
+                        list.add(entry);
+                    }
+                }
+                return mapping.withEntries(list);
+            }
+        }
     }
+
     private static class DeletePropertyVisitor<P> extends YamlIsoVisitor<P> {
         private final Yaml.Mapping.Entry scope;
 

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
@@ -122,14 +122,38 @@ class ChangePropertyKeyTest : YamlRecipeTest {
         """
     )
 
+    @Nested
+    inner class AvoidsRegenerativeChanges {
+        @Test
+        fun `indented property`() = assertUnchanged(
+            recipe = ChangePropertyKey("a.b.c", "a.b.c.d", null, null, null),
+            before = """
+            a:
+              b:
+                c:
+                  d: true
+            """
+        )
+
+        @Test
+        fun `dot-separated property equal to newPropertyKey`() = assertUnchanged(
+            recipe = ChangePropertyKey("a.b.c", "a.b.c.d", null, null, null),
+            before = "a.b.c.d: true",
+        )
+
+        @Test
+        fun `dot-separated property including newPropertyKey`() = assertUnchanged(
+            recipe = ChangePropertyKey("a.b.c", "a.b.c.d", null, null, null),
+            before = "a.b.c.d.x: true",
+        )
+    }
+
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1114")
     fun `change path to one path longer`() = assertChanged(
         recipe = ChangePropertyKey("a.b.c", "a.b.c.d", null, null, null),
         before = "a.b.c: true",
         after = "a.b.c.d: true",
-        cycles = 1,
-        expectedCyclesThatMakeChanges = 1
     )
 
     @Test

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangePropertyKeyTest.kt
@@ -31,13 +31,14 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "management.metrics.binders.*.enabled",
             "management.metrics.enable.process.files",
             null,
+            null,
             null
         )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1873")
     @Test
     fun `shorter new key with indented config`() = assertChanged(
-        recipe = ChangePropertyKey("a.b.c.d.e", "x.y", null, null),
+        recipe = ChangePropertyKey("a.b.c.d.e", "x.y", null, null, null),
         before =
         """
         a:
@@ -56,7 +57,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1873")
     @Test
     fun `longer new key with indented config`() = assertChanged(
-        recipe = ChangePropertyKey("x.y", "a.b.c.d.e",  null, null),
+        recipe = ChangePropertyKey("x.y", "a.b.c.d.e",  null, null, null),
         before =
         """
         x:
@@ -86,6 +87,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
         recipe = ChangePropertyKey(
             "management.metrics.binders.files.enabled",
             "management.metrics.enable.process.files",
+            null,
             null,
             null
         ),
@@ -123,7 +125,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1114")
     fun `change path to one path longer`() = assertChanged(
-        recipe = ChangePropertyKey("a.b.c", "a.b.c.d", null, null),
+        recipe = ChangePropertyKey("a.b.c", "a.b.c.d", null, null, null),
         before = "a.b.c: true",
         after = "a.b.c.d: true",
         cycles = 1,
@@ -132,7 +134,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
 
     @Test
     fun `change path to one path shorter`() = assertChanged(
-        recipe = ChangePropertyKey("a.b.c.d", "a.b.c", null, null),
+        recipe = ChangePropertyKey("a.b.c.d", "a.b.c", null, null, null),
         before = "a.b.c.d: true",
         after = "a.b.c: true"
     )
@@ -151,7 +153,8 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "management.metrics.binders.files.enabled",
             "management.metrics.enable.process.files",
             null,
-            "**/a.yml"
+            "**/a.yml",
+            null
         )
         assertChanged(recipe = recipe, before = matchingFile, after = "management.metrics.enable.process.files: true")
         assertUnchanged(recipe = recipe, before = nonMatchingFile)
@@ -167,7 +170,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     )
     @Issue("https://github.com/openrewrite/rewrite/issues/1168")
     fun relaxedBinding(propertyKey: String) = assertChanged(
-        recipe = ChangePropertyKey(propertyKey, "acme.my-project.person.changed-first-name-key", true, null),
+        recipe = ChangePropertyKey(propertyKey, "acme.my-project.person.changed-first-name-key", true, null, null),
         before = """
             unrelated.root: true
             acme.my-project:
@@ -193,6 +196,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "acme.my-project.person.first-name",
             "acme.my-project.person.changed-first-name-key",
             false,
+            null,
             null
         ),
         before = """
@@ -214,6 +218,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "i",
             "a.b.c",
             false,
+            null,
             null
         ),
         before = """
@@ -243,6 +248,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "old-property",
             "new-property.sub-property.super-sub",
             true,
+            null,
             null
         ),
         before = """
@@ -271,6 +277,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "a.b.c.a0",
             "a.b.a0",
             true,
+            null,
             null
         ),
         before = """
@@ -291,6 +298,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "description",
             "newDescription",
             false,
+            null,
             null
         ),
         before = """
@@ -308,7 +316,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1744")
     @Test
     fun updatePropertyWithMapping() = assertChanged(
-        recipe = ChangePropertyKey("app.foo.change.from", "app.bar.change.to", null, null),
+        recipe = ChangePropertyKey("app.foo.change.from", "app.bar.change.to", null, null, null),
         before = """
             app:
               foo.change.from: hi
@@ -328,20 +336,20 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @Test
     fun checkValidation() {
-        var recipe = ChangePropertyKey(null, null, null, null)
+        var recipe = ChangePropertyKey(null, null, null, null, null)
         var valid = recipe.validate()
         assertThat(valid.isValid).isFalse
         assertThat(valid.failures()).hasSize(2)
         assertThat(valid.failures()[0].property).isEqualTo("newPropertyKey")
         assertThat(valid.failures()[1].property).isEqualTo("oldPropertyKey")
 
-        recipe = ChangePropertyKey(null, "management.metrics.enable.process.files", null, null)
+        recipe = ChangePropertyKey(null, "management.metrics.enable.process.files", null, null, null)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse
         assertThat(valid.failures()).hasSize(1)
         assertThat(valid.failures()[0].property).isEqualTo("oldPropertyKey")
 
-        recipe = ChangePropertyKey("management.metrics.binders.files.enabled", null, null, null)
+        recipe = ChangePropertyKey("management.metrics.binders.files.enabled", null, null, null, null)
         valid = recipe.validate()
         assertThat(valid.isValid).isFalse
         assertThat(valid.failures()).hasSize(1)
@@ -351,6 +359,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             ChangePropertyKey(
                 "management.metrics.binders.files.enabled",
                 "management.metrics.enable.process.files",
+                null,
                 null,
                 null
             )
@@ -382,7 +391,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1841")
     fun relocatesPropertyIfNothingElseInFamily() = assertChanged(
-        recipe = ChangePropertyKey("a.b.c", "x.y.z", true, null),
+        recipe = ChangePropertyKey("a.b.c", "x.y.z", true, null, null),
         before = """
             a:
               b:
@@ -404,6 +413,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
             "spring.elasticsearch.rest.sniffer.interval",
             "spring.elasticsearch.restclient.sniffer.interval",
             true,
+            null,
             null
         ),
         before = """
@@ -425,7 +435,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
     inner class WhenOldPropertyKeyIsPrefixOfDotSeparatedKey {
         @Test
         fun `scalar value`() = assertChanged(
-            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null),
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, null),
             before = """
                 spring.profiles.group.prod: proddb,prodmq,prodmetrics
             """,
@@ -436,7 +446,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
 
         @Test
         fun `mapping value`() = assertChanged(
-            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null),
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, null),
             before = """
                 spring.profiles.group:
                   prod: proddb,prodmq,prodmetrics
@@ -449,7 +459,7 @@ class ChangePropertyKeyTest : YamlRecipeTest {
 
         @Test
         fun `match split across parent entries`() = assertChanged(
-            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null),
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, null),
             before = """
                 spring:
                   profiles.group:
@@ -459,6 +469,168 @@ class ChangePropertyKeyTest : YamlRecipeTest {
                 spring:
                   config.activate.on-profile.group:
                     prod: proddb,prodmq,prodmetrics
+            """
+        )
+    }
+
+    @Nested
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/189")
+    inner class Except {
+        @Nested
+        inner class DotAndIndentCombinations {
+            @Test
+            fun `dot dot dot`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring.profiles.group.prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `dot dot indent`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring.profiles.group:
+                      prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `dot indent dot`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring.profiles:
+                      group.prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `dot indent indent`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring.profiles:
+                      group:
+                        prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `indent dot dot`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring:
+                      profiles.group.prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `indent dot indent`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring:
+                      profiles.group:
+                        prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `indent indent dot`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring:
+                      profiles:
+                        group.prod: proddb,prodmq,prodmetrics
+                """
+            )
+
+            @Test
+            fun `indent indent indent`() = assertUnchanged(
+                recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+                before = """
+                    spring:
+                      profiles:
+                        group:
+                          prod: proddb,prodmq,prodmetrics
+                """
+            )
+        }
+
+        @Test
+        fun `multiple excluded entries`() = assertChanged(
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group", "active", "include")),
+            before = """
+                spring:
+                  profiles:
+                    active: allEnvs
+                    include: baseProfile
+                    foo: bar
+                    group:
+                      prod: proddb,prodmq,prodmetrics
+            """,
+            after = """
+                spring:
+                  profiles:
+                    active: allEnvs
+                    include: baseProfile
+                    group:
+                      prod: proddb,prodmq,prodmetrics
+                  config.activate.on-profile:
+                    foo: bar
+            """
+        )
+
+        @Test
+        fun `target mapping includes non-excluded entry with scalar value`() = assertChanged(
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+            before = """
+                spring:
+                  profiles:
+                    foo: bar
+                    group:
+                      prod: proddb,prodmq,prodmetrics
+            """,
+            after = """
+                spring:
+                  profiles:
+                    group:
+                      prod: proddb,prodmq,prodmetrics
+                  config.activate.on-profile:
+                    foo: bar
+            """
+        )
+
+        @Test
+        fun `target mapping includes non-excluded entry with mapping value`() = assertChanged(
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+            before = """
+                spring:
+                  profiles:
+                    foo:
+                      bar: qwe
+                    group:
+                      prod: proddb,prodmq,prodmetrics
+            """,
+            after = """
+                spring:
+                  profiles:
+                    group:
+                      prod: proddb,prodmq,prodmetrics
+                  config.activate.on-profile:
+                    foo:
+                      bar: qwe
+            """
+        )
+
+        @Test
+        fun `target mapping has scalar value`() = assertChanged(
+            recipe = ChangePropertyKey("spring.profiles", "spring.config.activate.on-profile", null, null, listOf("group")),
+            before = """
+                spring:
+                  profiles: foo
+            """,
+            after = """
+                spring:
+                  config.activate.on-profile: foo
             """
         )
     }


### PR DESCRIPTION
First commit solves the `ChangePropertyKey` edge case with dot-separated values mentioned here: https://github.com/openrewrite/rewrite-spring/issues/189#issuecomment-1143992762

Second commit adds a new recipe option (`List<String> except`) which can be used in rewrite-spring to solve the original finding on the same issue: https://github.com/openrewrite/rewrite-spring/issues/189

(The diff is probably more intuitive if the two commits are reviewed individually)