### PR TITLE
Add RemoveUnneededAssertion Recipe

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveMethodCallVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveMethodCallVisitor.java
@@ -75,6 +75,9 @@ public class RemoveMethodCallVisitor<P> extends JavaIsoVisitor<P> {
                 return visitSuper.get();
             }
         }
+        if (methodCall.getMethodType() != null) {
+            maybeRemoveImport(methodCall.getMethodType().getDeclaringType());
+        }
         return null;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededAssertion.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededAssertion.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.function.BiPredicate;
+
+public class RemoveUnneededAssertion extends Recipe {
+    private static final MethodMatcher JUNIT_JUPITER_ASSERT_TRUE_MATCHER =
+            new MethodMatcher("org.junit.jupiter.api.Assertions assertTrue(..)");
+    private static final MethodMatcher JUNIT_JUPITER_ASSERT_FALSE_MATCHER =
+            new MethodMatcher("org.junit.jupiter.api.Assertions assertFalse(..)");
+    private static final MethodMatcher JUNIT_ASSERT_TRUE_MATCHER =
+            new MethodMatcher("org.junit.Assert assertTrue(boolean)");
+    private static final MethodMatcher JUNIT_ASSERT_FALSE_MATCHER =
+            new MethodMatcher("org.junit.Assert assertFalse(boolean)");
+
+    private static final MethodMatcher JUNIT_ASSERT_MESSAGE_TRUE_MATCHER =
+            new MethodMatcher("org.junit.Assert assertTrue(String, boolean)");
+    private static final MethodMatcher JUNIT_ASSERT_MESSAGE_FALSE_MATCHER =
+            new MethodMatcher("org.junit.Assert assertFalse(String, boolean)");
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Unneeded Assertions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove unneeded assertions like `assert true`, `assertTrue(true)`, or `assertFalse(false)`.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                doAfterVisit(new UsesMethod<>(JUNIT_JUPITER_ASSERT_TRUE_MATCHER));
+                doAfterVisit(new UsesMethod<>(JUNIT_JUPITER_ASSERT_FALSE_MATCHER));
+                doAfterVisit(new UsesMethod<>(JUNIT_ASSERT_TRUE_MATCHER));
+                doAfterVisit(new UsesMethod<>(JUNIT_ASSERT_FALSE_MATCHER));
+                doAfterVisit(new UsesMethod<>(JUNIT_ASSERT_MESSAGE_TRUE_MATCHER));
+                doAfterVisit(new UsesMethod<>(JUNIT_ASSERT_MESSAGE_FALSE_MATCHER));
+                return super.visitCompilationUnit(cu, executionContext);
+            }
+
+            @Override
+            public J.Assert visitAssert(J.Assert _assert, ExecutionContext executionContext) {
+                if (J.Literal.isLiteralValue(_assert.getCondition(), true)) {
+                    return _assert.withMarkers(_assert.getMarkers().searchResult());
+                }
+                return _assert;
+            }
+        };
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RemoveUnneededAssertionVisitor<>();
+    }
+
+    private static class RemoveUnneededAssertionVisitor<P> extends JavaIsoVisitor<P> {
+
+        @FunctionalInterface
+        private interface InvokeRemoveMethodCallVisitor {
+            J.CompilationUnit invoke(
+                    J.CompilationUnit cu,
+                    MethodMatcher methodMatcher,
+                    BiPredicate<Integer, Expression> argumentPredicate
+            );
+        }
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, P p) {
+            J.CompilationUnit compilationUnit = super.visitCompilationUnit(cu, p);
+            // We can compute the types in use once, because this logic only removes method calls, never adds them.
+            TypesInUse typesInUse = compilationUnit.getTypesInUse();
+            InvokeRemoveMethodCallVisitor invokeRemoveMethodCallVisitor = (inputCu, methodMatcher, argumentPredicate) -> {
+                if (typesInUse.getUsedMethods().stream().anyMatch(methodMatcher::matches)) {
+                    // Only visit the subtree when we know the method is present.
+                    return (J.CompilationUnit) new RemoveMethodCallVisitor<>(methodMatcher, argumentPredicate)
+                            .visitNonNull(cu, p, getCursor().getParentOrThrow());
+                }
+                return inputCu;
+            };
+
+            // Junit Jupiter
+            compilationUnit = invokeRemoveMethodCallVisitor.invoke(
+                    compilationUnit,
+                    JUNIT_JUPITER_ASSERT_TRUE_MATCHER,
+                    (arg, expr) -> !arg.equals(0) || J.Literal.isLiteralValue(expr, true)
+            );
+            compilationUnit = invokeRemoveMethodCallVisitor.invoke(
+                    compilationUnit,
+                    JUNIT_JUPITER_ASSERT_FALSE_MATCHER,
+                    (arg, expr) -> !arg.equals(0) || J.Literal.isLiteralValue(expr, false)
+            );
+
+            // Junit 4
+            compilationUnit = invokeRemoveMethodCallVisitor.invoke(
+                    compilationUnit,
+                    JUNIT_ASSERT_TRUE_MATCHER,
+                    (arg, expr) -> arg.equals(0) && J.Literal.isLiteralValue(expr, true)
+            );
+            compilationUnit = invokeRemoveMethodCallVisitor.invoke(
+                    compilationUnit,
+                    JUNIT_ASSERT_FALSE_MATCHER,
+                    (arg, expr) -> arg.equals(0) && J.Literal.isLiteralValue(expr, false)
+            );
+            compilationUnit = invokeRemoveMethodCallVisitor.invoke(
+                    compilationUnit,
+                    JUNIT_ASSERT_MESSAGE_TRUE_MATCHER,
+                    (arg, expr) -> !arg.equals(1) || J.Literal.isLiteralValue(expr, true)
+            );
+            compilationUnit = invokeRemoveMethodCallVisitor.invoke(
+                    compilationUnit,
+                    JUNIT_ASSERT_MESSAGE_FALSE_MATCHER,
+                    (arg, expr) -> !arg.equals(1) || J.Literal.isLiteralValue(expr, false)
+            );
+            return compilationUnit;
+        }
+
+        @Override
+        public J.Assert visitAssert(J.Assert _assert, P p) {
+            if (_assert.getCondition() instanceof J.Literal) {
+                if (J.Literal.isLiteralValue(_assert.getCondition(), true)) {
+                    //noinspection ConstantConditions
+                    return null;
+                }
+            }
+            return super.visitAssert(_assert, p);
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecution.java
@@ -195,11 +195,11 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
         }
 
         private static boolean isLiteralTrue(@Nullable Expression expression) {
-            return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(true);
+            return J.Literal.isLiteralValue(expression, Boolean.TRUE);
         }
 
         private static boolean isLiteralFalse(@Nullable Expression expression) {
-            return expression instanceof J.Literal && ((J.Literal) expression).getValue() == Boolean.valueOf(false);
+            return J.Literal.isLiteralValue(expression, Boolean.FALSE);
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2838,6 +2838,22 @@ public interface J extends Tree {
             @With
             String codePoint;
         }
+
+        /**
+         * Checks if the given {@link Expression} is a {@link Literal} with the given value.
+         *
+         * @param maybeLiteral An expresssion that may be an {@link Literal}.
+         * @param value The value to compare against.
+         * @return {@code true} if the given {@link Expression} is a {@link Literal} with the given value.
+         */
+        @Incubating(since = "7.25.0")
+        public static boolean isLiteralValue(@Nullable Expression maybeLiteral, Object value) {
+            if (maybeLiteral instanceof Literal) {
+                Literal literal = (Literal) maybeLiteral;
+                return literal.getValue() != null && literal.getValue().equals(value);
+            }
+            return false;
+        }
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     implementation("com.google.auto.service:auto-service:latest.release")
 
     implementation("org.apache.hbase:hbase-shaded-client:2.4.11")
+    runtimeOnly("junit:junit:latest.release") {
+        because("Used for RemoveUnneededAssertionTest")
+    }
+
     testRuntimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin:latest.release")
     testCompileOnly("org.projectlombok:lombok:1.18.24")
     annotationProcessor("org.projectlombok:lombok:1.18.24")

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -408,6 +408,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class RemoveRemoveRedundantTypeCastTck : RemoveRedundantTypeCastTest
 
     @Nested
+    inner class RemoveUnneededAssertionTck: RemoveUnneededAssertionTest
+
+    @Nested
     inner class RemoveUnneededBlockTck : RemoveUnneededBlockTest
 
     @Nested

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveMethodCallVisitorTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveMethodCallVisitorTest.kt
@@ -38,7 +38,7 @@ interface RemoveMethodCallVisitorTest : RewriteTest {
 
     fun RecipeSpec.asserTrueTestVisitor() =
         testVisitor(MethodMatcher("* assertTrue(..)")) { arg, expr ->
-            arg == 0 && (expr as? J.Literal)?.value == true
+            arg == 0 && J.Literal.isLiteralValue(expr, true)
         }
 
     @Test
@@ -87,7 +87,7 @@ interface RemoveMethodCallVisitorTest : RewriteTest {
     )
 
     @Test
-    fun `asertTrue("message", true) is removed`() = rewriteRun(
+    fun `asertTrue(message, true) is removed`() = rewriteRun(
         { spec ->
             spec.testVisitor(MethodMatcher("* assertTrue(..)")) { arg, expr ->
                 (arg == 1 && (expr as? J.Literal)?.value == true) || arg != 1

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededAssertionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/RemoveUnneededAssertionTest.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.JavaParser
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
+
+@Suppress("FunctionName")
+interface RemoveUnneededAssertionTest: RewriteTest {
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(RemoveUnneededAssertion())
+    }
+
+    @Test
+    fun `assert true`() = rewriteRun(
+        java(
+            """
+                public class A {
+                    public void m() {
+                        System.out.println("Hello");
+                        assert true;
+                        System.out.println("World");
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                        System.out.println("Hello");
+                        System.out.println("World");
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `assert false`() = rewriteRun(
+        java(
+            """
+                public class A {
+                    public void m() {
+                        System.out.println("Hello");
+                        assert false;
+                        System.out.println("World");
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit jupiter assertTrue(true)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api").build()) },
+        java(
+            """
+                import static org.junit.jupiter.api.Assertions.assertTrue;
+                public class A {
+                    public void m() {
+                        assertTrue(true);
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit jupiter assertFalse(false)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api").build()) },
+        java(
+            """
+                import static org.junit.jupiter.api.Assertions.assertFalse;
+                public class A {
+                    public void m() {
+                        assertFalse(false);
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit jupiter assertTrue(true, message)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api").build()) },
+        java(
+            """
+                import static org.junit.jupiter.api.Assertions.assertTrue;
+                public class A {
+                    public void m() {
+                        assertTrue(true, "message");
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit jupiter assertFalse(false, message)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api").build()) },
+        java(
+            """
+                import static org.junit.jupiter.api.Assertions.assertFalse;
+                public class A {
+                    public void m() {
+                        assertFalse(false, "message");
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit4 assertTrue(true)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit").build()) },
+        java(
+            """
+                import static org.junit.Assert.assertTrue;
+                public class A {
+                    public void m() {
+                        assertTrue(true);
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit4 assertFalse(false)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit").build()) },
+        java(
+            """
+                import static org.junit.Assert.assertFalse;
+                public class A {
+                    public void m() {
+                        assertFalse(false);
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit4 assertTrue(message, true)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit").build()) },
+        java(
+            """
+                import static org.junit.Assert.assertTrue;
+                public class A {
+                    public void m() {
+                        assertTrue("message", true);
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun `junit4 assertFalse(message, false)`() = rewriteRun(
+        { spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit").build()) },
+        java(
+            """
+                import static org.junit.Assert.assertFalse;
+                public class A {
+                    public void m() {
+                        assertFalse("message", false);
+                    }
+                }
+            """,
+            """
+                public class A {
+                    public void m() {
+                    }
+                }
+            """
+        )
+    )
+}


### PR DESCRIPTION
For Junit Jupiter & Junit4 removes method invocations like:
 - `assertTrue(true)`
 - `assertFalse(false)`

Also removes assert statements like:
 - `assert true`

Related https://github.com/openrewrite/rewrite-java-security/issues/33
