### PR TITLE
Fix SimplifyConstantIfBranch not being exaustive

### DIFF
--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/cleanup/SimplifyConstantIfBranchExecutionTest.kt
@@ -649,4 +649,23 @@ interface SimplifyConstantIfBranchExecutionTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun `negated (true && true)`(jp: JavaParser) = assertChanged(
+        before = """
+            public class A {
+                void test() {
+                    if (!(true && true)) {
+                        throw new RuntimeException();
+                    }
+                }
+            }
+        """,
+        after = """
+            public class A {
+                void test() {
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
Previously this wasn't fixed:

```java
if (!(true && true)) {
    throw new RuntimeException();
}
```
