### PR TITLE
support tfvars files for HCL parsing

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
@@ -92,7 +92,7 @@ public class HclParser implements Parser<Hcl.ConfigFile> {
 
     @Override
     public boolean accept(Path path) {
-        return path.toString().endsWith(".tf");
+        return path.toString().endsWith(".tf") || path.toString().endsWith(".tfvars");
     }
 
     @Override


### PR DESCRIPTION
This is minor change to support parsing of `.tfvars` files. According to the HCL Language specification, tfvars files are valid HCL files:

`.tfvars` files are a list of expressions - all `.tfvars` files are valid HCL files (vice-versa is not true)
https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md
```
ConfigFile   = Body;
Body         = (Attribute | Block | OneLineBlock)*;
Attribute    = Identifier "=" Expression Newline;
Block        = Identifier (StringLit|Identifier)* "{" Newline Body "}" Newline;
OneLineBlock = Identifier (StringLit|Identifier)* "{" (Identifier "=" Expression)? "}" Newline;
```

Although ideally, we would have a `VariableFile` type synonymous to `ConfigFile` with the corresponding grammar, this feels like an ok middleground atleast for the timebeing.

Testcase:
```
class ParserTest {
    @Test
    fun test() {
        val parser = HclParser.builder().build()

        val source = """
stringvar = "myvalue"
num = 10
objectvar = {
  foo = "bar"
}
arrayvar = [1, 2, 3]
complexvar = [
  {
    str = "value"
    arr = ["1", "2", "3"]
    sub = {
      val = {
        str = "value"
      }
    }
  }
]
""".trimIndent()

        val ctx = InMemoryExecutionContext(Consumer { t: Throwable -> throw t })
        val sources = parser.parse(ctx, source)
        assertEquals(source, (sources[0] as ConfigFile).printAll())
    }
}
```