### PR TITLE
API Breaking Change: Remove Dataflow from JavaVisitor

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -18,7 +18,6 @@ package org.openrewrite.java;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.dataflow.Dataflow;
 import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -49,16 +48,6 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      */
     protected JavadocVisitor<P> getJavadocVisitor() {
         return new JavadocVisitor<>(this);
-    }
-
-    @Incubating(since = "7.24.0")
-    public Dataflow dataflow() {
-        return Dataflow.startingAt(getCursor());
-    }
-
-    @Incubating(since = "7.24.0")
-    public Dataflow dataflow(Cursor cursor) {
-        return Dataflow.startingAt(cursor);
     }
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/Dataflow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/Dataflow.java
@@ -28,6 +28,9 @@ import org.openrewrite.java.tree.J;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * <a href="https://en.wikipedia.org/wiki/Dataflow_programming">Dataflow</a>.
+ */
 @Incubating(since = "7.24.0")
 @RequiredArgsConstructor(staticName = "startingAt")
 public class Dataflow {

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/FindLocalFlowPaths.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/FindLocalFlowPaths.java
@@ -64,7 +64,7 @@ public class FindLocalFlowPaths extends JavaIsoVisitor<ExecutionContext> {
 
     @Override
     public Expression visitExpression(Expression expression, ExecutionContext ctx) {
-        dataflow().findSinks(spec).ifPresent(flow -> {
+        Dataflow.startingAt(getCursor()).findSinks(spec).ifPresent(flow -> {
             if (flow.isNotEmpty()) {
                 List<SinkFlow<?, ?>> flowGraphs = getCursor().getNearestMessage(FLOW_GRAPHS);
                 assert flowGraphs != null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/package-info.java
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * This package is used to analyze the dataflow through a program.
+ * <p>
+ * The primary entry point for interacting with this logic is
+ * {@link org.openrewrite.java.dataflow.Dataflow#startingAt(org.openrewrite.Cursor)}.
+ */
 @NonNullApi
 package org.openrewrite.java.dataflow;
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UriCreatedWithHttpScheme.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UriCreatedWithHttpScheme.java
@@ -22,6 +22,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.dataflow.Dataflow;
 import org.openrewrite.java.dataflow.LocalFlowSpec;
 import org.openrewrite.java.controlflow.Guard;
 import org.openrewrite.java.tree.Expression;
@@ -83,7 +84,7 @@ public class UriCreatedWithHttpScheme extends Recipe {
             @Override
             public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
                 J.Literal l = super.visitLiteral(literal, ctx);
-                if (dataflow().findSinks(INSECURE_URI_CREATE).isPresent()) {
+                if (Dataflow.startingAt(getCursor()).findSinks(INSECURE_URI_CREATE).isPresent()) {
                     //noinspection ConstantConditions
                     return l.withValue(l.getValue().toString().replace("http://", "https://"))
                             .withValueSource(l.getValueSource().replace("http://", "https://"));

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -123,10 +123,10 @@ abstract class JavaVisitorCompatibilityKit {
     inner class CovariantEqualsTck : CovariantEqualsTest
 
     @Nested
-    inner class DataFlowInsanityTck : DataFlowInsanityTest
+    inner class DataflowInsanityTck : DataflowInsanityTest
 
     @Nested
-    inner class DataFlowRealWorldExamplesTck : DataFlowRealWorldExamplesTest
+    inner class DataflowRealWorldExamplesTck : DataflowRealWorldExamplesTest
 
     @Nested
     inner class DefaultComesLastTck : DefaultComesLastTest

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/dataflow/DataflowInsanityTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/dataflow/DataflowInsanityTest.kt
@@ -25,10 +25,10 @@ import org.openrewrite.test.RecipeSpec
 import org.openrewrite.test.RewriteTest
 
 @Suppress("FunctionName")
-interface DataFlowInsanityTest : RewriteTest {
+interface DataflowInsanityTest : RewriteTest {
 
     fun JavaIsoVisitor<ExecutionContext>.doRunDataFlow() {
-        dataflow().findSinks(object : LocalTaintFlowSpec<Expression, Expression>() {
+        Dataflow.startingAt(cursor).findSinks(object : LocalTaintFlowSpec<Expression, Expression>() {
             override fun isSource(source: Expression, cursor: Cursor) = true
 
             override fun isSink(sink: Expression, cursor: Cursor) = true

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/dataflow/DataflowRealWorldExamplesTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/dataflow/DataflowRealWorldExamplesTest.kt
@@ -23,7 +23,7 @@ import org.openrewrite.test.RecipeSpec
 import org.openrewrite.test.RewriteTest
 
 @Suppress("FunctionName")
-interface DataFlowRealWorldExamplesTest: RewriteTest {
+interface DataflowRealWorldExamplesTest: RewriteTest {
 
     override fun defaults(spec: RecipeSpec) {
         val zipEntryGetMethod = MethodMatcher("java.util.zip.ZipEntry getName()", true)


### PR DESCRIPTION
ControlFlow and DataFlow classes were classloaded like AST types.
Meaning they are parent-classloaded (unlike all Recipe classes).
So any change to those classes in rewrite-core require rewrite-core to be released (happens automatically on push), then any recipe jars to be published from github (e.g. rewrite-java-security) then worker has to be published from github.
Deploying in Spinnaker just redeploys the same version, it doesn't rebuild the docker image with the latest dependencies.

This was causing the old logic to be executed, even when fixes were made to data flow and control flow.
