### PR TITLE
Bugfix - RemoveImports and non-static wildcards

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     testImplementation(project(":rewrite-test"))
 
-    integTestImplementation("io.micrometer:micrometer-registry-prometheus:1.+")
+    integTestImplementation("io.micrometer:micrometer-registry-prometheus:1.9+")
 }
 
 java {

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -107,7 +107,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
 
         J.CompilationUnit c = cu;
 
-        boolean keepImport = typeUsed && !force;
+        boolean keepImport = !force && (typeUsed || !otherTypesInPackageUsed.isEmpty() && type.endsWith(".*"));
         AtomicReference<Space> spaceForNextImport = new AtomicReference<>();
         c = c.withImports(ListUtils.flatMap(c.getImports(), impoort -> {
             if (spaceForNextImport.get() != null) {

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     integTestImplementation("org.eclipse.aether:aether-transport-http:latest.release")
     integTestImplementation("org.apache.maven:maven-aether-provider:latest.release")
     integTestImplementation("org.apache.maven:maven-core:latest.release")
-    integTestImplementation("io.micrometer:micrometer-registry-prometheus:1.+")
+    integTestImplementation("io.micrometer:micrometer-registry-prometheus:1.9+")
     integTestImplementation("org.rocksdb:rocksdbjni:latest.release")
 
     integTestImplementation(project(":rewrite-java-11"))

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     api("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
 
-    compileOnly("io.micrometer:micrometer-registry-prometheus:1.+")
+    compileOnly("io.micrometer:micrometer-registry-prometheus:1.9+")
 
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
 

--- a/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
+++ b/rewrite-test/src/main/kotlin/org/openrewrite/java/RemoveImportTest.kt
@@ -51,6 +51,18 @@ interface RemoveImportTest : JavaRecipeTest {
     )
 
     @Test
+    fun leaveWildcardImportIfRemovedTypeIsStillReferredTo(jp: JavaParser) = assertUnchanged(
+        jp,
+        recipe = removeImport("java.util.*"),
+        before = """
+            import java.util.*;
+            class A {
+               List<Integer> list;
+            }
+        """
+    )
+
+    @Test
     fun removeStarImportIfNoTypesReferredTo(jp: JavaParser) = assertChanged(
         jp,
         recipe = removeImport("java.util.List"),


### PR DESCRIPTION
The micrometer pins are in line with this commit: https://github.com/openrewrite/rewrite/commit/dc328c457a32806dc81bd2326221fba532a6feaa