### PR TITLE
Fix semantic version comparators

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -19,7 +19,7 @@ import org.openrewrite.Validated;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Scanner;
 import java.util.regex.Matcher;
 
 import static java.lang.Integer.parseInt;
@@ -39,8 +39,8 @@ public class LatestRelease implements VersionComparator {
             return false;
         }
         return metadataPattern == null ||
-                (StringUtils.isBlank(metadataPattern) && matcher.group(5) == null) ||
-                (matcher.group(5) != null && matcher.group(5).matches(metadataPattern));
+                (StringUtils.isBlank(metadataPattern) && matcher.group(6) == null) ||
+                (matcher.group(6) != null && matcher.group(6).matches(metadataPattern));
     }
 
     static String normalizeVersion(String version) {
@@ -52,9 +52,9 @@ public class LatestRelease implements VersionComparator {
 
         long versionParts = countVersionParts(version);
 
-        if (versionParts < 2) {
+        if (versionParts <= 2) {
             String[] versionAndMetadata = version.split("(?=[-+])");
-            for (; versionParts < 2; versionParts++) {
+            for (; versionParts <= 2; versionParts++) {
                 versionAndMetadata[0] += ".0";
             }
             version = versionAndMetadata[0] + (versionAndMetadata.length > 1 ?
@@ -65,16 +65,17 @@ public class LatestRelease implements VersionComparator {
     }
 
     static long countVersionParts(String version) {
-        AtomicBoolean beforeMetadata = new AtomicBoolean(true);
-        return version.chars()
-                .filter(c -> {
-                    if (c == '-' || c == '+') {
-                        beforeMetadata.set(false);
-                    }
-                    return beforeMetadata.get();
-                })
-                .filter(c -> c == '.')
-                .count();
+        long count = 0;
+        Scanner scanner = new Scanner(version);
+        scanner.useDelimiter("[.\\-$]");
+        while (scanner.hasNext()) {
+            String part = scanner.next();
+            if (part.isEmpty() || !Character.isDigit(part.charAt(0))) {
+                break;
+            }
+            count++;
+        }
+        return count;
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -110,7 +111,7 @@ public class LatestRelease implements VersionComparator {
         String normalized1 = metadataPattern == null ? nv1.toString() : nv1.toString().replace(metadataPattern, "");
         String normalized2 = metadataPattern == null ? nv2.toString() : nv1.toString().replace(metadataPattern, "");
 
-        for (int i = 1; i < nv1.length(); i++) {
+        for (int i = 1; i <= Math.max(vp1, vp2); i++) {
             String v1Part = v1Gav.group(i);
             String v2Part = v2Gav.group(i);
             if (v1Part == null) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -17,6 +17,7 @@ package org.openrewrite.semver;
 
 import org.openrewrite.Incubating;
 import org.openrewrite.Validated;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.Scanner;
@@ -55,23 +56,26 @@ public class Semver {
     @Incubating(since = "7.16.0")
     public static String majorVersion(String version) {
         Scanner scanner = new Scanner(version);
-        scanner.useDelimiter("[.$]");
+        scanner.useDelimiter("[.\\-$]");
         if (scanner.hasNext()) {
             return scanner.next();
         }
-        return version;
+        return "0";
     }
 
     @Incubating(since = "7.16.0")
     public static String minorVersion(String version) {
         Scanner scanner = new Scanner(version);
-        scanner.useDelimiter("[.$]");
+        scanner.useDelimiter("[.\\-$]");
         if (scanner.hasNext()) {
             scanner.next();
         }
         if (scanner.hasNext()) {
-            return scanner.next();
+            String minor = scanner.next();
+            if (StringUtils.isNumeric(minor)) {
+                return minor;
+            }
         }
-        return version;
+        return "0";
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -60,7 +60,7 @@ public class Semver {
         if (scanner.hasNext()) {
             return scanner.next();
         }
-        return "0";
+        return version;
     }
 
     @Incubating(since = "7.16.0")
@@ -76,6 +76,6 @@ public class Semver {
                 return minor;
             }
         }
-        return "0";
+        return version;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 public interface VersionComparator extends Comparator<String> {
-    Pattern RELEASE_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?([-+].*)?");
+    Pattern RELEASE_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?([-+].*)?");
     Pattern PRE_RELEASE_ENDING = Pattern.compile("[.-](SNAPSHOT|RC|rc|M|m|milestone|beta|alpha)[.-]?\\d*$");
 
     @Deprecated

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/HyphenRangeTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/HyphenRangeTest.kt
@@ -43,7 +43,7 @@ class HyphenRangeTest {
         assertThat(hyphenRange.isValid("1.0", "1.2.3.0.RELEASE")).isTrue
         assertThat(hyphenRange.isValid("1.0", "1.2.3")).isTrue
         assertThat(hyphenRange.isValid("1.0", "1.2.3.0")).isTrue
-        assertThat(hyphenRange.isValid("1.0", "1.2.3.0.0")).isFalse
+        assertThat(hyphenRange.isValid("1.0", "1.2.3.0.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.3.4")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.3.4.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.3.4.1")).isFalse
@@ -62,7 +62,7 @@ class HyphenRangeTest {
         assertThat(hyphenRange.isValid("1.0", "1.1.9.9")).isFalse
         assertThat(hyphenRange.isValid("1.0", "1.2.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "1.2.0.0")).isTrue
-        assertThat(hyphenRange.isValid("1.0", "1.2.0.0.0")).isFalse
+        assertThat(hyphenRange.isValid("1.0", "1.2.0.0.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.0.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.0.0.0")).isTrue
         assertThat(hyphenRange.isValid("1.0", "2.0.1")).isFalse

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
@@ -32,7 +32,7 @@ class LatestReleaseTest {
             { assertThat(latestRelease.isValid("1.0", "1")).isTrue },
             { assertThat(latestRelease.isValid("1.0", "1.1.a")).isFalse },
             { assertThat(latestRelease.isValid("1.0", "1.1.1.1.a")).isFalse },
-            { assertThat(latestRelease.isValid("1.0", "1.1.1.1.1")).isFalse },
+            { assertThat(latestRelease.isValid("1.0", "1.1.1.1.1")).isTrue },
             { assertThat(latestRelease.isValid("1.0", "1.1.1.1.1-SNAPSHOT")).isFalse },
             { assertThat(latestRelease.isValid("1.0", "1.1.0-SNAPSHOT")).isFalse }
         )

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/TildeRangeTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/TildeRangeTest.kt
@@ -49,7 +49,7 @@ class TildeRangeTest {
 
         assertThat(tildeRange.isValid("1.0", "1.2.3.5")).isTrue
         assertThat(tildeRange.isValid("1.0", "1.2.3.0")).isFalse
-        assertThat(tildeRange.isValid("1.0", "1.2.3.5.0")).isFalse
+        assertThat(tildeRange.isValid("1.0", "1.2.3.5.0")).isTrue
         assertThat(tildeRange.isValid("1.0", "1.2.3")).isFalse
         assertThat(tildeRange.isValid("1.0", "1.2.4")).isFalse
         assertThat(tildeRange.isValid("1.0", "1.2.4.0")).isFalse


### PR DESCRIPTION
Fixing several issues in the semantic version comparators: 

- Found a case where there is a 5-digit semantic version in the wild and we need to support this use case. `2.10.1.1.11`. This required modifying the regular expression to capture an extra group. We did attempt to use an expression to capture n number of version parts, but this did not work. [Please see this stack overflow answer, as it reflects the behavior we encountered.](https://stackoverflow.com/a/37004214/3075815)
- `LatestRelease.countVersionParts()` was using a method introduced in Java 9, I am not even sure what would happen if one attempted to call this method on a Java 8 VM. Converted the method to use a scanner instead.
- `LatestRelease.countVersionParts()` was returning the number of dots, not the number of version parts. This becomes more important in the next bulleted item.
- `LatestRelease.compare()` passed both versions through a regular expression matcher and then enumerates each version part (comparing each of those). The for loop in which each group is compared uses an index that is bounded by the string length of the first version. This has been corrected to be bounded by the normalized number of version parts (from the `countVersionParts()` method.)
