### PR TITLE
Decouple cobol from rewrite-test

### DIFF
--- a/build-src/settings.gradle.kts
+++ b/build-src/settings.gradle.kts
@@ -1,4 +1,3 @@
 plugins {
     id("com.gradle.enterprise") version "latest.release"
-    id("com.gradle.enterprise.test-distribution") version "latest.release"
 }

--- a/rewrite-cobol/build.gradle.kts
+++ b/rewrite-cobol/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
     api("com.fasterxml.jackson.core:jackson-annotations:latest.release")
 
+    compileOnly(project(":rewrite-test"))
+
     implementation("org.antlr:antlr4:4.9.+")
     implementation("io.micrometer:micrometer-core:1.+")
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/test/CobolTest.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/test/CobolTest.java
@@ -1,0 +1,47 @@
+package org.openrewrite.cobol.test;
+
+import org.openrewrite.cobol.CobolParser;
+import org.openrewrite.cobol.tree.Cobol;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.ParserSupplier;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.SourceSpecs;
+
+import java.util.function.Consumer;
+
+public interface CobolTest extends RewriteTest {
+
+    default SourceSpecs cobol(@Nullable String before) {
+        return cobol(before, s -> {
+        });
+    }
+
+    default SourceSpecs cobol(@Nullable String before, Consumer<SourceSpec<Cobol.CompilationUnit>> spec) {
+        SourceSpec<Cobol.CompilationUnit> cobol = new SourceSpec<>(Cobol.CompilationUnit.class, null, before, null);
+        spec.accept(cobol);
+        return cobol;
+    }
+
+    default SourceSpecs cobol(@Nullable String before, String after) {
+        return cobol(before, after, s -> {
+        });
+    }
+
+    default SourceSpecs cobol(@Nullable String before, String after,
+                              Consumer<SourceSpec<Cobol.CompilationUnit>> spec) {
+        SourceSpec<Cobol.CompilationUnit> cobol = new SourceSpec<>(Cobol.CompilationUnit.class, null, before, after);
+        spec.accept(cobol);
+        return cobol;
+    }
+
+    @Override
+    default ParserSupplier parserSupplierFor(SourceSpec<?> sourceSpec) {
+        if(Cobol.CompilationUnit.class.equals(sourceSpec.getSourceFileType())) {
+            return new ParserSupplier(Cobol.CompilationUnit.class, sourceSpec.getDsl(), CobolParser::new);
+        }
+        return RewriteTest.super.parserSupplierFor(sourceSpec);
+    }
+}

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/test/package-info.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/test/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package org.openrewrite.cobol.test;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolCompatibilityTest.kt
+++ b/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolCompatibilityTest.kt
@@ -18,13 +18,13 @@ package org.openrewrite.cobol.tree
 import io.github.classgraph.ClassGraph
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.openrewrite.cobol.test.CobolTest
 import org.openrewrite.internal.StringUtils
-import org.openrewrite.test.RewriteTest
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.stream.Stream
 
-class CobolCompatibilityTest : RewriteTest {
+class CobolCompatibilityTest : CobolTest {
     @ParameterizedTest
     @MethodSource
     fun nist(resourcePath: Path) = rewriteRun(

--- a/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolDivisionTest.kt
+++ b/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolDivisionTest.kt
@@ -19,11 +19,11 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.ExecutionContext
 import org.openrewrite.cobol.CobolVisitor
+import org.openrewrite.cobol.test.CobolTest
 import org.openrewrite.test.RecipeSpec
-import org.openrewrite.test.RewriteTest
 import org.openrewrite.test.RewriteTest.toRecipe
 
-class CobolDivisionTest : RewriteTest {
+class CobolDivisionTest : CobolTest {
 
     override fun defaults(spec: RecipeSpec) {
         spec.recipe(toRecipe {

--- a/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolNistTest.kt
+++ b/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolNistTest.kt
@@ -19,11 +19,11 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.ExecutionContext
 import org.openrewrite.cobol.CobolVisitor
+import org.openrewrite.cobol.test.CobolTest
 import org.openrewrite.test.RecipeSpec
-import org.openrewrite.test.RewriteTest
 import org.openrewrite.test.RewriteTest.toRecipe
 
-class CobolNistTest : RewriteTest {
+class CobolNistTest : CobolTest {
 
     override fun defaults(spec: RecipeSpec) {
         spec.recipe(toRecipe {

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    api(project(":rewrite-cobol"))
     api(project(":rewrite-core"))
     api(project(":rewrite-gradle"))
     api(project(":rewrite-groovy"))

--- a/rewrite-test/src/main/java/org/openrewrite/test/ParserSupplier.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/ParserSupplier.java
@@ -25,8 +25,7 @@ import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public
-class ParserSupplier implements Supplier<Parser<?>> {
+public class ParserSupplier implements Supplier<Parser<?>> {
     @EqualsAndHashCode.Include
     private final Class<? extends SourceFile> sourceFileType;
 

--- a/rewrite-test/src/main/java/org/openrewrite/test/ParserSupplier.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/ParserSupplier.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public
 class ParserSupplier implements Supplier<Parser<?>> {
     @EqualsAndHashCode.Include
     private final Class<? extends SourceFile> sourceFileType;

--- a/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
@@ -16,6 +16,7 @@
 package org.openrewrite.test;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.lang.Nullable;
@@ -28,6 +29,7 @@ import java.util.function.Consumer;
 
 @RequiredArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Getter
 public class SourceSpec<T extends SourceFile> implements SourceSpecs {
     @EqualsAndHashCode.Include
     final UUID id = UUID.randomUUID();

--- a/rewrite-test/src/main/java/org/openrewrite/test/SourceSpecs.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/SourceSpecs.java
@@ -17,7 +17,6 @@ package org.openrewrite.test;
 
 import org.intellij.lang.annotations.Language;
 import org.openrewrite.SourceFile;
-import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.hcl.tree.Hcl;
 import org.openrewrite.internal.lang.Nullable;
@@ -42,29 +41,6 @@ public interface SourceSpecs extends Iterable<SourceSpec<?>> {
 
     default SourceSpecs dir(String dir, Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... sources) {
         return new Dir(dir, spec, sources);
-    }
-
-    default SourceSpecs cobol(@Nullable String before) {
-        return cobol(before, s -> {
-        });
-    }
-
-    default SourceSpecs cobol(@Nullable String before, Consumer<SourceSpec<Cobol.CompilationUnit>> spec) {
-        SourceSpec<Cobol.CompilationUnit> cobol = new SourceSpec<>(Cobol.CompilationUnit.class, null, before, null);
-        spec.accept(cobol);
-        return cobol;
-    }
-
-    default SourceSpecs cobol(@Nullable String before, String after) {
-        return cobol(before, after, s -> {
-        });
-    }
-
-    default SourceSpecs cobol(@Nullable String before, String after,
-                             Consumer<SourceSpec<Cobol.CompilationUnit>> spec) {
-        SourceSpec<Cobol.CompilationUnit> cobol = new SourceSpec<>(Cobol.CompilationUnit.class, null, before, after);
-        spec.accept(cobol);
-        return cobol;
     }
 
     default SourceSpecs java(@Language("java") @Nullable String before) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,6 @@ include(
 plugins {
     id("com.gradle.enterprise") version "latest.release"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "latest.release"
-    id("com.gradle.enterprise.test-distribution") version "latest.release"
 }
 
 gradleEnterprise {


### PR DESCRIPTION
I put CobolTest in the main SourceSet so it would be easy for any separate repositories which may end up taking depedencies on rewrite-cobol to use it