### PR TITLE
Improve ExecutionContext customization in RewriteTest/Assertions

### DIFF
--- a/rewrite-core/src/test/kotlin/org/openrewrite/RecipeSchedulerTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/RecipeSchedulerTest.kt
@@ -18,26 +18,27 @@ package org.openrewrite
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.openrewrite.test.RewriteTest
-import org.openrewrite.test.SourceSpecs
 import org.openrewrite.test.SourceSpecs.text
 import org.openrewrite.text.PlainText
 import org.openrewrite.text.PlainTextVisitor
 
 class RecipeSchedulerTest : RewriteTest {
+    override fun defaultExecutionContext(): ExecutionContext {
+        return InMemoryExecutionContext()
+    }
 
     @Test
     fun exceptionsCauseResult() = rewriteRun(
             { spec ->
                 spec
-                        .executionContext(InMemoryExecutionContext())
                         .recipe(BoomRecipe())
                         .afterRecipe { results -> assertThat(results[0].recipeErrors).isNotEmpty() }
             },
             text(
                     "hello",
                     "~~(org.openrewrite.BoomException: boom\n" +
-                            "  org.openrewrite.BoomRecipe\$getVisitor\$1.visitText(RecipeSchedulerTest.kt:49)\n" +
-                            "  org.openrewrite.BoomRecipe\$getVisitor\$1.visitText(RecipeSchedulerTest.kt:47))~~>hello"
+                            "  org.openrewrite.BoomRecipe\$getVisitor\$1.visitText(RecipeSchedulerTest.kt:50)\n" +
+                            "  org.openrewrite.BoomRecipe\$getVisitor\$1.visitText(RecipeSchedulerTest.kt:48))~~>hello"
             )
     )
 }

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/RecipeExceptionDemonstrationTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/RecipeExceptionDemonstrationTest.kt
@@ -18,11 +18,15 @@ package org.openrewrite.java
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
 import org.openrewrite.InMemoryExecutionContext
 import org.openrewrite.java.Assertions.java
 import org.openrewrite.test.RewriteTest
 
 interface RecipeExceptionDemonstrationTest : RewriteTest {
+    override fun defaultExecutionContext(): ExecutionContext {
+        return InMemoryExecutionContext()
+    }
 
     @BeforeEach
     fun beforeEach() {
@@ -40,7 +44,6 @@ interface RecipeExceptionDemonstrationTest : RewriteTest {
             spec
                 .recipe(RecipeExceptionDemonstration("java.util.List add(..)"))
                 .parser(jp)
-                .executionContext(InMemoryExecutionContext())
         },
         java(
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -19,7 +19,6 @@ import org.intellij.lang.annotations.Language;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaSourceSet;
@@ -27,7 +26,6 @@ import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.java.search.FindMissingTypes;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.marker.Markers;
 import org.openrewrite.test.*;
 
 import java.util.Collections;
@@ -114,7 +112,15 @@ public class Assertions {
 
     public static SourceSpecs java(@Language("java") @Nullable String before, @Language("java") String after,
                                    Consumer<SourceSpec<J.CompilationUnit>> spec) {
-        SourceSpec<J.CompilationUnit> java = new SourceSpec<>(J.CompilationUnit.class, null, javaParserSupplier, before, after);
+        SourceSpec<J.CompilationUnit> java = new SourceSpec<>(
+                J.CompilationUnit.class,
+                null,
+                javaParserSupplier,
+                before,
+                after,
+                Assertions::validateTypes,
+                Assertions::customizeExecutionContext
+                );
         spec.accept(java);
         return java;
     }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -48,7 +48,7 @@ public class RecipeSpec {
     List<Parser<?>> parsers = new ArrayList<>();
 
     @Nullable
-    ExecutionContext executionContext;
+    Consumer<ExecutionContext> customizeExecutionContext;
 
     @Nullable
     Path relativeTo;
@@ -102,8 +102,8 @@ public class RecipeSpec {
         return this;
     }
 
-    public RecipeSpec executionContext(ExecutionContext executionContext) {
-        this.executionContext = executionContext;
+    public RecipeSpec customizeExecutionContext(Consumer<ExecutionContext> customizeExecutionContext) {
+        this.customizeExecutionContext = customizeExecutionContext;
         return this;
     }
 
@@ -152,7 +152,7 @@ public class RecipeSpec {
     }
 
     @Nullable
-    ExecutionContext getExecutionContext() {
-        return executionContext;
+    Consumer<ExecutionContext> getCustomizeExecutionContext() {
+        return customizeExecutionContext;
     }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -124,16 +124,15 @@ public interface RewriteTest extends SourceSpecs {
         RecipeSchedulerCheckingExpectedCycles recipeSchedulerCheckingExpectedCycles =
                 new RecipeSchedulerCheckingExpectedCycles(DirectScheduler.common(), expectedCyclesThatMakeChanges);
 
-        ExecutionContext executionContext;
-        if (testMethodSpec.getExecutionContext() != null) {
-            executionContext = testMethodSpec.getExecutionContext();
-        } else if (testClassSpec.getExecutionContext() != null) {
-            executionContext = testClassSpec.getExecutionContext();
-        } else {
-            executionContext = defaultExecutionContext(sourceSpecs);
-        }
+        ExecutionContext executionContext = defaultExecutionContext();
         for(SourceSpec<?> s : sourceSpecs) {
-            s.customizeExecutionContext.accept(executionContext);
+            s.getCustomizeExecutionContext().accept(executionContext);
+        }
+
+        if (testMethodSpec.getCustomizeExecutionContext() != null) {
+            testMethodSpec.getCustomizeExecutionContext().accept(executionContext);
+        } else if (testClassSpec.getCustomizeExecutionContext() != null) {
+            testClassSpec.getCustomizeExecutionContext().accept(executionContext);
         }
 
         Map<ParserSupplier, List<SourceSpec<?>>> sourceSpecsByParser = new HashMap<>();
@@ -369,7 +368,7 @@ public interface RewriteTest extends SourceSpecs {
         }, sources);
     }
 
-    default ExecutionContext defaultExecutionContext(SourceSpec<?>[] sourceSpecs) {
+    default ExecutionContext defaultExecutionContext() {
         return new InMemoryExecutionContext(t -> fail("Failed to parse sources or run recipe", t));
     }
 


### PR DESCRIPTION
Currently, any customizations made to the execution context via a RecipeSpec can be potentially stomped on by a SourceSpec.

This PR changes things such that a context is initially created via a defaultExecutionContext() method, 

Then SourceSpecs are allowed to customize the context, followed by further customization by a RecipeSpec (either defined at the class or method level)