### PR TITLE
fixed case where ResolvedPom.resolveDependencies can return incomplete data (#2151)

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -552,7 +552,7 @@ public class ResolvedPom {
                                     .getResolutionListener()
                                     .clear();
                             return resolveDependencies(scope, requirements, downloader, ctx);
-                        } else {
+                        } else if (contains(dependencies, ga)) {
                             // we've already resolved this previously and the requirement didn't change,
                             // so just skip and continue on
                             continue;
@@ -622,6 +622,15 @@ public class ResolvedPom {
         }
 
         return dependencies;
+    }
+
+    private boolean contains(List<ResolvedDependency> dependencies, GroupArtifact ga) {
+        for (ResolvedDependency it : dependencies) {
+            if (it.getGroupId().equals(ga.getGroupId()) && it.getArtifactId().equals(ga.getArtifactId())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Scope getDependencyScope(Dependency d2, ResolvedPom containingPom) {


### PR DESCRIPTION
Note: I can refactor `dependencies` to a `LinkedHashSet` if we're concerned about performance of those `contains` calls across many iterations.

Fixes #2151