### PR TITLE
Introduced matchUnknownTypes option to MethodMatcher (for MethodInvocation) and ChangeMethodTargetToStatic

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -26,6 +26,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.copyOfRange;
@@ -548,7 +549,7 @@ public class StringUtils {
                 .replace("$", "\\$")
                 .replace("[", "\\[")
                 .replace("]", "\\]")
-                .replaceAll("([^.]*)\\.([^.]*)", "$1\\.$2")
+                .replaceAll("(?:([^.]+)|^)\\.(?:([^.]+)|$)", "$1" + Matcher.quoteReplacement("[.$]") + "$2")
                 .replace("*", "[^.]*")
                 .replace("..", "\\.(.+\\.)?");
     }

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
@@ -113,15 +113,6 @@ interface MethodMatcherTest {
     }
 
     @Test
-    fun matchesSuperclassArgumentTypes(jp: JavaParser) {
-        assertTrue(MethodMatcher("Object equals(Object)", true).matchesTargetType(JavaType.ShallowClass.build("java.lang.String")))
-        assertFalse(MethodMatcher("Object equals(Object)").matchesTargetType(JavaType.ShallowClass.build("java.lang.String")))
-        // ensuring subtypes do not match parents, regardless of matchOverrides
-        assertFalse(MethodMatcher("String equals(String)", true).matchesTargetType(JavaType.ShallowClass.build("java.lang.Object")))
-        assertFalse(MethodMatcher("String equals(String)").matchesTargetType(JavaType.ShallowClass.build("java.lang.Object")))
-    }
-
-    @Test
     fun matchesMethodSymbolsWithVarargs(jp: JavaParser) {
         argRegex("A foo(String, Object...)").matches("String,Object[]")
     }

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
@@ -17,13 +17,14 @@ package org.openrewrite.java
 
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.openrewrite.Issue
-import org.openrewrite.java.tree.Expression
 import org.openrewrite.java.tree.J
 import org.openrewrite.java.tree.JavaType
 
-@Suppress("ClassInitializerMayBeStatic")
+@Suppress("ClassInitializerMayBeStatic", "JUnitMalformedDeclaration")
 interface MethodMatcherTest {
     fun typeRegex(signature: String) = MethodMatcher(signature).targetTypePattern.toRegex()
     fun nameRegex(signature: String) = MethodMatcher(signature).methodNamePattern.toRegex()
@@ -284,5 +285,118 @@ interface MethodMatcherTest {
     fun wildcardType(jp: JavaParser) {
         assertTrue(MethodMatcher("*..* build()").matchesTargetType(JavaType.ShallowClass.build("javax.ws.rs.core.Response")))
         assertTrue(MethodMatcher("javax..* build()").matchesTargetType(JavaType.ShallowClass.build("javax.ws.rs.core.Response")))
+    }
+
+    @Test
+    fun siteExample(jp: JavaParser) {
+        val cu = jp.parse(
+            """
+            package com.yourorg;
+
+            class Foo {
+                void bar(int i, String s) {}
+                void other() {
+                    bar(0, "");
+                }
+            }
+        """
+        ).first()
+        val classDecl = cu.classes.first()
+        val methodDecl = classDecl.body.statements[1] as J.MethodDeclaration
+        val fooMethod = methodDecl.body!!.statements[0] as J.MethodInvocation
+        assertTrue(MethodMatcher("com.yourorg.Foo bar(int, String)").matches(fooMethod))
+    }
+
+    @Test
+    fun matchUnknownTypesNoSelect(jp: JavaParser) {
+        val mi = "assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("org.junit.Assert assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesQualifiedStaticMethod(jp: JavaParser) {
+        val mi = "Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("org.junit.Assert assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesPackageQualifiedStaticMethod(jp: JavaParser) {
+        val mi = "org.junit.Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("org.junit.Assert assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesWildcardReceiverType(jp: JavaParser) {
+        val mi = "Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("*..* assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesFullWildcardReceiverType(jp: JavaParser) {
+        val mi = "Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("* assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesExplicitPackageWildcardReceiverType(jp: JavaParser) {
+        val mi = "Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("org.junit.* assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesRejectsMismatchedMethodName(jp: JavaParser) {
+        val mi = "Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertFalse(MethodMatcher("org.junit.Assert assertFalse(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesRejectsStaticSelectMismatch(jp: JavaParser) {
+        val mi = "Assert.assertTrue(Foo.bar());".asMethodInvocation(jp)
+        assertFalse(MethodMatcher("org.junit.FooAssert assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesRejectsTooManyArguments(jp: JavaParser) {
+        val mi = """Assert.assertTrue(Foo.bar(), "message");""".asMethodInvocation(jp)
+        assertFalse(MethodMatcher("org.junit.Assert assertTrue(boolean)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesRejectsTooFewArguments(jp: JavaParser) {
+        val mi = """Assert.assertTrue(Foo.bar());""".asMethodInvocation(jp)
+        assertFalse(MethodMatcher("org.junit.Assert assertTrue(boolean, String)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesRejectsMismatchingKnownArgument(jp: JavaParser) {
+        val mi = """Assert.assertTrue(Foo.bar(), "message");""".asMethodInvocation(jp)
+        assertFalse(MethodMatcher("org.junit.Assert assertTrue(boolean, int)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesWildcardArguments(jp: JavaParser) {
+        val mi = """Assert.assertTrue(Foo.bar(), "message");""".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("org.junit.Assert assertTrue(..)").matches(mi, true))
+    }
+
+    @Test
+    fun matchUnknownTypesSingleWildcardArgument(jp: JavaParser) {
+        val mi = """Assert.assertTrue(Foo.bar(), "message");""".asMethodInvocation(jp)
+        assertTrue(MethodMatcher("org.junit.Assert assertTrue(*, String)").matches(mi, true))
+    }
+
+    fun String.asMethodInvocation(jp: JavaParser): J.MethodInvocation {
+        val cu = jp.parse(
+            """
+                class MyTest {
+                    void test() {
+                        $this
+                    }
+                }
+            """,
+        ).first()
+        val classDecl = cu.classes.first()
+        val testMethod = classDecl.body.statements[0] as J.MethodDeclaration
+        return testMethod.body!!.statements[0] as J.MethodInvocation
     }
 }

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -55,12 +55,12 @@ tasks.withType<Javadoc> {
     // generated ANTLR sources violate doclint
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
 
-    // ChangePackage and OrderImports due to lombok error which looks similar to this:
+    // Items besides JavaParser due to lombok error which looks similar to this:
     //     openrewrite/rewrite/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java:42: error: cannot find symbol
     // @AllArgsConstructor(onConstructor_=@JsonCreator)
     //                     ^
     //   symbol:   method onConstructor_()
     //   location: @interface AllArgsConstructor
     // 1 error
-    exclude("**/JavaParser**", "**/ChangePackage**", "**/OrderImports**")
+    exclude("**/JavaParser**", "**/ChangeMethodTargetToStatic**")
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -100,10 +100,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      * @param fullyQualifiedName Fully-qualified name of the class.
      */
     public void maybeAddImport(String fullyQualifiedName) {
-        AddImport<P> op = new AddImport<>(fullyQualifiedName, null, true);
-        if (!getAfterVisit().contains(op)) {
-            doAfterVisit(op);
-        }
+        maybeAddImport(fullyQualifiedName, null, true);
     }
 
     /**
@@ -115,7 +112,15 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      * @param statik             The static method or field to be imported. A wildcard "*" may also be used to statically import all methods/fields.
      */
     public void maybeAddImport(String fullyQualifiedName, String statik) {
-        AddImport<P> op = new AddImport<>(fullyQualifiedName, statik, true);
+        maybeAddImport(fullyQualifiedName, statik, true);
+    }
+
+    public void maybeAddImport(String fullyQualifiedName, boolean onlyIfReferenced) {
+        maybeAddImport(fullyQualifiedName, null, onlyIfReferenced);
+    }
+
+    public void maybeAddImport(String fullyQualifiedName, @Nullable String statik, boolean onlyIfReferenced) {
+        AddImport<P> op = new AddImport<>(fullyQualifiedName, statik, onlyIfReferenced);
         if (!getAfterVisit().contains(op)) {
             doAfterVisit(op);
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -256,7 +256,7 @@ public class MethodMatcher {
      * @param fieldAccess A J.FieldAccess that hopefully has the same fully qualified type as this matcher.
      */
     public boolean isFullyQualifiedClassReference(J.FieldAccess fieldAccess) {
-        String hopefullyFullyQualifiedMethod = this.getTargetTypePattern().pattern() + "." + this.getMethodNamePattern().pattern();
+        String hopefullyFullyQualifiedMethod = this.getTargetTypePattern().pattern().replaceAll(Pattern.quote(StringUtils.aspectjNameToPattern(".")), ".") + "." + this.getMethodNamePattern().pattern();
         return fieldAccess.isFullyQualifiedClassReference(hopefullyFullyQualifiedMethod);
     }
 


### PR DESCRIPTION
Supports this PR: https://github.com/openrewrite/rewrite-testing-frameworks/pull/250

As mentioned in the javadocs, the new `matchUnknownTypes` option is a bit risky, but in scenarios which are extra vulnerable to missing type info, the risk can pay off. And I've added a slew of test cases to ensure that the `matchUnknownTypes` option is as clever as it can be (ie reducing risk of false positives), short of actually having the real type information.