### PR TITLE
RemoveRedundantDependencyVersions no longer checks scope, in accordance with Maven behavior (fixes #2131)

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -37,7 +37,7 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
 public class RemoveRedundantDependencyVersions extends Recipe {
     @Option(displayName = "Group",
             description = "Group glob expression pattern used to match dependencies that should be managed." +
-                    "Group is the the first part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
+                    "Group is the first part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
             example = "com.google.*",
             required = false)
     @Nullable
@@ -76,7 +76,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 if (!isManagedDependencyTag()) {
                     ResolvedDependency d = findDependency(tag);
-                    if (d != null && matchesVersion(d) && matchesScope(d, tag) &&
+                    if (d != null && matchesVersion(d) &&
                             matchesGroup(d) && matchesArtifact(d)) {
                         Xml.Tag version = tag.getChild("version").orElse(null);
                         return tag.withContent(ListUtils.map(tag.getContent(), c -> c == version ? null : c));
@@ -102,13 +102,6 @@ public class RemoveRedundantDependencyVersions extends Recipe {
 
             private boolean ignoreVersionMatching() {
                 return Boolean.FALSE.equals(onlyIfVersionsMatch);
-            }
-
-            private boolean matchesScope(ResolvedDependency d, Xml.Tag dependencyTag) {
-                return Objects.equals(
-                        Scope.fromName(dependencyTag.getChildValue("scope").orElse(null)),
-                        getResolutionResult().getPom().getManagedScope(d.getGroupId(), d.getArtifactId(), d.getRequested().getType(),
-                                d.getRequested().getClassifier()));
             }
         };
     }

--- a/rewrite-maven/src/test/kotlin/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.kt
+++ b/rewrite-maven/src/test/kotlin/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.kt
@@ -22,7 +22,7 @@ class RemoveRedundantDependencyVersionsTest : MavenRecipeTest {
     override val recipe = RemoveRedundantDependencyVersions(null, null, null)
 
     @Test
-    fun givenScopeIsDefinedWhenVersionMatchesParentDmForDifferentScopeThenKeepIt() {
+    fun givenScopeIsDefinedWhenVersionMatchesParentDmForDifferentScopeThenStillRemoveIt() {
         val parent = """
             <?xml version="1.0" encoding="UTF-8"?>
             <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -83,9 +83,34 @@ class RemoveRedundantDependencyVersionsTest : MavenRecipeTest {
             before = parent,
         )
 
-        assertUnchanged(
+        assertChanged(
             dependsOn = arrayOf(parent),
             before = child,
+            after = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <parent>
+                    <artifactId>parent-pom-test</artifactId>
+                    <groupId>org.example</groupId>
+                    <version>1.0-SNAPSHOT</version>
+                </parent>
+                <modelVersion>4.0.0</modelVersion>
+            
+                <artifactId>child-module-1</artifactId>
+                <packaging>pom</packaging>
+            
+                <dependencies>
+                    <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                </dependencies>
+            
+            </project>
+        """.trimIndent()
         )
     }
 
@@ -362,218 +387,6 @@ class RemoveRedundantDependencyVersionsTest : MavenRecipeTest {
             
             </project>
         """.trimIndent()
-        )
-    }
-
-    @Test
-    fun givenScopeIsDefinedWhenVersionMatchesParentDmForSameScopeAndDifferentScopeThenRemoveCorrectOne() {
-        val parent = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <project xmlns="http://maven.apache.org/POM/4.0.0"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                <modelVersion>4.0.0</modelVersion>
-            
-                <groupId>org.example</groupId>
-                <artifactId>parent-pom-test</artifactId>
-                <packaging>pom</packaging>
-                <version>1.0-SNAPSHOT</version>
-                <modules>
-                    <module>child-module1</module>
-                </modules>
-            
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                            <version>30.0-jre</version>
-                            <scope>test</scope>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                            <version>29.0-jre</version>
-                            <scope>runtime</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-            </project>
-        """.trimIndent()
-
-        val child = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <project xmlns="http://maven.apache.org/POM/4.0.0"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                <parent>
-                    <artifactId>parent-pom-test</artifactId>
-                    <groupId>org.example</groupId>
-                    <version>1.0-SNAPSHOT</version>
-                </parent>
-                <modelVersion>4.0.0</modelVersion>
-            
-                <artifactId>child-module-1</artifactId>
-                <packaging>pom</packaging>
-            
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <version>30.0-jre</version>
-                        <scope>test</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <version>30.0-jre</version>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
-            
-            </project>
-        """.trimIndent()
-
-        assertUnchanged(
-            dependsOn = arrayOf(child),
-            before = parent,
-        )
-
-        assertChanged(
-            dependsOn = arrayOf(parent),
-            before = child,
-            after = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <project xmlns="http://maven.apache.org/POM/4.0.0"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                <parent>
-                    <artifactId>parent-pom-test</artifactId>
-                    <groupId>org.example</groupId>
-                    <version>1.0-SNAPSHOT</version>
-                </parent>
-                <modelVersion>4.0.0</modelVersion>
-            
-                <artifactId>child-module-1</artifactId>
-                <packaging>pom</packaging>
-            
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <scope>test</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <version>30.0-jre</version>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
-            
-            </project>
-        """.trimIndent()
-        )
-    }
-
-    @Test
-    fun givenScopeIsDefinedAndNestedPomsWhenVersionMatchesTopLevelParentForSameScopeThenNextLevelParentForDifferentScopeThenRemoveItCorrectOne() {
-        val parent = """
-            <project xmlns="http://maven.apache.org/POM/4.0.0"
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-            <modelVersion>4.0.0</modelVersion>
-        
-            <groupId>org.example</groupId>
-            <artifactId>parent-pom-test</artifactId>
-            <packaging>pom</packaging>
-            <version>1.0-SNAPSHOT</version>
-            <modules>
-                <module>child-module-1</module>
-            </modules>
-        
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <version>29.0-jre</version>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-        </project>
-        """.trimIndent()
-
-        val child1 = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <project xmlns="http://maven.apache.org/POM/4.0.0"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                <parent>
-                    <artifactId>parent-pom-test</artifactId>
-                    <groupId>org.example</groupId>
-                    <version>1.0-SNAPSHOT</version>
-                </parent>
-                <modelVersion>4.0.0</modelVersion>
-
-                <artifactId>child-module-1</artifactId>
-                <packaging>pom</packaging>
-                <modules>
-                    <module>child-module-2</module>
-                </modules>
-                
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.google.guava</groupId>
-                            <artifactId>guava</artifactId>
-                            <version>29.0-jre</version>
-                            <scope>runtime</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-            </project>
-        """.trimIndent()
-
-        val child2 = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <project xmlns="http://maven.apache.org/POM/4.0.0"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                <parent>
-                    <artifactId>child-module-1</artifactId>
-                    <groupId>org.example</groupId>
-                    <version>1.0-SNAPSHOT</version>
-                </parent>
-                <modelVersion>4.0.0</modelVersion>
-            
-                <artifactId>child-module-2</artifactId>
-            
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <version>29.0-jre</version>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </project>
-        """.trimIndent()
-
-        assertUnchanged(
-            dependsOn = arrayOf(child1, child2),
-            before = parent,
-        )
-
-        assertUnchanged(
-            dependsOn = arrayOf(parent, child2),
-            before = child1,
-        )
-
-        assertUnchanged(
-            dependsOn = arrayOf(parent, child1),
-            before = child2,
         )
     }
 


### PR DESCRIPTION
After some testing, it looks like the scope-checking in this recipe is actually not aligned with how Maven works (at least with 3.8.6). Maven only seems to care about the scope tag in `dependencyManagement` if it's an `import`; in any other case, it allows the declared version to apply to any scope.

Sample:
https://i.imgur.com/ASj8av5.png

Fixes #2131
