### PR TITLE
Update BlockStatementTemplateGenerator to handle lambda bodies which are instances of J.Block  (fixes #2181)

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaTemplateTest.kt
@@ -2220,7 +2220,7 @@ interface JavaTemplateTest : RewriteTest, JavaRecipeTest {
 
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/66")
     @Test
-    fun lamdaBodyIsNewClassDeclaration() = rewriteRun(
+    fun lambdaIsNewClass() = rewriteRun(
         { spec ->
             spec.recipe(toRecipe {
                 object : JavaIsoVisitor<ExecutionContext>() {
@@ -2240,21 +2240,23 @@ interface JavaTemplateTest : RewriteTest, JavaRecipeTest {
         java(
             """
             class T {
+                public T (int a, Runnable r, String s) { }
                 static void method() {
-                    new Thread(() -> {
+                    new T(1, () -> {
                         int i;
                         i = Integer.valueOf(1);
-                    }).start();
+                    }, "hello" );
                 }
             }
             """,
             """
             class T {
+                public T (int a, Runnable r, String s) { }
                 static void method() {
-                    new Thread(() -> {
+                    new T(1, () -> {
                         int i;
                         i = 1;
-                    }).start();
+                    }, "hello" );
                 }
             }
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -240,9 +240,11 @@ public class BlockStatementTemplateGenerator {
                 after.append(";");
             }
             before.insert(0, "{ if(true) {");
-            after.append("}\nreturn ").append(valueOfType(l.getType())).append(";\n};\n");
-
-            before.insert(0, l.withBody(null).withPrefix(Space.EMPTY).printTrimmed(cursor).trim());
+            after.append("}");
+            if (!(l.getBody() instanceof J.Block)) {
+                after.append("\nreturn ").append(valueOfType(l.getType())).append(";\n};\n");
+                before.insert(0, l.withBody(null).withPrefix(Space.EMPTY).printTrimmed(cursor).trim());
+            }
         } else if (j instanceof J.VariableDeclarations) {
             before.insert(0, variable((J.VariableDeclarations) j, false, cursor) + '=');
         } else if(j instanceof J.MethodInvocation) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -205,12 +205,31 @@ public class BlockStatementTemplateGenerator {
             }
 
             after.append('}');
-            if (parent instanceof J.Lambda) {
-                after.append(';');
-            }
         } else if (j instanceof J.NewClass) {
             J.NewClass n = (J.NewClass) j;
-            if (n.getArguments().stream().noneMatch(arg -> referToSameElement(prior, arg))) {
+            if (n.getArguments().stream().anyMatch(arg -> referToSameElement(prior, arg))) {
+                StringBuilder beforeSegments = new StringBuilder();
+                StringBuilder afterSegments = new StringBuilder();
+                beforeSegments.append("new ").append(n.getClazz().printTrimmed(cursor)).append("(");
+                boolean priorFound = false;
+                for(Expression arg : n.getArguments()) {
+                    if(!priorFound) {
+                        if (referToSameElement(prior, arg)) {
+                            priorFound = true;
+                            continue;
+                        }
+                        beforeSegments.append(valueOfType(arg.getType())).append(",");
+                    } else {
+                        afterSegments.append(",").append(valueOfType(arg.getType()));
+                    }
+                }
+                afterSegments.append(")");
+                before.insert(0, beforeSegments);
+                after.append(afterSegments);
+                if(next(cursor).getValue() instanceof J.Block) {
+                    after.append(";");
+                }
+            } else {
                 n = n.withBody(null).withPrefix(Space.EMPTY);
                 before.insert(0, n.printTrimmed(cursor).trim());
                 after.append(';');
@@ -239,11 +258,19 @@ public class BlockStatementTemplateGenerator {
                 before.insert(0,"return ");
                 after.append(";");
             }
-            before.insert(0, "{ if(true) {");
+            before.insert(0, l.withBody(null).withPrefix(Space.EMPTY).printTrimmed(cursor).trim() + "{ if(true) {");
+
+            after.append("}\n");
+            JavaType.Method mt = findSingleAbstractMethod(l.getType());
+            if(mt == null) {
+                // Missing type information, but usually the Java compiler can soldier on anyway
+                after.append("return null;\n");
+            } else if(mt.getReturnType() != JavaType.Primitive.Void) {
+                after.append("return ").append(valueOfType(mt.getReturnType())).append(";\n");
+            }
             after.append("}");
-            if (!(l.getBody() instanceof J.Block)) {
-                after.append("\nreturn ").append(valueOfType(l.getType())).append(";\n};\n");
-                before.insert(0, l.withBody(null).withPrefix(Space.EMPTY).printTrimmed(cursor).trim());
+            if(next(cursor).getValue() instanceof J.Block) {
+                after.append(";");
             }
         } else if (j instanceof J.VariableDeclarations) {
             before.insert(0, variable((J.VariableDeclarations) j, false, cursor) + '=');
@@ -405,5 +432,21 @@ public class BlockStatementTemplateGenerator {
 
     private static boolean referToSameElement(@Nullable Tree t1, @Nullable Tree t2) {
         return t1 == t2 || (t1 != null && t2 != null && t1.getId().equals(t2.getId()));
+    }
+
+    /**
+     * Accepts a @FunctionalInterface and returns the single abstract method from it, or null if the single abstract
+     * method cannot be found
+     */
+    @Nullable
+    private static JavaType.Method findSingleAbstractMethod(@Nullable JavaType javaType) {
+        if(javaType == null) {
+            return null;
+        }
+        JavaType.FullyQualified fq = TypeUtils.asFullyQualified(javaType);
+        if(fq == null) {
+            return null;
+        }
+        return fq.getMethods().stream().filter(method -> method.hasFlags(Flag.Abstract)).findAny().orElse(null);
     }
 }


### PR DESCRIPTION
Update BlockStatementTemplateGenerator to handle lambda bodies which are instances of J.Block (fixes #2181)