### PR TITLE
Refinements to UpgradeDependencyVersion

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -38,9 +38,13 @@ public class LatestRelease implements VersionComparator {
         if (!matcher.matches() || PRE_RELEASE_ENDING.matcher(version).find()) {
             return false;
         }
-        return metadataPattern == null ||
-                (StringUtils.isBlank(metadataPattern) && matcher.group(6) == null) ||
-                (matcher.group(6) != null && matcher.group(6).matches(metadataPattern));
+        boolean requireMeta = !StringUtils.isNullOrEmpty(metadataPattern);
+        String versionMeta = matcher.group(6);
+        if (requireMeta) {
+            return versionMeta != null && versionMeta.matches(metadataPattern);
+        } else {
+            return versionMeta == null;
+        }
     }
 
     static String normalizeVersion(String version) {

--- a/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/semver/LatestReleaseTest.kt
@@ -92,6 +92,8 @@ class LatestReleaseTest {
         assertThat(LatestRelease("-jre").isValid("1.0", "29.0")).isFalse
         assertThat(LatestRelease("-jre").isValid("1.0", "29.0-android")).isFalse
         assertThat(LatestRelease("").isValid("1.0", "29.0")).isTrue
+        assertThat(LatestRelease("").isValid("1.0", "29.0-jre")).isFalse
+        assertThat(LatestRelease(null).isValid("1.0", "29.0-jre")).isFalse
     }
 
     @Test


### PR DESCRIPTION
- Fixes version comparison when there is no metadata pattern on the initial version but versions that are being compared have metadata patterns.
- UpgradeDependencyVersion will not attempt to upgrade a dependency if the artifact is mapped to a project pom.