### PR TITLE
Request Result Exception

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeRunException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeRunException.java
@@ -21,7 +21,7 @@ import org.openrewrite.internal.lang.Nullable;
 import java.util.StringJoiner;
 import java.util.UUID;
 
-public class UncaughtVisitorException extends RuntimeException {
+public class RecipeRunException extends RuntimeException {
     @Getter
     private final UUID id = UUID.randomUUID();
 
@@ -32,12 +32,12 @@ public class UncaughtVisitorException extends RuntimeException {
     @Nullable
     private final Cursor cursor;
 
-    public UncaughtVisitorException(Throwable cause, @Nullable Cursor cursor) {
+    public RecipeRunException(Throwable cause, @Nullable Cursor cursor) {
         super(cause);
         this.cursor = cursor;
     }
 
-    public UncaughtVisitorException(Throwable cause) {
+    public RecipeRunException(Throwable cause) {
         this(cause, null);
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/RecipeRunExceptionResult.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeRunExceptionResult.java
@@ -18,11 +18,11 @@ package org.openrewrite;
 import lombok.Getter;
 import org.openrewrite.marker.SearchResult;
 
-public class UncaughtVisitorExceptionResult extends SearchResult {
+public class RecipeRunExceptionResult extends SearchResult {
     @Getter
-    private final UncaughtVisitorException exception;
+    private final RecipeRunException exception;
 
-    public UncaughtVisitorExceptionResult(UncaughtVisitorException exception) {
+    public RecipeRunExceptionResult(RecipeRunException exception) {
         super(exception.getId(), exception.getSanitizedStackTrace());
         this.exception = exception;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -66,8 +66,8 @@ public class Result {
     @Nullable
     private Path relativeTo;
 
-    public List<UncaughtVisitorException> getRecipeErrors() {
-        List<UncaughtVisitorException> exceptions = new ArrayList<>();
+    public List<RecipeRunException> getRecipeErrors() {
+        List<RecipeRunException> exceptions = new ArrayList<>();
         new TreeVisitor<Tree, Integer>() {
             @Nullable
             @Override
@@ -76,7 +76,7 @@ public class Result {
                     try {
                         Method getMarkers = tree.getClass().getDeclaredMethod("getMarkers");
                         Markers markers = (Markers) getMarkers.invoke(tree);
-                        markers.findFirst(UncaughtVisitorExceptionResult.class)
+                        markers.findFirst(RecipeRunExceptionResult.class)
                                 .ifPresent(e -> exceptions.add(e.getException()));
                     } catch (Throwable ignored) {
                     }

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -246,11 +246,11 @@ public abstract class TreeVisitor<T extends Tree, P> {
                 afterVisit = null;
             }
         } catch (Throwable e) {
-            if (e instanceof UncaughtVisitorException) {
+            if (e instanceof RecipeRunException) {
                 // bubbling up from lower in the tree
                 throw e;
             }
-            throw new UncaughtVisitorException(e, getCursor());
+            throw new RecipeRunException(e, getCursor());
         }
 
         //noinspection unchecked

--- a/rewrite-core/src/main/java/org/openrewrite/internal/FindRecipeRunException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/FindRecipeRunException.java
@@ -17,21 +17,21 @@ package org.openrewrite.internal;
 
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.UncaughtVisitorException;
-import org.openrewrite.UncaughtVisitorExceptionResult;
+import org.openrewrite.RecipeRunException;
+import org.openrewrite.RecipeRunExceptionResult;
 import org.openrewrite.marker.Markers;
 
 import java.lang.reflect.Method;
 
 import static java.util.Objects.requireNonNull;
 
-public class FindUncaughtVisitorException extends TreeVisitor<Tree, Integer> {
-    private final UncaughtVisitorException vt;
+public class FindRecipeRunException extends TreeVisitor<Tree, Integer> {
+    private final RecipeRunException vt;
     private final Tree nearestTree;
 
-    public FindUncaughtVisitorException(UncaughtVisitorException vt) {
-        this.vt = vt;
-        this.nearestTree = (Tree) requireNonNull(vt.getCursor()).getPath(Tree.class::isInstance).next();
+    public FindRecipeRunException(RecipeRunException rre) {
+        this.vt = rre;
+        this.nearestTree = (Tree) requireNonNull(rre.getCursor()).getPath(Tree.class::isInstance).next();
     }
 
     @Override
@@ -42,7 +42,7 @@ public class FindUncaughtVisitorException extends TreeVisitor<Tree, Integer> {
                 Method withMarkers = tree.getClass().getDeclaredMethod("withMarkers", Markers.class);
                 Markers markers = (Markers) getMarkers.invoke(tree);
                 return (Tree) withMarkers.invoke(tree, markers
-                        .computeByType(new UncaughtVisitorExceptionResult(vt), (s1, s2) -> s1 == null ? s2 : s1));
+                        .computeByType(new RecipeRunExceptionResult(vt), (s1, s2) -> s1 == null ? s2 : s1));
             } catch (Throwable ignored) {
             }
         }

--- a/rewrite-java-11/src/test/java/org/openrewrite/RecipeRunExceptionTest.java
+++ b/rewrite-java-11/src/test/java/org/openrewrite/RecipeRunExceptionTest.java
@@ -1,0 +1,50 @@
+package org.openrewrite;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.Markers;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecipeRunExceptionTest {
+
+    @Test
+    void addExceptionToTree() {
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build().parse("class Test {}").get(0);
+
+        cu = (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier ident, Integer p) {
+                J.Identifier i = super.visitIdentifier(ident, p);
+                return i.withException(new IllegalStateException("boom"), null);
+            }
+        }.visitNonNull(cu, 0);
+
+        List<RecipeRunException> exceptions = new ArrayList<>();
+        new TreeVisitor<Tree, Integer>() {
+            @Nullable
+            @Override
+            public Tree visit(@Nullable Tree tree, Integer p) {
+                if (tree != null) {
+                    try {
+                        Method getMarkers = tree.getClass().getDeclaredMethod("getMarkers");
+                        Markers markers = (Markers) getMarkers.invoke(tree);
+                        markers.findFirst(RecipeRunExceptionResult.class)
+                                .ifPresent(e -> exceptions.add(e.getException()));
+                    } catch (Throwable ignored) {
+                    }
+                }
+                return super.visit(tree, p);
+            }
+        }.visit(cu, 0);
+
+        Assertions.assertThat(exceptions).hasSize(1);
+        Assertions.assertThat(exceptions.get(0).getCause()).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/rewrite-java-11/src/test/java/org/openrewrite/RecipeRunExceptionTest.java
+++ b/rewrite-java-11/src/test/java/org/openrewrite/RecipeRunExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite;
 
 import org.assertj.core.api.Assertions;

--- a/rewrite-java-11/src/test/java/org/openrewrite/internal/TreeVisitorAdapterTest.java
+++ b/rewrite-java-11/src/test/java/org/openrewrite/internal/TreeVisitorAdapterTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.UncaughtVisitorException;
+import org.openrewrite.RecipeRunException;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
@@ -41,18 +41,18 @@ public class TreeVisitorAdapterTest {
     void findUncaught() {
         J.CompilationUnit cu = JavaParser.fromJavaVersion().build().parse("class Test {}").get(0);
 
-        AtomicReference<UncaughtVisitorException> e = new AtomicReference<>();
+        AtomicReference<RecipeRunException> e = new AtomicReference<>();
         new JavaVisitor<Integer>() {
             @Override
             public J visitIdentifier(J.Identifier ident, Integer p) {
-                e.set(new UncaughtVisitorException(new IllegalStateException("boom"), getCursor()));
+                e.set(new RecipeRunException(new IllegalStateException("boom"), getCursor()));
                 return super.visitIdentifier(ident, p);
             }
         }.visit(cu, 0);
 
         //noinspection unchecked
         JavaVisitor<Integer> jv = TreeVisitorAdapter.adapt(
-                new FindUncaughtVisitorException(e.get()), JavaVisitor.class);
+                new FindRecipeRunException(e.get()), JavaVisitor.class);
 
         jv.visitNonNull(cu, 0);
     }


### PR DESCRIPTION
- Generalize the name of the exception and result that are attached as markers on Tree to `RecipeRunExecption` and `RecipeRunExceptionResult`
- add a wither method to `Tree` to allow exceptions to be quickly added as a marker.