### PR TITLE
Let the BlockStatementTemplateGenerator manage statement semicolons a…

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -143,6 +143,14 @@ public class BlockStatementTemplateGenerator {
                         }
                     }
                 }
+                // Catch any templated trees having a STOP_COMMENT which are missed due to invalid type information
+                else if (tree != null && !js.isEmpty()){
+                    //noinspection unchecked
+                    J2 trimmed = (J2) TemplatedTreeTrimmer.trimTree((J) tree);
+                    if (trimmed != tree) {
+                        done = true;
+                    }
+                }
 
                 return super.visit(tree, p);
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -143,7 +143,7 @@ public class BlockStatementTemplateGenerator {
                         }
                     }
                 }
-                // Catch any templated trees having a STOP_COMMENT which are missed due to invalid type information
+                // Catch any trees having a STOP_COMMENT that are not an instance of `expected`
                 else if (tree != null && !js.isEmpty()){
                     //noinspection unchecked
                     J2 trimmed = (J2) TemplatedTreeTrimmer.trimTree((J) tree);

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -171,9 +171,9 @@ public class JavaTemplateParser {
         J.MethodInvocation method = cursor.getValue();
         String methodWithReplacedNameAndArgs;
         if (method.getSelect() == null) {
-            methodWithReplacedNameAndArgs = template + ";";
+            methodWithReplacedNameAndArgs = template;
         } else {
-            methodWithReplacedNameAndArgs = method.getSelect().print(cursor) + "." + template + ";";
+            methodWithReplacedNameAndArgs = method.getSelect().print(cursor) + "." + template;
         }
         // TODO: The stub string includes the scoped elements of each original AST, and therefore is not a good
         //       cache key. There are virtual no cases where a stub key will result in re-use. If we can come up with
@@ -188,7 +188,7 @@ public class JavaTemplateParser {
     public J.MethodInvocation parseMethodArguments(Cursor cursor, String template, Space.Location location) {
         J.MethodInvocation method = cursor.getValue();
         String methodWithReplacementArgs = method.withArguments(Collections.emptyList()).printTrimmed(cursor)
-                .replaceAll("\\)$", template + ");");
+                .replaceAll("\\)$", template + ")");
         // TODO: The stub string includes the scoped elements of each original AST, and therefore is not a good
         //       cache key. There are virtual no cases where a stub key will result in re-use. If we can come up with
         //       a safe, reusable key, we can consider using the cache for block statements.


### PR DESCRIPTION
…nd add catch for trimming trees having invalid type information and a STOP_COMMENT.