### PR TITLE
New recipe to remove unnecessary catch blocks

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -35,6 +35,7 @@ import org.openrewrite.java.tree.TypeTreeTest
 // Tests are in alphabetical order.
 //----------------------------------------------------------------------------------------
 
+@Suppress("unused")
 @ExtendWith(JavaParserResolver::class)
 abstract class JavaVisitorCompatibilityKit {
     abstract fun javaParser(): JavaParser.Builder<*, *>
@@ -518,6 +519,9 @@ abstract class JavaVisitorCompatibilityKit {
 
     @Nested
     inner class UnnecessaryPrimitiveAnnotationsTck : UnnecessaryPrimitiveAnnotationsTest
+
+    @Nested
+    inner class UnnecessaryCatchTck : UnnecessaryCatchTest
 
     @Nested
     inner class UnnecessaryCloseInTryWithResourcesTck : UnnecessaryCloseInTryWithResourcesTest

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UnnecessaryCatchTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UnnecessaryCatchTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.Assertions.java
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
+
+interface UnnecessaryCatchTest : RewriteTest {
+
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(UnnecessaryCatch())
+    }
+
+    @Test
+    fun unwrapTry() = rewriteRun(
+        java(
+            """
+                import java.io.IOException;
+                
+                public class AnExample {
+                    public void method() {
+                        try {
+                            java.util.Base64.getDecoder().decode("abc".getBytes());
+                        } catch (IOException e) {
+                            System.out.println("an exception!");
+                        }
+                    }
+                }
+            """,
+            """
+                public class AnExample {
+                    public void method() {
+                        java.util.Base64.getDecoder().decode("abc".getBytes());
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun removeCatch() = rewriteRun(
+        java(
+            """
+                import java.io.IOException;
+                
+                public class AnExample {
+                    public void method() {
+                        try {
+                            java.util.Base64.getDecoder().decode("abc".getBytes());
+                        } catch (IOException e1) {
+                            System.out.println("an exception!");
+                        } catch (IllegalStateException e2) {
+                            System.out.println("another exception!");
+                        }
+                    }
+                }
+            """,
+            """
+                public class AnExample {
+                    public void method() {
+                        try {
+                            java.util.Base64.getDecoder().decode("abc".getBytes());
+                        } catch (IllegalStateException e2) {
+                            System.out.println("another exception!");
+                        }
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun doNotRemoveRuntimeException() = rewriteRun(
+        java(
+            """ 
+                public class AnExample {
+                    public void method() {
+                        try {
+                            java.util.Base64.getDecoder().decode("abc".getBytes());
+                        } catch (IllegalStateException e) {
+                            System.out.println("an exception!");            
+                        }
+                    }
+                }
+            """
+        )
+    )
+
+    @Test
+    fun doNotRemoveThrownException() = rewriteRun(
+        java(
+            """
+                import java.io.IOException;
+                
+                public class AnExample {
+                    public void method() {
+                        try {
+                            fred();
+                        } catch (IOException e) {
+                            System.out.println("an exception!");            
+                        }
+                    }
+                    
+                    public void fred() throws IOException {
+                    }
+                }
+            """
+        )
+    )
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryCatch.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryCatch.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class UnnecessaryCatch extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove catch for a checked exception if the try block does not throw that exception";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A refactoring operation may result in a checked exception that is no longer thrown from a `try` block. This recipe will find and remove unnecessary catch blocks.";
+    }
+
+    @Override
+    public JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+                J.Block b = super.visitBlock(block, ctx);
+                return b.withStatements(ListUtils.flatMap(b.getStatements(), statement -> {
+                    if (statement instanceof J.Try) {
+                        // if a try has no catches, no finally, and no resources get rid of it and merge its statements into the current block
+                        J.Try aTry = (J.Try) statement;
+                        if (aTry.getCatches().isEmpty() && aTry.getResources() == null && aTry.getFinally() == null) {
+                            return ListUtils.map(aTry.getBody().getStatements(), tryStat -> autoFormat(tryStat, ctx, getCursor()));
+                        }
+                    }
+                    return statement;
+                }));
+            }
+
+            @Override
+            public J.Try visitTry(J.Try tryable, ExecutionContext executionContext) {
+                J.Try t = super.visitTry(tryable, executionContext);
+
+                List<JavaType.FullyQualified> thrownExceptions = new ArrayList<>();
+                AtomicBoolean missingTypeInformation = new AtomicBoolean(false);
+                //Collect any checked exceptions thrown from the try block.
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer integer) {
+                        JavaType.Method methodType = method.getMethodType();
+                        if (methodType == null) {
+                            //Do not make any changes if there is missing type information.
+                            missingTypeInformation.set(true);
+                        } else {
+                            thrownExceptions.addAll(methodType.getThrownExceptions());
+                        }
+                        return super.visitMethodInvocation(method, integer);
+                    }
+                }.visit(t.getBody(), 0);
+
+                //If there is any missing type information, it is not safe to make any transformations.
+                if (missingTypeInformation.get()) {
+                    return t;
+                }
+
+                //!e.isAssignableTo("java.lang.RuntimeException")
+                //For any checked exceptions being caught, if the exception is not thrown, remove the catch block.
+                return t.withCatches(ListUtils.map(t.getCatches(), (i, aCatch) -> {
+                    JavaType parameterType = aCatch.getParameter().getType();
+                    if (parameterType == null || TypeUtils.isAssignableTo("java.lang.RuntimeException", parameterType)) {
+                        return aCatch;
+                    }
+                    for (JavaType.FullyQualified e : thrownExceptions) {
+                        if (TypeUtils.isAssignableTo(e, parameterType)) {
+                            return aCatch;
+                        }
+                    }
+                    maybeRemoveImport(TypeUtils.asFullyQualified(parameterType));
+                    return null;
+                }));
+            }
+
+        };
+    }
+}


### PR DESCRIPTION
A refactoring operation may result in a checked exception that is no longer thrown from a `try` block. This recipe will find and remove unnecessary catch blocks.