### PR TITLE
fix issue with HCL attribute name casting to Identifier

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclVisitor.java
@@ -56,7 +56,7 @@ public class HclVisitor<P> extends TreeVisitor<Hcl, P> {
         a = a.withPrefix(visitSpace(a.getPrefix(), Space.Location.ATTRIBUTE, p));
         a = a.withMarkers(visitMarkers(a.getMarkers(), p));
         a = (Hcl.Attribute) visitBodyContent(a, p);
-        a = a.withName((Hcl.Identifier) visit(a.getName(), p));
+        a = a.withName((Expression) visit(a.getName(), p));
         visitSpace(a.getPadding().getType().getBefore(), Space.Location.ATTRIBUTE_ASSIGNMENT, p);
         a = a.withValue((Expression) visit(a.getValue(), p));
         return a;


### PR DESCRIPTION
Now that HCL attribute names can be a `QuotedTemplate` or an `Identifier` (https://github.com/openrewrite/rewrite/pull/2195), I missed updating the visitor to cast appropriately to an `Expression` instead