### PR TITLE
don't treat leading underscore as snake case

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DynamicTest

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/MethodMatcherTest.kt
@@ -399,4 +399,20 @@ interface MethodMatcherTest {
         val testMethod = classDecl.body.statements[0] as J.MethodDeclaration
         return testMethod.body!!.statements[0] as J.MethodInvocation
     }
+    @Test
+    fun arrayExample(jp: JavaParser) {
+        val cu = jp.parse(
+            """
+            package com.yourorg;
+
+            class Foo {
+                void bar(String[] s) {}
+            }
+        """
+        ).first()
+        val classDecl = cu.classes.first()
+        val methodDecl = classDecl.body.statements[0] as J.MethodDeclaration
+        assertEquals("MethodDeclaration{com.yourorg.Foo{name=bar,return=void,parameters=[java.lang.String[]]}}", methodDecl.toString())
+        assertTrue(MethodMatcher("com.yourorg.Foo bar(String[])").matches(methodDecl, classDecl))
+    }
 }

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/MethodNameCasingTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/MethodNameCasingTest.kt
@@ -286,5 +286,70 @@ interface MethodNameCasingTest: JavaRecipeTest, RewriteTest {
                 }
             }
         """
-    );
+    )
+
+    @Test
+    fun `keep camel case when removing leading underscore 2`() = assertChanged(
+        before = """
+            import java.util.*;
+            
+            class Test {
+                private List<String> _getNames() {
+                    List<String> result = new ArrayList<>();
+                    result.add("Alice");
+                    result.add("Bob");
+                    result.add("Carol");
+                    return result;
+                }
+                
+                public void run() {
+                    for (String n: _getNames()) {
+                        System.out.println(n);
+                    }
+                }
+            }
+        """,
+        after = """
+            import java.util.*;
+            
+            class Test {
+                private List<String> getNames() {
+                    List<String> result = new ArrayList<>();
+                    result.add("Alice");
+                    result.add("Bob");
+                    result.add("Carol");
+                    return result;
+                }
+                
+                public void run() {
+                    for (String n: getNames()) {
+                        System.out.println(n);
+                    }
+                }
+            }
+        """
+    )
+    @Test
+    fun `change name of method with array argument`() = assertChanged(
+        before = """
+            import java.util.*;
+            
+            class Test {
+                private List<String> _getNames(String[] names) {
+                    List<String> result = new ArrayList<>(Arrays.asList(names));
+                    return result;
+                }
+            }
+        """,
+        after = """
+            import java.util.*;
+            
+            class Test {
+                private List<String> getNames(String[] names) {
+                    List<String> result = new ArrayList<>(Arrays.asList(names));
+                    return result;
+                }
+            }
+        """
+    )
 }

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/MethodNameCasingTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/MethodNameCasingTest.kt
@@ -269,4 +269,22 @@ interface MethodNameCasingTest: JavaRecipeTest, RewriteTest {
             """
         )
     )
+
+    @Test
+    fun `keep camel case when removing leading underscore`() = assertChanged(
+        before = """
+            class Test {
+                private void _theMethod() {
+                
+                }
+            }
+        """,
+        after = """
+            class Test {
+                private void theMethod() {
+                
+                }
+            }
+        """
+    );
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.internal.grammar.MethodSignatureParserBaseVisitor;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
@@ -149,24 +150,31 @@ public class MethodMatcher {
                 // match constructors
                 (method.getMethodType() != null && methodNamePattern.matcher(method.getMethodType().getName()).matches());
 
+        String arguments = method.getParameters().stream()
+                .map(this::variableDeclarationsType)
+                .filter(Objects::nonNull)
+                .map(MethodMatcher::typePattern)
+                .filter(Objects::nonNull)
+                .collect(joining(","));
         return matchesMethodName &&
-                argumentPattern.matcher(method.getParameters().stream()
-                        .map(v -> {
-                            if (v instanceof J.VariableDeclarations) {
-                                J.VariableDeclarations vd = (J.VariableDeclarations) v;
-                                if (vd.getTypeAsFullyQualified() != null) {
-                                    return vd.getTypeAsFullyQualified();
-                                } else {
-                                    return vd.getTypeExpression() != null ? vd.getTypeExpression().getType() : null;
-                                }
-                            } else {
-                                return null;
-                            }
-                        })
-                        .filter(Objects::nonNull)
-                        .map(MethodMatcher::typePattern)
-                        .filter(Objects::nonNull)
-                        .collect(joining(","))).matches();
+                argumentPattern.matcher(arguments).matches();
+    }
+
+    @Nullable
+    private JavaType variableDeclarationsType(Statement v) {
+        if (v instanceof J.VariableDeclarations) {
+            J.VariableDeclarations vd = (J.VariableDeclarations) v;
+            List<J.VariableDeclarations.NamedVariable> variables = vd.getVariables();
+            if (!variables.isEmpty() && variables.get(0).getType() != null) {
+                return variables.get(0).getType();
+            } else if (vd.getTypeAsFullyQualified() != null) {
+                return vd.getTypeAsFullyQualified();
+            } else {
+                return vd.getTypeExpression() != null ? vd.getTypeExpression().getType() : null;
+            }
+        } else {
+            return null;
+        }
     }
 
     public boolean matches(@Nullable Expression maybeMethod) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HideUtilityClassConstructorVisitor.java
@@ -180,7 +180,7 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
                             JavaType.Primitive.Void.equals(md.getReturnTypeExpression().getType()) &&
 
                             // note that the matcher for "main(String)" will match on "main(String[]) as expected.
-                            new MethodMatcher(c.getType().getFullyQualifiedName() + " main(String)")
+                            new MethodMatcher(c.getType().getFullyQualifiedName() + " main(String\\[\\])")
                                     .matches(md, c)) {
                         return true;
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
@@ -73,7 +73,7 @@ public class MethodNameCasing extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         Pattern standardMethodName = Pattern.compile("^[a-z][a-zA-Z0-9]*$");
-        Pattern snakeCase = Pattern.compile("^[a-zA-Z0-9_]*$");
+        Pattern snakeCase = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_]*$");
         return new JavaIsoVisitor<ExecutionContext>() {
 
             @Override


### PR DESCRIPTION
A convention I have seen is to prefix private method names with an underscore. The MethodNameCasing recipe currently treats this as a snake case name.

This diff changes the Patterns so that a leading underscore isn't treated as snake case. I added a test case and existing tests pass.