### PR TITLE
fix: keep inner class imports (#2231)

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/RemoveUnusedImportsTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/RemoveUnusedImportsTest.kt
@@ -898,4 +898,23 @@ interface RemoveUnusedImportsTest : JavaRecipeTest, RewriteTest {
         """,
         expectedCyclesThatMakeChanges = 2
     )
+
+    @Test
+    fun keepInnerClassImports(jp: JavaParser) = assertUnchanged(
+        jp,
+        before = """
+            import java.util.*;
+            import java.util.Map.Entry;
+
+            import static java.util.Collections.*;
+
+            class A {
+               Collection<Integer> c = emptyList();
+               Set<Integer> s = emptySet();
+               List<String> l = Arrays.asList("c","b","a");
+               Iterator<Short> i = emptyIterator();
+               Entry<String, Integer> entry;
+            }
+        """
+    )
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -243,7 +243,7 @@ public class RemoveUnusedImports extends Recipe {
                             changed = true;
                         }
                     } else {
-                        if (usedWildcardImports.contains(elem.getPackageName())) {
+                        if (usedWildcardImports.contains(elem.getPackageName()) && !elem.getTypeName().contains("$")) {
                             anImport.used = false;
                             changed = true;
                         }


### PR DESCRIPTION
Currently inner class imports will be removed if a package matching wildcard import is present. This PR fixes this bug.