### PR TITLE
Improved YamlPrinter behavior for scalars with double-quoted values containing escape sequences

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -113,12 +113,28 @@ public class YamlPrinter<P> extends YamlVisitor<PrintOutputCapture<P>> {
         switch (scalar.getStyle()) {
             case DOUBLE_QUOTED:
                 p.out.append('"')
-                        .append(scalar.getValue().replaceAll("\\n", "\\\\n"))
+                        .append(scalar.getValue()
+                                .replace("\\", "\\\\")
+                                .replace("\0", "\\0")
+                                .replace("\u0007", "\\a")
+                                .replace("\b", "\\b")
+                                .replace("\t", "\\t")
+                                .replace("\n", "\\n")
+                                .replace("\u000B", "\\v")
+                                .replace("\f", "\\f")
+                                .replace("\r", "\\r")
+                                .replace("\u001B", "\\e")
+                                .replace("\"", "\\\"")
+                                .replace("\u0085", "\\N")
+                                .replace("\u00A0", "\\_")
+                                .replace("\u2028", "\\L")
+                                .replace("\u2029", "\\P")
+                        )
                         .append('"');
                 break;
             case SINGLE_QUOTED:
                 p.out.append('\'')
-                        .append(scalar.getValue().replaceAll("\\n", "\\\\n"))
+                        .append(scalar.getValue())
                         .append('\'');
                 break;
             case LITERAL:

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/tree/MappingTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/tree/MappingTest.kt
@@ -18,6 +18,8 @@ package org.openrewrite.yaml.tree
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.openrewrite.Issue
 import org.openrewrite.yaml.YamlParser
 
@@ -295,4 +297,44 @@ class MappingTest: YamlParserTest {
       : 
         - value
     """)
+
+    @ParameterizedTest
+    @ValueSource(strings = [
+        """ '\\n' """,
+        """ '\n' """,
+        """ \n """,
+        """ "\\." """,
+        """ "\\0" """,
+        """ "\0" """,
+        """ "\\a" """,
+        """ "\a" """,
+        """ "\\b" """,
+        """ "\b" """,
+        """ "\\t" """,
+        """ "\t" """,
+        """ "\\n" """,
+        """ "\n" """,
+        """ "\\v" """,
+        """ "\v" """,
+        """ "\\f" """,
+        """ "\f" """,
+        """ "\\r" """,
+        """ "\r" """,
+        """ "\\e" """,
+        """ "\e" """,
+        """ "\\\\" """,
+        """ "\\" """,
+        """ "\\\"" """,
+        """ "\"" """,
+        """ "\\N" """,
+        """ "\N" """,
+        """ "\\_" """,
+        """ "\_" """,
+        """ "\\L" """,
+        """ "\L" """,
+        """ "\\P" """,
+        """ "\P" """,
+    ])
+    // https://github.com/yaml/yaml-grammar/blob/master/yaml-spec-1.2.txt#L1914
+    fun escapeSequences(string: String) = assertRoundTrip("escaped-value: $string")
 }


### PR DESCRIPTION
Handled all supported sequences specified in YAML spec: https://github.com/yaml/yaml-grammar/blob/master/yaml-spec-1.2.txt#L1914

...except for \x20 (space) and arbitrary unicode escapes (eg \x00, \u0000, \U00000000), because they were causing tricky interactions

Fixes #2154 