### PR TITLE
Add Anchor and Alias support to the Yaml model and JsonPathMatcher 

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeKey.java
@@ -68,7 +68,9 @@ public class ChangeKey extends Recipe {
             public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext context) {
                 Yaml.Mapping.Entry e = super.visitMappingEntry(entry, context);
                 if (matcher.matches(getCursor())) {
-                    e = e.withKey(e.getKey().withValue(newKey));
+                    if (e.getKey() instanceof Yaml.Scalar) {
+                        e = e.withKey(((Yaml.Scalar)e.getKey()).withValue(newKey));
+                    }
                 }
                 return e;
             }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
@@ -30,6 +30,9 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
 
     @Override
     public Yaml.Document visitDocument(Yaml.Document document, P p) {
+        if (document != new ReplaceAliasWithAnchorValueVisitor<P>().visit(document, p)) {
+            return document;
+        }
         findIndent.visit(document, p);
         return super.visitDocument(document, p);
     }
@@ -47,7 +50,7 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
                 if (valueMapping.getEntries().size() == 1) {
                     Yaml.Mapping.Entry subEntry = valueMapping.getEntries().iterator().next();
                     if (!subEntry.getPrefix().contains("#")) {
-                        Yaml.Scalar coalescedKey = entry.getKey().withValue(entry.getKey().getValue() + "." + subEntry.getKey().getValue());
+                        Yaml.Scalar coalescedKey = ((Yaml.Scalar) entry.getKey()).withValue(entry.getKey().getValue() + "." + subEntry.getKey().getValue());
 
                         entries.add(entry.withKey(coalescedKey)
                                 .withValue(subEntry.getValue()));

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
@@ -86,6 +86,16 @@ public class DeleteProperty extends Recipe {
     @Override
     public YamlVisitor<ExecutionContext> getVisitor() {
         return new YamlIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public Yaml.Documents visitDocuments(Yaml.Documents documents, ExecutionContext executionContext) {
+                // TODO: Update DeleteProperty to support documents having Anchor / Alias Pairs
+                if (documents != new ReplaceAliasWithAnchorValueVisitor<ExecutionContext>().visit(documents, executionContext)) {
+                    return documents;
+                }
+                return super.visitDocuments(documents, executionContext);
+            }
+
             @Override
             public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
                 Yaml.Mapping.Entry e = super.visitMappingEntry(entry, ctx);

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueVisitor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml;
+
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReplaceAliasWithAnchorValueVisitor<P> extends YamlVisitor<P> {
+    Map<String, Yaml> scopedAnchors = new HashMap<>();
+    @Override
+    public Yaml visitMapping(Yaml.Mapping mapping, P p) {
+        if (mapping.getAnchor() != null) {
+            scopedAnchors.put(mapping.getAnchor().getKey(), mapping.withAnchor(null));
+        }
+        return super.visitMapping(mapping, p);
+    }
+
+    @Override
+    public Yaml visitScalar(Yaml.Scalar scalar, P p) {
+        if (scalar.getAnchor() != null) {
+            scopedAnchors.put(scalar.getAnchor().getKey(), scalar.withAnchor(null));
+        }
+        return super.visitScalar(scalar, p);
+    }
+
+    @Override
+    public Yaml visitAlias(Yaml.Alias alias, P p) {
+        Yaml.Alias al = (Yaml.Alias) super.visitAlias(alias, p);
+        Yaml anchorVal = scopedAnchors.get(al.getAnchor().getKey());
+        if (anchorVal != null) {
+            return anchorVal;
+        }
+        return al;
+    }
+}

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueVisitor.java
@@ -21,11 +21,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ReplaceAliasWithAnchorValueVisitor<P> extends YamlVisitor<P> {
-    Map<String, Yaml> scopedAnchors = new HashMap<>();
+    Map<String, Yaml> anchorValues = new HashMap<>();
     @Override
     public Yaml visitMapping(Yaml.Mapping mapping, P p) {
         if (mapping.getAnchor() != null) {
-            scopedAnchors.put(mapping.getAnchor().getKey(), mapping.withAnchor(null));
+            anchorValues.put(mapping.getAnchor().getKey(), mapping.withAnchor(null));
         }
         return super.visitMapping(mapping, p);
     }
@@ -33,7 +33,7 @@ public class ReplaceAliasWithAnchorValueVisitor<P> extends YamlVisitor<P> {
     @Override
     public Yaml visitScalar(Yaml.Scalar scalar, P p) {
         if (scalar.getAnchor() != null) {
-            scopedAnchors.put(scalar.getAnchor().getKey(), scalar.withAnchor(null));
+            anchorValues.put(scalar.getAnchor().getKey(), scalar.withAnchor(null));
         }
         return super.visitScalar(scalar, p);
     }
@@ -41,7 +41,7 @@ public class ReplaceAliasWithAnchorValueVisitor<P> extends YamlVisitor<P> {
     @Override
     public Yaml visitAlias(Yaml.Alias alias, P p) {
         Yaml.Alias al = (Yaml.Alias) super.visitAlias(alias, p);
-        Yaml anchorVal = scopedAnchors.get(al.getAnchor().getKey());
+        Yaml anchorVal = anchorValues.get(al.getAnchor().getKey());
         if (anchorVal != null) {
             return anchorVal;
         }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -30,6 +30,7 @@ import org.openrewrite.marker.Markers;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 import org.openrewrite.yaml.tree.Yaml;
+import org.openrewrite.yaml.tree.YamlKey;
 import org.yaml.snakeyaml.events.*;
 import org.yaml.snakeyaml.parser.Parser;
 import org.yaml.snakeyaml.parser.ParserImpl;
@@ -418,7 +419,7 @@ public class YamlParser implements org.openrewrite.Parser<Yaml.Documents> {
         private final List<Yaml.Mapping.Entry> entries = new ArrayList<>();
 
         @Nullable
-        private Yaml.Scalar key;
+        private YamlKey key;
 
         private MappingBuilder(String prefix, @Nullable String startBracePrefix, @Nullable Yaml.Anchor anchor) {
             this.prefix = prefix;
@@ -430,6 +431,8 @@ public class YamlParser implements org.openrewrite.Parser<Yaml.Documents> {
         public void push(Yaml.Block block) {
             if (key == null && block instanceof Yaml.Scalar) {
                 key = (Yaml.Scalar) block;
+            } else if (key == null && block instanceof Yaml.Alias) {
+                key = (Yaml.Alias) block;
             } else {
                 String keySuffix = block.getPrefix();
                 block = block.withPrefix(keySuffix.substring(commentAwareIndexOf(':', keySuffix) + 1));

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
@@ -193,7 +193,7 @@ public interface Yaml extends Tree {
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class Scalar implements Block {
+    class Scalar implements Block, YamlKey {
         @EqualsAndHashCode.Include
         UUID id;
 
@@ -288,7 +288,7 @@ public interface Yaml extends Tree {
 
             String prefix;
             Markers markers;
-            Scalar key;
+            YamlKey key;
 
             // https://yaml.org/spec/1.2/spec.html#:%20mapping%20value//
             String beforeMappingValueIndicator;
@@ -411,7 +411,7 @@ public interface Yaml extends Tree {
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class Alias implements Block {
+    class Alias implements Block, YamlKey {
         @EqualsAndHashCode.Include
         UUID id;
 
@@ -427,6 +427,11 @@ public interface Yaml extends Tree {
         @Override
         public <P> Yaml acceptYaml(YamlVisitor<P> v, P p) {
             return v.visitAlias(this, p);
+        }
+
+        @Override
+        public String getValue() {
+            return anchor.key;
         }
 
         @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/YamlKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/YamlKey.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml.tree;
+
+/**
+ * Yaml Keys are either Scalar or Alias blocks
+ */
+public interface YamlKey extends Yaml {
+    String getValue();
+    YamlKey copyPaste();
+
+    YamlKey withPrefix(String prefix);
+}

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class ReplaceAliasWithAnchorValueTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(RewriteTest.toRecipe(ReplaceAliasWithAnchorValueVisitor::new));
+    }
+
+    @Test
+    void simpleCase() {
+        rewriteRun(
+          yaml("""
+              bar:
+                &abc yo: friend
+              baz:
+                *abc: friendly
+              """,
+            """
+              bar:
+                &abc yo: friend
+              baz:
+                yo: friendly
+              """
+          )
+        );
+    }
+
+    @Test
+    void aliasRefersToLastKnownAnchorValue() {
+        rewriteRun(
+          yaml("""
+              definitions:
+                steps:
+                  - step: &build-test
+                      name: Build and test
+                  - step2: &build-deploy
+                      name: Build and Deploy
+              pipelines:
+                branches:
+                  develop:
+                    - step: *build-test
+                  master:
+                    - step: *build-deploy
+              environments:
+                branches:
+                  test:
+                    - step: &build-test
+                        name: ReUsed Build and Test
+                  qa:
+                    - step: *build-test
+              """,
+            """
+              definitions:
+                steps:
+                  - step: &build-test
+                      name: Build and test
+                  - step2: &build-deploy
+                      name: Build and Deploy
+              pipelines:
+                branches:
+                  develop:
+                    - step:
+                      name: Build and test
+                  master:
+                    - step:
+                      name: Build and Deploy
+              environments:
+                branches:
+                  test:
+                    - step: &build-test
+                        name: ReUsed Build and Test
+                  qa:
+                    - step:
+                        name: ReUsed Build and Test
+              """
+          )
+        );
+    }
+
+    @Test
+    void howAboutSequences() {
+        rewriteRun(
+          yaml("""
+              stages:
+                - id: &id ping_api_endpoint
+                  name: *id
+                - id: &id get_token
+                  name: *id
+                - id: &id do_something
+                  name: *id
+                - id: &id revoke_token
+                  name: *id
+              """,
+            """
+              stages:
+                - id: &id ping_api_endpoint
+                  name: ping_api_endpoint
+                - id: &id get_token
+                  name: get_token
+                - id: &id do_something
+                  name: do_something
+                - id: &id revoke_token
+                  name: revoke_token
+              """
+          )
+        );
+    }
+
+}

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangeValueTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/ChangeValueTest.kt
@@ -42,6 +42,27 @@ class ChangeValueTest : YamlRecipeTest {
     )
 
     @Test
+    fun changeAliasedKeyValue() = assertChanged(
+        recipe = ChangeValue(
+            "$.*.yo",
+            "howdy",
+            null
+        ),
+        before = """
+            bar:
+              &abc yo: friend
+            baz:
+              *abc: friendly
+        """,
+        after = """
+            bar:
+              &abc yo: howdy
+            baz:
+              *abc: howdy
+        """
+    )
+
+    @Test
     fun changeSequenceValue() = assertChanged(
         recipe = ChangeValue(
             "$.metadata.name",

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/CoalescePropertiesTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/CoalescePropertiesTest.kt
@@ -224,5 +224,17 @@ class CoalescePropertiesTest : YamlRecipeTest {
               g: g-value
         """
     )
-
+    @Test
+    fun doNotCoalesceDocumentsHavingAnchorsAndAliases() = assertUnchanged(
+        before = """
+            management:
+                metrics:
+                    &id enable.process.files: true
+                endpoint:
+                    health:
+                        show-components: always
+                        show-details: always
+                        *id: false
+        """
+    )
 }

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DeletePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DeletePropertyKeyTest.kt
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.yaml
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -86,7 +85,6 @@ class DeletePropertyKeyTest : YamlRecipeTest {
     )
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2273")
-    @Disabled
     @Test
     fun aliasAnchorPairs() = assertUnchanged(
         recipe = DeleteProperty("bar.yo", null, null, null),

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DeletePropertyKeyTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/DeletePropertyKeyTest.kt
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -82,6 +83,19 @@ class DeletePropertyKeyTest : YamlRecipeTest {
             enabled: true
           server.port: 8080
         """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2273")
+    @Disabled
+    @Test
+    fun aliasAnchorPairs() = assertUnchanged(
+        recipe = DeleteProperty("bar.yo", null, null, null),
+        before = """
+          bar:
+            &abc yo: friend
+          baz:
+            *abc: friendly
+          """
     )
 
     @ParameterizedTest

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/JsonPathMatcherTest.kt
@@ -90,6 +90,18 @@ class JsonPathMatcherTest {
       """.trimIndent())
 
     @Test
+    fun findsAlias() = assertMatched(
+        jsonPath = "$.*.yo",
+        before = arrayOf("""
+            bar:
+              &abc yo: friend
+            baz:
+              *abc: friendly
+        """),
+        after = arrayOf("&abc yo: friend", "*abc: friendly")
+    )
+
+    @Test
     fun doesNotMatchMissingProperty() = assertNotMatched(
         jsonPath = "$.none",
         before = simple

--- a/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/tree/MappingTest.kt
+++ b/rewrite-yaml/src/test/kotlin/org/openrewrite/yaml/tree/MappingTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
 import org.openrewrite.yaml.YamlParser
+import org.openrewrite.yaml.tree.Yaml.Scalar
 
 @Suppress("YAMLUnusedAnchor")
 class MappingTest: YamlParserTest {
@@ -47,7 +48,7 @@ class MappingTest: YamlParserTest {
                 name : org.openrewrite.text.ChangeTextToJon
             """,
             afterConditions = { y ->
-                Assertions.assertThat((y.documents[0].block as Yaml.Mapping).entries.map { it.key.value })
+                Assertions.assertThat((y.documents[0].block as Yaml.Mapping).entries.map { (it.key as Scalar).value })
                         .containsExactly("type", "name")
             }
     )
@@ -60,7 +61,7 @@ class MappingTest: YamlParserTest {
             """,
             afterConditions = { y ->
                 val mapping = y.documents[0].block as Yaml.Mapping
-                Assertions.assertThat(mapping.entries.map { it.key.value }).containsExactly("type")
+                Assertions.assertThat(mapping.entries.map { (it.key as Scalar).value }).containsExactly("type")
                 Assertions.assertThat(mapping.entries[0].value).isInstanceOf(Yaml.Mapping::class.java)
             }
     )
@@ -219,7 +220,6 @@ class MappingTest: YamlParserTest {
         config: [first: *first, stage: *stage, last: *last]
     """)
 
-    @Disabled
     @Test
     fun scalarKeyAnchor() = assertRoundTrip("""
         foo:
@@ -238,7 +238,14 @@ class MappingTest: YamlParserTest {
           - end: end
     """)
 
-    @Disabled
+    @Test
+    fun aliasEntryKey() = assertRoundTrip("""
+        bar:
+          &abc yo: friend
+        baz:
+          *abc: friendly
+    """)
+
     @Test
     fun scalarKeyAnchorInBrackets() = assertRoundTrip("""
         foo: [start: start, &anchor buz: buz, *anchor: baz, end: end]


### PR DESCRIPTION
fixes: #1161

- Add a new `EntryKey` interface for `Mapping.Entry.key` values which are either scalar or alias blocks.
- Update `YamlParser` to handle `Mapping.Entry.key` as an instance of `EntryKey`
- New `ReplaceAliasWithAnchorValueVisitor`.
- Update `JsonPathMatcher` to replace alias trees with their associated anchor value before searching.
- Update `CoalesceProperties` to prevent transforming documents having anchor/alias pairs.
- Update `org.openrewrite.yaml.DeleteProperty` to prevent deleting properties from documents having anchor/alias pars.
