### PR TITLE
Update UseDiamondOperator (fixes: #2274)

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
@@ -62,23 +62,28 @@ interface UseDiamondOperatorTest: RewriteTest {
         {spec -> spec.expectedCyclesThatMakeChanges(2)},
         java(
             """
-            import java.util.Map;
+            import java.util.ArrayList;
             import java.util.HashMap;
             import java.util.function.Predicate;
             import java.util.List;
+            import java.util.Map;
             
             class Foo<T> {
                 Map<String, Integer> map;
+                Map unknownMap;
                 public Foo(Predicate<T> p) {}
                 public void something(Foo<List<String>> foos){}
+                public void somethingEasy(List<List<String>> l){}
                 
                 Foo getFoo() {
                     // variable type initializer
                     Foo<List<String>> f = new Foo<List<String>>(it -> it.stream().anyMatch(baz -> true));
                     // assignment
                     map = new HashMap<String, Integer>();
+                    unknownMap = new HashMap<String, Integer>();
                     // method argument type assignment
                     something(new Foo<List<String>>(it -> it.stream().anyMatch(b -> true)));
+                    somethingEasy(new ArrayList<List<String>>());
                     // return type and assignment type unknown
                     Object o = new Foo<List<String>>(it -> it.stream().anyMatch(baz -> true));
                     // return type unknown
@@ -92,23 +97,28 @@ interface UseDiamondOperatorTest: RewriteTest {
             }
         """,
             """
-            import java.util.Map;
+            import java.util.ArrayList;
             import java.util.HashMap;
             import java.util.function.Predicate;
             import java.util.List;
+            import java.util.Map;
             
             class Foo<T> {
                 Map<String, Integer> map;
+                Map unknownMap;
                 public Foo(Predicate<T> p) {}
                 public void something(Foo<List<String>> foos){}
+                public void somethingEasy(List<List<String>> l){}
                 
                 Foo getFoo() {
                     // variable type initializer
                     Foo<List<String>> f = new Foo<>(it -> it.stream().anyMatch(baz -> true));
                     // assignment
                     map = new HashMap<>();
+                    unknownMap = new HashMap<String, Integer>();
                     // method argument type assignment
                     something(new Foo<>(it -> it.stream().anyMatch(b -> true)));
+                    somethingEasy(new ArrayList<>());
                     // return type and assignment type unknown
                     Object o = new Foo<List<String>>(it -> it.stream().anyMatch(baz -> true));
                     // return type unknown
@@ -194,7 +204,7 @@ interface UseDiamondOperatorTest: RewriteTest {
     fun notAsAChainedMethodInvocation() = rewriteRun(
         java("""
             class Test {
-                public static ResponseBuilder<String> bResponse(String entity) {
+                public static ResponseBuilder<String> bResponseEntity(String entity) {
                     return new ResponseBuilder<String>().entity(entity);
                 }
                 public static ResponseBuilder<String> bResponse(String entity) {
@@ -210,7 +220,7 @@ interface UseDiamondOperatorTest: RewriteTest {
         """,
         """
             class Test {
-                public static ResponseBuilder<String> bResponse(String entity) {
+                public static ResponseBuilder<String> bResponseEntity(String entity) {
                     return new ResponseBuilder<String>().entity(entity);
                 }
                 public static ResponseBuilder<String> bResponse(String entity) {

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
@@ -59,7 +59,6 @@ interface UseDiamondOperatorTest: RewriteTest {
     @Suppress("rawtypes")
     @Test
     fun useDiamondOperatorTest2() = rewriteRun(
-        {spec -> spec.expectedCyclesThatMakeChanges(2)},
         java(
             """
             import java.util.ArrayList;

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/UseDiamondOperatorTest.kt
@@ -60,17 +60,23 @@ interface UseDiamondOperatorTest: RewriteTest {
     @Test
     fun useDiamondOperatorTest2() = rewriteRun(
         {spec -> spec.expectedCyclesThatMakeChanges(2)},
-        java("""
+        java(
+            """
+            import java.util.Map;
+            import java.util.HashMap;
             import java.util.function.Predicate;
             import java.util.List;
             
             class Foo<T> {
+                Map<String, Integer> map;
                 public Foo(Predicate<T> p) {}
                 public void something(Foo<List<String>> foos){}
                 
                 Foo getFoo() {
                     // variable type initializer
                     Foo<List<String>> f = new Foo<List<String>>(it -> it.stream().anyMatch(baz -> true));
+                    // assignment
+                    map = new HashMap<String, Integer>();
                     // method argument type assignment
                     something(new Foo<List<String>>(it -> it.stream().anyMatch(b -> true)));
                     // return type and assignment type unknown
@@ -86,16 +92,21 @@ interface UseDiamondOperatorTest: RewriteTest {
             }
         """,
             """
+            import java.util.Map;
+            import java.util.HashMap;
             import java.util.function.Predicate;
             import java.util.List;
             
             class Foo<T> {
+                Map<String, Integer> map;
                 public Foo(Predicate<T> p) {}
                 public void something(Foo<List<String>> foos){}
                 
                 Foo getFoo() {
                     // variable type initializer
                     Foo<List<String>> f = new Foo<>(it -> it.stream().anyMatch(baz -> true));
+                    // assignment
+                    map = new HashMap<>();
                     // method argument type assignment
                     something(new Foo<>(it -> it.stream().anyMatch(b -> true)));
                     // return type and assignment type unknown

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
@@ -15,16 +15,19 @@
  */
 package org.openrewrite.java.cleanup;
 
-import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singletonList;
@@ -54,58 +57,93 @@ public class UseDiamondOperator extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new UseDiamondOperatorVisitor();
+    }
 
-        return new JavaIsoVisitor<ExecutionContext>() {
+    private static class UseDiamondOperatorVisitor extends JavaIsoVisitor<ExecutionContext> {
 
-            @Override
-            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
-                if (multiVariable.getType() == null || multiVariable.getType() instanceof JavaType.Unknown) {
-                    return multiVariable;
+        @Override
+        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext executionContext) {
+            J.VariableDeclarations.NamedVariable nv = super.visitVariable(variable, executionContext);
+            J.VariableDeclarations variableDeclarations = getCursor().firstEnclosing(J.VariableDeclarations.class);
+            if (variableDeclarations != null && variableDeclarations.getTypeExpression() instanceof J.ParameterizedType) {
+                if (nv.getInitializer() instanceof J.NewClass) {
+                    nv = nv.withInitializer(maybeRemoveParams(
+                            parameterizedTypes((J.ParameterizedType)variableDeclarations.getTypeExpression()), (J.NewClass) nv.getInitializer()));
                 }
-                return super.visitVariableDeclarations(multiVariable, executionContext);
             }
+            return nv;
+        }
 
-            @Override
-            public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
-                J.NewClass n = super.visitNewClass(newClass, executionContext);
-                if (n.getClazz() instanceof J.ParameterizedType && n.getBody() == null) {
-                    J.ParameterizedType parameterizedType = (J.ParameterizedType) n.getClazz();
-                    if (useDiamondOperator(newClass, parameterizedType)) {
-                        n = n.withClazz(parameterizedType.withTypeParameters(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY))));
-                        if (parameterizedType.getTypeParameters() != null) {
-                            parameterizedType.getTypeParameters().stream()
-                                    .map(e -> TypeUtils.asFullyQualified(e.getType()))
-                                    .forEach(this::maybeRemoveImport);
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+            JavaType.Method methodType = mi.getMethodType();
+            if (methodType != null) {
+                mi = mi.withArguments(ListUtils.map(mi.getArguments(), (i, arg) -> {
+                    if (arg instanceof J.NewClass) {
+                        JavaType.Parameterized paramType = TypeUtils.asParameterized(methodType.getParameterTypes().get(i));
+                        J.NewClass nc = (J.NewClass) arg;
+                        if (paramType != null && nc.getClazz() instanceof J.ParameterizedType) {
+                            return maybeRemoveParams(parameterizedTypes((J.ParameterizedType) nc.getClazz()), nc);
                         }
                     }
-                }
-                return n;
+                    return arg;
+                }));
             }
+            return mi;
+        }
 
-            private boolean useDiamondOperator(J.NewClass newClass, J.ParameterizedType parameterizedType) {
-                if (parameterizedType.getTypeParameters() == null || parameterizedType.getTypeParameters().isEmpty()
-                        || parameterizedType.getTypeParameters().get(0) instanceof J.Empty) {
-                    return false;
-                }
-
-                Cursor c = getCursor().dropParentUntil(J.class::isInstance);
-
-                if (c.getValue() instanceof J.VariableDeclarations.NamedVariable) {
-                    //If the immediate parent is named variable, check the variable declaration to make sure it's
-                    //not using local variable type inference.
-                    J.VariableDeclarations variableDeclaration = c.firstEnclosing(J.VariableDeclarations.class);
-                    return variableDeclaration != null && (variableDeclaration.getTypeExpression() == null ||
-                            !variableDeclaration.getTypeExpression().getMarkers().findFirst(JavaVarKeyword.class).isPresent());
-                } else if (c.getValue() instanceof J.MethodInvocation) {
-                    //Do not remove the type parameters if the newClass is the receiver of a method invocation.
-                    J.MethodInvocation invocation = c.getValue();
-                    return invocation.getSelect() != newClass;
-                } else {
-                    //If the immediate parent is a block, this new operation is a statement and there is no left side to
-                    //infer the type parameters.
-                    return !(c.getValue() instanceof J.Block);
+        @Override
+        public J.Return visitReturn(J.Return _return, ExecutionContext executionContext) {
+            J.Return rtn = super.visitReturn(_return, executionContext);
+            J.NewClass nc = rtn.getExpression() instanceof J.NewClass ? (J.NewClass)rtn.getExpression() : null;
+            if (nc != null && nc.getClazz() instanceof J.ParameterizedType) {
+                J parentBlock = getCursor().dropParentUntil(v -> v instanceof J.MethodDeclaration || v instanceof J.Lambda).getValue();
+                if (parentBlock instanceof J.MethodDeclaration) {
+                    J.MethodDeclaration md = (J.MethodDeclaration) parentBlock;
+                    if (md.getReturnTypeExpression() instanceof J.ParameterizedType) {
+                        rtn = rtn.withExpression(
+                                maybeRemoveParams(parameterizedTypes((J.ParameterizedType) md.getReturnTypeExpression()), nc));
+                    }
                 }
             }
-        };
+            return rtn;
+        }
+
+        @Nullable
+        private List<JavaType> parameterizedTypes(J.ParameterizedType parameterizedType) {
+            if (parameterizedType.getTypeParameters() == null) {
+                return null;
+            }
+            List<JavaType> types = new ArrayList<>(parameterizedType.getTypeParameters().size());
+            for (Expression typeParameter : parameterizedType.getTypeParameters()) {
+                types.add(typeParameter.getType());
+            }
+            return types;
+        }
+
+
+        private J.NewClass maybeRemoveParams(@Nullable List<JavaType> paramTypes, J.NewClass newClass) {
+            if (paramTypes != null && newClass.getBody() == null && newClass.getClazz() instanceof J.ParameterizedType) {
+                J.ParameterizedType newClassType = (J.ParameterizedType) newClass.getClazz();
+                if (newClassType.getTypeParameters() != null){
+                    if (paramTypes.size() != newClassType.getTypeParameters().size()) {
+                        return newClass;
+                    } else {
+                        for (int i = 0; i < paramTypes.size(); i++) {
+                            if (!TypeUtils.isOfType(paramTypes.get(i), newClassType.getTypeParameters().get(i).getType())) {
+                                return newClass;
+                            }
+                        }
+                    }
+                    newClassType.getTypeParameters().stream()
+                            .map(e -> TypeUtils.asFullyQualified(e.getType()))
+                            .forEach(this::maybeRemoveImport);
+                    newClass = newClass.withClazz(newClassType.withTypeParameters(singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY))));
+                }
+            }
+            return newClass;
+        }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseDiamondOperator.java
@@ -148,7 +148,7 @@ public class UseDiamondOperator extends Recipe {
                         return newClass;
                     } else {
                         for (int i = 0; i < paramTypes.size(); i++) {
-                            if (!TypeUtils.isOfType(paramTypes.get(i), newClassType.getTypeParameters().get(i).getType())) {
+                            if (!TypeUtils.isAssignableTo(paramTypes.get(i), newClassType.getTypeParameters().get(i).getType())) {
                                 return newClass;
                             }
                         }


### PR DESCRIPTION
 - check MethodDeclaration.returnTypeExpression for context when the new class is a return expression.
 - verify the parameterized types are equivalent