### PR TITLE
TypeSignatureBuilder tests must use unrestricted class loader

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -16,22 +16,13 @@
 package org.openrewrite.java;
 
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Parser;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -84,8 +75,7 @@ public class Java11Parser implements JavaParser {
             }
 
             ClassLoader appClassLoader = Java11Parser.class.getClassLoader();
-            moduleClassLoader = new UnrestrictedModuleClassLoader(appClassLoader);
-
+            moduleClassLoader = new Java11UnrestrictedClassLoader(appClassLoader);
         }
 
         @Override
@@ -108,96 +98,6 @@ public class Java11Parser implements JavaParser {
                 return new Java11Parser(delegate);
             } catch (Exception e) {
                 throw new IllegalStateException("Unable to construct Java11Parser.", e);
-            }
-        }
-    }
-
-    /**
-     * Rewrite's JavaParser is reliant on java's compiler internal classes that are now encapsulated within Java's
-     * module system. Starting in Java 17, the JVM now enforces strong encapsulation of these internal classes and
-     * default behavior is to throw a security exception when attempting to use these internal classes. This classloader
-     * circumvents these security restrictions by isolating Rewrite's Java 17 parser implementation classes and then
-     * loading any of the internal classes directly from the .jmod files.
-     *
-     * NOTE: Any classes in the package "org.openrewrite.java.isolated" will be loaded into this isolated classloader.
-     */
-    private static class UnrestrictedModuleClassLoader extends ClassLoader {
-
-        static {
-            ClassLoader.registerAsParallelCapable();
-        }
-
-        final List<Path> modules;
-
-        private UnrestrictedModuleClassLoader(ClassLoader parentClassloader) {
-            super(parentClassloader);
-
-            //A list of modules to load internal classes from
-            final FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
-            modules = List.of(
-                    fs.getPath("modules", "jdk.compiler"),
-                    fs.getPath("modules", "java.compiler"),
-                    fs.getPath("modules", "java.base")
-            );
-        }
-
-        @Override
-        public Class<?> loadClass(String name) throws ClassNotFoundException {
-
-            synchronized (getClassLoadingLock(name)) {
-                // First, check if the class has already been loaded
-                Class<?> c = findLoadedClass(name);
-                if (c != null) {
-                    return c;
-                }
-
-                String internalName = name.replace('.', '/') + ".class";
-
-                //If the class is in the package "org.openrewrite.java.internal", load it from this class loader.
-                Class<?> _class = loadIsolatedClass(name);
-                if (_class != null) {
-                    return _class;
-                }
-
-                //Otherwise look for internal classes in the list of modules.
-                if (name.startsWith("com.sun") || name.startsWith("sun")) {
-                    try {
-                        for (Path path : modules) {
-                            Path classFile = path.resolve(internalName);
-                            if (Files.exists(classFile)) {
-                                byte[] bytes = Files.readAllBytes(classFile);
-                                return defineClass(name, bytes, 0, bytes.length);
-                            }
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-            return super.loadClass(name);
-        }
-
-        @Nullable
-        private Class<?> loadIsolatedClass(String className) {
-            if (!className.startsWith("org.openrewrite.java.isolated")) {
-                return null;
-            }
-            String internalName = className.replace('.', '/') + ".class";
-            URL url = Java11Parser.class.getClassLoader().getResource(internalName);
-            if (url == null) {
-                return null;
-            }
-
-            try (InputStream stream = url.openStream()) {
-                ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
-                byte[] bytes = new byte[4096];
-                int bytesRead;
-                while ((bytesRead = stream.read(bytes)) > 0) {
-                    classBytes.write(bytes, 0, bytesRead);
-                }
-                return defineClass(className, classBytes.toByteArray(), 0, classBytes.size());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
             }
         }
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11UnrestrictedClassLoader.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11UnrestrictedClassLoader.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.openrewrite.internal.lang.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Rewrite's JavaParser is reliant on java's compiler internal classes that are now encapsulated within Java's
+ * module system. Starting in Java 17, the JVM now enforces strong encapsulation of these internal classes and
+ * default behavior is to throw a security exception when attempting to use these internal classes. This classloader
+ * circumvents these security restrictions by isolating Rewrite's Java 17 parser implementation classes and then
+ * loading any of the internal classes directly from the .jmod files.
+ * <p>
+ * NOTE: Any classes in the package "org.openrewrite.java.isolated" will be loaded into this isolated classloader.
+ */
+public class Java11UnrestrictedClassLoader extends ClassLoader {
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    final List<Path> modules;
+
+    public Java11UnrestrictedClassLoader(ClassLoader parentClassloader) {
+        super(parentClassloader);
+
+        //A list of modules to load internal classes from
+        final FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
+        modules = List.of(
+                fs.getPath("modules", "jdk.compiler"),
+                fs.getPath("modules", "java.compiler"),
+                fs.getPath("modules", "java.base")
+        );
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+
+        synchronized (getClassLoadingLock(name)) {
+            // First, check if the class has already been loaded
+            Class<?> c = findLoadedClass(name);
+            if (c != null) {
+                return c;
+            }
+
+            String internalName = name.replace('.', '/') + ".class";
+
+            //If the class is in the package "org.openrewrite.java.internal", load it from this class loader.
+            Class<?> _class = loadIsolatedClass(name);
+            if (_class != null) {
+                return _class;
+            }
+
+            //Otherwise look for internal classes in the list of modules.
+            if (name.startsWith("com.sun") || name.startsWith("sun")) {
+                try {
+                    for (Path path : modules) {
+                        Path classFile = path.resolve(internalName);
+                        if (Files.exists(classFile)) {
+                            byte[] bytes = Files.readAllBytes(classFile);
+                            return defineClass(name, bytes, 0, bytes.length);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return super.loadClass(name);
+    }
+
+    @Nullable
+    private Class<?> loadIsolatedClass(String className) {
+        if (!className.startsWith("org.openrewrite.java.isolated")) {
+            return null;
+        }
+        String internalName = className.replace('.', '/') + ".class";
+        URL url = Java11Parser.class.getClassLoader().getResource(internalName);
+        if (url == null) {
+            return null;
+        }
+
+        try (InputStream stream = url.openStream()) {
+            ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+            byte[] bytes = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = stream.read(bytes)) > 0) {
+                classBytes.write(bytes, 0, bytesRead);
+            }
+            return defineClass(className, classBytes.toByteArray(), 0, classBytes.size());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/rewrite-java-11/src/test/java/org/openrewrite/java/Java11TypeSignatureBuilderTest.java
+++ b/rewrite-java-11/src/test/java/org/openrewrite/java/Java11TypeSignatureBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.lang.reflect.Constructor;
+
+@SuppressWarnings("ConstantConditions")
+public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderTest {
+
+    @Nullable
+    private static JavaTypeSignatureBuilderTest delegate;
+
+    @BeforeAll
+    static void setup() {
+        ClassLoader moduleClassLoader = new Java11UnrestrictedClassLoader(Java11TypeSignatureBuilderTest.class.getClassLoader());
+
+        try {
+            Class<?> typeGoatBuilder = Class.forName("org.openrewrite.java.isolated.Java11TypeSignatureBuilderTestDelegate", true, moduleClassLoader);
+            Constructor<?> typeGoatBuilderConstructor = typeGoatBuilder.getDeclaredConstructor();
+            typeGoatBuilderConstructor.setAccessible(true);
+            delegate = (JavaTypeSignatureBuilderTest) typeGoatBuilderConstructor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to construct JavaTypeGoatBuilder.", e);
+        }
+    }
+
+    @Override
+    public String fieldSignature(String field) {
+        return delegate.fieldSignature(field);
+    }
+
+    @Override
+    public String methodSignature(String methodName) {
+        return delegate.methodSignature(methodName);
+    }
+
+    @Override
+    public String constructorSignature() {
+        return delegate.constructorSignature();
+    }
+
+    @Override
+    public Object firstMethodParameter(String methodName) {
+        return delegate.firstMethodParameter(methodName);
+    }
+
+    @Override
+    public Object innerClassSignature(String innerClassSimpleName) {
+        return delegate.innerClassSignature(innerClassSimpleName);
+    }
+
+    @Override
+    public Object lastClassTypeParameter() {
+        return delegate.lastClassTypeParameter();
+    }
+
+    @Override
+    public JavaTypeSignatureBuilder signatureBuilder() {
+        return delegate.signatureBuilder();
+    }
+}

--- a/rewrite-java-11/src/test/java/org/openrewrite/java/isolated/Java11TypeSignatureBuilderTestDelegate.java
+++ b/rewrite-java-11/src/test/java/org/openrewrite/java/isolated/Java11TypeSignatureBuilderTestDelegate.java
@@ -36,28 +36,30 @@ import java.nio.file.Paths;
 
 import static java.util.Collections.singletonList;
 
-@Disabled("Test disabled until we can solve how to load the tests in a classloader that allows access to internal types.")
-public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderTest {
-    private static final String goat = StringUtils.readFully(
-      Java17TypeSignatureBuilderTest.class.getResourceAsStream("/JavaTypeGoat.java"), StandardCharsets.UTF_8);
+@Disabled("Do not run the tests directly on the delegate")
+public class Java11TypeSignatureBuilderTestDelegate implements JavaTypeSignatureBuilderTest {
 
-    private static final JCTree.JCCompilationUnit cu = ReloadableJava17Parser.builder()
-      .logCompilationWarningsAndErrors(true)
-      .build()
-      .parseInputsToCompilerAst(
-        singletonList(new Parser.Input(Paths.get("JavaTypeGoat.java"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))),
-        new InMemoryExecutionContext(Throwable::printStackTrace))
-      .entrySet()
-      .iterator()
-      .next()
-      .getValue();
+    @SuppressWarnings("ConstantConditions")
+    private static final String goat = StringUtils.readFully(
+            Java11TypeSignatureBuilderTestDelegate.class.getResourceAsStream("/JavaTypeGoat.java"), StandardCharsets.UTF_8);
+
+    private static final JCTree.JCCompilationUnit cu = ReloadableJava11Parser.builder()
+            .logCompilationWarningsAndErrors(true)
+            .build()
+            .parseInputsToCompilerAst(
+                    singletonList(new Parser.Input(Paths.get("JavaTypeGoat.java"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))),
+                    new InMemoryExecutionContext(Throwable::printStackTrace))
+            .entrySet()
+            .iterator()
+            .next()
+            .getValue();
 
     @Override
     public String fieldSignature(String field) {
         return new TreeScanner<String, Integer>() {
             @Override
             public String visitVariable(VariableTree node, Integer integer) {
-                if (node.getName().toString().equals(field)) {
+                if(node.getName().toString().equals(field)) {
                     return signatureBuilder().variableSignature(((JCTree.JCVariableDecl) node).sym);
                 }
                 //noinspection ConstantConditions
@@ -78,7 +80,7 @@ public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public String visitMethod(MethodTree node, Integer p) {
                 JCTree.JCMethodDecl method = (JCTree.JCMethodDecl) node;
-                if (method.getName().toString().equals(methodName)) {
+                if(method.getName().toString().equals(methodName)) {
                     return signatureBuilder().methodSignature(method.type, method.sym);
                 }
                 //noinspection ConstantConditions
@@ -99,7 +101,7 @@ public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public String visitMethod(MethodTree node, Integer p) {
                 JCTree.JCMethodDecl method = (JCTree.JCMethodDecl) node;
-                if (method.name.toString().equals("<init>")) {
+                if(method.name.toString().equals("<init>")) {
                     return signatureBuilder().methodSignature(method.type, method.sym);
                 }
                 //noinspection ConstantConditions
@@ -120,7 +122,7 @@ public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public Type visitMethod(MethodTree node, Integer p) {
                 JCTree.JCMethodDecl method = (JCTree.JCMethodDecl) node;
-                if (method.getName().toString().equals(methodName)) {
+                if(method.getName().toString().equals(methodName)) {
                     List<JCTree.JCVariableDecl> params = method.getParameters();
                     return params.iterator().next().type;
                 }
@@ -142,7 +144,7 @@ public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public Type visitClass(ClassTree node, Integer integer) {
                 JCTree.JCClassDecl clazz = (JCTree.JCClassDecl) node;
-                if (innerClassSimpleName.equals(clazz.getSimpleName().toString())) {
+                if(innerClassSimpleName.equals(clazz.getSimpleName().toString())) {
                     return clazz.type;
                 }
                 return super.visitClass(node, integer);
@@ -168,7 +170,7 @@ public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
     }
 
     @Override
-    public ReloadableJava17TypeSignatureBuilder signatureBuilder() {
-        return new ReloadableJava17TypeSignatureBuilder();
+    public ReloadableJava11TypeSignatureBuilder signatureBuilder() {
+        return new ReloadableJava11TypeSignatureBuilder();
     }
 }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
@@ -21,12 +21,7 @@ import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
@@ -79,7 +74,7 @@ public class Java17Parser implements JavaParser {
             }
 
             ClassLoader appClassLoader = Java17Parser.class.getClassLoader();
-            moduleClassLoader = new UnrestrictedModuleClassLoader(appClassLoader);
+            moduleClassLoader = new Java17UnrestrictedClassLoader(appClassLoader);
 
         }
 
@@ -103,112 +98,6 @@ public class Java17Parser implements JavaParser {
                 return new Java17Parser(delegate);
             } catch (Exception e) {
                 throw new IllegalStateException("Unable to construct Java17Parser.", e);
-            }
-        }
-    }
-
-    /**
-     * Rewrite's JavaParser is reliant on java's compiler internal classes that are now encapsulated within Java's
-     * module system. Starting in Java 17, the JVM now enforces strong encapsulation of these internal classes and
-     * default behavior is to throw a security exception when attempting to use these internal classes. This classloader
-     * circumvents these security restrictions by isolating Rewrite's Java 17 parser implementation classes and then
-     * loading any of the internal classes directly from the .jmod files.
-     *
-     * NOTE: Any classes in the package "org.openrewrite.java.isolated" will be loaded into this isolated classloader.
-     */
-    private static class UnrestrictedModuleClassLoader extends ClassLoader {
-
-        static {
-            ClassLoader.registerAsParallelCapable();
-        }
-
-        final List<Path> modules;
-
-        private UnrestrictedModuleClassLoader(ClassLoader parentClassloader) {
-            super(parentClassloader);
-
-            //A list of modules to load internal classes from
-            final FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
-            modules = List.of(
-                    fs.getPath("modules", "jdk.compiler"),
-                    fs.getPath("modules", "java.compiler"),
-                    fs.getPath("modules", "java.base")
-            );
-        }
-
-        @Override
-        public Class<?> loadClass(String name) throws ClassNotFoundException {
-
-            synchronized (getClassLoadingLock(name)) {
-                // First, check if the class has already been loaded
-                Class<?> c = findLoadedClass(name);
-                if (c != null) {
-                    return c;
-                }
-
-                String internalName = name.replace('.', '/') + ".class";
-
-                //If the class is in the package "org.openrewrite.java.internal", load it from this class loader.
-                Class<?> _class = loadIsolatedClass(name);
-                if (_class != null) {
-                    return _class;
-                }
-
-                //Otherwise look for internal classes in the list of modules.
-                if (name.startsWith("com.sun") || name.startsWith("sun")) {
-                    try {
-                        for (Path path : modules) {
-                            Path classFile = path.resolve(internalName);
-                            if (Files.exists(classFile)) {
-                                byte[] bytes = Files.readAllBytes(classFile);
-                                return defineClass(name, bytes, 0, bytes.length);
-                            }
-                        }
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-            return super.loadClass(name);
-        }
-
-        @Override
-        @Nullable
-        public URL getResource(String name) {
-            try {
-                for (Path path : modules) {
-                    Path classFile = path.resolve(name);
-                    if (Files.exists(classFile)) {
-                        return classFile.toUri().toURL();
-                    }
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return super.getResource(name);
-        }
-
-        @Nullable
-        private Class<?> loadIsolatedClass(String className) {
-            if (!className.startsWith("org.openrewrite.java.isolated")) {
-                return null;
-            }
-            String internalName = className.replace('.', '/') + ".class";
-            URL url = Java17Parser.class.getClassLoader().getResource(internalName);
-            if (url == null) {
-                return null;
-            }
-
-            try (InputStream stream = url.openStream()) {
-                ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
-                byte[] bytes = new byte[4096];
-                int bytesRead;
-                while ((bytesRead = stream.read(bytes)) > 0) {
-                    classBytes.write(bytes, 0, bytesRead);
-                }
-                return defineClass(className, classBytes.toByteArray(), 0, classBytes.size());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
             }
         }
     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17UnrestrictedClassLoader.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17UnrestrictedClassLoader.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.openrewrite.internal.lang.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Rewrite's JavaParser is reliant on java's compiler internal classes that are now encapsulated within Java's
+ * module system. Starting in Java 17, the JVM now enforces strong encapsulation of these internal classes and
+ * default behavior is to throw a security exception when attempting to use these internal classes. This classloader
+ * circumvents these security restrictions by isolating Rewrite's Java 17 parser implementation classes and then
+ * loading any of the internal classes directly from the .jmod files.
+ * <p>
+ * NOTE: Any classes in the package "org.openrewrite.java.isolated" will be loaded into this isolated classloader.
+ */
+public class Java17UnrestrictedClassLoader extends ClassLoader {
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    final List<Path> modules;
+
+    public Java17UnrestrictedClassLoader(ClassLoader parentClassloader) {
+        super(parentClassloader);
+
+        //A list of modules to load internal classes from
+        final FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
+        modules = List.of(
+                fs.getPath("modules", "jdk.compiler"),
+                fs.getPath("modules", "java.compiler"),
+                fs.getPath("modules", "java.base")
+        );
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+
+        synchronized (getClassLoadingLock(name)) {
+            // First, check if the class has already been loaded
+            Class<?> c = findLoadedClass(name);
+            if (c != null) {
+                return c;
+            }
+
+            String internalName = name.replace('.', '/') + ".class";
+
+            //If the class is in the package "org.openrewrite.java.internal", load it from this class loader.
+            Class<?> _class = loadIsolatedClass(name);
+            if (_class != null) {
+                return _class;
+            }
+
+            //Otherwise look for internal classes in the list of modules.
+            if (name.startsWith("com.sun") || name.startsWith("sun")) {
+                try {
+                    for (Path path : modules) {
+                        Path classFile = path.resolve(internalName);
+                        if (Files.exists(classFile)) {
+                            byte[] bytes = Files.readAllBytes(classFile);
+                            return defineClass(name, bytes, 0, bytes.length);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return super.loadClass(name);
+    }
+
+    @Override
+    @Nullable
+    public URL getResource(String name) {
+        try {
+            for (Path path : modules) {
+                Path classFile = path.resolve(name);
+                if (Files.exists(classFile)) {
+                    return classFile.toUri().toURL();
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return super.getResource(name);
+    }
+
+    @Nullable
+    private Class<?> loadIsolatedClass(String className) {
+        if (!className.startsWith("org.openrewrite.java.isolated")) {
+            return null;
+        }
+        String internalName = className.replace('.', '/') + ".class";
+        URL url = Java17Parser.class.getClassLoader().getResource(internalName);
+        if (url == null) {
+            return null;
+        }
+
+        try (InputStream stream = url.openStream()) {
+            ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+            byte[] bytes = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = stream.read(bytes)) > 0) {
+                classBytes.write(bytes, 0, bytesRead);
+            }
+            return defineClass(className, classBytes.toByteArray(), 0, classBytes.size());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/rewrite-java-17/src/test/java/org/openrewrite/java/Java17TypeSignatureBuilderTest.java
+++ b/rewrite-java-17/src/test/java/org/openrewrite/java/Java17TypeSignatureBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.lang.reflect.Constructor;
+
+@SuppressWarnings("ConstantConditions")
+public class Java17TypeSignatureBuilderTest implements JavaTypeSignatureBuilderTest {
+
+    @Nullable
+    private static JavaTypeSignatureBuilderTest delegate;
+
+    @BeforeAll
+    static void setup() {
+        ClassLoader moduleClassLoader = new Java17UnrestrictedClassLoader(Java17TypeSignatureBuilderTest.class.getClassLoader());
+
+        try {
+            Class<?> typeGoatBuilder = Class.forName("org.openrewrite.java.isolated.Java17TypeSignatureBuilderTestDelegate", true, moduleClassLoader);
+            Constructor<?> typeGoatBuilderConstructor = typeGoatBuilder.getDeclaredConstructor();
+            typeGoatBuilderConstructor.setAccessible(true);
+            delegate = (JavaTypeSignatureBuilderTest) typeGoatBuilderConstructor.newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to construct JavaTypeGoatBuilder.", e);
+        }
+    }
+
+    @Override
+    public String fieldSignature(String field) {
+        return delegate.fieldSignature(field);
+    }
+
+    @Override
+    public String methodSignature(String methodName) {
+        return delegate.methodSignature(methodName);
+    }
+
+    @Override
+    public String constructorSignature() {
+        return delegate.constructorSignature();
+    }
+
+    @Override
+    public Object firstMethodParameter(String methodName) {
+        return delegate.firstMethodParameter(methodName);
+    }
+
+    @Override
+    public Object innerClassSignature(String innerClassSimpleName) {
+        return delegate.innerClassSignature(innerClassSimpleName);
+    }
+
+    @Override
+    public Object lastClassTypeParameter() {
+        return delegate.lastClassTypeParameter();
+    }
+
+    @Override
+    public JavaTypeSignatureBuilder signatureBuilder() {
+        return delegate.signatureBuilder();
+    }
+}

--- a/rewrite-java-17/src/test/java/org/openrewrite/java/isolated/Java17TypeSignatureBuilderTestDelegate.java
+++ b/rewrite-java-17/src/test/java/org/openrewrite/java/isolated/Java17TypeSignatureBuilderTestDelegate.java
@@ -36,28 +36,29 @@ import java.nio.file.Paths;
 
 import static java.util.Collections.singletonList;
 
-@Disabled("Test disabled until we can solve how to load the tests in a classloader that allows access to internal types.")
-public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderTest {
+@Disabled("Do not run tests directly on the delegate")
+public class Java17TypeSignatureBuilderTestDelegate implements JavaTypeSignatureBuilderTest {
+    @SuppressWarnings("ConstantConditions")
     private static final String goat = StringUtils.readFully(
-            Java11TypeSignatureBuilderTest.class.getResourceAsStream("/JavaTypeGoat.java"), StandardCharsets.UTF_8);
+      Java17TypeSignatureBuilderTestDelegate.class.getResourceAsStream("/JavaTypeGoat.java"), StandardCharsets.UTF_8);
 
-    private static final JCTree.JCCompilationUnit cu = ReloadableJava11Parser.builder()
-            .logCompilationWarningsAndErrors(true)
-            .build()
-            .parseInputsToCompilerAst(
-                    singletonList(new Parser.Input(Paths.get("JavaTypeGoat.java"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))),
-                    new InMemoryExecutionContext(Throwable::printStackTrace))
-            .entrySet()
-            .iterator()
-            .next()
-            .getValue();
+    private static final JCTree.JCCompilationUnit cu = ReloadableJava17Parser.builder()
+      .logCompilationWarningsAndErrors(true)
+      .build()
+      .parseInputsToCompilerAst(
+        singletonList(new Parser.Input(Paths.get("JavaTypeGoat.java"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))),
+        new InMemoryExecutionContext(Throwable::printStackTrace))
+      .entrySet()
+      .iterator()
+      .next()
+      .getValue();
 
     @Override
     public String fieldSignature(String field) {
         return new TreeScanner<String, Integer>() {
             @Override
             public String visitVariable(VariableTree node, Integer integer) {
-                if(node.getName().toString().equals(field)) {
+                if (node.getName().toString().equals(field)) {
                     return signatureBuilder().variableSignature(((JCTree.JCVariableDecl) node).sym);
                 }
                 //noinspection ConstantConditions
@@ -78,7 +79,7 @@ public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public String visitMethod(MethodTree node, Integer p) {
                 JCTree.JCMethodDecl method = (JCTree.JCMethodDecl) node;
-                if(method.getName().toString().equals(methodName)) {
+                if (method.getName().toString().equals(methodName)) {
                     return signatureBuilder().methodSignature(method.type, method.sym);
                 }
                 //noinspection ConstantConditions
@@ -99,7 +100,7 @@ public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public String visitMethod(MethodTree node, Integer p) {
                 JCTree.JCMethodDecl method = (JCTree.JCMethodDecl) node;
-                if(method.name.toString().equals("<init>")) {
+                if (method.name.toString().equals("<init>")) {
                     return signatureBuilder().methodSignature(method.type, method.sym);
                 }
                 //noinspection ConstantConditions
@@ -120,7 +121,7 @@ public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public Type visitMethod(MethodTree node, Integer p) {
                 JCTree.JCMethodDecl method = (JCTree.JCMethodDecl) node;
-                if(method.getName().toString().equals(methodName)) {
+                if (method.getName().toString().equals(methodName)) {
                     List<JCTree.JCVariableDecl> params = method.getParameters();
                     return params.iterator().next().type;
                 }
@@ -142,7 +143,7 @@ public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
             @Override
             public Type visitClass(ClassTree node, Integer integer) {
                 JCTree.JCClassDecl clazz = (JCTree.JCClassDecl) node;
-                if(innerClassSimpleName.equals(clazz.getSimpleName().toString())) {
+                if (innerClassSimpleName.equals(clazz.getSimpleName().toString())) {
                     return clazz.type;
                 }
                 return super.visitClass(node, integer);
@@ -168,7 +169,7 @@ public class Java11TypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
     }
 
     @Override
-    public ReloadableJava11TypeSignatureBuilder signatureBuilder() {
-        return new ReloadableJava11TypeSignatureBuilder();
+    public ReloadableJava17TypeSignatureBuilder signatureBuilder() {
+        return new ReloadableJava17TypeSignatureBuilder();
     }
 }


### PR DESCRIPTION
Reenable type signature builder tests in Java 11 and Java 17.