### PR TITLE
Positions for Properties source files and fix for position assignment

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/PositionPrintOutputCapture.java
+++ b/rewrite-core/src/main/java/org/openrewrite/PositionPrintOutputCapture.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Range;
+
+public class PositionPrintOutputCapture<P> extends PrintOutputCapture<P> {
+        private int pos = 0;
+        private int line = 1;
+        private int column = 0;
+        private boolean lineBoundary;
+
+        public PositionPrintOutputCapture(P p) {
+            super(p);
+        }
+
+        public PositionPrintOutputCapture(P p, Range.Position pos) {
+            this(p);
+            this.pos = pos.getOffset();
+            this.line = pos.getLine();
+            this.column = pos.getColumn();
+        }
+
+        @Override
+        public PrintOutputCapture<P> append(char c) {
+            pos++;
+            if (lineBoundary) {
+                line++;
+                column = 0;
+                lineBoundary = false;
+            } else {
+                column++;
+            }
+            if (c == '\n') {
+                lineBoundary = true;
+            }
+            return super.append(c);
+        }
+
+        @Override
+        public PrintOutputCapture<P> append(@Nullable String text) {
+            if (text != null) {
+                if (lineBoundary) {
+                    line++;
+                    column = 0;
+                    lineBoundary = false;
+                }
+                pos += text.length();
+                long numberOfLines = text.chars().filter(c -> c == '\n').count();
+                if (numberOfLines > 0) {
+                    line += numberOfLines;
+                    column = text.length() - (text.lastIndexOf('\n') + 1);
+                } else {
+                    column += text.length();
+                }
+            }
+            return super.append(text);
+        }
+
+        public Range.Position getPosition() {
+            return new Range.Position(pos, line, column);
+        }
+    }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
@@ -41,8 +41,15 @@ public class PropertiesVisitor<P> extends TreeVisitor<Properties, P> {
 
     public Properties visitEntry(Properties.Entry entry, P p) {
         Properties.Entry e = entry;
+        e = e.withValue((Properties.Value) visit(entry.getValue(), p));
         e = e.withMarkers(visitMarkers(e.getMarkers(), p));
         return e;
+    }
+
+    public Properties.Value visitValue(Properties.Value value, P p) {
+        Properties.Value v = value;
+        v = v.withMarkers(visitMarkers(v.getMarkers(), p));
+        return v;
     }
 
     public Properties visitComment(Properties.Comment comment, P p) {

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/UpdateSourcePositions.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/UpdateSourcePositions.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.properties;
+
+import org.openrewrite.*;
+import org.openrewrite.marker.Range;
+import org.openrewrite.properties.internal.PropertiesPrinter;
+import org.openrewrite.properties.tree.Properties;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import static org.openrewrite.Tree.randomId;
+
+public class UpdateSourcePositions extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Update Properties source positions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Calculate start position and length for every Properties AST element.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        Map<Tree, Range> positionMap = new IdentityHashMap<>();
+        PositionPrintOutputCapture ppoc = new PositionPrintOutputCapture(new InMemoryExecutionContext());
+
+        PropertiesPrinter<ExecutionContext> printer = new PropertiesPrinter<ExecutionContext>() {
+
+            @Override
+            public void printEntry(Properties.Entry entry, PrintOutputCapture<ExecutionContext> p) {
+                Range.Position startPosition = ppoc.getPosition();
+                super.printEntry(entry, p);
+                Range.Position endPosition = ppoc.getPosition();
+                positionMap.put(entry, new Range(randomId(), startPosition, endPosition));
+            }
+
+            @Override
+            public void printComment(Properties.Comment comment, PrintOutputCapture<ExecutionContext> p) {
+                Range.Position startPosition = ppoc.getPosition();
+                super.printComment(comment, p);
+                Range.Position endPosition = ppoc.getPosition();
+                positionMap.put(comment, new Range(randomId(), startPosition, endPosition));
+            }
+
+
+            @Override
+            protected void printValue(Properties.Value value, PrintOutputCapture<ExecutionContext> p) {
+                Range.Position startPosition = ppoc.getPosition();
+                super.printValue(value, p);
+                Range.Position endPosition = ppoc.getPosition();
+                positionMap.put(value, new Range(randomId(), startPosition, endPosition));
+            }
+        };
+
+        return new PropertiesIsoVisitor<ExecutionContext>() {
+
+            boolean firstVisit = true;
+
+            @Override
+            public Properties visit(Tree tree, ExecutionContext ctx) {
+                if (tree == null) {
+                    return null;
+                }
+                if (firstVisit) {
+                    tree = printer.visit(tree, ppoc);
+                    firstVisit = false;
+                }
+
+                Range range = positionMap.get(tree);
+                if (range != null) {
+                    Tree t = tree.withMarkers(tree.getMarkers().add(range));
+                    return super.visit(t, ctx);
+                }
+                return super.visit(tree, ctx);
+            }
+        };
+    }
+
+}

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
@@ -30,7 +30,7 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
     public Properties visitFile(Properties.File file, PrintOutputCapture<P> p) {
         beforeSyntax(file, p);
         visit(file.getContent(), p);
-        p.out.append(file.getEof());
+        p.append(file.getEof());
         afterSyntax(file, p);
         return file;
     }
@@ -38,22 +38,42 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
     @Override
     public Properties visitEntry(Properties.Entry entry, PrintOutputCapture<P> p) {
         beforeSyntax(entry, p);
-        p.out.append(entry.getKey())
-                .append(entry.getBeforeEquals())
-                .append('=');
-        beforeSyntax(entry.getValue().getPrefix(), entry.getValue().getMarkers(), p);
-        p.out.append(entry.getValue().getText());
-        afterSyntax(entry.getValue().getMarkers(), p);
+        printEntry(entry, p);
         afterSyntax(entry, p);
         return entry;
     }
 
     @Override
+    public Properties.Value visitValue(Properties.Value value, PrintOutputCapture<P> p) {
+        beforeSyntax(value.getPrefix(), value.getMarkers(), p);
+        printValue(value, p);
+        afterSyntax(value.getMarkers(), p);
+        return value;
+    }
+
+    protected void printEntry(Properties.Entry entry, PrintOutputCapture<P> p) {
+        p.append(entry.getKey())
+                .append(entry.getBeforeEquals())
+                .append('=');
+        super.visitEntry(entry, p);
+    }
+
+    protected void printValue(Properties.Value value, PrintOutputCapture<P> p) {
+        p.append(value.getText());
+        super.visitValue(value, p);
+    }
+
+    @Override
     public Properties visitComment(Properties.Comment comment, PrintOutputCapture<P> p) {
         beforeSyntax(comment, p);
-        p.out.append('#').append(comment.getMessage());
+        printComment(comment, p);
         afterSyntax(comment, p);
         return comment;
+    }
+
+    protected void printComment(Properties.Comment comment, PrintOutputCapture<P> p) {
+        p.append('#').append(comment.getMessage());
+        super.visitComment(comment, p);
     }
 
     private static final UnaryOperator<String> PROPERTIES_MARKER_WRAPPER =
@@ -65,12 +85,12 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
 
     private void beforeSyntax(String prefix, Markers markers, PrintOutputCapture<P> p) {
         for (Marker marker : markers.getMarkers()) {
-            p.out.append(p.getMarkerPrinter().beforePrefix(marker, new Cursor(getCursor(), marker), PROPERTIES_MARKER_WRAPPER));
+            p.append(p.getMarkerPrinter().beforePrefix(marker, new Cursor(getCursor(), marker), PROPERTIES_MARKER_WRAPPER));
         }
-        p.out.append(prefix);
+        p.append(prefix);
         visitMarkers(markers, p);
         for (Marker marker : markers.getMarkers()) {
-            p.out.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), PROPERTIES_MARKER_WRAPPER));
+            p.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), PROPERTIES_MARKER_WRAPPER));
         }
     }
 
@@ -80,7 +100,7 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
 
     private void afterSyntax(Markers markers, PrintOutputCapture<P> p) {
         for (Marker marker : markers.getMarkers()) {
-            p.out.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(getCursor(), marker), PROPERTIES_MARKER_WRAPPER));
+            p.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(getCursor(), marker), PROPERTIES_MARKER_WRAPPER));
         }
     }
 }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
@@ -127,13 +127,19 @@ public interface Properties extends Tree {
     @lombok.Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class Value {
+    class Value implements Content {
         @EqualsAndHashCode.Include
         UUID id;
 
         String prefix;
         Markers markers;
         String text;
+
+        @Override
+        public <P> Properties acceptProperties(PropertiesVisitor<P> v, P p) {
+            return v.visitValue(this, p);
+        }
+
     }
 
     @lombok.Value

--- a/rewrite-properties/src/test/kotlin/org/openrewrite/properties/UpdateSourcePositionsTest.kt
+++ b/rewrite-properties/src/test/kotlin/org/openrewrite/properties/UpdateSourcePositionsTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.properties
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.openrewrite.marker.Range
+import org.openrewrite.properties.tree.Properties
+
+class UpdateSourcePositionsTest : PropertiesRecipeTest {
+
+    @Test
+    fun singleEntry() {
+        val props = PropertiesParser().parse("key=value\n")[0]
+        Assertions.assertThat(props.printAll()).isEqualTo("key=value\n");
+
+        val p = UpdateSourcePositions().run(listOf(props)).results[0].after as Properties.File;
+        Assertions.assertThat(p).isNotNull;
+        val entries = p.content.map { it as Properties.Entry }
+        var r = entries[0].markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(1);
+        Assertions.assertThat(r.start.column).isEqualTo(0);
+        Assertions.assertThat(r.end.line).isEqualTo(1);
+        Assertions.assertThat(r.end.column).isEqualTo(9);
+
+        r = entries[0].value.markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(1);
+        Assertions.assertThat(r.start.column).isEqualTo(4);
+        Assertions.assertThat(r.end.line).isEqualTo(1);
+        Assertions.assertThat(r.end.column).isEqualTo(9);
+    }
+
+    @Test
+    fun singleEntryMultilines() {
+        val props = PropertiesParser().parse("\n\n   key=value\n")[0]
+        Assertions.assertThat(props.printAll()).isEqualTo("\n\n   key=value\n");
+
+        val p = UpdateSourcePositions().run(listOf(props)).results[0].after as Properties.File;
+        Assertions.assertThat(p).isNotNull;
+        val entries = p.content.map { it as Properties.Entry }
+        var r = entries[0].markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(3);
+        Assertions.assertThat(r.start.column).isEqualTo(3);
+        Assertions.assertThat(r.end.line).isEqualTo(3);
+        Assertions.assertThat(r.end.column).isEqualTo(12);
+
+        r = entries[0].value.markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(3);
+        Assertions.assertThat(r.start.column).isEqualTo(7);
+        Assertions.assertThat(r.end.line).isEqualTo(3);
+        Assertions.assertThat(r.end.column).isEqualTo(12);
+    }
+
+    @Test
+    fun multiEntryMultilines() {
+        val props = PropertiesParser().parse("\n\n   key1=value1\n   \n  \n  key2   = value2\n\n\n")[0]
+        Assertions.assertThat(props.printAll()).isEqualTo("\n\n   key1=value1\n   \n  \n  key2   = value2\n\n\n");
+
+        val p = UpdateSourcePositions().run(listOf(props)).results[0].after as Properties.File;
+        Assertions.assertThat(p).isNotNull;
+        val entries = p.content.map { it as Properties.Entry }
+
+        // entry 1
+        var r = entries[0].markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(3);
+        Assertions.assertThat(r.start.column).isEqualTo(3);
+        Assertions.assertThat(r.end.line).isEqualTo(3);
+        Assertions.assertThat(r.end.column).isEqualTo(14);
+        // value 1
+        r = entries[0].value.markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(3);
+        Assertions.assertThat(r.start.column).isEqualTo(8);
+        Assertions.assertThat(r.end.line).isEqualTo(3);
+        Assertions.assertThat(r.end.column).isEqualTo(14);
+
+        // entry 2
+        r = entries[1].markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(6);
+        Assertions.assertThat(r.start.column).isEqualTo(2);
+        Assertions.assertThat(r.end.line).isEqualTo(6);
+        Assertions.assertThat(r.end.column).isEqualTo(17);
+        // value 2
+        r = entries[1].value.markers.findFirst(Range::class.java).get()
+        Assertions.assertThat(r.start.line).isEqualTo(6);
+        Assertions.assertThat(r.start.column).isEqualTo(11);
+        Assertions.assertThat(r.end.line).isEqualTo(6);
+        Assertions.assertThat(r.end.column).isEqualTo(17);
+    }
+}


### PR DESCRIPTION
- Assign `Range` markers to Properties AST nodes
- `Properties.Value` node visit infrastructure
- `PositionPrintOutputCapture` - bug fixed and factored out into a standalone re-usable class