### PR TITLE
Generate a unique variable signature based on the Symbol reference.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -30,7 +30,7 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     private Set<String> typeVariableNameStack;
 
     @Nullable
-    private HashMap<String, Set<Symbol>> nameScopeSymbols;
+    private HashMap<String, Map<Symbol, Integer>> symbolNameScope;
 
     @Override
     public String signature(@Nullable Object t) {
@@ -269,13 +269,15 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         String signature = owner + "{name=" + symbol.name.toString() + '}';
-        if (nameScopeSymbols == null) {
-            nameScopeSymbols = new HashMap<>();
+        if (symbolNameScope == null) {
+            symbolNameScope = new HashMap<>();
         }
 
-        Set<Symbol> nameScopes = nameScopeSymbols.computeIfAbsent(signature, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
-        nameScopes.add(symbol);
-        signature += nameScopes.size();
+        Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
+        Integer variableId;
+        variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
+        signature += variableId;
+
         return signature;
     }
 }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -274,8 +274,7 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
-        Integer variableId;
-        variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
+        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
         signature += variableId;
 
         return signature;

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -23,13 +23,14 @@ import org.openrewrite.java.JavaTypeSignatureBuilder;
 import org.openrewrite.java.tree.JavaType;
 
 import javax.lang.model.type.NullType;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.StringJoiner;
+import java.util.*;
 
 class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
     private Set<String> typeVariableNameStack;
+
+    @Nullable
+    private HashMap<String, Set<Symbol>> nameScopeSymbols;
 
     @Override
     public String signature(@Nullable Object t) {
@@ -266,6 +267,15 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
                 owner = owner.substring(0, owner.indexOf('<'));
             }
         }
-        return owner + "{name=" + symbol.name.toString() + '}';
+
+        String signature = owner + "{name=" + symbol.name.toString() + '}';
+        if (nameScopeSymbols == null) {
+            nameScopeSymbols = new HashMap<>();
+        }
+
+        Set<Symbol> nameScopes = nameScopeSymbols.computeIfAbsent(signature, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
+        nameScopes.add(symbol);
+        signature += nameScopes.size();
+        return signature;
     }
 }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -274,8 +274,11 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
-        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
-        signature += variableId;
+        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size());
+        if (variableId > 0) {
+            // Sync the type signature builders with the default signature printer.
+            signature += variableId;
+        }
 
         return signature;
     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -23,13 +23,14 @@ import org.openrewrite.java.JavaTypeSignatureBuilder;
 import org.openrewrite.java.tree.JavaType;
 
 import javax.lang.model.type.NullType;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.StringJoiner;
+import java.util.*;
 
 class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
     private Set<String> typeVariableNameStack;
+
+    @Nullable
+    private HashMap<String, Set<Symbol>> nameScopeSymbols;
 
     @Override
     public String signature(@Nullable Object t) {
@@ -266,6 +267,15 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
                 owner = owner.substring(0, owner.indexOf('<'));
             }
         }
-        return owner + "{name=" + symbol.name.toString() + '}';
+
+        String signature = owner + "{name=" + symbol.name.toString() + '}';
+        if (nameScopeSymbols == null) {
+            nameScopeSymbols = new HashMap<>();
+        }
+
+        Set<Symbol> nameScopes = nameScopeSymbols.computeIfAbsent(signature, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
+        nameScopes.add(symbol);
+        signature += nameScopes.size();
+        return signature;
     }
 }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -274,8 +274,7 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
-        Integer variableId;
-        variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
+        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
         signature += variableId;
 
         return signature;

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -30,7 +30,7 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     private Set<String> typeVariableNameStack;
 
     @Nullable
-    private HashMap<String, Set<Symbol>> nameScopeSymbols;
+    private HashMap<String, Map<Symbol, Integer>> symbolNameScope;
 
     @Override
     public String signature(@Nullable Object t) {
@@ -269,13 +269,15 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         String signature = owner + "{name=" + symbol.name.toString() + '}';
-        if (nameScopeSymbols == null) {
-            nameScopeSymbols = new HashMap<>();
+        if (symbolNameScope == null) {
+            symbolNameScope = new HashMap<>();
         }
 
-        Set<Symbol> nameScopes = nameScopeSymbols.computeIfAbsent(signature, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
-        nameScopes.add(symbol);
-        signature += nameScopes.size();
+        Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
+        Integer variableId;
+        variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
+        signature += variableId;
+
         return signature;
     }
 }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -274,8 +274,11 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
-        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
-        signature += variableId;
+        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size());
+        if (variableId > 0) {
+            // Sync the type signature builders with the default signature printer.
+            signature += variableId;
+        }
 
         return signature;
     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -273,8 +273,11 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
-        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
-        signature += variableId;
+        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size());
+        if (variableId > 0) {
+            // Sync the type signature builders with the default signature printer.
+            signature += variableId;
+        }
 
         return signature;
     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -273,8 +273,7 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
-        Integer variableId;
-        variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
+        Integer variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
         signature += variableId;
 
         return signature;

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -22,13 +22,14 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.tree.JavaType;
 
 import javax.lang.model.type.NullType;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.StringJoiner;
+import java.util.*;
 
 class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
     private Set<String> typeVariableNameStack;
+
+    @Nullable
+    private HashMap<String, Set<Symbol>> nameScopeSymbols;
 
     @Override
     public String signature(@Nullable Object t) {
@@ -265,6 +266,15 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
                 owner = owner.substring(0, owner.indexOf('<'));
             }
         }
-        return owner + "{name=" + symbol.name.toString() + '}';
+
+        String signature = owner + "{name=" + symbol.name.toString() + '}';
+        if (nameScopeSymbols == null) {
+            nameScopeSymbols = new HashMap<>();
+        }
+
+        Set<Symbol> nameScopes = nameScopeSymbols.computeIfAbsent(signature, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
+        nameScopes.add(symbol);
+        signature += nameScopes.size();
+        return signature;
     }
 }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -29,7 +29,7 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     private Set<String> typeVariableNameStack;
 
     @Nullable
-    private HashMap<String, Set<Symbol>> nameScopeSymbols;
+    private HashMap<String, Map<Symbol, Integer>> symbolNameScope;
 
     @Override
     public String signature(@Nullable Object t) {
@@ -268,13 +268,15 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         }
 
         String signature = owner + "{name=" + symbol.name.toString() + '}';
-        if (nameScopeSymbols == null) {
-            nameScopeSymbols = new HashMap<>();
+        if (symbolNameScope == null) {
+            symbolNameScope = new HashMap<>();
         }
 
-        Set<Symbol> nameScopes = nameScopeSymbols.computeIfAbsent(signature, k -> Collections.newSetFromMap(new IdentityHashMap<>()));
-        nameScopes.add(symbol);
-        signature += nameScopes.size();
+        Map<Symbol, Integer> nameScopes = symbolNameScope.computeIfAbsent(signature, k -> new IdentityHashMap<>());
+        Integer variableId;
+        variableId = nameScopes.computeIfAbsent(symbol, k -> nameScopes.size() + 1);
+        signature += variableId;
+
         return signature;
     }
 }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
@@ -50,7 +50,7 @@ public interface JavaTypeSignatureBuilderTest {
     @Test
     default void parameterizedField() {
         assertThat(fieldSignature("parameterizedField"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=parameterizedField}");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=parameterizedField}1");
     }
 
     @Test

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaTypeSignatureBuilderTest.java
@@ -50,7 +50,7 @@ public interface JavaTypeSignatureBuilderTest {
     @Test
     default void parameterizedField() {
         assertThat(fieldSignature("parameterizedField"))
-                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=parameterizedField}1");
+                .isEqualTo("org.openrewrite.java.JavaTypeGoat{name=parameterizedField}");
     }
 
     @Test

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaParserTypeMappingTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaParserTypeMappingTest.kt
@@ -17,7 +17,6 @@ package org.openrewrite.java
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.openrewrite.InMemoryExecutionContext
@@ -144,7 +143,6 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
         assertThat(cu).isNotNull
     }
 
-    @Disabled("Requires updates to variable names in method scope.")
     @Issue("https://github.com/openrewrite/rewrite/issues/2118")
     @Test
     fun variousMethodScopeIdentifierTypes() {
@@ -153,7 +151,7 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
             import java.util.stream.Collectors;
             
             @SuppressWarnings("ALL")
-            class Test {
+            class MakeEasyToFind {
                 void method(List<MultiMap> multiMaps) {
                     List<Integer> ints;
                     ints.forEach(it -> {
@@ -208,7 +206,7 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
         assertThat(intsItType.toString()).isEqualTo("java.lang.Integer")
 
         val multiMapItType = ((((((((methodBody
-            .statements[0] as J.MethodInvocation)
+            .statements[2] as J.MethodInvocation)
             .arguments[0] as J.Lambda)
             .body as J.Block)
             .statements[0] as J.If)
@@ -217,7 +215,7 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
             .left as J.Identifier)
             .fieldType as JavaType.Variable)
             .type
-        assertThat(multiMapItType.toString()).isEqualTo("Test${'$'}MultiMap")
+        assertThat(multiMapItType.toString()).isEqualTo("MakeEasyToFind${'$'}MultiMap")
 
         val whileLoopItType = (((((((methodBody
             .statements[3] as J.WhileLoop)
@@ -231,7 +229,6 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
         assertThat(whileLoopItType.toString()).isEqualTo("java.lang.Long")
     }
 
-    @Disabled("Requires updates to variable names in method scope.")
     @Issue("https://github.com/openrewrite/rewrite/issues/2118")
     @Test
     fun multiMapWithSameLambdaParamNames() {
@@ -240,7 +237,7 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
             import java.util.stream.Collectors;
             
             @SuppressWarnings("ALL")
-            class Test {
+            class MakeEasyToFind {
                 void method(List<MultiMap> multiMaps) {
                     Object obj = multiMaps.stream()
                         .map(it -> it.getInners())
@@ -282,7 +279,7 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
             .variables[0] as J.VariableDeclarations.NamedVariable)
             .name as J.Identifier)
             .type!!
-        assertThat(firstMultiMapLambdaParamItType.toString()).isEqualTo("Test${'$'}MultiMap")
+        assertThat(firstMultiMapLambdaParamItType.toString()).isEqualTo("MakeEasyToFind${'$'}MultiMap")
 
         val secondMultiMapLambdaParamItType = ((((multiLambda
             .arguments[0] as J.Lambda)
@@ -290,6 +287,6 @@ interface JavaParserTypeMappingTest : JavaTypeMappingTest {
             .variables[0] as J.VariableDeclarations.NamedVariable)
             .name as J.Identifier)
             .type!!
-        assertThat(secondMultiMapLambdaParamItType.toString()).isNotEqualTo(firstMultiMapLambdaParamItType.toString())
+        assertThat(secondMultiMapLambdaParamItType.toString()).isEqualTo("java.util.List<MakeEasyToFind${'$'}MultiMap${'$'}Inner>")
     }
 }


### PR DESCRIPTION
Changes:
- Use the Symbol reference to distinguish variable names and generate a unique signature in the Java signature builders.
- Fixed Java17TypeMappingTest.

fixes #2118