### PR TITLE
Update jackson bom for CVE-2022-42003

### DIFF
--- a/build-src/src/main/kotlin/org.openrewrite.java-library.gradle.kts
+++ b/build-src/src/main/kotlin/org.openrewrite.java-library.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
     testCompileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
-    api(platform("com.fasterxml.jackson:jackson-bom:2.13.4"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.13.4.20221013"))
 
     implementation("org.jetbrains:annotations:latest.release")
     compileOnly("com.google.code.findbugs:jsr305:latest.release")


### PR DESCRIPTION
[CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) 

https://github.com/FasterXML/jackson-databind/issues/3590 
https://github.com/FasterXML/jackson/jackson-databind/issues/3627