### PR TITLE
Expanded fix for edge case with code obfuscaters and inner classes

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -212,11 +212,14 @@ public class JavaSourceSet implements SourceSet {
                 }
                 if(i == outerClasses.size() - 1) {
                     sb.append(outerClass.getName()).append(".");
+                } else if (!outerClass.getName().startsWith(sb.toString())) {
+                    // Code obfuscaters can generate inner classes which don't share a common package prefix with their outer class
+                    return classInfo.getName();
                 } else {
                     sb.append(outerClass.getName().substring(sb.length())).append(".");
                 }
             }
-            if (sb.length() >= classInfo.getName().length()) {
+            if (!classInfo.getName().startsWith(sb.toString())) {
                 // Code obfuscaters can generate inner classes which don't share a common package prefix with their outer class
                 return classInfo.getName();
             }


### PR DESCRIPTION
Made the condition a little more precise, and added the check to another spot where StringIndexOutOfBoundsExceptions were at risk

#2002