### PR TITLE
Fix parsing issue when annotation comments. Fixes #2313

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1839,7 +1839,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 } else {
                     leadingAnnotations.add(annotation);
                 }
-                i = cursor;
+                i = cursor -1;
                 lastAnnotationPosition = cursor;
                 continue;
             }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1881,7 +1881,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 } else {
                     leadingAnnotations.add(annotation);
                 }
-                i = cursor;
+                i = cursor -1;
                 lastAnnotationPosition = cursor;
                 continue;
             }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1817,7 +1817,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 } else {
                     leadingAnnotations.add(annotation);
                 }
-                i = cursor;
+                i = cursor -1;
                 lastAnnotationPosition = cursor;
                 continue;
             }


### PR DESCRIPTION
There was a parser error that resulted in a modifier being places in a whitespace prefix when an annotation had a comment with no whitespace between the end of the annotation and the comment