### PR TITLE
Update JavaDoc params along with fields in HiddenField

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/JavaVisitorCompatibilityKit.kt
@@ -446,6 +446,9 @@ abstract class JavaVisitorCompatibilityKit {
     inner class RemoveUnusedPrivateMethodsTck : RemoveUnusedPrivateMethodsTest
 
     @Nested
+    inner class RenameJavaDocParamNameVisitorTck : RenameJavaDocParamNameVisitorTest
+
+    @Nested
     inner class RenameExceptionInEmptyCatchTck : RenameExceptionInEmptyCatchTest
 
     @Nested

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/HiddenFieldTest.kt
@@ -18,18 +18,20 @@ package org.openrewrite.java.cleanup
 
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
-import org.openrewrite.Recipe
 import org.openrewrite.Tree
+import org.openrewrite.java.Assertions.java
 import org.openrewrite.java.JavaParser
-import org.openrewrite.java.JavaRecipeTest
 import org.openrewrite.java.style.Checkstyle
 import org.openrewrite.java.style.HiddenFieldStyle
 import org.openrewrite.style.NamedStyles
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
 
 @Suppress("UnnecessaryLocalVariable")
-interface HiddenFieldTest : JavaRecipeTest {
-    override val recipe: Recipe?
-        get() = HiddenField()
+interface HiddenFieldTest : RewriteTest {
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(HiddenField())
+    }
 
     fun hiddenFieldStyle(with: HiddenFieldStyle.() -> HiddenFieldStyle = { this }) =
         listOf(
@@ -41,197 +43,233 @@ interface HiddenFieldTest : JavaRecipeTest {
         )
 
     @Test
-    fun ignoreUnaffectedVariables() = assertUnchanged(
-        before = """
+    fun ignoreUnaffectedVariables() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             class Test {
                 private String field;
-
+            
                 public Test(String someField) {
                 }
-
+            
                 static void method(String someField) {
                     String localVariable = someField;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun renameHiddenFields() = assertChanged(
-        dependsOn = arrayOf(
-            """
+    fun renameHiddenFields() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class B {
                 protected int n2;
                 int n3;
                 private int n4;
             }
-            """
+          """
         ),
-        before = """
+        //language=java
+        java(
+          """
             public class A extends B {
                 int n;
                 int n1;
-
+            
                 class C {
                     public void method(int n) {
                         int n1 = n;
                     }
                 }
-
+            
                 static class D {
                     public void method(int n) {
                     }
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A extends B {
                 int n;
                 int n1;
-
+            
                 class C {
                     public void method(int n2) {
                         int n3 = n2;
                     }
                 }
-
+            
                 static class D {
                     public void method(int n) {
                     }
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun constructorParameter(jp: JavaParser.Builder<*, *>) = assertChanged(
-        jp.styles(hiddenFieldStyle {
-            withIgnoreConstructorParameter(false)
-        }).build(),
-        before = """
+    fun constructorParameter(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        { spec ->
+            spec.parser(
+                jp.styles(hiddenFieldStyle {
+                    withIgnoreConstructorParameter(false)
+                })
+            )
+        },
+        //language=java
+        java(
+          """
             public class A {
                 private String field;
-
+            
                 public A(String field) {
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A {
                 private String field;
-
+            
                 public A(String field1) {
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun ignoreConstructorParameter(jp: JavaParser.Builder<*, *>) = assertUnchanged(
-        jp.styles(hiddenFieldStyle {
-            withIgnoreConstructorParameter(true)
-        }).build(),
-        before = """
+    fun ignoreConstructorParameter(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        { spec ->
+            spec.parser(
+                jp.styles(hiddenFieldStyle {
+                    withIgnoreConstructorParameter(true)
+                })
+            )
+        },
+        //language=java
+        java(
+          """
             public class A {
                 private String field;
-
+            
                 public A(String field) {
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun methodParameter(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun methodParameter() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class A {
                 private String field;
-
+            
                 public void method(String field) {
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A {
                 private String field;
-
+            
                 public void method(String field1) {
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun methodBodyLocalVariable(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun methodBodyLocalVariable() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class A {
                 private String field;
-
+            
                 public void method(String param) {
                     String field = param;
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A {
                 private String field;
-
+            
                 public void method(String param) {
                     String field1 = param;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun forLoops(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun forLoops() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class A {
                 int n;
-
+            
                 public void standardForLoop() {
                     for (int n = 0; n < 1; n++) {
                         int x = n;
                     }
                 }
-
+            
                 public void enhancedForLoop(int[] arr) {
                     for (int n : arr) {
                         int x = n;
                     }
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A {
                 int n;
-
+            
                 public void standardForLoop() {
                     for (int n1 = 0; n1 < 1; n1++) {
                         int x = n1;
                     }
                 }
-
+            
                 public void enhancedForLoop(int[] arr) {
                     for (int n1 : arr) {
                         int x = n1;
                     }
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Suppress("Convert2MethodRef", "ResultOfMethodCallIgnored")
     @Test
-    fun lambdaWithTypedParameterHides(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun lambdaWithTypedParameterHides() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             import java.util.List;
             import java.util.Arrays;
-
+            
             public class A {
                 List<Integer> numbers = Arrays.asList(1, 2, 3);
                 Integer value = 0;
@@ -239,11 +277,11 @@ interface HiddenFieldTest : JavaRecipeTest {
                     numbers.forEach((Integer value) -> String.valueOf(value));
                 }
             }
-        """,
-        after = """
+          """,
+          """
             import java.util.List;
             import java.util.Arrays;
-
+            
             public class A {
                 List<Integer> numbers = Arrays.asList(1, 2, 3);
                 Integer value = 0;
@@ -251,361 +289,446 @@ interface HiddenFieldTest : JavaRecipeTest {
                     numbers.forEach((Integer value1) -> String.valueOf(value1));
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun nestedClasses(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun nestedClasses() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class Outer {
                 int outer;
-
+            
                 public class Inner {
                     int inner;
-
+            
                     public Inner() {
                         int inner = 0;
                     }
-
+            
                     public Inner(int inner) {
                     }
-
+            
                     public void method() {
                         int outer = 0;
                     }
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class Outer {
                 int outer;
-
+            
                 public class Inner {
                     int inner;
-
+            
                     public Inner() {
                         int inner1 = 0;
                     }
-
+            
                     public Inner(int inner) {
                     }
-
+            
                     public void method() {
                         int outer1 = 0;
                     }
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun incrementRenamedVariableNameUntilUnique(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun incrementRenamedVariableNameUntilUnique() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class A {
                 int n, n1;
-
+            
                 public void method(int n) {
                     int n1 = 0;
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A {
                 int n, n1;
-
+            
                 public void method(int n2) {
                     int n3 = 0;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun incrementRenamedVariableNameShouldNotCollideWithExistingVariablesInUse(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun incrementRenamedVariableNameShouldNotCollideWithExistingVariablesInUse() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class A {
                 int n, n1;
-
+            
                 public void method(int n) {
                     int n2 = 0;
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A {
                 int n, n1;
-
+            
                 public void method(int n3) {
                     int n2 = 0;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun ignoreEnums(jp: JavaParser) = assertUnchanged(
-        jp,
-        before = """
+    fun ignoreEnums() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             enum ExampleEnum {
                 A(0),
                 B(1),
                 C(2) {
                     int hidden;
-
+            
                     public void method() {
                         int hidden = 0;
                     }
                 };
-
+            
                 int hidden;
                 static int hiddenStatic;
-
+            
                 ExampleEnum(int hidden) {
                 }
-
+            
                 public void method() {
                     int hidden = 0;
                 }
-
+            
                 public static void methodStatic() {
                     int hiddenStatic = 0;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Suppress("UnusedAssignment")
     @Test
-    fun ignoreStaticMethodsAndInitializers(jp: JavaParser) = assertUnchanged(
-        jp,
-        before = """
+    fun ignoreStaticMethodsAndInitializers() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class StaticMethods {
                 private int notHidden;
-
+            
                 public static void method() {
                     // local variables of static methods don't hide instance fields.
                     int notHidden;
                 }
-
+            
                 static {
                     // local variables of static initializers don't hide instance fields.
                     int notHidden;
                 }
-
+            
                 private int x;
                 private static int y;
-
+            
                 static class Inner {
                     void useX(int x) {
                         x++;
                     }
-
+            
                     void useY(int y) {
                         y++;
                     }
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun ignoreInterfaces(jp: JavaParser) = assertUnchanged(
-        jp,
-        before = """
+    fun ignoreInterfaces() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             interface A {
                 int n = 0;
-
+            
                 void method(int n);
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun renamesSetters(jp: JavaParser.Builder<*, *>) = assertChanged(
-        jp.styles(hiddenFieldStyle {
-            withIgnoreSetter(false)
-        }).build(),
-        before = """
+    fun renamesSetters(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        { spec ->
+            spec.parser(
+                jp.styles(hiddenFieldStyle {
+                    withIgnoreSetter(false)
+                })
+            )
+        },
+        //language=java
+        java(
+          """
             class A {
                 int n;
-
+            
                 public void setN(int n) {
                     this.n = n;
                 }
             }
-    
+            
             class B {
                 int n;
-
+            
                 public B setN(int n) {
                     this.n = n;
                     return this;
                 }
             }
-        """,
-        after = """
+          """,
+          """
             class A {
                 int n;
-
+            
                 public void setN(int n1) {
                     this.n = n1;
                 }
             }
-    
+            
             class B {
                 int n;
-
+            
                 public B setN(int n1) {
                     this.n = n1;
                     return this;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun ignoreVoidSettersAndChangeSettersThatReturnItsClass(jp: JavaParser.Builder<*, *>) = assertChanged(
-        jp.styles(hiddenFieldStyle {
-            withIgnoreSetter(true)
-                .withSetterCanReturnItsClass(false)
-        }).build(),
-        before = """
+    fun ignoreVoidSettersAndChangeSettersThatReturnItsClass(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        { spec ->
+            spec.parser(
+                jp.styles(hiddenFieldStyle {
+                    withIgnoreSetter(true)
+                        .withSetterCanReturnItsClass(false)
+                })
+            )
+        },
+        //language=java
+        java(
+          """
             class A {
                 int n;
-
+            
                 public void setN(int n) {
                     this.n = n;
                 }
             }
-    
+            
             class B {
                 int n;
-
+            
                 public B setN(int n) {
                     this.n = n;
                     return this;
                 }
             }
-        """,
-        after = """
+          """,
+          """
             class A {
                 int n;
-
+            
                 public void setN(int n) {
                     this.n = n;
                 }
             }
-
+            
             class B {
                 int n;
-
+            
                 public B setN(int n1) {
                     this.n = n1;
                     return this;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1129")
-    fun ignoreVoidSettersAndSettersThatReturnItsClass(jp: JavaParser.Builder<*, *>) = assertUnchanged(
-        jp.styles(hiddenFieldStyle {
-            withIgnoreSetter(true)
-                .withSetterCanReturnItsClass(true)
-        }).build(),
-        before = """
+    @Test
+    fun ignoreVoidSettersAndSettersThatReturnItsClass(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        { spec ->
+            spec.parser(
+                jp.styles(hiddenFieldStyle {
+                    withIgnoreSetter(true)
+                        .withSetterCanReturnItsClass(true)
+                })
+            )
+        },
+        //language=java
+        java(
+          """
             class A {
                 int n;
-
+            
                 public void setN(int n) {
                     this.n = n;
                 }
             }
-    
+            
             class B {
                 int n;
-
+            
                 public B setN(int n) {
                     this.n = n;
                     return this;
                 }
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun renamesAbstractMethodParameters(jp: JavaParser) = assertChanged(
-        jp,
-        before = """
+    fun renamesAbstractMethodParameters() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public abstract class A {
                 int n;
-
+            
                 public abstract void method(int n);
             }
-        """,
-        after = """
+          """,
+          """
             public abstract class A {
                 int n;
-
+            
                 public abstract void method(int n1);
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun ignoreAbstractMethodParameters(jp: JavaParser.Builder<*, *>) = assertUnchanged(
-        jp.styles(hiddenFieldStyle {
-            withIgnoreAbstractMethods(true)
-        }).build(),
-        before = """
+    fun ignoreAbstractMethodParameters(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        { spec ->
+            spec.parser(
+                jp.styles(hiddenFieldStyle {
+                    withIgnoreAbstractMethods(true)
+                })
+            )
+        },
+        //language=java
+        java(
+          """
             public abstract class A {
                 int n;
-
+            
                 public abstract void method(int n);
             }
-        """
-    )
+          """
+        )
+      )
 
     @Test
-    fun renamingVariableInSubclassShouldNotTakeSuperclassFieldsIntoAccount(jp: JavaParser) = assertChanged(
-        jp,
-        dependsOn = arrayOf(
-            """
+    fun updateJavaDocParamName(jp: JavaParser.Builder<*, *>) =
+      rewriteRun(
+        //language=java
+        java(
+          """
+            public abstract class A {
+                int n;
+            
+                /**
+                 * @param n rename param
+                 */
+                public abstract void method(int n);
+            }
+          """,
+                """
+            public abstract class A {
+                int n;
+            
+                /**
+                 * @param n1 rename param
+                 */
+                public abstract void method(int n1);
+            }
+          """
+        )
+      )
+
+    @Test
+    fun renamingVariableInSubclassShouldNotTakeSuperclassFieldsIntoAccount() =
+      rewriteRun(
+        //language=java
+        java(
+          """
             public class B {
                 protected Integer n2;
                 Integer n3;
                 private Integer n4;
             }
-        """
+          """
         ),
-        before = """
+        //language=java
+        java(
+          """
             public class A extends B {
                 Integer n;
                 Integer n1;
-
+            
                 class C {
                     public void method(Integer n) {
                         Integer n1 = n;
                     }
                 }
             }
-        """,
-        after = """
+          """,
+          """
             public class A extends B {
                 Integer n;
                 Integer n1;
-
+            
                 class C {
                     public void method(Integer n2) {
                         Integer n3 = n2;
                     }
                 }
             }
-        """
-    )
-
+          """
+        )
+      )
 }

--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/RenameJavaDocParamNameVisitorTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/RenameJavaDocParamNameVisitorTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.ExecutionContext
+import org.openrewrite.java.Assertions.java
+import org.openrewrite.java.JavaIsoVisitor
+import org.openrewrite.java.tree.J
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
+import org.openrewrite.test.RewriteTest.toRecipe
+
+@Suppress("JavadocDeclaration", "JavadocReference")
+interface RenameJavaDocParamNameVisitorTest : RewriteTest {
+
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(toRecipe {
+            object : JavaIsoVisitor<ExecutionContext>() {
+                override fun visitMethodDeclaration(
+                    method: J.MethodDeclaration,
+                    p: ExecutionContext
+                ): J.MethodDeclaration {
+                    var md = method
+                    if ("method" == md.name.simpleName && md.parameters.stream().anyMatch {
+                            it is J.VariableDeclarations && it.variables.stream().anyMatch { it2 ->
+                                "oldName" == it2.name.simpleName
+                            }
+                    }) {
+                        md = RenameJavaDocParamNameVisitor<ExecutionContext>(
+                            md,
+                            "oldName",
+                            "newName"
+                        ).visitMethodDeclaration(md, p)
+                    }
+                    return super.visitMethodDeclaration(md, p)
+                }
+
+                override fun visitVariable(
+                    variable: J.VariableDeclarations.NamedVariable,
+                    p: ExecutionContext
+                ): J.VariableDeclarations.NamedVariable {
+                    var v = super.visitVariable(variable, p)
+                    if ("oldName" == variable.simpleName) {
+                        v = v.withName(v.name.withSimpleName("newName"))
+                    }
+                    return v
+                }
+            }
+        })
+    }
+
+    @Test
+    fun noJavaDocParamMatch() =
+      rewriteRun(
+        java(
+          """
+            class Test {
+                /**
+                 * @param noMatch
+                 */
+                void method(String oldName) {
+                }
+            }
+          """,
+          """
+            class Test {
+                /**
+                 * @param noMatch
+                 */
+                void method(String newName) {
+                }
+            }
+          """
+        )
+      )
+
+    @Test
+    fun renameParamName() =
+      rewriteRun(
+        java(
+          """
+            class Test {
+                /**
+                 * @param oldName
+                 */
+                void method(String oldName) {
+                }
+            }
+          """,
+          """
+            class Test {
+                /**
+                 * @param newName
+                 */
+                void method(String newName) {
+                }
+            }
+          """
+        )
+      )
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenameJavaDocParamNameVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RenameJavaDocParamNameVisitor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Javadoc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Incubating(since = "7.33.0")
+public class RenameJavaDocParamNameVisitor<P> extends JavaIsoVisitor<P> {
+    private final MethodMatcher methodMatcher;
+    private final String oldName;
+    private final String newName;
+
+    public RenameJavaDocParamNameVisitor(J.MethodDeclaration targetScope,
+                                         String oldName,
+                                         String newName) {
+        String methodPattern = MethodMatcher.methodPattern(targetScope);
+        this.methodMatcher = new MethodMatcher(methodPattern);
+        this.oldName = oldName;
+        this.newName = newName;
+    }
+
+    @Override
+    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, P p) {
+        J.MethodDeclaration md = super.visitMethodDeclaration(method, p);
+        if (methodMatcher.matches(md.getMethodType()) && md.getComments().stream().anyMatch(it -> it instanceof Javadoc.DocComment)) {
+            List<Comment> comments = new ArrayList<>(md.getComments().size());
+            for (Comment comment : md.getComments()) {
+                if (comment instanceof Javadoc.DocComment) {
+                    Javadoc.DocComment docComment = (Javadoc.DocComment) comment;
+                    Comment newComment = (Comment) new RenameParamVisitor<P>(oldName, newName).visit(docComment, p);
+                    comments.add(newComment);
+                } else {
+                    comments.add(comment);
+                }
+            }
+            md = md.withPrefix(md.getPrefix().withComments(comments));
+        }
+        return md;
+    }
+
+    private static class RenameParamVisitor<P> extends JavadocVisitor<P> {
+        private final String oldName;
+        private final String newName;
+
+        public RenameParamVisitor(String oldName,
+                                  String newName) {
+            super(new JavaVisitor<>());
+            this.oldName = oldName;
+            this.newName = newName;
+        }
+
+        @Override
+        public Javadoc visitParameter(Javadoc.Parameter parameter, P p) {
+            Javadoc.Parameter pp = (Javadoc.Parameter) super.visitParameter(parameter, p);
+            if (pp.getNameReference() != null) {
+                if (pp.getNameReference().getTree() instanceof J.Identifier &&
+                        oldName.equals(((J.Identifier) pp.getNameReference().getTree()).getSimpleName())) {
+                    J.Identifier id = ((J.Identifier) pp.getNameReference().getTree()).withSimpleName(newName);
+                    pp = pp.withNameReference(pp.getNameReference().withTree(id));
+                }
+            }
+            return pp;
+        }
+    }
+}


### PR DESCRIPTION
Changes:
- Added `RenameJavaDocParamNameVisitor`. The `RenameJavaDocParamNameVisitor` will update a `@param` name in a JavaDoc.
- Updated `HiddenFieldVisitor` to rename Java doc params long with renamed fields.

Polish:
- Updated HiddenFieldTest to use RewriteTest.

fixes #2298