### PR TITLE
Add public qualifier to HCL TabsAndIndentsVisitor

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/TabsAndIndentsVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/TabsAndIndentsVisitor.java
@@ -27,7 +27,7 @@ import org.openrewrite.internal.lang.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-class TabsAndIndentsVisitor<P> extends HclIsoVisitor<P> {
+public class TabsAndIndentsVisitor<P> extends HclIsoVisitor<P> {
     @Nullable
     private final Tree stopAfter;
 


### PR DESCRIPTION
I hit an issue trying to use this class to create a custom formatter that is different from default AutoFormatVisitor. 
I'm guessing this was unintentional. No reason to make this class package private.