### PR TITLE
New Maven `RemoveDuplicateDependencies` recipe

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -222,19 +222,17 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     @Nullable
     public ResolvedDependency findDependency(Xml.Tag tag) {
         Map<Scope, List<ResolvedDependency>> dependencies = getResolutionResult().getDependencies();
-        for (Scope scope : Scope.values()) {
-            if (dependencies.containsKey(scope)) {
-                for (ResolvedDependency resolvedDependency : dependencies.get(scope)) {
-                    Dependency req = resolvedDependency.getRequested();
-                    String reqGroup = req.getGroupId();
-                    String reqVersion = req.getVersion();
-                    if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                            req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                            (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null))) &&
-                            (req.getClassifier() == null || req.getClassifier().equals(tag.getChildValue("classifier").orElse(null))) &&
-                            scope == Scope.fromName(tag.getChildValue("scope").orElse("compile"))) {
-                        return resolvedDependency;
-                    }
+        Scope scope = Scope.fromName(tag.getChildValue("scope").orElse("compile"));
+        if (dependencies.containsKey(scope)) {
+            for (ResolvedDependency resolvedDependency : dependencies.get(scope)) {
+                Dependency req = resolvedDependency.getRequested();
+                String reqGroup = req.getGroupId();
+                String reqVersion = req.getVersion();
+                if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
+                        req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                        (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null))) &&
+                        (req.getClassifier() == null || req.getClassifier().equals(tag.getChildValue("classifier").orElse(null)))) {
+                    return resolvedDependency;
                 }
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.tree.Dependency;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedManagedDependency;
+import org.openrewrite.maven.tree.Scope;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.time.Duration;
+import java.util.*;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class RemoveDuplicateDependencies extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove duplicate Maven dependencies";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes duplicated dependencies in the `<dependencies>` and `<dependencyManagement>` sections of the `pom.xml`.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RemoveDuplicateDependenciesVisitor();
+    }
+
+    @Override
+    protected MavenIsoVisitor<ExecutionContext> getApplicableTest() {
+        return new MavenIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
+                Xml.Tag root = document.getRoot();
+                if (root.getChild("dependencies").isPresent() || root.getChild("dependencyManagement").isPresent()) {
+                    return SearchResult.found(document);
+                }
+                return document;
+            }
+        };
+    }
+
+    private static class RemoveDuplicateDependenciesVisitor extends MavenIsoVisitor<ExecutionContext> {
+        private static final XPathMatcher DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencies");
+        private static final XPathMatcher MANAGED_DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencyManagement/dependencies");
+
+        @Override
+        public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            if (isDependenciesTag()) {
+                ctx.putMessage("dependencies", new HashMap<DependencyKey, Xml.Tag>());
+            } else if (isManagedDependenciesTag()) {
+                ctx.putMessage("managedDependencies", new HashMap<DependencyKey, Xml.Tag>());
+            } else if (isDependencyTag()) {
+                Map<DependencyKey, Xml.Tag> dependencies = ctx.getMessage("dependencies");
+                DependencyKey dependencyKey = getDependencyKey(tag);
+                if (dependencyKey != null) {
+                    Xml.Tag existing = dependencies.putIfAbsent(dependencyKey, tag);
+                    if (existing != null && existing != tag) {
+                        maybeUpdateModel();
+                        return null;
+                    }
+                }
+            } else if (isManagedDependencyTag()) {
+                Map<DependencyKey, Xml.Tag> dependencies = ctx.getMessage("managedDependencies");
+                DependencyKey dependencyKey = getManagedDependencyKey(tag);
+                if (dependencyKey != null) {
+                    Xml.Tag existing = dependencies.putIfAbsent(dependencyKey, tag);
+                    if (existing != null && existing != tag) {
+                        maybeUpdateModel();
+                        return null;
+                    }
+                }
+            }
+            return super.visitTag(tag, ctx);
+        }
+
+        private boolean isDependenciesTag() {
+            return DEPENDENCIES_MATCHER.matches(getCursor());
+        }
+
+        private boolean isManagedDependenciesTag() {
+            return MANAGED_DEPENDENCIES_MATCHER.matches(getCursor());
+        }
+
+        @Nullable
+        private DependencyKey getDependencyKey(Xml.Tag tag) {
+            Map<Scope, List<ResolvedDependency>> dependencies = getResolutionResult().getDependencies();
+            Scope scope = tag.getChildValue("scope").map(Scope::fromName).orElse(Scope.Compile);
+            if (dependencies.containsKey(scope)) {
+                for (ResolvedDependency resolvedDependency : dependencies.get(scope)) {
+                    Dependency req = resolvedDependency.getRequested();
+                    String reqGroup = req.getGroupId();
+                    if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
+                            Objects.equals(req.getArtifactId(), tag.getChildValue("artifactId").orElse(null)) &&
+                            Objects.equals(Optional.ofNullable(req.getType()).orElse("jar"), tag.getChildValue("type").orElse("jar")) &&
+                            Objects.equals(req.getClassifier(), tag.getChildValue("classifier").orElse(null))) {
+                        return DependencyKey.from(resolvedDependency, scope);
+                    }
+                }
+            }
+            return null;
+        }
+
+        @Nullable
+        private DependencyKey getManagedDependencyKey(Xml.Tag tag) {
+            ResolvedManagedDependency resolvedDependency = findManagedDependency(tag);
+            return resolvedDependency != null ? DependencyKey.from(resolvedDependency) : null;
+        }
+    }
+
+    @Value
+    private static class DependencyKey {
+        @Nullable
+        String groupId;
+        String artifactId;
+        String type;
+        @Nullable
+        String classifier;
+        Scope scope;
+
+        public static DependencyKey from(ResolvedDependency dependency, Scope scope) {
+            return new DependencyKey(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), dependency.getClassifier(), scope);
+        }
+
+        public static DependencyKey from(ResolvedManagedDependency dependency) {
+            return new DependencyKey(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), dependency.getClassifier(), Scope.Compile);
+        }
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
@@ -74,14 +74,15 @@ public class RemoveDuplicateDependencies extends Recipe {
         private static final XPathMatcher DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencies");
         private static final XPathMatcher MANAGED_DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencyManagement/dependencies");
 
+        @SuppressWarnings("DataFlowIssue")
         @Override
         public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
             if (isDependenciesTag()) {
-                ctx.putMessage("dependencies", new HashMap<DependencyKey, Xml.Tag>());
+                getCursor().putMessage("dependencies", new HashMap<DependencyKey, Xml.Tag>());
             } else if (isManagedDependenciesTag()) {
-                ctx.putMessage("managedDependencies", new HashMap<DependencyKey, Xml.Tag>());
+                getCursor().putMessage("managedDependencies", new HashMap<DependencyKey, Xml.Tag>());
             } else if (isDependencyTag()) {
-                Map<DependencyKey, Xml.Tag> dependencies = ctx.getMessage("dependencies");
+                Map<DependencyKey, Xml.Tag> dependencies = getCursor().getNearestMessage("dependencies");
                 DependencyKey dependencyKey = getDependencyKey(tag);
                 if (dependencyKey != null) {
                     Xml.Tag existing = dependencies.putIfAbsent(dependencyKey, tag);
@@ -91,7 +92,7 @@ public class RemoveDuplicateDependencies extends Recipe {
                     }
                 }
             } else if (isManagedDependencyTag()) {
-                Map<DependencyKey, Xml.Tag> dependencies = ctx.getMessage("managedDependencies");
+                Map<DependencyKey, Xml.Tag> dependencies = getCursor().getNearestMessage("managedDependencies");
                 DependencyKey dependencyKey = getManagedDependencyKey(tag);
                 if (dependencyKey != null) {
                     Xml.Tag existing = dependencies.putIfAbsent(dependencyKey, tag);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class RemoveDuplicateDependenciesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.expectedCyclesThatMakeChanges(1).recipe(new RemoveDuplicateDependencies());
+    }
+
+    @Test
+    void notApplicable() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeSingleDuplicate() {
+        rewriteRun(
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """,
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesComments() {
+        rewriteRun(
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <!-- comment 1 -->
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <!-- comment 2 -->
+                      <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                      </dependency>
+                      <!-- comment 3 -->
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """,
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <!-- comment 1 -->
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <!-- comment 2 -->
+                      <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                      </dependency>
+                      <!-- comment 3 -->
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeMultipleDuplicates() {
+        rewriteRun(
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """,
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDependencyWithDifferentVersion() {
+        rewriteRun(
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                        <version>4.2.1</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                        <version>4.2.2</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """, """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                        <version>4.2.1</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepDependencyWithClassifier() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                        <version>4.2.2</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                        <version>4.2.2</version>
+                        <classifier>no_aop</classifier>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Disabled("Unsure if this is a valid use case or not")
+    @Test
+    void keepDependencyWithType() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                        <type>war</type>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepDependencyWithDifferentScope() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                        <scope>compile</scope>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                        <scope>test</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDependencyWithDefaultType() {
+        rewriteRun(
+          pomXml(
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                        <type>jar</type>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """,
+            """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
For now the recipe can only remove duplicates, but in the future it could maybe also sort dependencies (only by scope since sorting dependencies within a scope may have undesired effects due to Maven's dependency resolution).

Fixes #2381
