### PR TITLE
Add repo - model not changed. Also fixes #2398

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddRepository.java
@@ -121,6 +121,7 @@ public class AddRepository extends Recipe {
                             } else {
                                 repositories = (Xml.Tag) new ChangeTagValueVisitor<>(repo.getChild("layout").get(), repoName).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                             }
+                            maybeUpdateModel();
                         }
                         if (!isReleasesEqual(repo)) {
                             Xml.Tag releases = repo.getChild("releases").orElse(null);
@@ -132,6 +133,7 @@ public class AddRepository extends Recipe {
                                     repositories = (Xml.Tag) new AddToTagVisitor<>(repo, Xml.Tag.build(assembleReleases())).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                                 }
                             }
+                            maybeUpdateModel();
                         }
                         if (!isSnapshotsEqual(repo)) {
                             Xml.Tag snapshots = repo.getChild("snapshots").orElse(null);
@@ -143,6 +145,7 @@ public class AddRepository extends Recipe {
                                     repositories = (Xml.Tag) new AddToTagVisitor<>(repo, Xml.Tag.build(assembleSnapshots())).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                                 }
                             }
+                            maybeUpdateModel();
                         }
                     } else {
                         StringBuilder sb = new StringBuilder();
@@ -157,6 +160,7 @@ public class AddRepository extends Recipe {
 
                         Xml.Tag repoTag = Xml.Tag.build(sb.toString());
                         repositories = (Xml.Tag) new AddToTagVisitor<>(repositories, repoTag).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
+                        maybeUpdateModel();
                     }
                 }
                 return repositories;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
@@ -269,7 +269,7 @@ public class AddRepositoryTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
             true, null, null,
-            null, null, null).doNext(new UpgradeParentVersion("org.springframework.boot", "*", "3.0.0-SNAPSHOT", null))),
+            null, null, null).doNext(new UpgradeParentVersion("org.springframework.boot", "spring-boot-starter-parent", "3.0.0-SNAPSHOT", null))),
           pomXml(
             """
                   <project>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
@@ -262,4 +262,51 @@ public class AddRepositoryTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void updateToSpringBoot30Snapshot() {
+
+        rewriteRun(
+          spec -> spec.recipe(new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
+            true, null, null,
+            null, null, null).doNext(new UpgradeParentVersion("org.springframework.boot", "*", "3.0.0-SNAPSHOT", null))),
+          pomXml(
+            """
+                  <project>
+                    <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.3</version>
+                    </parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  </project>
+              """,
+            """
+                  <project>
+                    <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>3.0.0-SNAPSHOT</version>
+                    </parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <repositories>
+                      <repository>
+                        <id>boot-snapshots</id>
+                        <url>https://repo.spring.io/snapshot</url>
+                        <snapshots>
+                          <enabled>true</enabled>
+                        </snapshots>
+                      </repository>
+                    </repositories>
+                  </project>
+              """
+          )
+        );
+    }
+
+
 }


### PR DESCRIPTION
Recently I've created a PR to add Maven Repository to the pom. However, I've noticed that although XML does appear the model sort of still misses the repo. I though I was missing `maybeUpdateModel()` but it didn't help.

Please see the test I have added. It'd be great if anyone could point me to what is missing. So far I think `UpdateMavenModel` visitor is likely missing the bit updating repositories.