### PR TITLE
Maven `RemoveExclusion` recipe should preserve comments

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveExclusionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveExclusionTest.java
@@ -75,6 +75,60 @@ class RemoveExclusionTest implements RewriteTest {
     }
 
     @Test
+    void preserveOtherExclusionsAndComments() {
+        rewriteRun(
+          pomXml(
+            """
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                        <exclusions>
+                          <exclusion>
+                            <groupId>commons-lang</groupId>
+                            <artifactId>commons-lang</artifactId>
+                          </exclusion>
+                          <!-- comment -->
+                          <exclusion>
+                            <groupId>foo</groupId>
+                            <artifactId>bar</artifactId>
+                          </exclusion>
+                        </exclusions>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """,
+            """
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>29.0-jre</version>
+                        <exclusions>
+                          <!-- comment -->
+                          <exclusion>
+                            <groupId>foo</groupId>
+                            <artifactId>bar</artifactId>
+                          </exclusion>
+                        </exclusions>
+                      </dependency>
+                    </dependencies>
+                  </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void removeUnusedExclusionsFromDependencyManagement() {
         rewriteRun(
           pomXml("""


### PR DESCRIPTION
Change `RemoveExclusion` recipe to use `Tag#getContent()` rather than `Tag#getChildren()` so that comments are preserved.
