### PR TITLE
Support multiproject builds from the IDE

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -88,7 +88,7 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
                         && Paths.get(cpEntry).toFile().isDirectory()) {
                     artifacts.add(Paths.get(cpEntry));
                     lacking = false;
-                    break;
+                    // Do not break because jarPattern matches "foo-bar-1.0.jar" and "foo-1.0.jar" to "foo"
                 }
             }
             if (lacking) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -84,8 +84,8 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
             for (URI cpEntry : runtimeClasspath) {
                 String cpEntryString = cpEntry.toString();
                 if (jarPattern.matcher(cpEntryString).find()
-                        || (explodedPattern.matcher(cpEntryString).find())
-                        && Paths.get(cpEntry).toFile().isDirectory()) {
+                        || (explodedPattern.matcher(cpEntryString).find()
+                        && Paths.get(cpEntry).toFile().isDirectory())) {
                     artifacts.add(Paths.get(cpEntry));
                     lacking = false;
                     // Do not break because jarPattern matches "foo-bar-1.0.jar" and "foo-1.0.jar" to "foo"


### PR DESCRIPTION
Support IDE multiprojects (including IntelliJ) so tests can be debugged even if they reside in the same multiproject as some of the artifacts they add to the classpath.

Solution: Don't just match on jars, but also on exploded artifact directories (regardless if they are maven or gradle format).

Fixes https://stackoverflow.com/questions/74386486/openrewrite-run-unit-test-in-the-ide-intellij-that-uses-classes-from-the-same