### PR TITLE
Added support for JavaType$Primitive in UsesType.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
@@ -43,8 +43,8 @@ public class UsesType<P> extends JavaIsoVisitor<P> {
         }
 
         for (JavaType type : c.getTypesInUse().getTypesInUse()) {
-            JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
-            if ((c = maybeMark(c, fq)) != cu) {
+            JavaType checkType = type instanceof JavaType.Primitive ? type : TypeUtils.asFullyQualified(type);
+            if ((c = maybeMark(c, checkType)) != cu) {
                 return c;
             }
         }
@@ -62,12 +62,12 @@ public class UsesType<P> extends JavaIsoVisitor<P> {
         return c;
     }
 
-    private JavaSourceFile maybeMark(JavaSourceFile c, @Nullable JavaType.FullyQualified fq) {
-        if (fq == null) {
+    private JavaSourceFile maybeMark(JavaSourceFile c, @Nullable JavaType type) {
+        if (type == null) {
             return c;
         }
 
-        if (TypeUtils.isAssignableTo(typePattern, fq)) {
+        if (TypeUtils.isAssignableTo(typePattern, type)) {
             return SearchResult.found(c);
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -230,6 +230,9 @@ public class TypeUtils {
                 return isAssignableTo(to, ((JavaType.Variable) from).getType());
             } else if (from instanceof JavaType.Method) {
                 return isAssignableTo(to, ((JavaType.Method) from).getReturnType());
+            } else if (from instanceof JavaType.Primitive) {
+                JavaType.Primitive primitive = (JavaType.Primitive) from;
+                return to.toString().equals(primitive.getKeyword());
             }
         } catch (Exception e) {
             return false;


### PR DESCRIPTION
Changes:

- UsesType supports `JavaType$Primitive`.
- TypeUtils#isAssignableTo(Pattern, Type) supports `JavaType$Primitive`.

fixes #2427