### PR TITLE
Fix for HCL AutoFormat issue where spaces around for-loop parts are moved incorrectly causing invalid HCL

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
@@ -48,16 +48,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
                 .orElse(BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
+        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
+                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
+                .visit(t, p, cursor.fork());
+
         t = new SpacesVisitor<>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
                 .orElse(SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new BlankLinesVisitor<>(Optional.ofNullable(cf.getStyle(BlankLinesStyle.class))
                 .orElse(BlankLinesStyle.DEFAULT), stopAfter)
-                .visit(t, p, cursor.fork());
-
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
-                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         if (t instanceof Hcl.ConfigFile) {
@@ -71,8 +71,14 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
     public Hcl visitConfigFile(Hcl.ConfigFile cf, P p) {
         Hcl.ConfigFile t = (Hcl.ConfigFile) new RemoveTrailingWhitespaceVisitor<>().visit(cf, p);
 
+        t = (Hcl.ConfigFile) new NormalizeFormatVisitor<>().visit(t, p);
+
         t = (Hcl.ConfigFile) new BracketsVisitor<>(Optional.ofNullable(cf.getStyle(BracketsStyle.class))
                 .orElse(BracketsStyle.DEFAULT), stopAfter)
+                .visit(t, p);
+
+        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
+                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
         t = (Hcl.ConfigFile) new SpacesVisitor<>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
@@ -81,10 +87,6 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         t = (Hcl.ConfigFile) new BlankLinesVisitor<>(Optional.ofNullable(cf.getStyle(BlankLinesStyle.class))
                 .orElse(BlankLinesStyle.DEFAULT), stopAfter)
-                .visit(t, p);
-
-        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
-                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
         assert t != null;

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/NormalizeFormatVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/NormalizeFormatVisitor.java
@@ -101,42 +101,6 @@ public class NormalizeFormatVisitor<P> extends HclIsoVisitor<P> {
     }
 
     @Override
-    public Hcl.ForIntro visitForIntro(Hcl.ForIntro forIntro, P p) {
-        Hcl.ForIntro f = super.visitForIntro(forIntro, p);
-
-        if (Space.firstPrefix(f.getVariables()) != Space.EMPTY) {
-            f = concatenateSpace(f, Space.firstPrefix(f.getVariables()));
-            f = f.withVariables(Space.formatFirstPrefix(f.getVariables(), Space.EMPTY));
-        }
-
-        return f;
-    }
-
-    @Override
-    public Hcl.ForObject visitForObject(Hcl.ForObject forObject, P p) {
-        Hcl.ForObject f = super.visitForObject(forObject, p);
-
-        if (f.getIntro().getPrefix() != Space.EMPTY) {
-            f = concatenateSpace(f, f.getIntro().getPrefix());
-            f = f.withIntro(f.getIntro().withPrefix(Space.EMPTY));
-        }
-
-        return f;
-    }
-
-    @Override
-    public Hcl.ForTuple visitForTuple(Hcl.ForTuple forTuple, P p) {
-        Hcl.ForTuple f = super.visitForTuple(forTuple, p);
-
-        if (f.getIntro().getPrefix() != Space.EMPTY) {
-            f = concatenateSpace(f, f.getIntro().getPrefix());
-            f = f.withIntro(f.getIntro().withPrefix(Space.EMPTY));
-        }
-
-        return f;
-    }
-
-    @Override
     public Hcl.FunctionCall visitFunctionCall(Hcl.FunctionCall functionCall, P p) {
         Hcl.FunctionCall f = super.visitFunctionCall(functionCall, p);
 

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/format/AutoFormatTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/format/AutoFormatTest.java
@@ -30,6 +30,19 @@ class AutoFormatTest implements RewriteTest {
     }
 
     @Test
+    void forLoops() {
+        rewriteRun(
+          hcl(
+          """
+              a = [for v in ["a", "b"] : v]
+              b = [for i, v in ["a", "b"] : i]
+              c = [for i, v in ["a", "b", "c"]: v if 1 && !0]
+          """
+          )
+        );
+    }
+
+    @Test
     void objectValues() {
         rewriteRun(
           hcl(

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/format/BracketSpacesTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/format/BracketSpacesTest.java
@@ -73,7 +73,6 @@ class BracketSpacesTest implements RewriteTest {
     @Test
     void objectValueBracesMulti() {
         rewriteRun(
-          spec -> spec.cycles(3),
           hcl(
             """
               resource "aws_ebs_volume" {
@@ -114,7 +113,6 @@ class BracketSpacesTest implements RewriteTest {
     @Test
     void objectValueBracesComplex() {
         rewriteRun(
-          spec -> spec.cycles(3),
           hcl(
             """
               resource "aws_ebs_volume" {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -68,28 +68,11 @@ public class MavenDependencyFailuresTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            """
-                <project>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>my-app</artifactId>
-                  <version>1</version>
-                  <dependencies>
-                    <!--~~(Unable to download metadata. Tried repositories:
-                https://repo.maven.apache.org/maven2: Did not attempt to download because of a previous failure to retrieve from this repository.)~~>--><dependency>
-                      <groupId>org.jenkins-ci.plugins</groupId>
-                      <artifactId>credentials</artifactId>
-                      <version>2.3.0</version>
-                    </dependency>
-                    <!--~~(Unable to download metadata. Tried repositories:
-                https://repo.maven.apache.org/maven2: HTTP 404)~~>--><!--~~(Unable to download POM. Tried repositories:
-                https://repo.maven.apache.org/maven2: HTTP 404)~~>--><dependency>
-                      <groupId>org.jenkins-ci.plugins</groupId>
-                      <artifactId>appio</artifactId>
-                      <version>1.3</version>
-                    </dependency>
-                  </dependencies>
-                </project>
-              """
+            spec -> spec.after(after -> {
+                //There should be two errors (one for each failed metadata download)
+                assertThat(after.split("Unable to download metadata")).hasSize(3);
+                return after;
+                })
           )
         );
     }


### PR DESCRIPTION
The way `NormalizeFormatVisitor` is moving spaces around the parts of for loops is causing the HCL to become invalid.

For example,
- `visitForIntro` is causing `a = [ for v in ["a", "b"] : v ]` to turn into `a = [ forv in ["a", "b"] : v ]`
- `visitForTuple` is causing `a = [ for v in ["a", "b"] : v ]` to turn into `a = [for v in ["a", "b"] : v ]`

This PR removes the offending blocks from NormalizeFormatVisitor. Also reodring the visitors in AutoFormatVisitor since I found a scenario where `SpacesVisitor` is dependent on the spaces created by `TabsAndIndentsVisitor`