### PR TITLE
feat: add option to ignore whitespace from diff

### DIFF
--- a/rewrite-core/src/test/kotlin/org/openrewrite/ResultTest.kt
+++ b/rewrite-core/src/test/kotlin/org/openrewrite/ResultTest.kt
@@ -39,6 +39,27 @@ class ResultTest {
     }
 
     @Test
+    fun ignoreWhitespace() {
+        val diff = Result.InMemoryDiffEntry(
+            Paths.get("com/netflix/MyJavaClass.java"),
+            Paths.get("com/netflix/MyJavaClass.java"),
+            null,
+            "public class A {} ",
+            "public class A {}",
+            emptySet()
+        )
+
+        val diffNoWs = diff.getDiff(true);
+        assertThat(
+            """
+            diff --git a/com/netflix/MyJavaClass.java b/com/netflix/MyJavaClass.java
+            index 9bfeb36..efd7fa3 100644
+            --- a/com/netflix/MyJavaClass.java
+            +++ b/com/netflix/MyJavaClass.java
+            """.trimIndent()
+        ).isEqualTo(diffNoWs.trimIndent());
+    }
+    @Test
     fun singleLineChange() {
         val diff = Result.InMemoryDiffEntry(
             filePath, filePath, null,


### PR DESCRIPTION
### Problem
There is currently no way to generate diffs that excludes (aka ignore) whitespace changes from recipes. This can be helpful when a recipe performs changes in addition to formatting, and the consumer wants to focus on the substantive changes.

### Solution
Add an additional option to the `diff` method to control the formatting algorithm used by jgit