### PR TITLE
Fix SOE visiting switch expressions.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -1039,7 +1039,6 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
         s = s.withSelector(visitAndCast(s.getSelector(), p));
         s = s.withCases(visitAndCast(s.getCases(), p));
-        visitType(s.getType(), p);
         return s;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -4644,11 +4644,12 @@ public interface J extends Tree {
         public JavaType getType() {
             return new JavaVisitor<AtomicReference<JavaType>>() {
                 @Override
-                public J visitCase(Case caze, AtomicReference<JavaType> javaType) {
-                    if (!caze.getExpressions().isEmpty()) {
+                public J visitBlock(Block block, AtomicReference<JavaType> javaType) {
+                    if (!block.getStatements().isEmpty()) {
+                        Case caze = (Case) block.getStatements().get(0);
                         javaType.set(caze.getExpressions().get(0).getType());
                     }
-                    return caze;
+                    return block;
                 }
             }.reduce(this, new AtomicReference<>()).get();
         }


### PR DESCRIPTION
Changes:
- visiting a `J.SwitchExpression` will not cause a StackOverflowException.
- `J.SwitchExpression#getType()` will return the appropriate `JavaType.`

fixes #2357