### PR TITLE
Exception hiding the actual cause leads to unusable information, fixes #2453

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenDownloadingExceptions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenDownloadingExceptions.java
@@ -43,6 +43,7 @@ public class MavenDownloadingExceptions extends Exception {
         if (current == null) {
             current = new MavenDownloadingExceptions();
         }
+        current.addSuppressed(exception);
         current.exceptions.add(exception);
         return current;
     }
@@ -52,6 +53,7 @@ public class MavenDownloadingExceptions extends Exception {
         if (current == null) {
             current = new MavenDownloadingExceptions();
         }
+        exceptions.getExceptions().forEach(current::addSuppressed);
         current.exceptions.addAll(exceptions.getExceptions());
         return current;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UncheckedMavenDownloadingException.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UncheckedMavenDownloadingException.java
@@ -24,13 +24,19 @@ public class UncheckedMavenDownloadingException extends RuntimeException {
 
     public UncheckedMavenDownloadingException(Xml.Document pom, MavenDownloadingExceptions e) {
         super("Failed to download dependencies for " + pom.getSourcePath() + ":\n" +
-              e.warn(pom).printAllTrimmed(), e);
-        this.pomWithWarnings = e.warn(pom);
+              warn(pom, e).printAllTrimmed(), e);
+        this.pomWithWarnings = warn(pom, e);
     }
 
     public UncheckedMavenDownloadingException(Xml.Document pom, MavenDownloadingException e) {
-        super("Failed to download dependencies for " + pom.getSourcePath() + ":\n" +
-              MavenDownloadingExceptions.append(null, e).warn(pom).printAllTrimmed(), e);
-        this.pomWithWarnings = MavenDownloadingExceptions.append(null, e).warn(pom);
+        this(pom, MavenDownloadingExceptions.append(null, e));
+    }
+
+    private static Xml.Document warn(Xml.Document pom, MavenDownloadingExceptions mde) {
+        try {
+            return mde.warn(pom);
+        } catch (Exception e) {
+            return pom;
+        }
     }
 }


### PR DESCRIPTION
Fixes #2453 
- Silently ignore exception occurring during the preparation of the exception
- Make sure the download exception cause are kept in the stack trace
