### PR TITLE
Fix various issues with Gradle Wrapper recipes

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
@@ -128,6 +128,7 @@ public class AddGradleWrapper extends Recipe {
                             "distributionBase=GRADLE_USER_HOME\n" +
                                     "distributionPath=wrapper/dists\n" +
                                     "distributionUrl=" + gradleWrapper.getPropertiesFormattedUrl() + "\n" +
+                                    "distributionSha256Sum=" + gradleWrapper.getDistributionChecksum() + "\n" +
                                     "zipStoreBase=GRADLE_USER_HOME\n" +
                                     "zipStorePath=wrapper/dists").get(0)
                     .withSourcePath(WRAPPER_PROPERTIES_LOCATION);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddGradleWrapper.java
@@ -128,7 +128,7 @@ public class AddGradleWrapper extends Recipe {
                             "distributionBase=GRADLE_USER_HOME\n" +
                                     "distributionPath=wrapper/dists\n" +
                                     "distributionUrl=" + gradleWrapper.getPropertiesFormattedUrl() + "\n" +
-                                    "distributionSha256Sum=" + gradleWrapper.getDistributionChecksum() + "\n" +
+                                    "distributionSha256Sum=" + gradleWrapper.getDistributionChecksum().getHexValue() + "\n" +
                                     "zipStoreBase=GRADLE_USER_HOME\n" +
                                     "zipStorePath=wrapper/dists").get(0)
                     .withSourcePath(WRAPPER_PROPERTIES_LOCATION);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -27,8 +27,10 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.LoathingOfOthers;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.properties.PropertiesVisitor;
+import org.openrewrite.properties.search.FindProperties;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.quark.Quark;
 import org.openrewrite.text.PlainText;
@@ -36,6 +38,7 @@ import org.openrewrite.text.PlainText;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.PathUtils.equalIgnoringSeparators;
@@ -141,15 +144,7 @@ public class UpdateGradleWrapper extends Recipe {
                 return gradlewBat;
             }
             if (sourceFile instanceof Properties.File && equalIgnoringSeparators(sourceFile.getSourcePath(), WRAPPER_PROPERTIES_LOCATION)) {
-                return (Properties.File) new PropertiesVisitor<ExecutionContext>() {
-                    @Override
-                    public Properties visitEntry(Properties.Entry entry, ExecutionContext context) {
-                        if (!"distributionUrl".equals(entry.getKey())) {
-                            return entry;
-                        }
-                        return entry.withValue(entry.getValue().withText(gradleWrapper.getPropertiesFormattedUrl()));
-                    }
-                }.visitNonNull(sourceFile, ctx);
+                return (Properties.File) new WrapperPropertiesVisitor(gradleWrapper).visitNonNull(sourceFile, ctx);
             }
             if (sourceFile instanceof Quark && equalIgnoringSeparators(sourceFile.getSourcePath(), WRAPPER_JAR_LOCATION)) {
                 return gradleWrapper.asRemote().withId(sourceFile.getId()).withMarkers(sourceFile.getMarkers());
@@ -168,6 +163,42 @@ public class UpdateGradleWrapper extends Recipe {
             return sourceFile.withFileAttributes(new FileAttributes(now, now, now, true, true, true, 1));
         } else {
             return sourceFile.withFileAttributes(sourceFile.getFileAttributes().withExecutable(true));
+        }
+    }
+
+    private static class WrapperPropertiesVisitor extends PropertiesVisitor<ExecutionContext> {
+
+        private static final String DISTRIBUTION_SHA_256_SUM_KEY = "distributionSha256Sum";
+        private final GradleWrapper gradleWrapper;
+
+        public WrapperPropertiesVisitor(GradleWrapper gradleWrapper) {
+            this.gradleWrapper = gradleWrapper;
+        }
+
+        @Override
+        public Properties visitFile(Properties.File file, ExecutionContext executionContext) {
+            Properties p = super.visitFile(file, executionContext);
+            if (!StringUtils.isBlank(gradleWrapper.getDistributionChecksum())) {
+                Set<Properties.Entry> properties = FindProperties.find(p, DISTRIBUTION_SHA_256_SUM_KEY, false);
+                if (properties.isEmpty()) {
+                    Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, gradleWrapper.getDistributionChecksum());
+                    Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, "", propertyValue);
+                    List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
+                    p = ((Properties.File) p).withContent(contentList);
+                }
+            }
+            return p;
+        }
+
+        @Override
+        public Properties visitEntry(Properties.Entry entry, ExecutionContext context) {
+            if ("distributionUrl".equals(entry.getKey())) {
+                return entry.withValue(entry.getValue().withText(gradleWrapper.getPropertiesFormattedUrl()));
+            }
+            if (!StringUtils.isBlank(gradleWrapper.getDistributionChecksum()) && DISTRIBUTION_SHA_256_SUM_KEY.equals(entry.getKey())) {
+                return entry.withValue(entry.getValue().withText(gradleWrapper.getDistributionChecksum()));
+            }
+            return entry;
         }
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -178,14 +178,12 @@ public class UpdateGradleWrapper extends Recipe {
         @Override
         public Properties visitFile(Properties.File file, ExecutionContext executionContext) {
             Properties p = super.visitFile(file, executionContext);
-            if (!StringUtils.isBlank(gradleWrapper.getDistributionChecksum())) {
-                Set<Properties.Entry> properties = FindProperties.find(p, DISTRIBUTION_SHA_256_SUM_KEY, false);
-                if (properties.isEmpty()) {
-                    Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, gradleWrapper.getDistributionChecksum());
-                    Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, "", propertyValue);
-                    List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
-                    p = ((Properties.File) p).withContent(contentList);
-                }
+            Set<Properties.Entry> properties = FindProperties.find(p, DISTRIBUTION_SHA_256_SUM_KEY, false);
+            if (properties.isEmpty()) {
+                Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, gradleWrapper.getDistributionChecksum().getHexValue());
+                Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, "", propertyValue);
+                List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
+                p = ((Properties.File) p).withContent(contentList);
             }
             return p;
         }
@@ -195,8 +193,8 @@ public class UpdateGradleWrapper extends Recipe {
             if ("distributionUrl".equals(entry.getKey())) {
                 return entry.withValue(entry.getValue().withText(gradleWrapper.getPropertiesFormattedUrl()));
             }
-            if (!StringUtils.isBlank(gradleWrapper.getDistributionChecksum()) && DISTRIBUTION_SHA_256_SUM_KEY.equals(entry.getKey())) {
-                return entry.withValue(entry.getValue().withText(gradleWrapper.getDistributionChecksum()));
+            if (DISTRIBUTION_SHA_256_SUM_KEY.equals(entry.getKey())) {
+                return entry.withValue(entry.getValue().withText(gradleWrapper.getDistributionChecksum().getHexValue()));
             }
             return entry;
         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/DistributionInfos.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/DistributionInfos.java
@@ -25,13 +25,15 @@ import java.net.URI;
 @Value
 public class DistributionInfos {
     String downloadUrl;
-    String checksum;
+    Checksum checksum;
+    Checksum wrapperJarChecksum;
 
     static DistributionInfos fetch(HttpSender httpSender, GradleWrapper.DistributionType distributionType,
                                    GradleWrapper.GradleVersion gradleVersion) throws IOException {
         String downloadUrl = toDistTypeUrl(distributionType, gradleVersion.getDownloadUrl());
-        String checksum = fetchChecksum(httpSender, toDistTypeUrl(distributionType, gradleVersion.getChecksumUrl()));
-        return new DistributionInfos(downloadUrl, checksum);
+        Checksum checksum = fetchChecksum(httpSender, toDistTypeUrl(distributionType, gradleVersion.getChecksumUrl()));
+        Checksum jarChecksum = fetchChecksum(httpSender, gradleVersion.getWrapperChecksumUrl());
+        return new DistributionInfos(downloadUrl, checksum, jarChecksum);
     }
 
     private static String toDistTypeUrl(GradleWrapper.DistributionType distributionType, String binUrl) {
@@ -41,8 +43,7 @@ public class DistributionInfos {
         return binUrl;
     }
 
-    private static String fetchChecksum(HttpSender httpSender, String checksumUrl) {
-        Checksum checksum = Checksum.fromUri(httpSender, URI.create(checksumUrl));
-        return checksum.getHexValue();
+    private static Checksum fetchChecksum(HttpSender httpSender, String checksumUrl) {
+        return Checksum.fromUri(httpSender, URI.create(checksumUrl));
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/DistributionInfos.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/DistributionInfos.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.util;
+
+import lombok.Value;
+import org.openrewrite.Checksum;
+import org.openrewrite.ipc.http.HttpSender;
+
+import java.io.IOException;
+import java.net.URI;
+
+@Value
+public class DistributionInfos {
+    String downloadUrl;
+    String checksum;
+
+    static DistributionInfos fetch(HttpSender httpSender, GradleWrapper.DistributionType distributionType,
+                                   GradleWrapper.GradleVersion gradleVersion) throws IOException {
+        String downloadUrl = toDistTypeUrl(distributionType, gradleVersion.getDownloadUrl());
+        String checksum = fetchChecksum(httpSender, toDistTypeUrl(distributionType, gradleVersion.getChecksumUrl()));
+        return new DistributionInfos(downloadUrl, checksum);
+    }
+
+    private static String toDistTypeUrl(GradleWrapper.DistributionType distributionType, String binUrl) {
+        if (distributionType == GradleWrapper.DistributionType.All) {
+            return binUrl.replace("-bin.zip", "-all.zip");
+        }
+        return binUrl;
+    }
+
+    private static String fetchChecksum(HttpSender httpSender, String checksumUrl) {
+        Checksum checksum = Checksum.fromUri(httpSender, URI.create(checksumUrl));
+        return checksum.getHexValue();
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -16,11 +16,13 @@
 package org.openrewrite.gradle.util;
 
 import lombok.Value;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.FileAttributes;
+import org.openrewrite.HttpSenderExecutionContextView;
+import org.openrewrite.Validated;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.ipc.http.HttpSender;
-import org.openrewrite.marker.Markers;
-import org.openrewrite.remote.RemoteArchive;
+import org.openrewrite.remote.Remote;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
@@ -137,11 +139,8 @@ public class GradleWrapper {
 
     static final FileAttributes WRAPPER_JAR_FILE_ATTRIBUTES = new FileAttributes(null, null, null, true, true, false, 0);
 
-    public RemoteArchive asRemote() {
-        return new RemoteArchive(Tree.randomId(), GradleWrapper.WRAPPER_JAR_LOCATION, Markers.EMPTY,
-                URI.create(getDistributionUrl()), null, false, WRAPPER_JAR_FILE_ATTRIBUTES,
-                "gradle-wrapper.jar is part of the gradle wrapper",
-                Paths.get("gradle-" + version + "/lib/gradle-wrapper-" + version + ".jar!gradle-wrapper.jar"));
+    public Remote asRemote() {
+        return new GradleWrapperJar(URI.create(getDistributionUrl()), version);
     }
 
     public enum DistributionType {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Value;
+import org.openrewrite.Checksum;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.FileAttributes;
 import org.openrewrite.HttpSenderExecutionContextView;
@@ -136,14 +137,14 @@ public class GradleWrapper {
         return getDistributionUrl().replaceAll("(?<!\\\\)://", "\\\\://");
     }
 
-    public String getDistributionChecksum() {
+    public Checksum getDistributionChecksum() {
         return distributionInfos.getChecksum();
     }
 
     static final FileAttributes WRAPPER_JAR_FILE_ATTRIBUTES = new FileAttributes(null, null, null, true, true, false, 0);
 
     public Remote asRemote() {
-        return new GradleWrapperJar(URI.create(getDistributionUrl()), version);
+        return new GradleWrapperJar(URI.create(getDistributionUrl()), version, distributionInfos.getWrapperJarChecksum());
     }
 
     public enum DistributionType {
@@ -155,14 +156,17 @@ public class GradleWrapper {
         String version;
         String downloadUrl;
         String checksumUrl;
+        String wrapperChecksumUrl;
 
         @JsonCreator
         public GradleVersion(@JsonProperty("version") String version,
                              @JsonProperty("downloadUrl") String downloadUrl,
-                             @JsonProperty("checksumUrl") String checksumUrl) {
+                             @JsonProperty("checksumUrl") String checksumUrl,
+                             @JsonProperty("wrapperChecksumUrl") String wrapperChecksumUrl) {
             this.version = version;
             this.downloadUrl = downloadUrl;
             this.checksumUrl = checksumUrl;
+            this.wrapperChecksumUrl = wrapperChecksumUrl;
         }
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapperJar.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapperJar.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
 import org.intellij.lang.annotations.Language;
+import org.openrewrite.Checksum;
 import org.openrewrite.FileAttributes;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
@@ -56,11 +57,13 @@ public class GradleWrapperJar implements Remote {
     @Language("markdown")
     String description;
     String version;
+    Checksum checksum;
 
     @lombok.experimental.Tolerate
-    public GradleWrapperJar(URI uri, String version) {
+    public GradleWrapperJar(URI uri, String version, Checksum checksum) {
         this.uri = uri;
         this.version = version;
+        this.checksum = checksum;
         this.description = "gradle-wrapper.jar is part of the gradle wrapper";
         this.sourcePath = GradleWrapper.WRAPPER_JAR_LOCATION;
         this.charset = null;
@@ -77,6 +80,7 @@ public class GradleWrapperJar implements Remote {
         InputStream body = response.getBody();
         return readIntoArchive(body, "gradle-" + version + "/**/" + "gradle-wrapper-*.jar!gradle-wrapper.jar");
     }
+
 
     private InputStream readIntoArchive(InputStream body, String pathPattern) {
         String pathBeforeBang;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapperJar.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapperJar.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.util;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
+import org.intellij.lang.annotations.Language;
+import org.openrewrite.FileAttributes;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.ipc.http.HttpSender;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.remote.Remote;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_JAR_FILE_ATTRIBUTES;
+
+@Value
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+@With
+public class GradleWrapperJar implements Remote {
+
+    @EqualsAndHashCode.Include
+    UUID id;
+    Path sourcePath;
+    Markers markers;
+    URI uri;
+    boolean charsetBomMarked;
+    @Nullable
+    FileAttributes fileAttributes;
+    @Nullable
+    Charset charset;
+    @Language("markdown")
+    String description;
+    String version;
+
+    @lombok.experimental.Tolerate
+    public GradleWrapperJar(URI uri, String version) {
+        this.uri = uri;
+        this.version = version;
+        this.description = "gradle-wrapper.jar is part of the gradle wrapper";
+        this.sourcePath = GradleWrapper.WRAPPER_JAR_LOCATION;
+        this.charset = null;
+        this.charsetBomMarked = false;
+        this.fileAttributes = WRAPPER_JAR_FILE_ATTRIBUTES;
+        this.markers = Markers.EMPTY;
+        this.id = Tree.randomId();
+    }
+
+    @Override
+    public InputStream getInputStream(HttpSender httpSender) {
+        //noinspection resource
+        HttpSender.Response response = httpSender.send(httpSender.get(uri.toString()).build());
+        InputStream body = response.getBody();
+        return readIntoArchive(body, "gradle-" + version + "/**/" + "gradle-wrapper-*.jar!gradle-wrapper.jar");
+    }
+
+    private InputStream readIntoArchive(InputStream body, String pathPattern) {
+        String pathBeforeBang;
+        String pathAfterBang = null;
+        int bangIndex = pathPattern.indexOf('!');
+        if(bangIndex == -1) {
+            pathBeforeBang = pathPattern;
+        } else {
+            pathBeforeBang = pathPattern.substring(0, bangIndex);
+            pathAfterBang = pathPattern.substring(bangIndex + 1);
+        }
+
+        ZipInputStream zis = new ZipInputStream(body);
+
+        try {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                // Starting from Gradle 7.5 a gradle-wrapper-shared.jar is introduced but it does not contain the gradle-wrapper.jar
+                if (StringUtils.matchesGlob(entry.getName(), pathBeforeBang) && !entry.getName().contains("gradle-wrapper-shared")) {
+                    if(pathAfterBang == null) {
+                        return new InputStream() {
+                            @Override
+                            public int read() throws IOException {
+                                return zis.read();
+                            }
+
+                            @Override
+                            public void close() throws IOException {
+                                zis.closeEntry();
+                                zis.close();
+                            }
+                        };
+                    } else {
+                        return readIntoArchive(zis, pathAfterBang);
+                    }
+                }
+            }
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to load path " + pathPattern + " in zip file " + uri, e);
+        }
+        throw new IllegalArgumentException("Unable to find path " + pathPattern + " in zip file " + uri);
+    }
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddGradleWrapperTest.java
@@ -47,6 +47,7 @@ class AddGradleWrapperTest implements RewriteTest {
           distributionBase=GRADLE_USER_HOME
           distributionPath=wrapper/dists
           distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+          distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
           zipStoreBase=GRADLE_USER_HOME
           zipStorePath=wrapper/dists
       """;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoteGradleWrapperJarTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoteGradleWrapperJarTest.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.gradle;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openrewrite.Checksum;
 import org.openrewrite.gradle.util.DistributionInfos;
 import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
@@ -25,29 +27,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoteGradleWrapperJarTest {
 
-    @Test
-    void gradleWrapper() {
-        Remote remoteArchive = new GradleWrapper("7.4.2",
-          new DistributionInfos("https://services.gradle.org/distributions/gradle-7.4.2-bin.zip",
-            "29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda")).asRemote();
-        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
-                .isNotEmpty();
+    @ParameterizedTest
+    @CsvSource(value = {"7.4.2,29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda,575098db54a998ff1c6770b352c3b16766c09848bee7555dab09afc34e8cf590",
+                        "6.9.3,dcf350b8ae1aa192fc299aed6efc77b43825d4fedb224c94118ae7faf5fb035d,e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637",
+                        "7.5-rc-1,8ba57a37e1e0b8c415e4d91718d51035223aa73131cf719a50c95a2a88269eb2,91a239400bb638f36a1795d8fdf7939d532cdc7d794d1119b7261aac158b1e60"})
+    void gradleWrapper(String version, String distChecksum, String jarChecksum) {
+        Remote remoteArchive = new GradleWrapper(version,
+          new DistributionInfos("https://services.gradle.org/distributions/gradle-" + version + "-bin.zip",
+            Checksum.fromHex("sha256", distChecksum),
+            Checksum.fromHex("sha256", jarChecksum))).asRemote();
+
+        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender())).isNotEmpty();
     }
 
-    @Test
-    void gradleWrapper693() {
-        Remote remoteArchive = new GradleWrapper("6.9.3",
-          new DistributionInfos("https://services.gradle.org/distributions/gradle-6.9.3-bin.zip",
-            "dcf350b8ae1aa192fc299aed6efc77b43825d4fedb224c94118ae7faf5fb035d")).asRemote();
-        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
-                .isNotEmpty();
-    }
-    @Test
-    void gradleWrapper75rc1() {
-        Remote remoteArchive = new GradleWrapper("7.5-rc-1",
-          new DistributionInfos("https://services.gradle.org/distributions/gradle-7.5-rc-1-bin.zip",
-            "8ba57a37e1e0b8c415e4d91718d51035223aa73131cf719a50c95a2a88269eb2")).asRemote();
-        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
-                .isNotEmpty();
-    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoteGradleWrapperJarTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoteGradleWrapperJarTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.gradle.util.DistributionInfos;
 import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 import org.openrewrite.remote.Remote;
@@ -26,27 +27,26 @@ public class RemoteGradleWrapperJarTest {
 
     @Test
     void gradleWrapper() {
-        Remote remoteArchive = new GradleWrapper("7.4.2", GradleWrapper.DistributionType.Bin).asRemote();
+        Remote remoteArchive = new GradleWrapper("7.4.2",
+          new DistributionInfos("https://services.gradle.org/distributions/gradle-7.4.2-bin.zip",
+            "29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda")).asRemote();
         assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
                 .isNotEmpty();
     }
 
     @Test
-    void gradleWrapper69() {
-        Remote remoteArchive = new GradleWrapper("6.9.3", GradleWrapper.DistributionType.Bin).asRemote();
+    void gradleWrapper693() {
+        Remote remoteArchive = new GradleWrapper("6.9.3",
+          new DistributionInfos("https://services.gradle.org/distributions/gradle-6.9.3-bin.zip",
+            "dcf350b8ae1aa192fc299aed6efc77b43825d4fedb224c94118ae7faf5fb035d")).asRemote();
         assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
                 .isNotEmpty();
     }
     @Test
-    void gradleWrapper75() {
-        Remote remoteArchive = new GradleWrapper("7.5-rc-1", GradleWrapper.DistributionType.Bin).asRemote();
-        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
-                .isNotEmpty();
-    }
-
-    @Test
-    void gradleWrapper76() {
-        Remote remoteArchive = new GradleWrapper("7.6", GradleWrapper.DistributionType.Bin).asRemote();
+    void gradleWrapper75rc1() {
+        Remote remoteArchive = new GradleWrapper("7.5-rc-1",
+          new DistributionInfos("https://services.gradle.org/distributions/gradle-7.5-rc-1-bin.zip",
+            "8ba57a37e1e0b8c415e4d91718d51035223aa73131cf719a50c95a2a88269eb2")).asRemote();
         assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
                 .isNotEmpty();
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoteGradleWrapperJarTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoteGradleWrapperJarTest.java
@@ -18,7 +18,7 @@ package org.openrewrite.gradle;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
-import org.openrewrite.remote.RemoteArchive;
+import org.openrewrite.remote.Remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,7 +26,27 @@ public class RemoteGradleWrapperJarTest {
 
     @Test
     void gradleWrapper() {
-        RemoteArchive remoteArchive = new GradleWrapper("7.4.2", GradleWrapper.DistributionType.Bin).asRemote();
+        Remote remoteArchive = new GradleWrapper("7.4.2", GradleWrapper.DistributionType.Bin).asRemote();
+        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
+                .isNotEmpty();
+    }
+
+    @Test
+    void gradleWrapper69() {
+        Remote remoteArchive = new GradleWrapper("6.9.3", GradleWrapper.DistributionType.Bin).asRemote();
+        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
+                .isNotEmpty();
+    }
+    @Test
+    void gradleWrapper75() {
+        Remote remoteArchive = new GradleWrapper("7.5-rc-1", GradleWrapper.DistributionType.Bin).asRemote();
+        assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
+                .isNotEmpty();
+    }
+
+    @Test
+    void gradleWrapper76() {
+        Remote remoteArchive = new GradleWrapper("7.6", GradleWrapper.DistributionType.Bin).asRemote();
         assertThat(remoteArchive.getInputStream(new HttpUrlConnectionSender()))
                 .isNotEmpty();
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.gradle;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.PathUtils;
@@ -83,12 +84,43 @@ class UpdateGradleWrapperTest implements RewriteTest {
               distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
               zipStoreBase=GRADLE_USER_HOME
               zipStorePath=wrapper/dists
+              distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
               """,
             spec -> spec.path(osPath)
           ),
           gradlew,
           gradlewBat,
           gradleWrapperJarQuark
+        );
+    }
+
+    @Test
+    void updateChecksumAlreadySet() {
+        rewriteRun(
+          spec -> spec.afterRecipe(run -> {
+              var gradleWrapperJar = result(run, Remote.class, "gradle-wrapper.jar");
+              assertThat(PathUtils.equalIgnoringSeparators(gradleWrapperJar.getSourcePath(), WRAPPER_JAR_LOCATION)).isTrue();
+              assertThat(gradleWrapperJar.getUri()).isEqualTo(URI.create("https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"));
+          }),
+          properties(
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4-all.zip
+              distributionSha256Sum=cd5c2958a107ee7f0722004a12d0f8559b4564c34daad7df06cffd4d12a426d0
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            """
+              distributionBase=GRADLE_USER_HOME
+              distributionPath=wrapper/dists
+              distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+              distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+              zipStoreBase=GRADLE_USER_HOME
+              zipStorePath=wrapper/dists
+              """,
+            spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
+          )
         );
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/DistributionInfosTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/DistributionInfosTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.util;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Checksum;
+import org.openrewrite.ipc.http.HttpSender;
+import org.openrewrite.ipc.http.HttpUrlConnectionSender;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DistributionInfosTest {
+
+    @Test
+    void fetch() throws IOException {
+        HttpSender httpSender = new HttpUrlConnectionSender();
+        GradleWrapper.GradleVersion gradleVersion = new GradleWrapper.GradleVersion(
+          "7.6",
+          "https://services.gradle.org/distributions/gradle-7.6-bin.zip",
+          "https://services.gradle.org/distributions/gradle-7.6-bin.zip.sha256",
+          "https://services.gradle.org/distributions/gradle-7.6-wrapper.jar.sha256"
+          );
+        DistributionInfos infos = DistributionInfos.fetch(httpSender, GradleWrapper.DistributionType.Bin, gradleVersion);
+
+        assertThat(infos).isEqualTo(new DistributionInfos(
+          "https://services.gradle.org/distributions/gradle-7.6-bin.zip",
+          Checksum.fromHex("SHA-256", "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b"),
+          Checksum.fromHex("SHA-256", "c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a")));
+    }
+}


### PR DESCRIPTION
- Fix `gradle-wrapper.jar` location
Gradle distributions contain the `gradle-wrapper.jar` in different paths depending on
Gradle versions.
Because of this current Gradle Wrapper Add/Upgrade recipes for Gradle 7.5 is broken, this will fix it.

- Set `distributionSha256Sum` in gradle-wrapper.properties
Gradle validates a newly downloaded wrapper distribution if the `distributionSha256Sum` property is set in gradle-wrapper.properties (see [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html#wrapper_checksum_verification) for more infos). This change will have the recipe fetch the checksum and add it or update it to the ù gradle-wrapper.properties`.

- Fetch the `gradle-wrapper.jar` checksum and associate it to the remote source file. I'm not sure though if it's checked at any point in time, I could not find a call to `Remote#getChecksum()` in the code base