### PR TITLE
Added parsing support for CompactConstructors on records.

### DIFF
--- a/rewrite-java-17/src/test/java/org/openrewrite/java/tree/RecordTest.java
+++ b/rewrite-java-17/src/test/java/org/openrewrite/java/tree/RecordTest.java
@@ -36,7 +36,6 @@ public class RecordTest implements RewriteTest {
         );
     }
 
-    @Disabled("Requires parsing support for record compact constructors.")
     @Issue("https://github.com/openrewrite/rewrite/issues/2455")
     @Test
     void compactConstructor() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.marker.CompactConstructor;
 import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.java.tree.J.*;
@@ -721,7 +722,9 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
         visit(method.getReturnTypeExpression(), p);
         visit(method.getAnnotations().getName().getAnnotations(), p);
         visit(method.getName(), p);
-        visitContainer("(", method.getPadding().getParameters(), JContainer.Location.METHOD_DECLARATION_PARAMETERS, ",", ")", p);
+        if (!method.getMarkers().findFirst(CompactConstructor.class).isPresent()) {
+            visitContainer("(", method.getPadding().getParameters(), JContainer.Location.METHOD_DECLARATION_PARAMETERS, ",", ")", p);
+        }
         visitContainer("throws", method.getPadding().getThrows(), JContainer.Location.THROWS, ",", null, p);
         visit(method.getBody(), p);
         visitLeftPadded("default", method.getPadding().getDefaultValue(), JLeftPadded.Location.METHOD_DECLARATION_DEFAULT_VALUE, p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/CompactConstructor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/CompactConstructor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Java 14 introduced compact constructors, which does not include the `()` for parameters.
+ * This marker prevents the {@link org.openrewrite.java.JavaPrinter} from printer the parameters.
+ */
+@Value
+@With
+public class CompactConstructor implements Marker {
+    UUID id;
+}


### PR DESCRIPTION
Changes:
- Added detection for CompactConstructors in ReloadableJava17ParserVisitor.
- Added CompactConstructor marker for records.

fixes #2455