### PR TITLE
ChangePackage bug reproducer test + fix: static import enum same package

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/ChangePackageTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/ChangePackageTest.kt
@@ -881,6 +881,50 @@ interface ChangePackageTest: JavaRecipeTest, RewriteTest {
     )
 
     @Test
+    fun staticImportEnumSamePackage(jp: JavaParser) = assertChanged(
+            jp,
+            dependsOn = arrayOf("""
+            package org.openrewrite;
+            public enum MyEnum {
+                A,
+                B
+            }
+        """.trimIndent()),
+            before = """
+            package org.openrewrite;
+            import static org.openrewrite.MyEnum.A;
+            import static org.openrewrite.MyEnum.B;
+
+            public class App {
+                public void test(String s) {
+                    if (s.equals(" " + A + B)) {
+
+                    }
+                }
+            }
+        """,
+            after = """
+            package org.openrewrite.test;
+            import static org.openrewrite.test.MyEnum.A;
+            import static org.openrewrite.test.MyEnum.B;
+
+            public class App {
+                public void test(String s) {
+                    if (s.equals(" " + A + B)) {
+
+                    }
+                }
+            }
+        """,
+            afterConditions = { cu ->
+                assertThat(cu.findType("org.openrewrite.MyEnum")).isEmpty()
+                assertThat(cu.findType("org.openrewrite.test.MyEnum")).isNotEmpty()
+                assertThat(cu.findType("org.openrewrite.App")).isEmpty()
+                assertThat(cu.findType("org.openrewrite.test.App")).isNotEmpty()
+            }
+    )
+
+    @Test
     fun changeTypeWithInnerClass(jp: JavaParser) = assertChanged(
         recipe = ChangePackage("com.acme.product", "com.acme.product.v2", null),
         dependsOn = arrayOf(

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -118,7 +118,7 @@ public class ChangePackage extends Recipe {
                 )));
 
                 for (J.Import anImport : c.getImports()) {
-                    if (anImport.getPackageName().equals(changingTo)) {
+                    if (anImport.getPackageName().equals(changingTo) && !anImport.isStatic()) {
                         c = new RemoveImport<ExecutionContext>(anImport.getTypeName(), true).visitJavaSourceFile(c, ctx);
                     }
                 }


### PR DESCRIPTION
**Problem**

Changing the package of a class files that does a static import of an enum _value_ for which the enum class resides in the same package (and also gets moved) creates uncompilable code.

**Why?**

In Java (Java Language Spec), you don't need to import classes from the same package explicitly.

But you do need to static import enum values from classes from the same package explicitly.
The same requirement applies to static import of methods.

**Proof**

The test fails locally as expected (see below). This PR is also includes a proposed fix.

![image](https://user-images.githubusercontent.com/176880/204748813-b89bf759-ef50-4c5b-8788-dac7953cf996.png)
