### PR TITLE
Update MethodInvocation type when applicable.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3571,7 +3571,11 @@ public interface J extends Tree {
             }
             JavaType.Method newType = null;
             if (this.methodType != null) {
-                newType = this.methodType.withName(name.getSimpleName());
+                if (name.getType() instanceof JavaType.Method && name.getType() != this.methodType) {
+                    newType = (JavaType.Method) name.getType();
+                } else {
+                    newType = this.methodType.getName().equals(name.getSimpleName()) ? this.methodType : this.methodType.withName(name.getSimpleName());
+                }
             }
             return new MethodInvocation(id, prefix, markers, select, typeParameters, name, arguments, newType);
         }


### PR DESCRIPTION
Changes:
- Updating the `J.MethodInvocation#name` will not create a new instance of `JavaType$Method` for changes unrelated to type info.

fixes #2493