### PR TITLE
adjusted MavenDownloadingException getMessage

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenDownloadingException.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenDownloadingException.java
@@ -78,7 +78,7 @@ public class MavenDownloadingException extends Exception {
     @Override
     public String getMessage() {
         String message = "";
-        if (root != null && !root.equals(failedOn)) {
+        if (!failedOn.equals(root)) {
             message += failedOn + " failed. ";
         }
         message += super.getMessage();


### PR DESCRIPTION
Trivial change, but didn't want to do it silently because:
- I know this stuff was written recently and I've seen discussion in slack about UX of the exception handling
- I also considered removing this if-check altogether, or, trying to catch the MavenDownloadingException and calling `setRoot` somewhere in the `parseInputs -> resolveParentDependenciesRecursively` flow (it felt like an oversight that the root wasn't being set somewhere for download exceptions during parsing)

Excluding the `failedOn` seems like an optimization for the scenario where this message is getting printed as a marker on the offending pom element, but it's a bad experience when you get the exception message in isolation somewhere else.

Eg, for the test case described over in this issue https://github.com/openrewrite/rewrite/issues/2504, currently we get an exception message like this:
> org.openrewrite.maven.MavenDownloadingException: Unable to download POM. Tried repositories: [...]

...whereas this commit yields a more-informative message:
> org.openrewrite.maven.MavenDownloadingException: org.mockito:mockito-bom:3.9.0 failed. Unable to download POM. Tried repositories: [...]