### PR TITLE
Add `visitValue()` to `PropertyVisitor`

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesVisitor.java
@@ -18,6 +18,7 @@ package org.openrewrite.properties;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.properties.tree.Properties;
 
 public class PropertiesVisitor<P> extends TreeVisitor<Properties, P> {
@@ -42,7 +43,16 @@ public class PropertiesVisitor<P> extends TreeVisitor<Properties, P> {
     public Properties visitEntry(Properties.Entry entry, P p) {
         Properties.Entry e = entry;
         e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        if (e.getValue() != null) {
+            e = e.withValue(visitValue(e.getValue(), p));
+        }
         return e;
+    }
+
+    //Note: Properties.Value does not currently implement Properties, so this is a bit of an outlier.
+    @Nullable
+    public Properties.Value visitValue(Properties.Value value, P p) {
+        return value.withMarkers(visitMarkers(value.getMarkers(), p));
     }
 
     public Properties visitComment(Properties.Comment comment, P p) {


### PR DESCRIPTION
`Property.Value` is a bit of an odd bird, in that it does not implement/extend from `Properties` even though it does have AST-like properties (It has a prefix and it has markers). 

Adding a `Properties.Value visitValue(Properties.Value)` method to the `PropertiesVisitor` to allow the visitor to navigate into the value and its markers.

Because `Value` does not extend a Tree, there is no `accept` method on `Value` and the method signature for `visitValue()` does NOT return a Properties instance.  

