### PR TITLE
Make `FinalizeLocalVariables` aware of non-modifying unary operators

### DIFF
--- a/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/FinalizeLocalVariablesTest.kt
+++ b/rewrite-java-tck/src/main/kotlin/org/openrewrite/java/cleanup/FinalizeLocalVariablesTest.kt
@@ -396,4 +396,28 @@ interface FinalizeLocalVariablesTest : RewriteTest {
             }
         """)
     )
+
+    @Test
+    fun nonModifyingUnaryOperatorAwareness() = rewriteRun(
+        java("""
+            class Test {
+                void test() {
+                    int i = 1;
+                    int j = -i;
+                    int k = +j;
+                    int l = ~k;
+                }
+            }
+        """,
+        """
+            class Test {
+                void test() {
+                    final int i = 1;
+                    final int j = -i;
+                    final int k = +j;
+                    final int l = ~k;
+                }
+            }
+        """)
+    )
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
@@ -146,7 +146,7 @@ public class FinalizeLocalVariables extends Recipe {
             }
 
             J.Unary u = super.visitUnary(unary, hasAssignment);
-            if (u.getExpression() instanceof J.Identifier) {
+            if (u.getOperator().isModifying() && u.getExpression() instanceof J.Identifier) {
                 J.Identifier i = (J.Identifier) u.getExpression();
                 if (i.getSimpleName().equals(variable.getSimpleName())) {
                     hasAssignment.set(true);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5278,7 +5278,19 @@ public interface J extends Tree {
             Positive,
             Negative,
             Complement,
-            Not
+            Not;
+
+            public boolean isModifying() {
+                switch (this) {
+                    case PreIncrement:
+                    case PreDecrement:
+                    case PostIncrement:
+                    case PostDecrement:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
         }
 
         public Padding getPadding() {


### PR DESCRIPTION
The non-modifying unary operators (`-`, `+`, `~`, and `!`) must not prevent a local variable from being made final.
