### PR TITLE
Preserve the source code delimiter of property entries in PropertiesParser.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ActivateStyle.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ActivateStyle.java
@@ -28,7 +28,6 @@ import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -140,7 +139,7 @@ public class ActivateStyle extends Recipe {
             if(!keyExists.get()) {
                 // Existing key not found, need to add one
                 p = p.withContent(ListUtils.concat(p.getContent(),
-                        new Properties.Entry(randomId(), "\n", Markers.EMPTY, STYLE_KEY, "",
+                        new Properties.Entry(randomId(), "\n", Markers.EMPTY, STYLE_KEY, "", Properties.Entry.Delimiter.EQUALS,
                                 new Properties.Value(randomId(), "", Markers.EMPTY, fullyQualifiedStyleName))));
             }
             return p;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddProperty.java
@@ -75,7 +75,7 @@ public class AddProperty extends Recipe {
                         sourceFile :
                         new ChangePropertyValue(key, value, null, null, null)
                                 .getVisitor().visitNonNull(sourceFile, ctx);
-                return (SourceFile) new org.openrewrite.properties.AddProperty(key, value, null)
+                return (SourceFile) new org.openrewrite.properties.AddProperty(key, value, null, null)
                         .getVisitor()
                         .visitNonNull(t, ctx);
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -181,7 +181,7 @@ public class UpdateGradleWrapper extends Recipe {
             Set<Properties.Entry> properties = FindProperties.find(p, DISTRIBUTION_SHA_256_SUM_KEY, false);
             if (properties.isEmpty()) {
                 Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, gradleWrapper.getDistributionChecksum().getHexValue());
-                Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, "", propertyValue);
+                Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, "", Properties.Entry.Delimiter.EQUALS, propertyValue);
                 List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
                 p = ((Properties.File) p).withContent(contentList);
             }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -42,6 +42,13 @@ public class AddProperty extends Recipe {
             example = "true")
     String value;
 
+    @Option(displayName = "Optional delimiter",
+            description = "Property entries support different delimiters (`=`, `:`, or whitespace). The default value is `=` unless provided the delimiter of the new property entry.",
+            required = false,
+            example = ":")
+    @Nullable
+    String delimiter;
+
     @Option(displayName = "Optional file matcher",
             description = "Matching files will be modified. This is a glob expression.",
             required = false,
@@ -77,7 +84,9 @@ public class AddProperty extends Recipe {
                     Set<Properties.Entry> properties = FindProperties.find(p, property, false);
                     if (properties.isEmpty()) {
                         Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, value);
-                        Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, property, "", propertyValue);
+                        Properties.Entry.Delimiter delimitedBy = delimiter != null && !delimiter.isEmpty() ? Properties.Entry.Delimiter.getDelimiter(delimiter) : Properties.Entry.Delimiter.EQUALS;
+                        String beforeEquals = delimitedBy == Properties.Entry.Delimiter.NONE ? delimiter : "";
+                        Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, property, beforeEquals, delimitedBy, propertyValue);
                         List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
                         p = ((Properties.File) p).withContent(contentList);
                     }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -200,6 +200,7 @@ public class PropertiesParser implements Parser<Properties.File> {
                 valuePrefix = new StringBuilder(),
                 value = new StringBuilder();
 
+        Properties.Entry.Delimiter delimiter = Properties.Entry.Delimiter.NONE;
         char prev = '$';
         int state = 0;
         for (char c : line.toCharArray()) {
@@ -216,6 +217,7 @@ public class PropertiesParser implements Parser<Properties.File> {
                             key.append(c);
                             break;
                         } else {
+                            delimiter = Properties.Entry.Delimiter.getDelimiter(String.valueOf(c));
                             state += 2;
                         }
                     } else if (!Character.isWhitespace(c)) {
@@ -228,6 +230,8 @@ public class PropertiesParser implements Parser<Properties.File> {
                     if (Character.isWhitespace(c)) {
                         equalsPrefix.append(c);
                         break;
+                    } else if (c == '=' || c == ':') {
+                        delimiter = Properties.Entry.Delimiter.getDelimiter(String.valueOf(c));
                     }
                     state++;
                 case 3:
@@ -265,6 +269,7 @@ public class PropertiesParser implements Parser<Properties.File> {
                 Markers.EMPTY,
                 key.toString(),
                 equalsPrefix.toString(),
+                delimiter,
                 new Properties.Value(randomId(), valuePrefix.toString(), Markers.EMPTY, value.toString())
         );
     }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
@@ -39,8 +39,10 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
     public Properties visitEntry(Properties.Entry entry, PrintOutputCapture<P> p) {
         beforeSyntax(entry, p);
         p.out.append(entry.getKey())
-                .append(entry.getBeforeEquals())
-                .append('=');
+                .append(entry.getBeforeEquals());
+        if (entry.getDelimiter() != Properties.Entry.Delimiter.NONE) {
+            p.out.append(entry.getDelimiter().getCharacter());
+        }
         beforeSyntax(entry.getValue().getPrefix(), entry.getValue().getMarkers(), p);
         p.out.append(entry.getValue().getText());
         afterSyntax(entry.getValue().getMarkers(), p);

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
@@ -111,11 +111,33 @@ public interface Properties extends Tree {
         Markers markers;
         String key;
         String beforeEquals;
+        Delimiter delimiter;
         Value value;
 
         @Override
         public <P> Properties acceptProperties(PropertiesVisitor<P> v, P p) {
             return v.visitEntry(this, p);
+        }
+
+        public enum Delimiter {
+            COLON(':'), EQUALS('='), NONE('\0');
+
+            private final Character character;
+
+            Delimiter(Character character) {
+                this.character = character;
+            }
+
+            public static Delimiter getDelimiter(String value) {
+                return "=".equals(value.trim()) ? Delimiter.EQUALS :
+                            ":".equals(value.trim()) ? Delimiter.COLON :
+                            "".equals(value.trim()) ? Delimiter.NONE :
+                                    Delimiter.EQUALS;
+            }
+
+            public Character getCharacter() {
+                return character;
+            }
         }
     }
 

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/ChangePropertyTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/ChangePropertyTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.properties;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.properties.Assertions.properties;
@@ -29,6 +30,7 @@ class ChangePropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "",
             "true",
+            null,
             null
           )),
           properties(
@@ -45,6 +47,7 @@ class ChangePropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "",
+            null,
             null
           )),
           properties(
@@ -61,6 +64,7 @@ class ChangePropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             null
           )),
           properties(
@@ -77,6 +81,7 @@ class ChangePropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             null
           )),
           properties(
@@ -91,12 +96,57 @@ class ChangePropertyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/2532")
+    @Test
+    void delimitedByColon() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty(
+            "management.metrics.enable.process.files",
+            "true",
+            ":",
+            null
+          )),
+          properties(
+            """
+              management=true
+              """,
+            """
+              management=true
+              management.metrics.enable.process.files:true
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2532")
+    @Test
+    void delimitedByWhitespace() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty(
+            "management.metrics.enable.process.files",
+            "true",
+            "    ",
+            null
+          )),
+          properties(
+            """
+              management=true
+              """,
+            """
+              management=true
+              management.metrics.enable.process.files    true
+              """
+          )
+        );
+    }
+
     @Test
     void changeOnlyMatchingFile() {
         rewriteRun(
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             "**/a.properties"
           )),
           properties(

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
@@ -74,7 +74,6 @@ class PropertiesParserTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/2499")
     @ParameterizedTest
     @ValueSource(strings = {"#", "!"})
-    @Disabled
     void commentThenEntry(String commentStyle) {
         rewriteRun(
           properties(
@@ -151,7 +150,6 @@ class PropertiesParserTest implements RewriteTest {
     @SuppressWarnings("WrongPropertyKeyValueDelimiter")
     @Issue("https://github.com/openrewrite/rewrite/issues/2501")
     @Test
-    @Disabled
     void delimitedByWhitespace() {
         rewriteRun(
           properties(


### PR DESCRIPTION
Changes:
- The PropertiesParser will preserve the delimiter in the source code.
    - Properties support `=`, `:` or whitespace as delimiters between the key and value. Before the changes the delimiter was always set to `=`.
- Added Option to `AddProperty` recipe to set the desired property entry delimiter (defaults to `=`).

fixes #2532