### PR TITLE
Improve performance of `EncodingDetectingInputStream`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainTextParser.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainTextParser.java
@@ -39,6 +39,7 @@ public class PlainTextParser implements Parser<PlainText> {
             Path path = source.getRelativePath(relativeTo);
             try {
                 EncodingDetectingInputStream is = source.getSource(ctx);
+                String sourceStr = is.readFully();
                 PlainText plainText = new PlainText(randomId(),
                         path,
                         Markers.EMPTY,
@@ -46,7 +47,7 @@ public class PlainTextParser implements Parser<PlainText> {
                         is.isCharsetBomMarked(),
                         source.getFileAttributes(),
                         null,
-                        is.readFully());
+                        sourceStr);
                 plainTexts.add(plainText);
                 parsingListener.parsed(source, plainText);
             } catch (Throwable t) {


### PR DESCRIPTION
Slightly improves the performance of `EncodingDetectingInputStream` by refactoring the `read()` method and avoiding the additional `byte[]` copy in `readFully()`.

Also make sure that `PlainTextParser#parseInputs()` reads the source text before the encoding, since the latter won't be correctly set otherwise.
