### PR TITLE
#2557 Do not rename public interface methods by default

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
@@ -93,6 +93,50 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
+    @Test
+    void doNotRenameExplicitPublicInterfaceMethods() {
+        rewriteRun(
+          java(
+            """
+                  public interface Test {
+                      public void getFoo_bar(){}
+                  }
+              """
+          )
+        );
+    }
+
+
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
+    @Test
+    void doNotRenameImplicitPublicInterfaceMethods() {
+        rewriteRun(
+          java(
+            """
+                  public interface Test {
+                      void getFoo_bar(){}
+                  }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
+    @Test
+    void doNotRenameImplicitPublicInterfaceMethodsOnPackagePrivateInterface() {
+        rewriteRun(
+          java(
+            """
+                  interface Test {
+                      void getFoo_bar(){}
+                  }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1741")
     @Test
     void doNotApplyToTest() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.VariableNameUtils;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.ClassDeclaration.Kind.Type;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -99,7 +100,7 @@ public class MethodNameCasing extends Recipe {
                 if(enclosingClass == null) {
                     return method;
                 }
-                if (containsValidModifiers(method) &&
+                if (containsValidModifiers(enclosingClass, method) &&
                         method.getMethodType() != null &&
                         enclosingClass.getType() != null &&
                         !method.isConstructor() &&
@@ -143,8 +144,10 @@ public class MethodNameCasing extends Recipe {
                 return super.visitMethodDeclaration(method, executionContext);
             }
 
-            private boolean containsValidModifiers(J.MethodDeclaration method) {
-                return !method.hasModifier(J.Modifier.Type.Public) || !Boolean.FALSE.equals(renamePublicMethods);
+            private boolean containsValidModifiers(J.ClassDeclaration enclosingClass, J.MethodDeclaration method) {
+                return !Boolean.FALSE.equals(renamePublicMethods)
+                    || (!enclosingClass.getKind().equals(Type.Interface)
+                    && !method.hasModifier(J.Modifier.Type.Public));
             }
 
             private boolean methodExists(JavaType.Method method, String newName) {


### PR DESCRIPTION
Methods on interfaces are Public by default. Add additional testcases to validate interface methods are not being renamed (by default).