### PR TITLE
Add dependency support for gradle

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     testRuntimeOnly("org.gradle:gradle-testing-jvm:latest.release")
     testRuntimeOnly("com.gradle:gradle-enterprise-gradle-plugin:latest.release")
     testRuntimeOnly(project(":rewrite-java-17"))
+    testRuntimeOnly("org.projectlombok:lombok:latest.release")
 }
 
 tasks.withType<ShadowJar> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.gradle.util.Dependency;
+import org.openrewrite.gradle.util.DependencyStringNotationConverter;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.java.marker.JavaSourceSet;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.semver.Semver;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class AddDependency extends Recipe {
+    @Option(displayName = "Group",
+            description = "The first part of a dependency coordinate 'com.google.guava:guava:VERSION'.",
+            example = "com.google.guava")
+    String groupId;
+
+    @Option(displayName = "Artifact",
+            description = "The second part of a dependency coordinate 'com.google.guava:guava:VERSION'",
+            example = "guava")
+    String artifactId;
+
+    @Option(displayName = "Version",
+            description = "An exact version number or node-style semver selector used to select the version number.",
+            example = "29.X")
+    String version;
+
+    @Option(displayName = "Version pattern",
+            description = "Allows version selection to be extended beyond the original Node Semver semantics. So for example, " +
+                    "Setting 'version' to \"25-29\" can be paired with a metadata pattern of \"-jre\" to select Guava 29.0-jre",
+            example = "-jre",
+            required = false)
+    @Nullable
+    String versionPattern;
+
+    @Option(displayName = "Configuration",
+            description = "A configuration to use when it is not what can be inferred from usage. Most of the time this will be left empty, but " +
+                    "is used when adding a new as of yet unused dependency.",
+            example = "implementation",
+            required = false)
+    @Nullable
+    String configuration;
+
+    @Option(displayName = "Only if using",
+            description = "Used to determine if the dependency will be added and in which scope it should be placed.",
+            example = "org.junit.jupiter.api.*")
+    String onlyIfUsing;
+
+    @Option(displayName = "Classifier",
+            description = "A Maven classifier to add. Mostly commonly used to select shaded to test variants of a library.",
+            example = "test",
+            required = false)
+    @Nullable
+    String classifier;
+
+    @Option(displayName = "Extension",
+            description = "The extension of the dependency to add. If omitted Gradle defaults to assuming the type is \"jar\".",
+            example = "jar",
+            required = false)
+    @Nullable
+    String extension;
+
+    @Option(displayName = "Family pattern",
+            description = "A pattern, applied to groupIds, used to determine which other dependencies should have aligned version numbers. " +
+                    "Accepts '*' as a wildcard character.",
+            example = "com.fasterxml.jackson*",
+            required = false)
+    @Nullable
+    String familyPattern;
+
+    static final String DEPENDENCY_PRESENT = "org.openrewrite.gradle.AddDependency.DEPENDENCY_PRESENT";
+
+    @Override
+    public String getDisplayName() {
+        return "Add Gradle dependency";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add a gradle dependency to a `build.gradle` file in the correct configuration based on where it is used.";
+    }
+
+    @Override
+    public Validated validate() {
+        Validated validated = super.validate();
+        if (version != null) {
+            validated = validated.or(Semver.validate(version, versionPattern));
+        }
+        return validated;
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        if (onlyIfUsing == null) {
+            return null;
+        }
+
+        return new UsesType<>(onlyIfUsing);
+    }
+
+    @Override
+    protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
+        Map<JavaProject, String> configurationByProject = new HashMap<>();
+        for (SourceFile source : before) {
+            source.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject ->
+                    source.getMarkers().findFirst(JavaSourceSet.class).ifPresent(sourceSet -> {
+                        if (source != new UsesType<>(onlyIfUsing).visit(source, ctx)) {
+                            configurationByProject.compute(javaProject, (jp, configuration) -> "implementation".equals(configuration) ?
+                                    configuration :
+                                    "test".equals(sourceSet.getName()) ? "testImplementation" : "implementation"
+                            );
+                        }
+                    }));
+        }
+
+        if (configurationByProject.isEmpty()) {
+            return before;
+        }
+
+        MethodMatcher dependencyDslMatcher = new MethodMatcher("DependencyHandlerSpec *(..)");
+        Pattern familyPatternCompiled = familyPattern == null ? null : Pattern.compile(familyPattern.replace("*", ".*"));
+
+        return ListUtils.map(before, s -> s.getMarkers().findFirst(JavaProject.class)
+                .map(javaProject -> (Tree) new GroovyIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        J.MethodInvocation m = super.visitMethodInvocation(method, executionContext);
+                        if (dependencyDslMatcher.matches(m) && (configuration == null || configuration.equals(m.getSimpleName()))) {
+                            if (m.getArguments().get(0) instanceof J.Literal) {
+                                Dependency dependency = new DependencyStringNotationConverter().parse((String) ((J.Literal) m.getArguments().get(0)).getValue());
+                                if (groupId.equals(dependency.getGroupId()) && artifactId.equals(dependency.getArtifactId())) {
+                                    getCursor().putMessageOnFirstEnclosing(G.CompilationUnit.class, DEPENDENCY_PRESENT, true);
+                                }
+                            } else if (m.getArguments().get(0) instanceof G.MapEntry) {
+                                G.MapEntry groupEntry = null;
+                                G.MapEntry artifactEntry = null;
+
+                                for (Expression e : m.getArguments()) {
+                                    if (!(e instanceof G.MapEntry)) {
+                                        continue;
+                                    }
+                                    G.MapEntry arg = (G.MapEntry) e;
+                                    if (!(arg.getKey() instanceof J.Literal) || !(arg.getValue() instanceof J.Literal)) {
+                                        continue;
+                                    }
+                                    J.Literal key = (J.Literal) arg.getKey();
+                                    J.Literal value = (J.Literal) arg.getValue();
+                                    if (!(key.getValue() instanceof String) || !(value.getValue() instanceof String)) {
+                                        continue;
+                                    }
+                                    if ("group".equals(key.getValue())) {
+                                        groupEntry = arg;
+                                    } else if ("name".equals(key.getValue())) {
+                                        artifactEntry = arg;
+                                    }
+                                }
+
+                                if (groupEntry == null || artifactEntry == null) {
+                                    return m;
+                                }
+
+                                if (groupId.equals(((J.Literal) groupEntry.getValue()).getValue())
+                                        && artifactId.equals(((J.Literal) artifactEntry.getValue()).getValue())) {
+                                    getCursor().putMessageOnFirstEnclosing(G.CompilationUnit.class, DEPENDENCY_PRESENT, true);
+                                }
+                            }
+                        }
+
+                        return m;
+                    }
+
+                    @Override
+                    public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext executionContext) {
+                        G.CompilationUnit g = super.visitCompilationUnit(cu, executionContext);
+
+                        if (getCursor().getMessage(DEPENDENCY_PRESENT, false)) {
+                            return g;
+                        }
+
+                        String resolvedConfiguration = configuration == null ? configurationByProject.get(javaProject) : configuration;
+
+                        return (G.CompilationUnit) new AddDependencyVisitor(groupId, artifactId, version, versionPattern, resolvedConfiguration,
+                                classifier, extension, familyPatternCompiled).visitNonNull(g, ctx);
+                    }
+                }.visit(s, ctx))
+                .map(SourceFile.class::cast)
+                .orElse(s)
+        );
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Validated;
+import org.openrewrite.gradle.internal.InsertDependencyComparator;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.semver.Semver;
+import org.openrewrite.semver.VersionComparator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor
+public class AddDependencyVisitor extends GroovyIsoVisitor<ExecutionContext> {
+    private static final MethodMatcher DEPENDENCIES_DSL_MATCHER = new MethodMatcher("RewriteGradleProject dependencies(..)");
+    private static final GradleParser GRADLE_PARSER = GradleParser.builder().build();
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    @Nullable
+    private final String versionPattern;
+
+    @Nullable
+    private final String configuration;
+
+    @Nullable
+    private final String classifier;
+
+    @Nullable
+    private final String extension;
+
+    @Nullable
+    private final Pattern familyRegex;
+
+    @Nullable
+    private VersionComparator versionComparator;
+
+    @Override
+    public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+        G.CompilationUnit groovy = super.visitCompilationUnit(cu, ctx);
+        boolean dependenciesBlockMissing = true;
+        for (Statement statement : groovy.getStatements()) {
+            if (statement instanceof J.MethodInvocation && DEPENDENCIES_DSL_MATCHER.matches((J.MethodInvocation) statement)) {
+                dependenciesBlockMissing = false;
+            }
+        }
+
+        Validated versionValidation = Semver.validate(version, versionPattern);
+        if (versionValidation.isValid()) {
+            versionComparator = versionValidation.getValue();
+        }
+
+        if (dependenciesBlockMissing) {
+            Statement dependenciesInvocation = GRADLE_PARSER.parse("dependencies {}").get(0).getStatements().get(0);
+            dependenciesInvocation = autoFormat(dependenciesInvocation, ctx, new Cursor(getCursor(), cu));
+            groovy = groovy.withStatements(ListUtils.concat(groovy.getStatements(), dependenciesInvocation));
+        }
+
+        doAfterVisit(new InsertDependencyInOrder(configuration));
+
+        return groovy;
+    }
+
+    @RequiredArgsConstructor
+    private class InsertDependencyInOrder extends GroovyIsoVisitor<ExecutionContext> {
+        private final String configuration;
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+            if (!DEPENDENCIES_DSL_MATCHER.matches(m)) {
+                return m;
+            }
+
+            J.Lambda dependenciesBlock = (J.Lambda) m.getArguments().get(0);
+            if (!(dependenciesBlock.getBody() instanceof J.Block)) {
+                return m;
+            }
+
+            J.Block body = (J.Block) dependenciesBlock.getBody();
+
+            String codeTemplate;
+            DependencyStyle style = autodetectDependencyStyle(body.getStatements());
+            if (style == DependencyStyle.String) {
+                codeTemplate = "dependencies {\n" +
+                        configuration + " \"" + groupId + ":" + artifactId + ":" + version + (classifier == null ? "" : ":" + classifier) + (extension == null ? "" : "@" + extension) + "\"" +
+                        "\n}";
+            } else {
+                codeTemplate = "dependencies {\n" +
+                        configuration + " group: \"" + groupId + "\", name: \"" + artifactId + "\", version: \"" + version + "\"" + (classifier == null ? "" : ", classifier: \"" + classifier + "\"") + (extension == null ? "" : ", ext: \"" + extension + "\"") +
+                        "\n}";
+            }
+            J.MethodInvocation addDependencyInvocation = (J.MethodInvocation) ((J.Return) (((J.Block) ((J.Lambda) ((J.MethodInvocation) GRADLE_PARSER.parse(codeTemplate)
+                    .get(0).getStatements().get(0)).getArguments().get(0)).getBody()).getStatements().get(0))).getExpression();
+            addDependencyInvocation = autoFormat(addDependencyInvocation, ctx, new Cursor(getCursor(), body));
+            InsertDependencyComparator dependencyComparator = new InsertDependencyComparator(body.getStatements(), addDependencyInvocation);
+
+            List<Statement> statements = new ArrayList<>(body.getStatements());
+            int i = 0;
+            for (; i < body.getStatements().size(); i++) {
+                Statement currentStatement = body.getStatements().get(i);
+                if (dependencyComparator.compare(currentStatement, addDependencyInvocation) > 0) {
+                    if (dependencyComparator.getBeforeDependency() != null) {
+                        J.MethodInvocation beforeDependency = (J.MethodInvocation) (dependencyComparator.getBeforeDependency() instanceof J.Return ? ((J.Return) dependencyComparator.getBeforeDependency()).getExpression() : dependencyComparator.getBeforeDependency());
+                        if (i == 0) {
+                            if (!addDependencyInvocation.getSimpleName().equals(beforeDependency.getSimpleName())) {
+                                statements.set(i, currentStatement.withPrefix(Space.format("\n\n" + currentStatement.getPrefix().getIndent())));
+                            }
+                        } else {
+                            Space originalPrefix = addDependencyInvocation.getPrefix();
+                            if (currentStatement instanceof J.VariableDeclarations) {
+                                J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) currentStatement;
+                                if (variableDeclarations.getTypeExpression() != null) {
+                                    addDependencyInvocation = addDependencyInvocation.withPrefix(variableDeclarations.getTypeExpression().getPrefix());
+                                }
+                            } else {
+                                addDependencyInvocation = addDependencyInvocation.withPrefix(currentStatement.getPrefix());
+                            }
+
+                            if (addDependencyInvocation.getSimpleName().equals(beforeDependency.getSimpleName())) {
+                                if (currentStatement instanceof J.VariableDeclarations) {
+                                    J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) currentStatement;
+                                    if (variableDeclarations.getTypeExpression() != null && !variableDeclarations.getTypeExpression().getPrefix().equals(originalPrefix)) {
+                                        statements.set(i, variableDeclarations.withTypeExpression(variableDeclarations.getTypeExpression().withPrefix(originalPrefix)));
+                                    }
+                                } else if (!currentStatement.getPrefix().equals(originalPrefix)) {
+                                    statements.set(i, currentStatement.withPrefix(originalPrefix));
+                                }
+                            }
+                        }
+                    }
+
+                    statements.add(i, addDependencyInvocation);
+                    break;
+                }
+            }
+            if (i == body.getStatements().size()) {
+                if (!body.getStatements().isEmpty()) {
+                    J.Return lastStatement = (J.Return) statements.remove(i - 1);
+                    statements.add(lastStatement.getExpression().withPrefix(lastStatement.getPrefix()));
+                    if (lastStatement.getExpression() instanceof J.MethodInvocation && !((J.MethodInvocation) lastStatement.getExpression()).getSimpleName().equals(addDependencyInvocation.getSimpleName())) {
+                        addDependencyInvocation = addDependencyInvocation.withPrefix(Space.format("\n\n" + addDependencyInvocation.getPrefix().getIndent()));
+                    }
+                }
+                statements.add(addDependencyInvocation);
+            }
+            body = body.withStatements(statements);
+            m = m.withArguments(Collections.singletonList(dependenciesBlock.withBody(body)));
+
+            return m;
+        }
+    }
+
+    enum DependencyStyle {
+        Map, String
+    }
+
+    private DependencyStyle autodetectDependencyStyle(List<Statement> statements) {
+        int string = 0;
+        int map = 0;
+        for (Statement statement : statements) {
+            if (statement instanceof J.Return && ((J.Return) statement).getExpression() instanceof J.MethodInvocation) {
+                J.MethodInvocation invocation = (J.MethodInvocation) ((J.Return) statement).getExpression();
+                if (invocation.getArguments().get(0) instanceof J.Literal || invocation.getArguments().get(0) instanceof G.GString) {
+                    string++;
+                } else if (invocation.getArguments().get(0) instanceof G.MapEntry) {
+                    map++;
+                }
+            } else if (statement instanceof J.MethodInvocation) {
+                J.MethodInvocation invocation = (J.MethodInvocation) statement;
+                if (invocation.getArguments().get(0) instanceof J.Literal || invocation.getArguments().get(0) instanceof G.GString) {
+                    string++;
+                } else if (invocation.getArguments().get(0) instanceof G.MapEntry) {
+                    map++;
+                }
+            }
+        }
+
+        return string >= map ? DependencyStyle.String : DependencyStyle.Map;
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
@@ -94,7 +94,7 @@ public class DependencyUseStringNotation extends Recipe {
                     }
                 } else if (m.getArguments().get(0) instanceof G.MapEntry) {
                     G.MapEntry firstEntry = (G.MapEntry) m.getArguments().get(0);
-                    Space prefix = firstEntry.getKey().getPrefix();
+                    Space prefix = firstEntry.getPrefix();
                     Markers markers = firstEntry.getMarkers();
 
                     for (Expression e : m.getArguments()) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/InsertDependencyComparator.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/InsertDependencyComparator.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.internal;
+
+import org.openrewrite.gradle.util.Dependency;
+import org.openrewrite.gradle.util.DependencyStringNotationConverter;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class InsertDependencyComparator implements Comparator<Statement> {
+    private final Map<Statement, Float> positions = new LinkedHashMap<>();
+
+    private Statement afterDependency;
+    private Statement beforeDependency;
+
+    public InsertDependencyComparator(List<Statement> existingStatements, J.MethodInvocation dependencyToAdd) {
+        for (int i = 0, len = existingStatements.size(); i < len; i++) {
+            positions.put(existingStatements.get(i), (float) i);
+        }
+
+        List<Statement> ideallySortedDependencies = existingStatements.stream()
+                .filter(s -> s instanceof J.MethodInvocation || (s instanceof J.Return && ((J.Return) s).getExpression() instanceof J.MethodInvocation))
+                .collect(Collectors.toList());
+
+        ideallySortedDependencies.add(dependencyToAdd);
+        ideallySortedDependencies.sort(dependenciesComparator);
+
+        for (int i = 0, len = ideallySortedDependencies.size(); i < len; i++) {
+            Statement d = ideallySortedDependencies.get(i);
+            if (dependencyToAdd == d) {
+                if (i > 0) {
+                    afterDependency = ideallySortedDependencies.get(i - 1);
+                }
+                if (i + 1 < ideallySortedDependencies.size()) {
+                    beforeDependency = ideallySortedDependencies.get(i + 1);
+                }
+                break;
+            }
+        }
+
+        float insertPos = afterDependency == null ? -0.5f : 0.5f;
+        List<Statement> statements = new ArrayList<>(positions.keySet());
+        for (float f = afterDependency == null ? 0 : positions.get(afterDependency); f < statements.size(); f++) {
+            Statement s = statements.get((int) f);
+            if (!(s instanceof J.MethodInvocation || (s instanceof J.Return && ((J.Return) s).getExpression() instanceof J.MethodInvocation))) {
+                continue;
+            }
+            positions.put(dependencyToAdd, positions.get(statements.get((int) f)) + insertPos);
+            break;
+        }
+    }
+
+    @Override
+    public int compare(Statement o1, Statement o2) {
+        return positions.get(o1).compareTo(positions.get(o2));
+    }
+
+    public Statement getAfterDependency() {
+        return afterDependency;
+    }
+
+    public Statement getBeforeDependency() {
+        return beforeDependency;
+    }
+
+    private static Comparator<Statement> dependenciesComparator = (s1, s2) -> {
+        J.MethodInvocation d1;
+        if (s1 instanceof J.Return) {
+            d1 = (J.MethodInvocation) ((J.Return) s1).getExpression();
+        } else {
+            d1 = (J.MethodInvocation) s1;
+        }
+
+        J.MethodInvocation d2;
+        if (s2 instanceof J.Return) {
+            d2 = (J.MethodInvocation) ((J.Return) s2).getExpression();
+        } else {
+            d2 = (J.MethodInvocation) s2;
+        }
+
+        String configuration1 = d1.getSimpleName();
+        String configuration2 = d2.getSimpleName();
+        if (!configuration1.equals(configuration2)) {
+            return configuration1.compareTo(configuration2);
+        }
+
+        String groupId1 = getEntry("group", d1).orElse("");
+        String groupId2 = getEntry("group", d2).orElse("");
+        if (!groupId1.equals(groupId2)) {
+            return comparePartByPart(groupId1, groupId2);
+        }
+
+        String artifactId1 = getEntry("name", d1).orElse("");
+        String artifactId2 = getEntry("name", d2).orElse("");
+        if (!artifactId1.equals(artifactId2)) {
+            return comparePartByPart(artifactId1, artifactId2);
+        }
+
+        String classifier1 = getEntry("classifier", d1).orElse(null);
+        String classifier2 = getEntry("classifier", d2).orElse(null);
+        if (classifier1 == null && classifier2 != null) {
+            return -1;
+        } else if (classifier1 != null) {
+            if (classifier2 == null) {
+                return 1;
+            }
+            if (!classifier1.equals(classifier2)) {
+                return classifier1.compareTo(classifier2);
+            }
+        }
+
+        // in every case imagined so far, group and artifact comparison are enough,
+        // so this is just for completeness
+        return getEntry("version", d1).orElse("")
+                .compareTo(getEntry("version", d2).orElse(""));
+    };
+
+    private static Optional<String> getEntry(String entry, J.MethodInvocation invocation) {
+        if (invocation.getArguments().get(0) instanceof J.Literal) {
+            Dependency dependency = new DependencyStringNotationConverter().parse((String) ((J.Literal) invocation.getArguments().get(0)).getValue());
+            switch (entry) {
+                case "group":
+                    return Optional.ofNullable(dependency.getGroupId());
+                case "name":
+                    return Optional.ofNullable(dependency.getArtifactId());
+                case "version":
+                    return Optional.ofNullable(dependency.getVersion());
+                case "classifier":
+                    return Optional.ofNullable(dependency.getClassifier());
+            }
+        } else if (invocation.getArguments().get(0) instanceof G.MapEntry) {
+            for (Expression e : invocation.getArguments()) {
+                if (!(e instanceof G.MapEntry)) {
+                    continue;
+                }
+
+                G.MapEntry mapEntry = (G.MapEntry) e;
+                if (!(mapEntry.getKey() instanceof J.Literal && mapEntry.getValue() instanceof J.Literal)) {
+                    continue;
+                }
+
+                if (entry.equals(((J.Literal) mapEntry.getKey()).getValue())) {
+                    return Optional.ofNullable((String) ((J.Literal) mapEntry.getValue()).getValue());
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static int comparePartByPart(String d1, String d2) {
+        String[] d1Parts = d1.split("[.-]");
+        String[] d2Parts = d2.split("[.-]");
+
+        for (int i = 0; i < Math.min(d1Parts.length, d2Parts.length); i++) {
+            if (!d1Parts[i].equals(d2Parts[i])) {
+                return d1Parts[i].compareTo(d2Parts[i]);
+            }
+        }
+
+        return d1Parts.length - d2Parts.length;
+    }
+}

--- a/rewrite-gradle/src/main/resources/RewriteGradleProject.groovy
+++ b/rewrite-gradle/src/main/resources/RewriteGradleProject.groovy
@@ -170,6 +170,10 @@ interface Plugin {
 }
 
 interface DependencyHandlerSpec extends DependencyHandler {
+    Dependency annotationProcessor(String dependencyNotation)
+    Dependency annotationProcessor(String dependencyNotation, @DelegatesTo(strategy=Closure.DELEGATE_ONLY, value= ModuleDependency) Closure closure)
+    Dependency annotationProcessor(Map<String, String> dependencyNotation)
+    Dependency annotationProcessor(Map<String, String> dependencyNotation, @DelegatesTo(strategy=Closure.DELEGATE_ONLY, value= ModuleDependency) Closure closure)
     Dependency api(String dependencyNotation)
     Dependency api(String dependencyNotation, @DelegatesTo(strategy=Closure.DELEGATE_ONLY, value= ModuleDependency) Closure closure)
     Dependency api(Map<String, String> dependencyNotation)

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -218,8 +218,6 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
-    // TODO: Figure out how to fix the extra space being added after the comma for each of the G.MapEntry
-    // Source: org.openrewrite.java.format.AutoFormatVisitor#visit(Tree, P, Cursor)L62
     @Test
     void addDependenciesToExistingGrouping() {
         rewriteRun(
@@ -251,8 +249,6 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
-    // TODO: Figure out how to fix the extra space being added after the comma for each of the G.MapEntry
-    // Source: org.openrewrite.java.format.AutoFormatVisitor#visit(Tree, P, Cursor)L62
     @Test
     void matchesDependencyDeclarationStyle() {
         rewriteRun(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.java.Assertions.*;
+
+class AddDependencyTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion()
+          .classpath("junit-jupiter-api", "guava", "jackson-databind", "jackson-core", "lombok"));
+    }
+
+    @Language("java")
+    private final String usingGuavaIntMath = """
+            import com.google.common.math.IntMath;
+            public class A {
+                boolean getMap() {
+                    return IntMath.isPrime(5);
+                }
+   
+            }
+      """;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
+    void onlyIfUsingTestScope(String onlyIfUsing) {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", onlyIfUsing)),
+          mavenProject("project",
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    testImplementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
+    void onlyIfUsingCompileScope(String onlyIfUsing) {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", onlyIfUsing)),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void notUsingType() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.collect.ImmutableMap")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              ""
+            )
+          )
+        );
+    }
+
+    @Test
+    void addInOrder() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation "commons-lang:commons-lang:1.0"
+                }
+                """,
+              """
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                    implementation "commons-lang:commons-lang:1.0"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addTestDependenciesAfterCompile() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation "commons-lang:commons-lang:1.0"
+                }
+                """,
+              """
+                dependencies {
+                    implementation "commons-lang:commons-lang:1.0"
+                    
+                    testImplementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addDependenciesKeepFormatting() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation "com.example:example:1.0"
+                    testImplementation "junit:junit:4.12"
+                }
+                """,
+              """
+                dependencies {
+                    implementation "com.example:example:1.0"
+                    implementation "com.google.guava:guava:29.0-jre"
+                    testImplementation "junit:junit:4.12"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addDependencyToNewGrouping() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("org.projectlombok:lombok:1.0", "lombok.Value", "annotationProcessor")),
+          mavenProject("project",
+            srcMainJava(
+              java("""
+                import lombok.Value;
+                
+                @Value
+                class A {
+                    String b;
+                }
+                """
+              )
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation "commons-lang:commons-lang:1.0"
+
+                    testImplementation "junit:junit:4.13"
+                }
+                """,
+              """
+                dependencies {
+                    annotationProcessor "org.projectlombok:lombok:1.0"
+                    
+                    implementation "commons-lang:commons-lang:1.0"
+                    
+                    testImplementation "junit:junit:4.13"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    // TODO: Figure out how to fix the extra space being added after the comma for each of the G.MapEntry
+    // Source: org.openrewrite.java.format.AutoFormatVisitor#visit(Tree, P, Cursor)L62
+    @Test
+    void addDependenciesToExistingGrouping() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation group: "commons-lang", name: "commons-lang", version: "1.0"
+
+                    def junitVersion = "4.12"
+                    testImplementation group: "junit", name: "junit", version: junitVersion
+                }
+                """,
+              """
+                dependencies {
+                    implementation group: "commons-lang", name: "commons-lang", version: "1.0"
+
+                    testImplementation group: "com.google.guava", name: "guava", version: "29.0-jre"
+                    def junitVersion = "4.12"
+                    testImplementation group: "junit", name: "junit", version: junitVersion
+                }
+                """
+            )
+          )
+        );
+    }
+
+    // TODO: Figure out how to fix the extra space being added after the comma for each of the G.MapEntry
+    // Source: org.openrewrite.java.format.AutoFormatVisitor#visit(Tree, P, Cursor)L62
+    @Test
+    void matchesDependencyDeclarationStyle() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation group: "commons-lang", name: "commons-lang", version: "1.0"
+                }
+                """,
+              """
+                dependencies {
+                    implementation group: "commons-lang", name: "commons-lang", version: "1.0"
+
+                    testImplementation group: "com.google.guava", name: "guava", version: "29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addDependencyDoesntAddWhenExistingDependency() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                dependencies {
+                    implementation "com.google.guava:guava:28.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"api", "compileOnly", "testRuntimeOnly"})
+    void addDependencyToConfiguration(String configuration) {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.fasterxml.jackson.core:jackson-core:2.12.0", "com.fasterxml.jackson.core.*", configuration)),
+          mavenProject("project",
+            srcMainJava(
+              java(
+                """
+                  public class A {
+                      com.fasterxml.jackson.core.Versioned v;
+                  }
+                  """
+              )
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    %s "com.fasterxml.jackson.core:jackson-core:2.12.0"
+                }
+                """.formatted(configuration)
+            )
+          )
+        );
+    }
+
+    private AddDependency addDependency(String gav, String onlyIfUsing) {
+        return addDependency(gav, onlyIfUsing, null);
+    }
+
+    private AddDependency addDependency(String gav, String onlyIfUsing, @Nullable String configuration) {
+        String[] gavParts = gav.split(":");
+        return new AddDependency(
+          gavParts[0], gavParts[1], gavParts[2], null, configuration, onlyIfUsing,
+          null, null, null
+        );
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1345,7 +1345,7 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitMapEntryExpression(MapEntryExpression expression) {
-            G.MapEntry mapEntry = new G.MapEntry(randomId(), EMPTY, Markers.EMPTY,
+            G.MapEntry mapEntry = new G.MapEntry(randomId(), whitespace(), Markers.EMPTY,
                     JRightPadded.build((Expression) visit(expression.getKeyExpression())).withAfter(sourceBefore(":")),
                     visit(expression.getValueExpression()),
                     null

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.groovy;
 
 import org.openrewrite.Cursor;
 import org.openrewrite.SourceFile;
+import org.openrewrite.groovy.format.MinimumViableSpacingVisitor;
 import org.openrewrite.groovy.format.OmitParenthesesForLastArgumentLambdaVisitor;
 import org.openrewrite.groovy.tree.*;
 import org.openrewrite.internal.ListUtils;
@@ -160,7 +161,10 @@ public class GroovyVisitor<P> extends JavaVisitor<P> {
     @Override
     public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, P p, Cursor cursor) {
         J after = super.autoFormat(j, stopAfter, p, cursor.fork());
+
         after = new OmitParenthesesForLastArgumentLambdaVisitor<>(stopAfter).visitNonNull(after, p, cursor.fork());
+
+        after = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(after, p, cursor.fork());
 
         //noinspection unchecked
         return (J2) after;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MinimumViableSpacingVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.Tree;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+
+@RequiredArgsConstructor
+public class MinimumViableSpacingVisitor<P> extends GroovyIsoVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
+        J.MethodInvocation m = super.visitMethodInvocation(method, p);
+        return method.withArguments(ListUtils.mapFirst(m.getArguments(), first -> {
+            if (first.getMarkers().findFirst(OmitParentheses.class).isPresent()) {
+                return first.getPrefix().getWhitespace().isEmpty() ?
+                        first.withPrefix(first.getPrefix().withWhitespace(" ")) :
+                        first;
+            }
+            return first;
+        }));
+    }
+
+    @Nullable
+    @Override
+    public J postVisit(J tree, P p) {
+        if (stopAfter != null && stopAfter.isScope(tree)) {
+            getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, "stop", true);
+        }
+        return super.postVisit(tree, p);
+    }
+
+    @Nullable
+    @Override
+    public J visit(@Nullable Tree tree, P p) {
+        if (getCursor().getNearestMessage("stop") != null) {
+            return (J) tree;
+        }
+        return super.visit(tree, p);
+    }
+}


### PR DESCRIPTION
This also fixes a whitespace bug in the GroovyParser for `G.MapEntry` types. Essentially, the whitespace was being placed on the key element, but should have been placed upon the `G.MapEntry` itself.