### PR TITLE
Issue 1698: adding additional check for nonstandard package names

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -859,6 +859,82 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/1698")
+    @Test
+    void correctlyRemoveImportsFromLowerCaseClassNames() {
+        rewriteRun(
+          java(
+            """
+              package com.source;
+
+              public class a {
+                  public static final short SHORT1 = (short)1;
+                  public static final short SHORT2 = (short)2;
+              }
+              """
+          ),
+          java(
+            """
+              package com.test;
+
+              import static com.source.a.SHORT1;
+              import static com.source.a.SHORT2;
+              
+              class Test {
+                  short uniqueCount = SHORT1;
+              }
+              """,
+            """
+              package com.test;
+
+              import static com.source.a.SHORT1;
+              
+              class Test {
+                  short uniqueCount = SHORT1;
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1698")
+    @Test
+    void correctlyRemoveImportsFromUpperCasedPackages() {
+        rewriteRun(
+          java(
+            """
+              package com.Source.$;
+
+              public class A {
+                  public static final short SHORT1 = (short)1;
+                  public static final short SHORT2 = (short)2;
+              }
+              """
+          ),
+          java(
+            """
+              package com.test;
+
+              import static com.Source.$.A.SHORT1;
+              import static com.Source.$.A.SHORT2;
+              
+              class Test {
+                  short uniqueCount = SHORT1;
+              }
+              """,
+            """
+              package com.test;
+
+              import static com.Source.$.A.SHORT1;
+              
+              class Test {
+                  short uniqueCount = SHORT1;
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void removeImportUsedAsLambdaParameter() {
         rewriteRun(


### PR DESCRIPTION
This PR attempts to address issue https://github.com/openrewrite/rewrite/issues/1698
I added tests for "nonstandard" package names. So far I have only found issues with imports that:

- include a lower case class name in the package path 
- include multiple camel cased names in the package path

I attempted to investigate why this was happening but ultimately found that the underlying code in the JCTree was returning these values. What I have proposed here was something I found to work by trial and error. 