### PR TITLE
Make `HiddenField` recipe predictable

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/HiddenFieldTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/HiddenFieldTest.java
@@ -254,6 +254,116 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
+    @Test
+    void blocks() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  int n;
+
+                  public void blocks() {
+                      {
+                          int n = 0;
+                          int x = n;
+                      }
+                      {
+                          int n = 0;
+                          int x = n;
+                      }
+                  }
+              }
+              """,
+            """
+              public class A {
+                  int n;
+
+                  public void blocks() {
+                      {
+                          int n1 = 0;
+                          int x = n1;
+                      }
+                      {
+                          int n1 = 0;
+                          int x = n1;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("ConstantValue")
+    void tryResources() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  int n;
+
+                  public void tryWithResources(int n4) {
+                      Object n1 = null;
+                      try (java.io.InputStream n = null; java.io.OutputStream n2 = null) {
+                          Object n3 = null;
+                          Object x = n;
+                      }
+                  }
+              }
+              """,
+            """
+              public class A {
+                  int n;
+
+                  public void tryWithResources(int n4) {
+                      Object n1 = null;
+                      try (java.io.InputStream n5 = null; java.io.OutputStream n2 = null) {
+                          Object n3 = null;
+                          Object x = n5;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"EmptyTryBlock", "CatchMayIgnoreException", "TryWithIdenticalCatches"})
+    void catchClause() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  int e;
+
+                  public void tryCatch() {
+                      try (java.io.InputStream e1 = null) {
+                      } catch (RuntimeException e) {
+                      } catch (java.io.IOException e) {
+                      } catch (Exception e) {
+                      }
+                  }
+              }
+              """,
+            """
+              public class A {
+                  int e;
+
+                  public void tryCatch() {
+                      try (java.io.InputStream e1 = null) {
+                      } catch (RuntimeException e2) {
+                      } catch (java.io.IOException e3) {
+                      } catch (Exception e4) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings({"Convert2MethodRef", "ResultOfMethodCallIgnored"})
     @Test
     void lambdaWithTypedParameterHides() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HiddenFieldVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/HiddenFieldVisitor.java
@@ -28,10 +28,7 @@ import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -100,7 +97,7 @@ public class HiddenFieldVisitor<P> extends JavaIsoVisitor<P> {
          * @return A set of existing variable definition of the {@param childTargetName} within the same name scope as the {@param childTargetName}.
          */
         public static Set<J.VariableDeclarations.NamedVariable> find(J j, Cursor childTargetReference, String childTargetName) {
-            Set<J.VariableDeclarations.NamedVariable> references = new HashSet<>();
+            Set<J.VariableDeclarations.NamedVariable> references = new LinkedHashSet<>();
             new FindExistingVariableDeclarations(childTargetReference, childTargetName).visit(j, references);
             return references;
         }
@@ -187,7 +184,7 @@ public class HiddenFieldVisitor<P> extends JavaIsoVisitor<P> {
          * @return A set representing any found {@link J.VariableDeclarations.NamedVariable} which shadow the provided {@param targetVariable}.
          */
         public static Set<J.VariableDeclarations.NamedVariable> find(J j, J.VariableDeclarations.NamedVariable targetVariable, J.ClassDeclaration targetVariableEnclosingClass, HiddenFieldStyle hiddenFieldStyle) {
-            Set<J.VariableDeclarations.NamedVariable> references = new HashSet<>();
+            Set<J.VariableDeclarations.NamedVariable> references = new LinkedHashSet<>();
             new FindNameShadows(targetVariable, targetVariableEnclosingClass, hiddenFieldStyle).visit(j, references);
             return references;
         }


### PR DESCRIPTION
By using a `LinkedHashSet` rather than a regular `HashSet` in `FindNameShadows#find()` to collect the shadowing variables, the renaming of the variables becomes predictable. I.e. the same variable always gets renamed to the same name if the recipe is tested multiple times. This is especially important for tests.

Fixes #2592
