### PR TITLE
Null `MavenMetaData.Snapshot#timestamp` causes maven parser failures.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -590,7 +590,7 @@ public class MavenPomDownloader {
                 return gav.getVersion();
             }
             MavenMetadata.Snapshot snapshot = mavenMetadata.getVersioning().getSnapshot();
-            if (snapshot != null) {
+            if (snapshot != null && snapshot.getTimestamp() != null) {
                 return gav.getVersion().replaceFirst("SNAPSHOT$", snapshot.getTimestamp() + "-" + snapshot.getBuildNumber());
             }
         }


### PR DESCRIPTION
This fix prevents a null timestamp from producing an invalid URI, resulting in `MavenDownloadingExceptions` and maven-parser failures.

```
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.openrewrite.maven:rewrite-maven-plugin:4.39.0-SNAPSHOT:run (default-cli) on project ...: Execution default-cli of goal org.openrewrite.maven:rewrite-maven-plugin:4.39.0-SNAPSHOT:run failed: Failed to download dependencies for .../pom.xml:
</dependency>
  <!--~~(Unable to download POM. Tried repositories:
   https://...-snapshot: HTTP 404)~~>--><dependency> 
 at org.openrewrite.maven.MavenParser.parseInputs (MavenParser.java:127)
    at org.openrewrite.Parser.parse (Parser.java:41)
    at org.openrewrite.maven.MavenMojoProjectParser.parseMaven (MavenMojoProjectParser.java:309)
    at org.openrewrite.maven.MavenMojoProjectParser.listSourceFiles (MavenMojoProjectParser.java:119)
    at org.openrewrite.maven.AbstractRewriteMojo.listResults (AbstractRewriteMojo.java:250)
```