### PR TITLE
Optimize and fix bug in `FindMissingTypes` recipe

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -466,12 +466,12 @@ class ChangeTypeTest implements RewriteTest {
               import a.A1;
                             
               public class B {
-                 public <T extends A1> T generic(T n, List<? super A1> in) {
+                 public <T extends A1> T generic(T n, java.util.List<? super A1> in) {
                  
                  }
                  public void test() {
                      A1.stat();
-                     this.<A1>generic(null, true);
+                     this.<A1>generic(null, java.util.List.of());
                  }
               }
               """,
@@ -479,12 +479,12 @@ class ChangeTypeTest implements RewriteTest {
               import a.A2;
                             
               public class B {
-                 public <T extends A2> T generic(T n, List<? super A2> in) {
+                 public <T extends A2> T generic(T n, java.util.List<? super A2> in) {
                  
                  }
                  public void test() {
                      A2.stat();
-                     this.<A2>generic(null, true);
+                     this.<A2>generic(null, java.util.List.of());
                  }
               }
               """


### PR DESCRIPTION
The `FindMissingTypes` recipe is typically used by `RewriteTest` which parse Java sources using `import static org.openrewrite.java.Assertions#java()`. Additionally, it is also used by the `NoMissingTypes` recipe, which in turn is used as a single-source applicability test by some recipes like `RemoveUnusedImports` and `RemoveUnusedPrivateMethods`.

By adding an overload `TypeUtils#isWellFormedType(JavaType, Set<JavaType>)`, the client can now check multiple types within a "session", as represented by the `Set<JavaType>` parameter, without having to transitively recheck the same types multiple times.
