### PR TITLE
Fix issue with configuring rewrite-java-* Gradle projects

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.openrewrite.build.language-library")
+    id("jvm-test-suite")
 }
 
 dependencies {
@@ -50,20 +51,31 @@ tasks.withType<Javadoc> {
     )
 }
 
-val testTask = tasks.register<Test>("compatibilityTest") {
-    description = "Test parser compatibility."
-    group = "verification"
-    useJUnitPlatform {
-        excludeTags("java17")
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class)
+
+        register("compatibilityTest", JvmTestSuite::class) {
+            dependencies {
+                implementation(project)
+                implementation(project(":rewrite-java-tck"))
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        useJUnitPlatform {
+                            excludeTags("java11", "java17")
+                        }
+                        jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
     }
-    jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
-    val tckSourceSet = project(":rewrite-java-tck").sourceSets.getByName("main")
-    testClassesDirs = tckSourceSet.output.classesDirs
-    classpath = tckSourceSet.runtimeClasspath
-            .plus(sourceSets.getByName("test").runtimeClasspath)
-            .plus(sourceSets.getByName("main").output.classesDirs)
-    shouldRunAfter(tasks.test)
 }
-tasks.test {
-    dependsOn(testTask)
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("compatibilityTest"))
 }

--- a/rewrite-java-17/build.gradle.kts
+++ b/rewrite-java-17/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.openrewrite.build.language-library")
+    id("jvm-test-suite")
 }
 
 dependencies {
@@ -44,19 +45,31 @@ tasks.withType<Javadoc> {
     )
 }
 
-val testTask = tasks.register<Test>("compatibilityTest") {
-    description = "Test parser compatibility."
-    group = "verification"
-    useJUnitPlatform()
-    jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
-    val tckSourceSet = project(":rewrite-java-tck").sourceSets.getByName("main")
-    testClassesDirs = tckSourceSet.output.classesDirs
-    classpath = tckSourceSet.runtimeClasspath
-            .plus(sourceSets.getByName("test").runtimeClasspath)
-            .plus(sourceSets.getByName("main").output.classesDirs)
-    shouldRunAfter(tasks.test)
-}
-tasks.test {
-    dependsOn(testTask)
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class)
+
+        register("compatibilityTest", JvmTestSuite::class) {
+            dependencies {
+                implementation(project)
+                implementation(project(":rewrite-java-tck"))
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        useJUnitPlatform {
+                            excludeTags("java11", "java17")
+                        }
+                        jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
 }
 
+tasks.named("check") {
+    dependsOn(testing.suites.named("compatibilityTest"))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.namespace!!.startsWith("org.openrewrite.build")) {
+            if (requested.id.namespace != null && requested.id.namespace!!.startsWith("org.openrewrite.build")) {
                 useVersion("1.4.0")
             }
         }
@@ -39,7 +39,9 @@ val allProjects = listOf(
 val includedProjects = file("IDE.properties").let {
     if (it.exists()) {
         val props = java.util.Properties()
-        props.load(it.reader())
+        it.reader().use { reader ->
+            props.load(reader)
+        }
         allProjects.intersect(props.keys)
     } else {
         allProjects


### PR DESCRIPTION
This initially presented only on Windows, but could easily have presented on any other operating system. Essentially, the `compatibilityTest` testing task was reaching into another project's configuration and specifically trying to get informaton about it's `sourceSet` configuration settings. However, if that project was not yet configured, then it would not have had the `JvmEcosystemPlugin` applied to it. Without the `JvmEcosystemPlugin`, this would mean that there was no `sourceSet` container to get information from ultimately leading to one of the rewrite-java-* projects failing to configure with a rather vague error messaging stating these same qualities. At first glance, it would appear that the `sourceSet` container was missing from the current project (ie. rewrite-java-*), while in fact it was missing from the rewrite-java-tck project (which hadn't yet been configured).