### PR TITLE
Change maven model flags to strings to support property placeholders

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -58,26 +58,41 @@ public class DependencyInsightTest implements RewriteTest {
               """,
             spec -> {
                 // This is really awkward, need a DSL or some other tooling support
-                Dependency requestedOrgWhatever = new Dependency(
-                  new GroupArtifactVersion("org.whatever", "test", "1.0"),
-                  null, "jar", "implementation", emptyList(), false);
-                ResolvedDependency resolvedOrgWhatever = new ResolvedDependency(null,
-                  new ResolvedGroupArtifactVersion(null, "org.whatever", "test", "1.0", null),
-                  requestedOrgWhatever, emptyList(), emptyList(), 0);
+                Dependency requestedOrgWhatever = Dependency.builder()
+                  .gav(new GroupArtifactVersion("org.whatever", "test", "1.0"))
+                  .type("jar")
+                  .scope("implementation")
+                  .build();
+                ResolvedDependency resolvedOrgWhatever = ResolvedDependency.builder()
+                  .gav(new ResolvedGroupArtifactVersion(null, "org.whatever", "test", "1.0", null))
+                  .requested(requestedOrgWhatever)
+                  .dependencies(emptyList())
+                  .licenses(emptyList())
+                  .build();
 
+                Dependency requestedBingBaz = Dependency.builder()
+                  .gav(new GroupArtifactVersion("com.example", "bing-baz", "latest.release"))
+                  .type("jar")
+                  .scope("implementation")
+                  .build();
+                ResolvedDependency resolvedBingBaz = ResolvedDependency.builder()
+                  .gav(new ResolvedGroupArtifactVersion(null, "com.example", "bing-baz", "1.0", null))
+                  .requested(requestedBingBaz)
+                  .dependencies(emptyList())
+                  .depth(1)
+                  .build();
 
-                Dependency requestedBingBaz = new Dependency(
-                  new GroupArtifactVersion("com.example", "bing-baz", "latest.release"),
-                  null, "jar", "implementation", emptyList(), false);
-                ResolvedDependency resolvedBingBaz = new ResolvedDependency(null,
-                  new ResolvedGroupArtifactVersion(null, "com.example", "bing-baz", "1.0", null),
-                  requestedBingBaz, emptyList(), emptyList(), 1);
-                Dependency requestedComExample = new Dependency(
-                  new GroupArtifactVersion("com.example", "foo-bar", "latest.release"),
-                  null, "jar", "implementation", emptyList(), false);
-                ResolvedDependency resolvedComExample = new ResolvedDependency(null,
-                  new ResolvedGroupArtifactVersion(null, "com.example", "foo-bar", "1.0", null),
-                  requestedComExample, List.of(resolvedBingBaz), emptyList(), 0);
+                Dependency requestedComExample = Dependency.builder()
+                  .gav(new GroupArtifactVersion("com.example", "foo-bar", "latest.release"))
+                  .type("jar")
+                  .scope("implementation")
+                  .build();
+                ResolvedDependency resolvedComExample = ResolvedDependency.builder()
+                  .gav(new ResolvedGroupArtifactVersion(null, "com.example", "foo-bar", "1.0", null))
+                  .requested(requestedComExample)
+                  .dependencies(List.of(resolvedBingBaz))
+                  .depth(0)
+                  .build();
 
                 spec.markers(new GradleProject(
                   randomId(),

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -223,8 +223,8 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
                         return new MavenRepository(
                                 repo.getId(),
                                 repo.getUrl(),
-                                repo.getReleases() == null || repo.getReleases().isEnabled(),
-                                repo.getSnapshots() != null && repo.getSnapshots().isEnabled(),
+                                repo.getReleases() == null ? null : repo.getReleases().getEnabled(),
+                                repo.getSnapshots() == null ? null : repo.getSnapshots().getEnabled(),
                                 null,
                                 null
                         );

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -172,7 +172,7 @@ public class MavenSettings {
             return MAVEN_LOCAL_DEFAULT;
         }
         if (mavenLocal == null) {
-            mavenLocal = MavenRepository.builder().setId("local").setUri(asUriString(localRepository)).setKnownToExist(true).build();
+            mavenLocal = MavenRepository.builder().id("local").uri(asUriString(localRepository)).knownToExist(true).build();
         }
         return mavenLocal;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -172,7 +172,7 @@ public class MavenSettings {
             return MAVEN_LOCAL_DEFAULT;
         }
         if (mavenLocal == null) {
-            mavenLocal = new MavenRepository("local", asUriString(localRepository), true, true, true, null, null, false);
+            mavenLocal = MavenRepository.builder().setId("local").setUri(asUriString(localRepository)).setKnownToExist(true).build();
         }
         return mavenLocal;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -74,7 +74,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                         dependency.getChildValue("type").orElse(null),
                         dependency.getChildValue("scope").orElse("compile"),
                         mapExclusions(dependency),
-                        dependency.getChildValue("optional").map(Boolean::parseBoolean).orElse(false)
+                        dependency.getChildValue("optional").orElse(null)
                 ));
             }
             requested = requested.withDependencies(requestedDependencies);
@@ -116,8 +116,8 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
             requested = requested.withRepositories(repos.get().getChildren("repository").stream().map(t -> new MavenRepository(
                     t.getChildValue("id").orElse(null),
                     t.getChildValue("url").get(),
-                    Boolean.TRUE.equals(t.getChild("releases").flatMap(s -> s.getChildValue("enabled").map(Boolean::valueOf)).orElse(null)),
-                    Boolean.TRUE.equals(t.getChild("snapshots").flatMap(s -> s.getChildValue("enabled").map(Boolean::valueOf)).orElse(null)),
+                    t.getChild("releases").flatMap(s -> s.getChildValue("enabled")).orElse(null),
+                    t.getChild("snapshots").flatMap(s -> s.getChildValue("enabled")).orElse(null),
                     null,
                     null
             )).collect(Collectors.toList()));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -133,7 +133,7 @@ public class RawPom {
         String classifier;
 
         @Nullable
-        Boolean optional;
+        String optional;
 
         @Nullable
         @JacksonXmlElementWrapper
@@ -405,8 +405,8 @@ public class RawPom {
                 pomRepositories = new ArrayList<>(unmappedRepos.size());
                 for (RawRepositories.Repository r : unmappedRepos) {
                     pomRepositories.add(new MavenRepository(r.getId(), r.getUrl(),
-                            r.getReleases() == null || r.getReleases().isEnabled(),
-                            r.getSnapshots() == null || r.getSnapshots().isEnabled(),
+                            r.getReleases() == null ? null : r.getReleases().getEnabled(),
+                            r.getSnapshots() == null ? null : r.getSnapshots().getEnabled(),
                             false, null, null, null));
                 }
 
@@ -443,7 +443,7 @@ public class RawPom {
                 for (Dependency d : unmappedDependencies) {
                     GroupArtifactVersion dGav = new GroupArtifactVersion(d.getGroupId(), d.getArtifactId(), d.getVersion());
                     dependencies.add(new org.openrewrite.maven.tree.Dependency(dGav, d.getClassifier(), d.getType(), d.getScope(), d.getExclusions(),
-                            d.getOptional() != null && d.getOptional()));
+                            d.getOptional()));
                 }
             }
         }
@@ -457,7 +457,7 @@ public class RawPom {
             for (Dependency d : rawDependencies) {
                 GroupArtifactVersion dGav = new GroupArtifactVersion(d.getGroupId(), d.getArtifactId(), d.getVersion());
                 dependencies.add(new org.openrewrite.maven.tree.Dependency(dGav, d.getClassifier(), d.getType(), d.getScope(), d.getExclusions(),
-                        d.getOptional() != null && d.getOptional()));
+                        d.getOptional()));
             }
         }
         return dependencies;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawRepositories.java
@@ -53,10 +53,12 @@ public class RawRepositories {
     @EqualsAndHashCode
     @Getter
     public static class ArtifactPolicy {
-        boolean enabled;
 
-        public ArtifactPolicy(@Nullable Boolean enabled) {
-            this.enabled = enabled == null || enabled;
+        @Nullable
+        String enabled;
+
+        public ArtifactPolicy(@Nullable String enabled) {
+            this.enabled = enabled;
         }
 
         /**
@@ -64,7 +66,7 @@ public class RawRepositories {
          */
         @SuppressWarnings("unused")
         public ArtifactPolicy() {
-            this(true);
+            this("true");
         }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/MavenMetadataFailures.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/MavenMetadataFailures.java
@@ -41,8 +41,8 @@ public class MavenMetadataFailures extends DataTable<MavenMetadataFailures.Row> 
         String artifactId;
         String version;
         String mavenRepositoryUri;
-        boolean snapshots;
-        boolean releases;
+        String snapshots;
+        String releases;
         String failure;
     }
 
@@ -61,8 +61,8 @@ public class MavenMetadataFailures extends DataTable<MavenMetadataFailures.Row> 
                         failedOn.getArtifactId(),
                         failedOn.getVersion(),
                         repositoryResponse.getKey().getUri(),
-                        repositoryResponse.getKey().isSnapshots(),
-                        repositoryResponse.getKey().isReleases(),
+                        repositoryResponse.getKey().getSnapshots(),
+                        repositoryResponse.getKey().getReleases(),
                         repositoryResponse.getValue()
                 ));
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
@@ -15,13 +15,14 @@
  */
 package org.openrewrite.maven.tree;
 
-import lombok.Value;
-import lombok.With;
+import lombok.*;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.List;
 
 @Value
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class Dependency {
     GroupArtifactVersion gav;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Dependency.java
@@ -40,7 +40,8 @@ public class Dependency {
     List<GroupArtifact> exclusions;
 
     @With
-    boolean optional;
+    @Nullable
+    String optional;
 
     @Nullable
     public String getGroupId() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import lombok.*;
+import lombok.experimental.Accessors;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import org.openrewrite.internal.lang.Nullable;
@@ -33,9 +34,10 @@ import java.net.URI;
 @Data
 @RequiredArgsConstructor
 public class MavenRepository {
-    public static final MavenRepository MAVEN_LOCAL_USER_NEUTRAL = new MavenRepository("local", new File("~/.m2/repository").toString(), true, true, true, null, null, false);
-    public static final MavenRepository MAVEN_LOCAL_DEFAULT = new MavenRepository("local", new File(System.getProperty("user.home") + "/.m2/repository").toURI().toString(), true, true, true, null, null, false);
-    public static final MavenRepository MAVEN_CENTRAL = new MavenRepository("central", "https://repo.maven.apache.org/maven2", true, false, true, null, null, true);
+
+    public static final MavenRepository MAVEN_LOCAL_USER_NEUTRAL = new MavenRepository("local", new File("~/.m2/repository").toString(), "true", "true", true, null, null, false);
+    public static final MavenRepository MAVEN_LOCAL_DEFAULT = new MavenRepository("local", new File(System.getProperty("user.home") + "/.m2/repository").toURI().toString(), "true", "true", true, null, null, false);
+    public static final MavenRepository MAVEN_CENTRAL = new MavenRepository("central", "https://repo.maven.apache.org/maven2", "true", "false", true, null, null, true);
 
     @EqualsAndHashCode.Include
     @With
@@ -78,7 +80,10 @@ public class MavenRepository {
     Boolean deriveMetadataIfMissing;
 
     @JsonIgnore
-    public MavenRepository(@Nullable String id, String uri, @Nullable String releases, @Nullable String snapshots, boolean knownToExist, @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing) {
+    public MavenRepository(
+            @Nullable String id, String uri, @Nullable String releases, @Nullable String snapshots, boolean knownToExist,
+            @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing
+    ) {
         this.id = id;
         this.uri = uri;
         this.releases = releases;
@@ -89,26 +94,47 @@ public class MavenRepository {
         this.deriveMetadataIfMissing = deriveMetadataIfMissing;
     }
 
-    // Two overloaded constructors to make it convient to use booleans for releases/snapshots
-    @JsonIgnore
-    public MavenRepository(@Nullable String id, String uri, boolean releases, boolean snapshots, @Nullable String username, @Nullable String password) {
-        this.id = id;
-        this.uri = uri;
-        this.releases = Boolean.toString(releases);
-        this.snapshots = Boolean.toString(snapshots);
-        this.username = username;
-        this.password = password;
+    public static Builder builder() {
+        return new Builder();
     }
 
-    @JsonIgnore
-    public MavenRepository(@Nullable String id, String uri, boolean releases, boolean snapshots, boolean knownToExist, @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing) {
-        this.id = id;
-        this.uri = uri;
-        this.releases = Boolean.toString(releases);
-        this.snapshots = Boolean.toString(snapshots);
-        this.knownToExist = knownToExist;
-        this.username = username;
-        this.password = password;
-        this.deriveMetadataIfMissing = deriveMetadataIfMissing;
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @Accessors(chain = true)
+    public static class Builder {
+        String id;
+        String uri;
+
+        String releases;
+        String snapshots;
+        boolean knownToExist;
+        String username;
+        String password;
+        Boolean deriveMetadataIfMissing;
+
+        private Builder() {
+        }
+
+        public MavenRepository build() {
+            return new MavenRepository(id, uri, releases, snapshots, knownToExist, username, password, deriveMetadataIfMissing);
+        }
+
+        public Builder setReleases(boolean releases) {
+            this.releases = Boolean.toString(releases);
+            return this;
+        }
+        public Builder setReleases(String releases) {
+            this.releases = releases;
+            return this;
+        }
+        public Builder setSnapshots(boolean snapshots) {
+            this.snapshots = Boolean.toString(snapshots);
+            return this;
+        }
+
+        public Builder setSnapshots(String snapshots) {
+            this.snapshots = snapshots;
+            return this;
+        }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -51,11 +51,13 @@ public class MavenRepository {
 
     @EqualsAndHashCode.Include
     @With
-    boolean releases;
+    @Nullable
+    String releases;
 
     @EqualsAndHashCode.Include
     @With
-    boolean snapshots;
+    @Nullable
+    String snapshots;
 
     @NonFinal
     boolean knownToExist;
@@ -76,7 +78,7 @@ public class MavenRepository {
     Boolean deriveMetadataIfMissing;
 
     @JsonIgnore
-    public MavenRepository(@Nullable String id, String uri, boolean releases, boolean snapshots, boolean knownToExist, @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing) {
+    public MavenRepository(@Nullable String id, String uri, @Nullable String releases, @Nullable String snapshots, boolean knownToExist, @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing) {
         this.id = id;
         this.uri = uri;
         this.releases = releases;
@@ -87,13 +89,26 @@ public class MavenRepository {
         this.deriveMetadataIfMissing = deriveMetadataIfMissing;
     }
 
-    public boolean acceptsVersion(String version) {
-        if (version.endsWith("-SNAPSHOT")) {
-            return snapshots;
-        } else if ("https://repo.spring.io/milestone".equalsIgnoreCase(uri)) {
-            // special case this repository since it will be so commonly used
-            return version.matches(".*(M|RC)\\d+$");
-        }
-        return releases;
+    // Two overloaded constructors to make it convient to use booleans for releases/snapshots
+    @JsonIgnore
+    public MavenRepository(@Nullable String id, String uri, boolean releases, boolean snapshots, @Nullable String username, @Nullable String password) {
+        this.id = id;
+        this.uri = uri;
+        this.releases = Boolean.toString(releases);
+        this.snapshots = Boolean.toString(snapshots);
+        this.username = username;
+        this.password = password;
+    }
+
+    @JsonIgnore
+    public MavenRepository(@Nullable String id, String uri, boolean releases, boolean snapshots, boolean knownToExist, @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing) {
+        this.id = id;
+        this.uri = uri;
+        this.releases = Boolean.toString(releases);
+        this.snapshots = Boolean.toString(snapshots);
+        this.knownToExist = knownToExist;
+        this.username = username;
+        this.password = password;
+        this.deriveMetadataIfMissing = deriveMetadataIfMissing;
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -100,7 +100,7 @@ public class MavenRepository {
 
     @Data
     @FieldDefaults(level = AccessLevel.PRIVATE)
-    @Accessors(chain = true)
+    @Accessors(fluent = true, chain = true)
     public static class Builder {
         String id;
         String uri;
@@ -119,20 +119,20 @@ public class MavenRepository {
             return new MavenRepository(id, uri, releases, snapshots, knownToExist, username, password, deriveMetadataIfMissing);
         }
 
-        public Builder setReleases(boolean releases) {
+        public Builder releases(boolean releases) {
             this.releases = Boolean.toString(releases);
             return this;
         }
-        public Builder setReleases(String releases) {
+        public Builder releases(String releases) {
             this.releases = releases;
             return this;
         }
-        public Builder setSnapshots(boolean snapshots) {
+        public Builder snapshots(boolean snapshots) {
             this.snapshots = Boolean.toString(snapshots);
             return this;
         }
 
-        public Builder setSnapshots(String snapshots) {
+        public Builder snapshots(String snapshots) {
             this.snapshots = snapshots;
             return this;
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
@@ -66,8 +66,8 @@ public class MavenRepositoryMirror {
         if (matches(repo) && !(repo.getUri().equals(url) && id.equals(repo.getId()))) {
             return repo.withUri(url)
                     .withId(id)
-                    .withReleases(!Boolean.FALSE.equals(releases))
-                    .withSnapshots(Boolean.TRUE.equals(snapshots));
+                    .withReleases(!Boolean.FALSE.equals(releases) ? "true" : "false")
+                    .withSnapshots(!Boolean.FALSE.equals(snapshots) ? "true" : "false");
         } else {
             return repo;
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -48,7 +48,7 @@ public class Pom {
      */
     public static int getModelVersion() {
         //NOTE: This value should be incremented if there are any model changes to Pom (or one of its referenced types)
-        return 1;
+        return 2;
     }
 
     @Nullable

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -49,6 +49,15 @@ public class ResolvedDependency {
 
     List<License> licenses;
 
+    @Nullable
+    String type;
+
+    @Nullable
+    String classifier;
+
+    @Nullable
+    Boolean optional;
+
     int depth;
 
     /**
@@ -76,16 +85,18 @@ public class ResolvedDependency {
     }
 
     public String getType() {
+        if (type != null) {
+            return type;
+        }
         return requested.getType() == null ? "jar" : requested.getType();
     }
 
-    @Nullable
-    public String getClassifier() {
-        return requested.getClassifier();
+    public @Nullable String getClassifier() {
+        return classifier != null ? classifier : requested.getClassifier();
     }
 
     public boolean isOptional() {
-        return requested.isOptional();
+        return optional != null ? optional : Boolean.valueOf(requested.getOptional());
     }
 
     public boolean isDirect() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -85,24 +85,14 @@ public class ResolvedDependency {
     }
 
     public String getType() {
-        if (type != null) {
-            return type;
-        }
-        return requested.getType() == null ? "jar" : requested.getType();
-    }
-
-    public @Nullable String getClassifier() {
-        return classifier != null ? classifier : requested.getClassifier();
-    }
-
-    public boolean isOptional() {
-        return optional != null ? optional : Boolean.valueOf(requested.getOptional());
+        return type == null ? "jar" : type;
     }
 
     public boolean isDirect() {
         return depth == 0;
     }
 
+    @SuppressWarnings("unused")
     public boolean isTransitive() {
         return depth != 0;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -18,8 +18,7 @@ package org.openrewrite.maven.tree;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import lombok.Value;
-import lombok.With;
+import lombok.*;
 import lombok.experimental.NonFinal;
 import org.openrewrite.internal.lang.Nullable;
 
@@ -30,6 +29,8 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
 @Value
 @With
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class ResolvedDependency {
     /**
      * This will be {@code null} when this is a project dependency.

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -424,8 +424,8 @@ public class ResolvedPom {
                     MavenRepository incoming = new MavenRepository(
                             getValue(incomingRepository.getId()),
                             getValue(incomingRepository.getUri()),
-                            incomingRepository.isReleases(),
-                            incomingRepository.isSnapshots(),
+                            incomingRepository.getReleases(),
+                            incomingRepository.getSnapshots(),
                             incomingRepository.isKnownToExist(),
                             incomingRepository.getUsername(),
                             incomingRepository.getPassword(),
@@ -590,6 +590,9 @@ public class ResolvedPom {
                     ResolvedDependency resolved = new ResolvedDependency(dPom.getRepository(),
                             resolvedPom.getGav(), dd.getDependency(), emptyList(),
                             resolvedPom.getRequested().getLicenses(),
+                            resolvedPom.getValue(dd.getDependency().getType()),
+                            resolvedPom.getValue(dd.getDependency().getClassifier()),
+                            Boolean.valueOf(resolvedPom.getValue(dd.getDependency().getOptional())),
                             depth);
 
                     MavenExecutionContextView.view(ctx)
@@ -612,7 +615,8 @@ public class ResolvedPom {
                         if (d2.getGroupId() == null) {
                             d2 = d2.withGav(d2.getGav().withGroupId(resolvedPom.getGroupId()));
                         }
-                        if (d2.isOptional()) {
+                        String optional = resolvedPom.getValue(d2.getOptional());
+                        if (optional != null && Boolean.parseBoolean(optional.trim())) {
                             continue;
                         }
                         if (d.getExclusions() != null) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -46,7 +46,7 @@ public class MavenDependencyFailuresTest implements RewriteTest {
           spec -> spec
             .recipe(new UpgradeDependencyVersion("*", "*", "latest.patch", null, null, null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
-              .setRepositories(List.of(new MavenRepository("jenkins", "https://repo.jenkins-ci.org/public", true, false, true, null, null, null))))
+              .setRepositories(List.of(MavenRepository.builder().setId("jenkins").setUri("https://repo.jenkins-ci.org/public").build())))
             .recipeExecutionContext(new InMemoryExecutionContext())
             .cycles(1)
             .expectedCyclesThatMakeChanges(1)
@@ -87,7 +87,7 @@ public class MavenDependencyFailuresTest implements RewriteTest {
           spec -> spec
             .recipe(new UpgradeParentVersion("*", "*", "latest.patch", null, null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
-              .setRepositories(List.of(new MavenRepository("jenkins", "https://repo.jenkins-ci.org/public", true, false, true, null, null, null))))
+              .setRepositories(List.of(MavenRepository.builder().setId("jenkins").setUri("https://repo.jenkins-ci.org/public").setKnownToExist(true).build())))
             .recipeExecutionContext(new InMemoryExecutionContext())
             .cycles(1)
             .expectedCyclesThatMakeChanges(1),
@@ -142,7 +142,8 @@ public class MavenDependencyFailuresTest implements RewriteTest {
             """
         );
 
-        MavenRepository mavenLocal = new MavenRepository("local", localRepository.toUri().toString(), true, false, true, null, null, null);
+        MavenRepository mavenLocal = MavenRepository.builder().setId("local").setUri(localRepository.toUri().toString())
+          .setSnapshots(false).setKnownToExist(true).build();
 
         rewriteRun(
           spec -> spec

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,7 +45,7 @@ public class MavenDependencyFailuresTest implements RewriteTest {
           spec -> spec
             .recipe(new UpgradeDependencyVersion("*", "*", "latest.patch", null, null, null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
-              .setRepositories(List.of(MavenRepository.builder().setId("jenkins").setUri("https://repo.jenkins-ci.org/public").build())))
+              .setRepositories(List.of(MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public").build())))
             .recipeExecutionContext(new InMemoryExecutionContext())
             .cycles(1)
             .expectedCyclesThatMakeChanges(1)
@@ -87,7 +86,7 @@ public class MavenDependencyFailuresTest implements RewriteTest {
           spec -> spec
             .recipe(new UpgradeParentVersion("*", "*", "latest.patch", null, null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
-              .setRepositories(List.of(MavenRepository.builder().setId("jenkins").setUri("https://repo.jenkins-ci.org/public").setKnownToExist(true).build())))
+              .setRepositories(List.of(MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public").knownToExist(true).build())))
             .recipeExecutionContext(new InMemoryExecutionContext())
             .cycles(1)
             .expectedCyclesThatMakeChanges(1),
@@ -142,8 +141,8 @@ public class MavenDependencyFailuresTest implements RewriteTest {
             """
         );
 
-        MavenRepository mavenLocal = MavenRepository.builder().setId("local").setUri(localRepository.toUri().toString())
-          .setSnapshots(false).setKnownToExist(true).build();
+        MavenRepository mavenLocal = MavenRepository.builder().id("local").uri(localRepository.toUri().toString())
+          .snapshots(false).knownToExist(true).build();
 
         rewriteRun(
           spec -> spec

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -65,7 +65,7 @@ class UpgradeParentVersionTest implements RewriteTest {
               MavenExecutionContextView
                 .view(new InMemoryExecutionContext())
                 .setRepositories(List.of(
-                  MavenRepository.builder().setId("jenkins").setUri("https://repo.jenkins-ci.org/public/").build()
+                  MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public/").build()
                 ))
             ),
           pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -65,7 +65,7 @@ class UpgradeParentVersionTest implements RewriteTest {
               MavenExecutionContextView
                 .view(new InMemoryExecutionContext())
                 .setRepositories(List.of(
-                  new MavenRepository("jenkins", "https://repo.jenkins-ci.org/public/", true, true, null, null)
+                  MavenRepository.builder().setId("jenkins").setUri("https://repo.jenkins-ci.org/public/").build()
                 ))
             ),
           pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cache/RocksdbMavenCacheTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cache/RocksdbMavenCacheTest.java
@@ -32,33 +32,35 @@ public class RocksdbMavenCacheTest {
     void invalidateCacheOnModelChange(@TempDir Path tempDir) throws Exception {
 
         String pathString = tempDir.resolve(".rewrite-cache").toString();
+        try {
+            //Create Cache
+            RocksdbMavenPomCache mavenCache = new RocksdbMavenPomCache(tempDir);
 
-        //Create Cache
-        RocksdbMavenPomCache mavenCache = new RocksdbMavenPomCache(tempDir);
+            //Add a pom:
+            Pom pom = parsePomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.foo</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.0</version>
+                    <name>test</name>
+                </project>
+                """);
 
-        //Add a pom:
-        Pom pom = parsePomXml(
-          """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.foo</groupId>
-                <artifactId>test</artifactId>
-                <version>1.0.0</version>
-                <name>test</name>
-            </project>
-            """);
+            mavenCache.putPom(pom.getGav(), pom);
+            RocksdbMavenPomCache.RocksCache cache = RocksdbMavenPomCache.getCache(pathString);
 
-        mavenCache.putPom(pom.getGav(), pom);
-        RocksdbMavenPomCache.RocksCache cache = RocksdbMavenPomCache.getCache(pathString);
+            // Reset model version to 0, close.
+            cache.updateDatabaseModelVersion(0);
+            RocksdbMavenPomCache.closeCache(pathString);
 
-        // Reset model version to 0, close.
-        cache.updateDatabaseModelVersion(0);
-        RocksdbMavenPomCache.closeCache(pathString);
-
-        //Re-open, the versions do not match, expect the database to be purged and no entry should be present
-        mavenCache = new RocksdbMavenPomCache(tempDir);
-
-        assertThat(mavenCache.getPom(pom.getGav())).isNull();
+            //Re-open, the versions do not match, expect the database to be purged and no entry should be present
+            mavenCache = new RocksdbMavenPomCache(tempDir);
+            assertThat(mavenCache.getPom(pom.getGav())).isNull();
+        } finally {
+            RocksdbMavenPomCache.closeCache(pathString);
+        }
     }
 
 
@@ -67,30 +69,34 @@ public class RocksdbMavenCacheTest {
 
         String pathString = tempDir.resolve(".rewrite-cache").toString();
 
-        //Create Cache
-        RocksdbMavenPomCache mavenCache = new RocksdbMavenPomCache(tempDir);
+        try {
+            //Create Cache
+            RocksdbMavenPomCache mavenCache = new RocksdbMavenPomCache(tempDir);
 
-        //Add a pom:
-        Pom pom = parsePomXml(
-          """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.foo</groupId>
-                <artifactId>test</artifactId>
-                <version>1.0.1</version>
-                <name>test</name>
-            </project>
-            """);
+            //Add a pom:
+            Pom pom = parsePomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.foo</groupId>
+                    <artifactId>test</artifactId>
+                    <version>1.0.1</version>
+                    <name>test</name>
+                </project>
+                """);
 
-        mavenCache.putPom(pom.getGav(), pom);
-        RocksdbMavenPomCache.closeCache(pathString);
+            mavenCache.putPom(pom.getGav(), pom);
+            RocksdbMavenPomCache.closeCache(pathString);
 
-        //Re-open and ensure cached value is correct.
-        mavenCache = new RocksdbMavenPomCache(tempDir);
+            //Re-open and ensure cached value is correct.
+            mavenCache = new RocksdbMavenPomCache(tempDir);
 
-        Optional<Pom> cached = mavenCache.getPom(pom.getGav());
-        assertThat(cached).isPresent();
-        assertThat(cached.get().getGav()).isEqualTo(pom.getGav());
+            Optional<Pom> cached = mavenCache.getPom(pom.getGav());
+            assertThat(cached).isPresent();
+            assertThat(cached.get().getGav()).isEqualTo(pom.getGav());
+        } finally {
+            RocksdbMavenPomCache.closeCache(pathString);
+        }
     }
 
     private Pom parsePomXml(String pom) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -78,7 +78,7 @@ class MavenPomDownloaderTest {
     void normalizeOssSnapshots() {
         var downloader = new MavenPomDownloader(emptyMap(), ctx);
         MavenRepository oss = downloader.normalizeRepository(
-          MavenRepository.builder().setId("oss").setUri("https://oss.sonatype.org/content/repositories/snapshots").build(),
+          MavenRepository.builder().id("oss").uri("https://oss.sonatype.org/content/repositories/snapshots").build(),
           null);
 
         assertThat(oss).isNotNull();
@@ -91,8 +91,8 @@ class MavenPomDownloaderTest {
         var downloader = new MavenPomDownloader(emptyMap(), ctx);
         mockServer(status, mockRepo -> {
             var originalRepo = MavenRepository.builder()
-              .setId("id")
-              .setUri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+              .id("id")
+              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
               .build();
             var normalizedRepo = downloader.normalizeRepository(originalRepo, null);
             assertThat(normalizedRepo).isEqualTo(originalRepo);
@@ -103,7 +103,7 @@ class MavenPomDownloaderTest {
     void normalizeRejectConnectException() {
         var downloader = new MavenPomDownloader(emptyMap(), ctx);
         var normalizedRepository = downloader.normalizeRepository(
-          MavenRepository.builder().setId("id").setUri("https//localhost").build(),
+          MavenRepository.builder().id("id").uri("https//localhost").build(),
           null
         );
         assertThat(normalizedRepository).isEqualTo(null);
@@ -117,12 +117,12 @@ class MavenPomDownloaderTest {
           repo1 -> mockServer(400, repo2 -> {
               var repositories = List.of(
                 MavenRepository.builder()
-                  .setId("id")
-                  .setUri("http://%s:%d/maven".formatted(repo1.getHostName(), repo1.getPort()))
+                  .id("id")
+                  .uri("http://%s:%d/maven".formatted(repo1.getHostName(), repo1.getPort()))
                   .build(),
                 MavenRepository.builder()
-                  .setId("id2")
-                  .setUri("http://%s:%d/maven".formatted(repo2.getHostName(), repo2.getPort()))
+                  .id("id2")
+                  .uri("http://%s:%d/maven".formatted(repo2.getHostName(), repo2.getPort()))
                   .build()
               );
 
@@ -157,10 +157,10 @@ class MavenPomDownloaderTest {
             });
             mockRepo.start();
             var repositories = List.of(MavenRepository.builder()
-              .setId("id")
-              .setUri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .setUsername("user")
-              .setPassword("pass")
+              .id("id")
+              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+              .username("user")
+              .password("pass")
               .build());
 
             assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
@@ -192,10 +192,10 @@ class MavenPomDownloaderTest {
             });
             mockRepo.start();
             var repositories = List.of(MavenRepository.builder()
-              .setId("id")
-              .setUri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .setUsername("user")
-              .setPassword("pass")
+              .id("id")
+              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+              .username("user")
+              .password("pass")
               .build());
 
             assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
@@ -321,10 +321,10 @@ class MavenPomDownloaderTest {
         Files.createDirectories(fred.resolve("2.0.0"));
 
         MavenRepository repository = MavenRepository.builder()
-          .setId("file-based")
-          .setUri(repoPath.toUri().toString())
-          .setKnownToExist(true)
-          .setDeriveMetadataIfMissing(true)
+          .id("file-based")
+          .uri(repoPath.toUri().toString())
+          .knownToExist(true)
+          .deriveMetadataIfMissing(true)
           .build();
         MavenMetadata metaData  = new MavenPomDownloader(emptyMap(), new InMemoryExecutionContext())
           .downloadMetadata(new GroupArtifact("fred", "fred"), null, List.of(repository));


### PR DESCRIPTION
Previously, the maven model was using Boolean in three places where flags can be defined in the pom files. The problem with using Booleans is that these fields will fail to deserialize if a property placeholder is used for those flags: 

The three places this was an issue were: 

```
<repositories>
  <repository>
    <releases><enabled>${prop}</enabled></releases>
    <snapshots><enabled>${prop}</enabled></snapshots>
  </repository>
</repositories>
 ...
 <dependencies>
   <dependency>
     <optional>${prop}</opitional>
   </dependency>
 </dependencies>
 ```
 
 To address this issue, these three fields need to be represented as nullable strings in both the `RawPom`, `Dependency`, and `MavenRepository` data models. 
 
All references to these fields in the code base have been swept to treat them as null strings and when a ResolvedPom is present, the fields will correctly handle any property placeholders.

- MavenRepository has several overloaded constructors to maintain existing contracts in the code while still using Strings to represent the flags.
- ResolvedDependency has three additional fields to represent type, classifier, and optional. These are the "resolved" fields after property placeholders have been resolved. To maintain backward compatibility, if these fields are null, the requested fields will be used.

 
 
 
