### PR TITLE
Add tree visiting hierarchy printer

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
@@ -1,0 +1,171 @@
+package org.openrewrite.java;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.J;
+
+import static java.util.stream.StreamSupport.*;
+
+
+/**
+ * A visitor to print a tree visiting order and hierarchy in format like below.
+ * <pre>
+ * #root
+ * \---J.CompilationUnit | "..."
+ *     |---#JRightPadded
+ *     |   \---J.Import | "..."
+ *     \---J.ClassDeclaration | "..."
+ *         |---J.Identifier | "..."
+ *         \---#JRightPadded
+ *             \---J.Return | "..."
+ * </pre>
+ */
+public class TreeVisitingPrinter extends JavaIsoVisitor<ExecutionContext> {
+    private static final String TAB = "    ";
+    private static final String PREFIX = "\\---";
+    // this prefix means it will not be visited by a visitX method
+    private static final String SKIPPED_PADDED_PREFIX = "#";
+    private static final char BRANCH_CONTINUE_CHAR = '|';
+    private static final char BRANCH_END_CHAR = '\\';
+
+    private List<Object> lastCursorStack;
+    private final List<StringBuilder> outputLines;
+
+    protected TreeVisitingPrinter() {
+        lastCursorStack = new ArrayList<>();
+        outputLines = new ArrayList<>();
+    }
+
+    public static String printTree(J j) {
+        TreeVisitingPrinter visitor = new TreeVisitingPrinter();
+        visitor.visit(j, new InMemoryExecutionContext());
+        return visitor.print();
+    }
+
+    private String print() {
+        return String.join("\n", outputLines);
+    }
+
+    /**
+     * print left padding for a line
+     * @param depth, depth starts from 0 (the root)
+     */
+    private static String leftPadding(int depth) {
+        StringBuilder sb = new StringBuilder();
+        int tabCount = depth - 1;
+        if (tabCount > 0) {
+            sb.append(String.join("", Collections.nCopies(tabCount, TAB)));
+        }
+        // only root has not prefix
+        if (depth > 0) {
+            sb.append(PREFIX);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Print a vertical line that connects the current element to the latest sibling.
+     * @param depth current element depth
+     */
+    private void connectToLatestSibling(int depth) {
+        if (depth <= 1) {
+            return;
+        }
+
+        int pos = (depth - 1) * TAB.length();
+        for (int j = outputLines.size() - 1; j > 0; j--) {
+            StringBuilder line = outputLines.get(j);
+            if (pos >= line.length()) {
+                break;
+            }
+
+            if (line.charAt(pos) != ' ') {
+                if (line.charAt(pos) == BRANCH_END_CHAR) {
+                    line.setCharAt(pos, BRANCH_CONTINUE_CHAR);
+                }
+                break;
+            }
+            line.setCharAt(pos, BRANCH_CONTINUE_CHAR);
+        }
+    }
+
+    private static String printTreeElement(Tree tree) {
+        // skip some specific types printed in the output to make the output looks clean
+        if (tree instanceof J.CompilationUnit
+            || tree instanceof J.ClassDeclaration
+            || tree instanceof J.Block
+            || tree instanceof J.Empty
+            || tree instanceof J.Literal
+            || tree instanceof J.Try
+            || tree instanceof J.Try.Catch
+            || tree instanceof J.WhileLoop
+        ) {
+            return "";
+        }
+
+        return tree.toString();
+    }
+
+    @Override
+    public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree == null) {
+            return super.visit((Tree) null, ctx);
+        }
+
+        Cursor cursor = this.getCursor();
+        List<Object> cursorStack =
+            stream(Spliterators.spliteratorUnknownSize(cursor.getPath(), 0), false)
+                .collect(Collectors.toList());
+        Collections.reverse(cursorStack);
+        int depth = cursorStack.size();
+
+        // Compare lastCursorStack vs cursorStack, find the fork and print the diff
+        int diffPos = -1;
+        for (int i = 0; i < cursorStack.size(); i++) {
+            if (i >= lastCursorStack.size() || cursorStack.get(i) != lastCursorStack.get(i)) {
+                diffPos = i;
+                break;
+            }
+        }
+
+        // print new added lines in the cursor stack
+        if (diffPos >= 0) {
+            for (int i = diffPos; i < cursorStack.size(); i++) {
+                Object element = cursorStack.get(i);
+                connectToLatestSibling(i);
+                StringBuilder newLine = new StringBuilder()
+                    .append(leftPadding(i))
+                    .append(SKIPPED_PADDED_PREFIX)
+                    .append(element instanceof String ? element : element.getClass().getSimpleName());
+                outputLines.add(newLine);
+            }
+        }
+
+        connectToLatestSibling(depth);
+
+        // print current visiting element
+        StringBuilder line = new StringBuilder();
+        String typeName = tree instanceof J ? tree.getClass()
+            .getCanonicalName()
+            .substring(tree.getClass().getPackage().getName().length() + 1) : tree.getClass().getCanonicalName();
+
+        line.append(leftPadding(depth)).append(typeName);
+        String content = printTreeElement(tree);
+        if (!content.isEmpty()) {
+            line.append(" | \"").append(content).append("\"");
+        }
+        outputLines.add(line);
+
+        cursorStack.add(tree);
+        lastCursorStack = cursorStack;
+        return super.visit(tree, ctx);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
@@ -81,8 +81,8 @@ public class TreeVisitingPrinter extends JavaIsoVisitor<ExecutionContext> {
         }
 
         int pos = (depth - 1) * TAB.length();
-        for (int j = outputLines.size() - 1; j > 0; j--) {
-            StringBuilder line = outputLines.get(j);
+        for (int i = outputLines.size() - 1; i > 0; i--) {
+            StringBuilder line = outputLines.get(i);
             if (pos >= line.length()) {
                 break;
             }
@@ -153,9 +153,9 @@ public class TreeVisitingPrinter extends JavaIsoVisitor<ExecutionContext> {
 
         // print current visiting element
         StringBuilder line = new StringBuilder();
-        String typeName = tree instanceof J ? tree.getClass()
-            .getCanonicalName()
-            .substring(tree.getClass().getPackage().getName().length() + 1) : tree.getClass().getCanonicalName();
+        String typeName = tree instanceof J
+            ? tree.getClass().getCanonicalName().substring(tree.getClass().getPackage().getName().length() + 1)
+            : tree.getClass().getCanonicalName();
 
         line.append(leftPadding(depth)).append(typeName);
         String content = printTreeElement(tree);


### PR DESCRIPTION
Add a visitor to print LST visiting order and hierarchy.
This visitor can help new developers (including me) to understand what the LST looks like, and what `visitX` method should use when implementing a recipe.

An example:
Code :
```
              import java.io.BufferedReader;
              class T {
                  public void doSomething(StringBuilder sb, BufferedReader br) {
                      String line;
                      try {
                          while ((line = br.readLine()) != null) {
                              sb.append(line);
                          }
                      } catch (Exception e) {
                          error("Exception", e);
                      }
                  }
                  private static void error(String s, Exception e) {
                  
                  }
              }
```

an example usage, add this code in any recipe visitor to print the LST to the console.
```
            @Override
            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
                System.out.println("------visitCompilationUnit LST Tree Start------");
                System.out.println(TreeVisitingPrinter.printTree(cu));
                System.out.println("------visitCompilationUnit LST Tree End------");
                return super.visitCompilationUnit(cu, executionContext);
            }
```

output
```
------visitCompilationUnit LST Tree Start------
#root
\---J.CompilationUnit
    |---#JRightPadded
    |   \---J.Import | "import java.io.BufferedReader"
    |       \---J.FieldAccess | "java.io.BufferedReader"
    |           |---J.FieldAccess | "java.io"
    |           |   |---J.Identifier | "java"
    |           |   \---#JLeftPadded
    |           |       \---J.Identifier | "io"
    |           \---#JLeftPadded
    |               \---J.Identifier | "BufferedReader"
    \---J.ClassDeclaration
        |---J.Identifier | "T"
        \---J.Block
            |---#JRightPadded
            |   \---J.MethodDeclaration | "MethodDeclaration{T{name=doSomething,return=void,parameters=[java.lang.StringBuilder,java.io.BufferedReader]}}"
            |       |---J.Modifier | "public"
            |       |---J.Primitive | "void"
            |       |---J.Identifier | "doSomething"
            |       |---#JContainer
            |       |   |---#JRightPadded
            |       |   |   \---J.VariableDeclarations | "StringBuilder sb"
            |       |   |       |---J.Identifier | "StringBuilder"
            |       |   |       \---#JRightPadded
            |       |   |           \---J.VariableDeclarations.NamedVariable | "sb"
            |       |   |               \---J.Identifier | "sb"
            |       |   \---#JRightPadded
            |       |       \---J.VariableDeclarations | "BufferedReader br"
            |       |           |---J.Identifier | "BufferedReader"
            |       |           \---#JRightPadded
            |       |               \---J.VariableDeclarations.NamedVariable | "br"
            |       |                   \---J.Identifier | "br"
            |       \---J.Block
            |           |---#JRightPadded
            |           |   \---J.VariableDeclarations | "String line"
            |           |       |---J.Identifier | "String"
            |           |       \---#JRightPadded
            |           |           \---J.VariableDeclarations.NamedVariable | "line"
            |           |               \---J.Identifier | "line"
            |           \---#JRightPadded
            |               \---J.Try
            |                   |---J.Block
            |                   |   \---#JRightPadded
            |                   |       \---J.WhileLoop
            |                   |           |---J.ControlParentheses | "((line = br.readLine()) != null)"
            |                   |           |   \---#JRightPadded
            |                   |           |       \---J.Binary | "(line = br.readLine()) != null"
            |                   |           |           |---J.Parentheses | "(line = br.readLine())"
            |                   |           |           |   \---#JRightPadded
            |                   |           |           |       \---J.Assignment | "line = br.readLine()"
            |                   |           |           |           |---J.Identifier | "line"
            |                   |           |           |           \---#JLeftPadded
            |                   |           |           |               \---J.MethodInvocation | "br.readLine()"
            |                   |           |           |                   |---#JRightPadded
            |                   |           |           |                   |   \---J.Identifier | "br"
            |                   |           |           |                   |---J.Identifier | "readLine"
            |                   |           |           |                   \---#JContainer
            |                   |           |           |                       \---#JRightPadded
            |                   |           |           |                           \---J.Empty
            |                   |           |           \---J.Literal
            |                   |           \---#JRightPadded
            |                   |               \---J.Block
            |                   |                   \---#JRightPadded
            |                   |                       \---J.MethodInvocation | "sb.append(line)"
            |                   |                           |---#JRightPadded
            |                   |                           |   \---J.Identifier | "sb"
            |                   |                           |---J.Identifier | "append"
            |                   |                           \---#JContainer
            |                   |                               \---#JRightPadded
            |                   |                                   \---J.Identifier | "line"
            |                   \---J.Try.Catch
            |                       |---J.ControlParentheses | "(Exception e)"
            |                       |   \---#JRightPadded
            |                       |       \---J.VariableDeclarations | "Exception e"
            |                       |           |---J.Identifier | "Exception"
            |                       |           \---#JRightPadded
            |                       |               \---J.VariableDeclarations.NamedVariable | "e"
            |                       |                   \---J.Identifier | "e"
            |                       \---J.Block
            |                           \---#JRightPadded
            |                               \---J.MethodInvocation | "error("Exception", e)"
            |                                   |---J.Identifier | "error"
            |                                   \---#JContainer
            |                                       |---#JRightPadded
            |                                       |   \---J.Literal
            |                                       \---#JRightPadded
            |                                           \---J.Identifier | "e"
            \---#JRightPadded
                \---J.MethodDeclaration | "MethodDeclaration{T{name=error,return=void,parameters=[java.lang.String,java.lang.Exception]}}"
                    |---J.Modifier | "private"
                    |---J.Modifier | "static"
                    |---J.Primitive | "void"
                    |---J.Identifier | "error"
                    |---#JContainer
                    |   |---#JRightPadded
                    |   |   \---J.VariableDeclarations | "String s"
                    |   |       |---J.Identifier | "String"
                    |   |       \---#JRightPadded
                    |   |           \---J.VariableDeclarations.NamedVariable | "s"
                    |   |               \---J.Identifier | "s"
                    |   \---#JRightPadded
                    |       \---J.VariableDeclarations | "Exception e"
                    |           |---J.Identifier | "Exception"
                    |           \---#JRightPadded
                    |               \---J.VariableDeclarations.NamedVariable | "e"
                    |                   \---J.Identifier | "e"
                    \---J.Block
------visitCompilationUnit LST Tree End------
```