### PR TITLE
Adding visited-file details to unexpected exceptions

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -321,6 +321,11 @@ public abstract class TreeVisitor<T extends Tree, P> {
                 throw e;
             }
 
+            final String visitedLocation = describeLocation(getCursor());
+            if (visitedLocation != null) {
+                throw new RecipeRunException(e, getCursor(),
+                        String.format("Exception while visiting project file '%s'", visitedLocation));
+            }
             throw new RecipeRunException(e, getCursor());
         }
 
@@ -409,5 +414,14 @@ public abstract class TreeVisitor<T extends Tree, P> {
             throw new IllegalArgumentException(getClass().getSimpleName() + " must be adaptable to " + adaptTo.getName() + ".");
         }
         return TreeVisitorAdapter.adapt(this, adaptTo);
+    }
+
+    @Nullable
+    protected String describeLocation(Cursor cursor) {
+        SourceFile sourceFile = cursor.firstEnclosing(SourceFile.class);
+        if (sourceFile == null) {
+            return null;
+        }
+        return sourceFile.getSourcePath().toString();
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -321,12 +321,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
                 throw e;
             }
 
-            final String visitedLocation = describeLocation(getCursor());
-            if (visitedLocation != null) {
-                throw new RecipeRunException(e, getCursor(),
-                        String.format("Exception while visiting project file '%s'", visitedLocation));
-            }
-            throw new RecipeRunException(e, getCursor());
+            throw new RecipeRunException(e, getCursor(), describeLocation(getCursor()));
         }
 
         //noinspection unchecked

--- a/rewrite-core/src/main/java/org/openrewrite/internal/FindRecipeRunException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/FindRecipeRunException.java
@@ -34,7 +34,7 @@ public class FindRecipeRunException extends TreeVisitor<Tree, Integer> {
     @Override
     public Tree preVisit(Tree tree, Integer integer) {
         if (tree == nearestTree) {
-            return Markup.error(tree, vt.getCause());
+            return Markup.error(tree, vt);
         }
         return tree;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeRunException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeRunException.java
@@ -31,4 +31,9 @@ public class RecipeRunException extends RuntimeException {
         super(cause);
         this.cursor = cursor;
     }
+
+    public RecipeRunException(Throwable cause, @Nullable Cursor cursor, String message) {
+        super(String.format("%s, caused by: %s", message, cause.toString()), cause);
+        this.cursor = cursor;
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeRunException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeRunException.java
@@ -28,12 +28,17 @@ public class RecipeRunException extends RuntimeException {
     private final Cursor cursor;
 
     public RecipeRunException(Throwable cause, @Nullable Cursor cursor) {
-        super(cause);
+        this(cause, cursor, null);
+    }
+
+    public RecipeRunException(Throwable cause, @Nullable Cursor cursor, @Nullable String visitedLocation) {
+        super(message(visitedLocation, cause), cause);
         this.cursor = cursor;
     }
 
-    public RecipeRunException(Throwable cause, @Nullable Cursor cursor, String message) {
-        super(String.format("%s, caused by: %s", message, cause.toString()), cause);
-        this.cursor = cursor;
+    @Nullable
+    private static String message(@Nullable String visitedLocation, Throwable cause) {
+        return visitedLocation == null ? null
+                : String.format("Exception while visiting project file '%s', caused by: %s", visitedLocation, cause);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/Markup.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/Markup.java
@@ -23,6 +23,7 @@ import org.openrewrite.Incubating;
 import org.openrewrite.RecipeScheduler;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ExceptionUtils;
+import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 
@@ -84,13 +85,17 @@ public interface Markup extends Marker {
 
         @Override
         public String getMessage() {
-            return exception.getMessage();
+            return getCause().getMessage();
         }
 
         @Override
         @NonNull
         public String getDetail() {
-            return ExceptionUtils.sanitizeStackTrace(exception, RecipeScheduler.class);
+            return ExceptionUtils.sanitizeStackTrace(getCause(), RecipeScheduler.class);
+        }
+
+        private Throwable getCause() {
+            return exception instanceof RecipeRunException ? exception.getCause() : exception;
         }
 
         @Override
@@ -115,13 +120,17 @@ public interface Markup extends Marker {
 
         @Override
         public String getMessage() {
-            return exception.getMessage();
+            return getCause().getMessage();
         }
 
         @Override
         @NonNull
         public String getDetail() {
-            return ExceptionUtils.sanitizeStackTrace(exception, RecipeScheduler.class);
+            return ExceptionUtils.sanitizeStackTrace(getCause(), RecipeScheduler.class);
+        }
+
+        private Throwable getCause() {
+            return exception instanceof RecipeRunException ? exception.getCause() : exception;
         }
 
         @Override

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
@@ -33,7 +33,10 @@ public class RecipeSchedulerTest implements RewriteTest {
           spec -> spec
             .executionContext(new InMemoryExecutionContext())
             .recipe(new BoomRecipe())
-            .afterRecipe(run -> assertThat(run.getResults().get(0).getRecipeErrors()).isNotEmpty()),
+            .afterRecipe(run -> assertThat(run.getResults().get(0).getRecipeErrors())
+              .singleElement()
+              .satisfies(t -> assertThat(t.getMessage()).isEqualTo("Exception while visiting project file 'file.txt', caused by: org.openrewrite.BoomException: boom"))
+            ),
           text(
             "hello",
             "~~(boom)~~>hello"

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -1378,5 +1379,21 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      */
     protected boolean isInSameNameScope(Cursor child) {
         return isInSameNameScope(getCursor(), child);
+    }
+
+    @Override
+    protected @Nullable String describeLocation(Cursor cursor) {
+        List<String> namedElements = new ArrayList<>();
+        for (Iterator<Object> it = cursor.getPath(); it.hasNext(); ) {
+            final Object tree = it.next();
+            if (tree instanceof J.ClassDeclaration) {
+                namedElements.add(0, ((J.ClassDeclaration) tree).getSimpleName());
+            } else if (tree instanceof J.MethodDeclaration) {
+                namedElements.add(0, ((J.MethodDeclaration) tree).getSimpleName());
+            }
+        }
+        String location = String.join(".", namedElements);
+        String filename = super.describeLocation(cursor);
+        return "".equals(location) ? filename : String.format("%s (in %s)", filename, location);
     }
 }


### PR DESCRIPTION
Minimally, these exceptions will now include the visited file, and grammar-specific visitors can add more precise info (eg for JavaVisitor I've added quick logic to specify by class/method name).

Would be neat to expand with line numbers, but, I didn't see an obvious way to get that during a visit

#2655