### PR TITLE
Fix NameCaseConvention#matches(NameCaseConvention, String)

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
@@ -95,7 +95,7 @@ public enum NameCaseConvention {
     }
 
     public static boolean matches(NameCaseConvention convention, String str) {
-        return str.matches(format(convention, str));
+        return str.equals(format(convention, str));
     }
 
     /**

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCaseTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCaseTest.java
@@ -52,6 +52,19 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
+    @Test
+    void lowerCaseWithLeadingDollarCharacter() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  private String $t = "";
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2294")
     @Test
     void nameConflict() {


### PR DESCRIPTION
The internal method `NameCaseConvention#matches(NameCaseConvention, String)` should not do a regex match of the provided string, but rather an equality check.

There is a provided test case which otherwise fails. While a regex match would typically also work (although "overkill"), it fails if the variable name being matched contains a `$` character.
