### PR TITLE
Fix one positive case of `FinalizePrivateField` recipe and add more test cases

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -29,7 +29,7 @@ class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void filedWithInitializerMadeFinal() {
+    void fieldWithInitializerMadeFinal() {
         rewriteRun(
           java(
             """
@@ -53,7 +53,7 @@ class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void filedWithInitializerViaMethodMadeFinal() {
+    void fieldWithInitializerViaMethodMadeFinal() {
         rewriteRun(
           java(
             """
@@ -79,7 +79,7 @@ class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void filedAssignedInConstructorMadeFinal() {
+    void fieldAssignedInConstructorMadeFinal() {
         rewriteRun(
           java(
             """
@@ -229,7 +229,7 @@ class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void fieldOfAFiledReassignedByAMethodUsingThis() {
+    void fieldOfAFieldReassignedByAMethodUsingThis() {
         rewriteRun(
           java(
             """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -15,20 +15,21 @@
  */
 package org.openrewrite.java.cleanup;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class FinalizePrivateFieldsTest implements RewriteTest {
+class FinalizePrivateFieldsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FinalizePrivateFields());
     }
 
     @Test
-    void initializerMadeFinal() {
+    void filedWithInitializerMadeFinal() {
         rewriteRun(
           java(
             """
@@ -52,7 +53,7 @@ public class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void initByMethodMadeFinal() {
+    void filedWithInitializerViaMethodMadeFinal() {
         rewriteRun(
           java(
             """
@@ -78,7 +79,7 @@ public class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void InitByConstructorMadeFinal() {
+    void filedAssignedInConstructorMadeFinal() {
         rewriteRun(
           java(
             """
@@ -184,7 +185,84 @@ public class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void fieldReassignedByConstructor() {
+    void fieldReassignedByAMethodUsingThis() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name = "ABC";
+                  private int a = 0;
+
+                  void func() {
+                      this.name = "XYZ";
+                      this.a += 1;
+                  }
+
+                  String getName() {
+                      return name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldReassignedByAMethodUsingClassAndThis() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name = "ABC";
+
+                  void func() {
+                      A.this.name = "XYZ";
+                  }
+
+                  String getName() {
+                      return name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldOfAFiledReassignedByAMethodUsingThis() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private B b = new B();
+
+                  void func() {
+                      this.b.num = 1;
+                  }
+              }
+              """,
+            """
+              class A {
+                  private final B b = new B();
+
+                  void func() {
+                      this.b.num = 1;
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class B {
+                  public int num = 0;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldReassignedInConstructor() {
         rewriteRun(
           java(
             """
@@ -201,7 +279,119 @@ public class FinalizePrivateFieldsTest implements RewriteTest {
     }
 
     @Test
-    void constructorInitTwiceOrMore() {
+    void fieldAssignedInConstructorViaThis() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name;
+
+                  A() {
+                    this.name = "XYZ";
+                  }
+              }
+              """,
+            """
+              class A {
+                  private final String name;
+
+                  A() {
+                    this.name = "XYZ";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled ("Doesn't support multiple constructors, to be enhanced")
+    @Test
+    void fieldAssignedInAllAlternateConstructors() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name;
+
+                  A() {
+                    name = "XYZ";
+                  }
+                  A(String n) {
+                    name = n;
+                  }
+              }
+              """,
+            """
+              class A {
+                  private final String name;
+
+                  A() {
+                    name = "XYZ";
+                  }
+                  A(String n) {
+                    name = n;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldAssignedIndirectlyInAllAlternateConstructors() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name;
+
+                  A() {
+                    this("ABC");
+                  }
+                  A(String name) {
+                    this.name = name;
+                  }
+              }
+              """,
+            """
+              class A {
+                  private final String name;
+
+                  A() {
+                    this("ABC");
+                  }
+                  A(String name) {
+                    this.name = name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldReassignedInAlternateConstructors() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name;
+
+                  A() {
+                    this("ABC");
+                    name = "XYZ";
+                  }
+                  A(String name) {
+                    this.name = name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldReassignedInConstructorMultipleTimes() {
         rewriteRun(
           java(
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
@@ -249,8 +249,8 @@ public class FinalizePrivateFields extends Recipe {
     @Value
     private static class FindLastIdentifier extends JavaIsoVisitor<List<J.Identifier>> {
         /**
-         * Find for a last identifier in a J.FieldAccess. The purpose is to check whether it's a private field.
-         * @param j the sub-tree to search, supposed to be a J.FieldAccess
+         * Find the last identifier in a J.FieldAccess. The purpose is to check whether it's a private field.
+         * @param j the subtree to search, supposed to be a J.FieldAccess
          * @return the last Identifier if found, otherwise null.
          */
         @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
@@ -15,23 +15,21 @@
  */
 package org.openrewrite.java.cleanup;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import lombok.Value;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import java.util.Map;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
@@ -150,29 +148,39 @@ public class FinalizePrivateFields extends Recipe {
             Expression expression,
             Map<JavaType.Variable, Integer> assignedCountMap
         ) {
-            if (expression instanceof J.Identifier) {
-                J.Identifier i = (J.Identifier) expression;
-                JavaType.Variable v = i.getFieldType();
+            JavaType.Variable privateField = null;
 
-                if (assignedCountMap.containsKey(v)) {
-                    // filtered so the variable is a private field here
-                    int assignedCount = assignedCountMap.get(v);
-
-                    // increment count rules are following
-                    // (1) any assignment in class constructor, instance variable initializer or initializer block count for 1.
-                    // (2) any assignment in other place count for 2.
-                    // (3) any assignment in a loop in anywhere count for 2.
-                    int increment;
-                    if (isInLoop(cursor)) {
-                        increment = 2;
-                    } else if (isInitializedByClass(cursor)) {
-                        increment = 1;
-                    } else {
-                        increment = 2;
-                    }
-
-                    assignedCountMap.put(v, assignedCount + increment);
+            if (expression instanceof J.FieldAccess) {
+                // to support case of field accessed via 'this' like 'this.member'.
+                J.Identifier lastId = FindLastIdentifier.getLastIdentifier(expression);
+                if (lastId != null && assignedCountMap.containsKey(lastId.getFieldType())) {
+                    privateField = lastId.getFieldType();
                 }
+            } else if (expression instanceof J.Identifier) {
+                J.Identifier i = (J.Identifier) expression;
+                if (assignedCountMap.containsKey(i.getFieldType())) {
+                    privateField = i.getFieldType();
+                }
+            }
+
+            if (privateField != null) {
+                // filtered so the variable is a private field here
+                int assignedCount = assignedCountMap.get(privateField);
+
+                // increment count rules are following
+                // (1) any assignment in class constructor, instance variable initializer or initializer block count for 1.
+                // (2) any assignment in other place count for 2.
+                // (3) any assignment in a loop in anywhere count for 2.
+                int increment;
+                if (isInLoop(cursor)) {
+                    increment = 2;
+                } else if (isInitializedByClass(cursor)) {
+                    increment = 1;
+                } else {
+                    increment = 2;
+                }
+
+                assignedCountMap.put(privateField, assignedCount + increment);
             }
         }
 
@@ -235,6 +243,26 @@ public class FinalizePrivateFields extends Recipe {
             return dropUntilMeetCondition(cursor,
                 CollectPrivateFieldsAssignmentCounts::dropCursorEndCondition,
                 parent -> parent instanceof J.WhileLoop);
+        }
+    }
+
+    @Value
+    private static class FindLastIdentifier extends JavaIsoVisitor<List<J.Identifier>> {
+        /**
+         * Find for a last identifier in a J.FieldAccess. The purpose is to check whether it's a private field.
+         * @param j the sub-tree to search, supposed to be a J.FieldAccess
+         * @return the last Identifier if found, otherwise null.
+         */
+        @Nullable
+        static J.Identifier getLastIdentifier(J j) {
+            List<J.Identifier> ids = new FindLastIdentifier().reduce(j, new ArrayList<>());
+            return !ids.isEmpty() ? ids.get(ids.size() - 1) : null;
+        }
+
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, List<J.Identifier> ids) {
+            ids.add(identifier);
+            return super.visitIdentifier(identifier, ids);
         }
     }
 }


### PR DESCRIPTION
@knutwannheden found a false positive case in[ this comment](https://github.com/openrewrite/rewrite/issues/2611#issuecomment-1396576672),  If the field is reassigned from some context using the `this` keyword like this, the `final` keyword will be added but it shouldn't.
```
    @Test
    void fieldReassignedByAMethodUsingThis() {
        rewriteRun(
          java(
            """
              class A {
                  private String name = "ABC";

                  void func() {
                      this.name = "XYZ";
                  }

                  String getName() {
                      return name;
                  }
              }
              """
          )
        );
    }
```

also added more test cases of different `this` keyword usage, and multiple constructor cases.