### PR TITLE
Fix handling of unary operator in `FinalizePrivateField`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -304,6 +304,26 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void fieldReferencedByNonModifyingUnaryOperator() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private int i = 42;
+                  private int j = -i;
+              }
+              """,
+            """
+              class A {
+                  private final int i = 42;
+                  private final int j = -i;
+              }
+              """
+          )
+        );
+    }
+
     @Disabled ("Doesn't support multiple constructors, to be enhanced")
     @Test
     void fieldAssignedInAllAlternateConstructors() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
@@ -140,7 +140,9 @@ public class FinalizePrivateFields extends Recipe {
         @Override
         public J.Unary visitUnary(J.Unary unary, Map<JavaType.Variable, Integer> assignedCountMap) {
             J.Unary u = super.visitUnary(unary, assignedCountMap);
-            updateAssignmentCount(getCursor(), u.getExpression(),assignedCountMap);
+            if (u.getOperator().isModifying()) {
+                updateAssignmentCount(getCursor(), u.getExpression(), assignedCountMap);
+            }
             return u;
         }
 


### PR DESCRIPTION
The recipe should distinguish between reading and modifying unary operators, as this may allow a few more fields to be made final.
