### PR TITLE
Fix an uncovered lambda case of FinalizePrivateField recipe

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -663,4 +663,24 @@ class FinalizePrivateFieldsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void fieldAssignedInLambdaInsideConstructor() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              class A {
+                  private int x;
+                  private int y;
+                  A() {
+                      List.of(1,2,3).forEach(n -> x = n);
+                      Runnable r = () -> y = 2;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
@@ -129,13 +129,15 @@ public class TreeVisitingPrinter extends JavaIsoVisitor<ExecutionContext> {
     private static String printTreeElement(Tree tree) {
         // skip some specific types printed in the output to make the output looks clean
         if (tree instanceof J.CompilationUnit
-                || tree instanceof J.ClassDeclaration
-                || tree instanceof J.Block
-                || tree instanceof J.Empty
-                || tree instanceof J.Literal
-                || tree instanceof J.Try
-                || tree instanceof J.Try.Catch
-                || tree instanceof J.WhileLoop
+            || tree instanceof J.ClassDeclaration
+            || tree instanceof J.Block
+            || tree instanceof J.Empty
+            || tree instanceof J.Literal
+            || tree instanceof J.Try
+            || tree instanceof J.Try.Catch
+            || tree instanceof J.WhileLoop
+            || tree instanceof J.Lambda
+            || tree instanceof J.Lambda.Parameters
         ) {
             return "";
         }


### PR DESCRIPTION
Fix uncovered lambda case by recipe `FinalizePrivateFields` found by @knutwannheden  at [here](https://github.com/openrewrite/rewrite/issues/2611#issuecomment-1397667017).