### PR TITLE
Fix an uncovered case of FinalizePrivateFields with `Lombok` `setter` annotation

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -749,15 +749,12 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import lombok.Setter;
-
-              @Setter
+              import lombok.Data;
+                          
+              @Data
               public class B {
-                      @Setter
-                      public int b;
-
                   private int num = 0;
-
+                          
                   void func() {
                       B b = new B();
                       b.setNum(1);

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -336,6 +336,7 @@ class FinalizePrivateFieldsTest implements RewriteTest {
                   A() {
                     name = "XYZ";
                   }
+
                   A(String n) {
                     name = n;
                   }
@@ -348,8 +349,44 @@ class FinalizePrivateFieldsTest implements RewriteTest {
                   A() {
                     name = "XYZ";
                   }
+
                   A(String n) {
                     name = n;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled("Doesn't support if-else conditions analysis, to be enhanced.")
+    @Test
+    void fieldAssignedInIfElseStatementsInConstructor() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name;
+
+                  A(boolean condition) {
+                      if (condition) {
+                          name = "ABC";
+                      } else {
+                          name = "XYZ";
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  private final String name;
+
+                  A(boolean condition) {
+                      if (condition) {
+                          name = "ABC";
+                      } else {
+                          name = "XYZ";
+                      }
                   }
               }
               """
@@ -677,6 +714,53 @@ class FinalizePrivateFieldsTest implements RewriteTest {
                   A() {
                       List.of(1,2,3).forEach(n -> x = n);
                       Runnable r = () -> y = 2;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void anyFieldAnnotationAppliedIgnored() {
+        rewriteRun(
+          java(
+            """
+              import lombok.Setter;
+
+              public class A {
+                  @Setter
+                  private int num = 1;
+                  private @Setter String name = "ABC";
+
+                  static void test() {
+                      A a = new A();
+                      a.setNum(2);
+                      a.setName("XYZ");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void anyAnnotationAppliedClassIgnored() {
+        rewriteRun(
+          java(
+            """
+              import lombok.Setter;
+
+              @Setter
+              public class B {
+                      @Setter
+                      public int b;
+
+                  private int num = 0;
+
+                  void func() {
+                      B b = new B();
+                      b.setNum(1);
                   }
               }
               """


### PR DESCRIPTION
Fix an uncovered case of FinalizePrivateFields with `Lombok` `setter` annotation.
This is to address @timtebeek 's comment [here](https://github.com/openrewrite/rewrite/pull/2663#issuecomment-1399605676).

**Issue**
If any field has an annotation like `@Setter` from Lombok, a setter method will be automatically generated.
Finalizing that field could make compile error if somewhere else used the generated setter method.
 
An example use case, 
```
import lombok.Setter;

public class A {
    private @Setter String name = "ABC";

    static void test() {
        A a = new A();
        a.setName("XYZ");
    }
}
```
**Solution:**
Skip all classes that have any annotation, or fields that have any annotation.
This solution will falsely skip some normal use cases and got a lot of classes uncovered, but technically, since we can not assume the behavior of each annotation, although we can do some specific filtering including `lombok.Setter` and `lombok.Data` but it's a not generic solution, we can not guarantee any other annotation doesn't do the similar thing.
To follow our `do-not-harm` rule, just skip all classes that have any annotation, or fields that have any annotation.