### PR TITLE
update version to fix a faild test of UpgradeDependencyVersion recipe

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -798,7 +798,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                       <dependency>
                           <groupId>com.fasterxml.jackson.core</groupId>
                           <artifactId>jackson-core</artifactId>
-                          <version>2.13.4</version>
+                          <version>2.13.5</version>
                       </dependency>
                   </dependencies>
               </project>


### PR DESCRIPTION
Build error:
```
UpgradeDependencyVersionTest > upgradeAllDependenciesToPatchReleases() FAILED
    org.opentest4j.AssertionFailedError: [Unexpected result in "pom.xml"] 
    expected: 
      "<project>
          <groupId>org.openrewrite.example</groupId>
          <artifactId>my-app-server</artifactId>
          <version>1</version>
          <properties>
              <guava.version>28.0-jre</guava.version>
              <spring.version>5.3.25</spring.version>
              <spring.artifact-id>spring-jdbc</spring.artifact-id>
          </properties>
          <dependencies>
              <dependency>
                  <groupId>com.google.guava</groupId>
                  <artifactId>guava</artifactId>
                  <version>${guava.version}</version>
              </dependency>
              <dependency>
                  <groupId>org.springframework</groupId>
                  <artifactId>${spring.artifact-id}</artifactId>
                  <version>${spring.version}</version>
              </dependency>
              <dependency>
                  <groupId>com.fasterxml.jackson.core</groupId>
                  <artifactId>jackson-core</artifactId>
                  <version>2.13.4</version>
              </dependency>
          </dependencies>
      </project>"
     but was: 
      "<project>
          <groupId>org.openrewrite.example</groupId>
          <artifactId>my-app-server</artifactId>
          <version>1</version>
          <properties>
              <guava.version>28.0-jre</guava.version>
              <spring.version>5.3.25</spring.version>
              <spring.artifact-id>spring-jdbc</spring.artifact-id>
          </properties>
          <dependencies>
              <dependency>
                  <groupId>com.google.guava</groupId>
                  <artifactId>guava</artifactId>
                  <version>${guava.version}</version>
              </dependency>
              <dependency>
                  <groupId>org.springframework</groupId>
                  <artifactId>${spring.artifact-id}</artifactId>
                  <version>${spring.version}</version>
              </dependency>
              <dependency>
                  <groupId>com.fasterxml.jackson.core</groupId>
                  <artifactId>jackson-core</artifactId>
                  <version>2.13.5</version>
              </dependency>
          </dependencies>
      </project>"
        at java.base@17.0.6/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.6/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.6/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.6/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at app//org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:423)
        at app//org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:128)
        at app//org.openrewrite.maven.UpgradeDependencyVersionTest.upgradeAllDependenciesToPatchReleases(UpgradeDependencyVersionTest.java:745)
```