### PR TITLE
Adds filtering null fieldType to finalizePrivateRecipe to fix error

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
@@ -21,7 +21,6 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.TreeVisitingPrinter;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -58,6 +57,7 @@ public class FinalizePrivateFields extends Recipe {
 
                 List<J.VariableDeclarations.NamedVariable> privateFields = collectPrivateFields(classDecl);
                 Map<JavaType.Variable, Integer> privateFieldAssignCountMap = privateFields.stream()
+                    .filter(v -> v.getVariableType() != null)
                     .collect(Collectors.toMap(J.VariableDeclarations.NamedVariable::getVariableType,
                         v -> v.getInitializer() != null ? 1 : 0));
 


### PR DESCRIPTION
When running the `finalizePrivateFields` recipe in SAAS, saw an [error](https://public.moderne.io/results/MP9pW/details/eyJfX3R5cGVuYW1lIjoiR2l0SHViUmVwb3NpdG9yeSIsImlkIjoiR2l0SHViUmVwb3NpdG9yeX5+Z2l0aHViLmNvbX5+TmV0ZmxpeC9nZW5pZX5+bWFzdGVyIiwib3JpZ2luIjoiZ2l0aHViLmNvbSIsInBhdGgiOiJOZXRmbGl4L2dlbmllIiwiYnJhbmNoIjoibWFzdGVyIiwib3JnYW5pemF0aW9uIjoiTmV0ZmxpeCIsIm5hbWUiOiJnZW5pZSJ9?onlyShowErrors=true&referrer=%2Fresults%2FMP9pW) here.

The error message is `Duplicate key null` (see the below picture), it turns out that some private fields have null `variableType`. so adding a null check filter to fix this error.

![Screen Shot 2023-01-23 at 2 59 51 PM](https://user-images.githubusercontent.com/122563761/214171566-9fd1f509-db2d-404f-bd83-cd6e99dd4182.png)
