### PR TITLE
Simplify java.time.Duration creation units to be more readable

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnitsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnitsTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class SimplifyDurationCreationUnitsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new SimplifyDurationCreationUnits());
+    }
+
+    @Test
+    void simplifyLiteralMillisToSeconds() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(5000);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofSeconds(5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralMillisToMinutes() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(300000);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMinutes(5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralMillisToHours() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(18000000);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofHours(5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralMillisToDays() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(432000000);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofDays(5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralMillisProduct() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(5 * 1000);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofSeconds(5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralMillisProductWithWeirdFactors() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(5 * 5000);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofSeconds(25);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralSeconds() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofSeconds(300);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMinutes(5);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralMinutes() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMinutes(120);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofHours(2);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyLiteralHours() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofHours(48);
+              }
+              """,
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofDays(2);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotChangeLiteralDays() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofDays(14);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeSubSecondMillis() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  static Duration duration = Duration.ofMillis(5500);
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * This is not a necessary constraint but should be considered carefully
+     * before removing: when an operation other than multiplication is present
+     * in one of these method invocations, what does it mean to the user?
+     *
+     * It's possible that simplifying units could obfuscate meaning.
+     * It may be better to distribute the multiplicative factor change, rather
+     * than simplify the expression; e.g. preferring
+     *
+     *     `Duration.ofMillis(1000 + 1000)`  --> `Duration.ofSeconds(1 + 1)`
+     *
+     * rather than
+     *
+     *     `Duration.ofMillis(1000 + 1000)`  --> `Duration.ofSeconds(2)`
+     */
+    @Test
+    void doesNotChangeNonMultiplicationArithmetic() {
+        rewriteRun(
+          java(
+            """
+            import java.time.Duration;
+                          
+            public class Test {
+                static Duration durationPlus = Duration.ofMillis(1000 + 1000);
+                static Duration durationMinus = Duration.ofMillis(2000 - 1000);
+                static Duration durationDivide = Duration.ofMillis(5000 / 5);
+            }
+            """
+          )
+        );
+    }
+
+    /**
+     * This is not a necessary constraint; the recipe could simplify when there's a
+     * constant multiplicative factor present (e.g. `Duration.ofSeconds(seconds)` here).
+     * <p>
+     * This test just documents the current behavior.
+     */
+    @Test
+    void doesNotChangeNonConstantUnitCount() {
+        rewriteRun(
+          java(
+              """
+              import java.time.Duration;
+                            
+              public class Test {
+                  int seconds = 30;
+                  static Duration duration = Duration.ofMillis(1000 * seconds);
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnits.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnits.java
@@ -66,11 +66,7 @@ public class SimplifyDurationCreationUnits extends Recipe {
 
     @Override
     protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
-        TreeVisitor<?, ExecutionContext>[] tests = new TreeVisitor[DurationUnits.values().length];
-        for (int i = 0; i < tests.length; i++) {
-            tests[i] = new UsesMethod(DurationUnits.values()[i].methodMatcher);
-        }
-        return Applicability.or(tests);
+        return new UsesMethod(new MethodMatcher("java.time.Duration of*(long)"));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnits.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnits.java
@@ -56,7 +56,7 @@ public class SimplifyDurationCreationUnits extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Simplify java.time.Duration units";
+        return "Simplify `java.time.Duration` units";
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnits.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyDurationCreationUnits.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Applicability;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+public class SimplifyDurationCreationUnits extends Recipe {
+
+    private enum DurationUnits {
+        // order is important; factors are tried in this order (largest-to-smallest)
+        // (the Java spec states that `.values()` uses declaration order)
+        DAYS("ofDays", ChronoUnit.DAYS),
+        HOURS("ofHours", ChronoUnit.HOURS),
+        MINUTES("ofMinutes", ChronoUnit.MINUTES),
+        SECONDS("ofSeconds", ChronoUnit.SECONDS),
+        MILLIS("ofMillis", ChronoUnit.MILLIS);
+
+        final String methodName;
+        final long millisFactor;
+        final MethodMatcher methodMatcher;
+
+        DurationUnits(String methodName, TemporalUnit unit) {
+            this.methodName = methodName;
+            this.millisFactor = Duration.of(1, unit).toMillis();
+            this.methodMatcher = new MethodMatcher("java.time.Duration " + methodName + "(long)");
+        }
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Simplify java.time.Duration units";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Simplifies java.time.Duration units to be more human-readable.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        TreeVisitor<?, ExecutionContext>[] tests = new TreeVisitor[DurationUnits.values().length];
+        for (int i = 0; i < tests.length; i++) {
+            tests[i] = new UsesMethod(DurationUnits.values()[i].methodMatcher);
+        }
+        return Applicability.or(tests);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                method = super.visitMethodInvocation(method, ctx);
+
+                @Nullable DurationUnits invocationUnits = null;
+                for (DurationUnits maybeUnit : DurationUnits.values()) {
+                    if (maybeUnit.methodMatcher.matches(method)) {
+                        invocationUnits = maybeUnit;
+                        break;
+                    }
+                }
+
+                if (invocationUnits == null) {
+                    return method;
+                }
+
+                Long invocationUnitCount = getConstantIntegralValue(method.getArguments().get(0));
+                if (invocationUnitCount == null) {
+                    return method;
+                }
+
+                final long millis = invocationUnitCount * invocationUnits.millisFactor;
+                @Nullable DurationUnits simplifiedUnits = null;
+                for (DurationUnits maybeUnit : DurationUnits.values()) {
+                    if (millis % maybeUnit.millisFactor == 0) {
+                        simplifiedUnits = maybeUnit;
+                        break;
+                    }
+                }
+
+                if (simplifiedUnits == null || simplifiedUnits == invocationUnits) {
+                    return method;
+                }
+
+                JavaTemplate template = JavaTemplate.builder(this::getCursor, "#{}(#{})").build();
+                return maybeAutoFormat(
+                        method,
+                        method.withTemplate(
+                                template,
+                                method.getCoordinates().replaceMethod(),
+                                simplifiedUnits.methodName,
+                                millis / simplifiedUnits.millisFactor
+                        ),
+                        ctx
+                );
+            }
+        };
+    }
+
+    private static @Nullable Long getConstantIntegralValue(Expression expression) {
+        if (expression instanceof J.Literal) {
+            J.Literal literal = (J.Literal) expression;
+            if (literal.getType() != JavaType.Primitive.Int && literal.getType() != JavaType.Primitive.Long) {
+                return null;
+            }
+            Object value = literal.getValue();
+            if (value instanceof Number) {
+                return ((Number) value).longValue();
+            }
+        } else if (expression instanceof J.Binary) {
+            J.Binary binary = (J.Binary) expression;
+            if (binary.getOperator() != J.Binary.Type.Multiplication) {
+                return null;
+            }
+
+            Long left = getConstantIntegralValue(binary.getLeft());
+            if (left == null) {
+                return null;
+            }
+
+            Long right = getConstantIntegralValue(binary.getRight());
+            if (right == null) {
+                return null;
+            }
+
+            return left * right;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
As requested in #2687; tests should fully illustrate the behavior.

I'm taking a stab at the condition covered by the last test case since it seems doable, but putting up a PR for this since it should be good-to-go without it.