### PR TITLE
`FinalizePrivateFields` also needs to update the `JavaType`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1121,7 +1121,7 @@ public interface JavaType {
         @NonFinal
         Integer managedReference;
 
-        @With(AccessLevel.NONE)
+        @With(AccessLevel.PRIVATE)
         long flagsBitMap;
 
         @With
@@ -1173,6 +1173,10 @@ public interface JavaType {
 
         public Set<Flag> getFlags() {
             return Flag.bitMapToFlags(flagsBitMap);
+        }
+
+        public Variable withFlags(Set<Flag> flags) {
+            return withFlagsBitMap(Flag.flagsToBitMap(flags));
         }
 
         @Override


### PR DESCRIPTION
Variable declaration modifiers are both stored as `J.Modifier` objects in the LST and as flags on the corresponding `JavaType.Variable` object. The recipe was only updating the former, which had the consequence that the recipe didn't play nicely with for example `RenamePrivateFieldsToCamelCase`, which is based on the latter.

Related to: #2611
