### PR TITLE
Default `MethodNameCasing#renamePublicMethods` to `false`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
@@ -126,7 +126,7 @@ class MethodNameCasingTest implements RewriteTest {
               class Test {
                   public void getFoo_bar() {}
               }
-              """
+            """
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
@@ -118,6 +118,21 @@ class MethodNameCasingTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     @Test
+    void doNotRenamePublicMethods_nullOptions() {
+        rewriteRun(
+        spec -> spec.recipe(new MethodNameCasing(null, null)),
+          java(
+            """
+              class Test {
+                  public void getFoo_bar() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
+    @Test
     void okToRenamePublicMethods() {
         rewriteRun(
           spec -> spec.recipe(new MethodNameCasing(true, true)),

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
@@ -118,7 +118,7 @@ class MethodNameCasingTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     @Test
-    void doNotRenamePublicMethods_nullOptions() {
+    void doNotRenamePublicMethodsNullOptions() {
         rewriteRun(
         spec -> spec.recipe(new MethodNameCasing(null, null)),
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodNameCasing.java
@@ -148,7 +148,7 @@ public class MethodNameCasing extends Recipe {
             }
 
             private boolean containsValidModifiers(J.MethodDeclaration method) {
-                return !method.hasModifier(J.Modifier.Type.Public) || !Boolean.FALSE.equals(renamePublicMethods);
+                return !method.hasModifier(J.Modifier.Type.Public) || Boolean.TRUE.equals(renamePublicMethods);
             }
 
             private boolean methodExists(JavaType.Method method, String newName) {


### PR DESCRIPTION
The Moderne SaaS appears to instantiate recipes using `null` values for `Boolean` options when the user doesn't explicitly select either the `true` or `false` radio button. In the case of `MethodNameCasing#renamePublicMethods` the `null` value had the same effect as `true`, which is now fixed.

Relates to: #2424
