### PR TITLE
Remove unused import

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
@@ -21,7 +21,6 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.NameTree;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 


### PR DESCRIPTION
In the [last PR](https://github.com/openrewrite/rewrite/pull/2730) I fixed a comment that was incorrect. However, I didn't realize that the link in the comment added an import to the file. This removes the unused import.
