### PR TITLE
Fix bug in `TabsAndIndentsVisitor`

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/TabsAndIndentsVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/TabsAndIndentsVisitor.java
@@ -25,7 +25,6 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.List;
-import java.util.Optional;
 
 public class TabsAndIndentsVisitor<P> extends HclIsoVisitor<P> {
     @Nullable
@@ -97,10 +96,9 @@ public class TabsAndIndentsVisitor<P> extends HclIsoVisitor<P> {
             return space;
         }
 
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
 
-        IndentType indentType = Optional.ofNullable(getCursor().getParentOrThrow().
-                <IndentType>getNearestMessage("indentType")).orElse(IndentType.ALIGN);
+        IndentType indentType = getCursor().getParentOrThrow().getNearestMessage("indentType", IndentType.ALIGN);
 
         // block spaces are always aligned to their parent
         boolean alignBlockToParent = loc.equals(Space.Location.BLOCK_CLOSE)|| loc.equals(Space.Location.OBJECT_VALUE_ATTRIBUTE_SUFFIX);
@@ -136,7 +134,7 @@ public class TabsAndIndentsVisitor<P> extends HclIsoVisitor<P> {
         T t = right.getElement();
         Space after;
 
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
         if (right.getElement() instanceof Hcl) {
             Hcl elem = (Hcl) right.getElement();
             if ((right.getAfter().getLastWhitespace().contains("\n") ||
@@ -203,7 +201,7 @@ public class TabsAndIndentsVisitor<P> extends HclIsoVisitor<P> {
         Space before;
         List<HclRightPadded<H>> js;
 
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
         if (container.getBefore().getLastWhitespace().contains("\n")) {
             if (loc == HclContainer.Location.FUNCTION_CALL_ARGUMENTS) {
                 before = indentTo(container.getBefore(), indent + style.getIndentSize(), loc.getBeforeLocation());

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -247,6 +247,31 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/2722")
+    @Test
+    void removeAllImportsInFileWithHeader() {
+        rewriteRun(
+          java(
+            """
+              /*
+               * header
+               */
+              package x;
+              import java.util.List;
+              class A {}
+              """,
+            """
+              /*
+               * header
+               */
+              package x;
+
+              class A {}
+              """
+          )
+        );
+    }
+
     @Test
     void removeStarImportIfNoTypesReferredTo() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -26,7 +26,6 @@ import org.openrewrite.java.tree.*;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
     @Nullable
@@ -69,7 +68,9 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
         }
         Iterator<Object> itr = parent.getPath(J.class::isInstance);
         J next = (itr.hasNext()) ? (J) itr.next() : null;
-        preVisit(next, p);
+        if (next != null) {
+            preVisit(next, p);
+        }
 
         return visit(tree, p);
     }
@@ -130,10 +131,9 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
             return space;
         }
 
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
 
-        IndentType indentType = Optional.ofNullable(getCursor().getParentOrThrow().
-                <IndentType>getNearestMessage("indentType")).orElse(IndentType.ALIGN);
+        IndentType indentType = getCursor().getParentOrThrow().getNearestMessage("indentType", IndentType.ALIGN);
 
         // block spaces are always aligned to their parent
         boolean alignBlockPrefixToParent = loc.equals(Space.Location.BLOCK_PREFIX) && space.getWhitespace().contains("\n") &&
@@ -186,7 +186,7 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
         T t = right.getElement();
         Space after;
 
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
         if (right.getElement() instanceof J) {
             J elem = (J) right.getElement();
             if ((right.getAfter().getLastWhitespace().contains("\n") ||
@@ -351,7 +351,7 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
         Space before;
         List<JRightPadded<J2>> js;
 
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
         if (container.getBefore().getLastWhitespace().contains("\n")) {
             switch (loc) {
                 case TYPE_PARAMETERS:

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
@@ -22,7 +22,6 @@ import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.style.IndentsStyle;
 import org.openrewrite.yaml.tree.Yaml;
 
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class IndentsVisitor<P> extends YamlIsoVisitor<P> {
@@ -58,15 +57,15 @@ public class IndentsVisitor<P> extends YamlIsoVisitor<P> {
     @Nullable
     @Override
     public Yaml preVisit(Yaml tree, P p) {
-        if (Optional.ofNullable(getCursor().<Boolean>getNearestMessage("stop")).orElse(false)) {
+        if (getCursor().getNearestMessage("stop", false)) {
             return tree;
         }
 
         Yaml y = tree;
-        int indent = Optional.ofNullable(getCursor().<Integer>getNearestMessage("lastIndent")).orElse(0);
+        int indent = getCursor().getNearestMessage("lastIndent", 0);
         if (y.getPrefix().contains("\n") && !isUnindentedTopLevel()) {
             if (y instanceof Yaml.Sequence.Entry) {
-                indent = Optional.ofNullable(getCursor().getParentOrThrow().<Integer>getMessage("sequenceEntryIndent")).orElse(indent);
+                indent = getCursor().getParentOrThrow().getMessage("sequenceEntryIndent", indent);
 
                 y = y.withPrefix(indentTo(y.getPrefix(), indent + style.getIndentSize()));
 


### PR DESCRIPTION
A problem with the logic in `TabsAndIndentsVisitor` which was observed with the `RemoveUnusedImports` recipe could lead to the whole or at least the beginning of compilation units with a copyright header getting indented. This problem may also affect other recipes using the `JavaVisitor#autoFormat()` method.

Fixes #2722
