### PR TITLE
Fix a bug of  recipe `NoDoubleBraceInitialization` when there is any method declared in the anonymous subclass and be invoked.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/NoDoubleBraceInitializationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/NoDoubleBraceInitializationTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.cleanup;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
@@ -333,7 +332,6 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
     void anonymousSubClassMethodInvoked() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoDoubleBraceInitialization.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoDoubleBraceInitialization.java
@@ -81,9 +81,9 @@ public class NoDoubleBraceInitialization extends Recipe {
                 return false;
             }
             if (nc.getBody() != null && !nc.getBody().getStatements().isEmpty()
+                    && nc.getBody().getStatements().size() == 1
                     && nc.getBody().getStatements().get(0) instanceof J.Block
                     && getCursor().getParent(3) != null) {
-
                 return TypeUtils.isAssignableTo(MAP_TYPE, nc.getType())
                         || TypeUtils.isAssignableTo(LIST_TYPE, nc.getType())
                         || TypeUtils.isAssignableTo(SET_TYPE, nc.getType());


### PR DESCRIPTION
To fix the issue https://github.com/openrewrite/rewrite/issues/2710

### Issue
A bug example.
```java
import java.util.HashMap;
import java.util.Map;

class A {
    void example() {
        Map<String, String> bMap = new HashMap<String, String>() {
            {
                subClassMethod();
                put("a", "A");
                put("b", "B");
            }
            void subClassMethod() {
            }
        };
    }
}
```
is turned into
```java
import java.util.HashMap;
  import java.util.Map;
  
  class A {
      void example() {
          Map<String, String> bMap = new HashMap<String, String>();
          bMap.subClassMethod();
          bMap.put("a", "A");
          bMap.put("b", "B");
      }
  }
```
method `subClassMethod` missed and break compile.

### Solution
Make sure for the double brace case,  there is only one statement in the first brace, not others like method declaration allowed.