### PR TITLE
Enhance the `Space` recipe to support transformation for multiple whitespaces

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.format;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.Tree;
@@ -107,11 +106,15 @@ class SpacesTest implements RewriteTest {
               class Test {
                   void method1 () {
                   }
+                  void method2    () {
+                  }
               }
               """,
             """
               class Test {
                   void method1() {
+                  }
+                  void method2() {
                   }
               }
               """
@@ -119,21 +122,31 @@ class SpacesTest implements RewriteTest {
         );
     }
 
-    @Disabled
+
     @Test
-    void beforeParensMethodDeclarationFalse2() {
+    void beforeParensMethodDeclarationFalseWithCommentIgnored() {
         rewriteRun(
           spaces(style -> style.withBeforeParentheses(style.getBeforeParentheses().withMethodDeclaration(false))),
           java(
             """
               class Test {
-                  void method1    () {
+                  void method1    /*comment*/    () {
                   }
               }
-              """,
+              """
+          )
+        );
+    }
+
+    @Test
+    void beforeParensMethodDeclarationFalseWithLineBreakIgnored() {
+        rewriteRun(
+          spaces(style -> style.withBeforeParentheses(style.getBeforeParentheses().withMethodDeclaration(false))),
+          java(
             """
               class Test {
-                  void method1() {
+                  void method1 
+                  () {
                   }
               }
               """
@@ -2388,11 +2401,15 @@ class SpacesTest implements RewriteTest {
               class Test {
                   public void foo(int x) {
                   }
+                  public void bar(    int y    ) {
+                  }
               }
               """,
             """
               class Test {
                   public void foo( int x ) {
+                  }
+                  public void bar( int y ) {
                   }
               }
               """
@@ -2400,21 +2417,41 @@ class SpacesTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
-    void withinMethodDeclarationParenthesesTrue2() {
+    void withinMethodDeclarationParenthesesTrueWithCommentIgnored() {
         rewriteRun(
           spaces(style -> style.withWithin(style.getWithin().withMethodDeclarationParentheses(true))),
           java(
             """
               class Test {
-                  public void foo(int x, int y    ) {
+                  void foo(    /*comment*/ int x    ) {
+                  }
+                  void bar(    int y    /*comment*/    ) {
                   }
               }
               """,
             """
               class Test {
-                  public void foo( int x, int y ) {
+                  void foo(    /*comment*/ int x ) {
+                  }
+                  void bar( int y    /*comment*/    ) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withinMethodDeclarationParenthesesTrueWithLineBreakIgnored() {
+        rewriteRun(
+          spaces(style -> style.withWithin(style.getWithin().withMethodDeclarationParentheses(true))),
+          java(
+            """
+              class Test {
+                  void foo(
+                      int x
+                  ) {
                   }
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
@@ -68,11 +68,42 @@ class SpacesTest implements RewriteTest {
               class Test {
                   void method1() {
                   }
+                  void method2()    {
+                  }
+                  void method3()	{
+                  }
               }
               """,
             """
               class Test {
                   void method1 () {
+                  }
+                  void method2 () {
+                  }
+                  void method3 () {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    void method1    /*comment*/ () {
+    }
+    @Test
+    void beforeParensMethodDeclarationTrueWithComment() {
+        rewriteRun(
+          spaces(style -> style.withBeforeParentheses(style.getBeforeParentheses().withMethodDeclaration(true))),
+          java(
+            """
+              class Test {
+                  void method1    /*comment*/() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method1    /*comment*/ () {
                   }
               }
               """
@@ -108,6 +139,8 @@ class SpacesTest implements RewriteTest {
                   }
                   void method2    () {
                   }
+                  void method3  	() {
+                  }
               }
               """,
             """
@@ -116,21 +149,28 @@ class SpacesTest implements RewriteTest {
                   }
                   void method2() {
                   }
+                  void method3() {
+                  }
               }
               """
           )
         );
     }
 
-
     @Test
-    void beforeParensMethodDeclarationFalseWithCommentIgnored() {
+    void beforeParensMethodDeclarationFalseWithComment() {
         rewriteRun(
           spaces(style -> style.withBeforeParentheses(style.getBeforeParentheses().withMethodDeclaration(false))),
           java(
             """
               class Test {
                   void method1    /*comment*/    () {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method1    /*comment*/() {
                   }
               }
               """
@@ -2418,23 +2458,50 @@ class SpacesTest implements RewriteTest {
     }
 
     @Test
-    void withinMethodDeclarationParenthesesTrueWithCommentIgnored() {
+    void compositeMethodDeclarationParentheses() {
         rewriteRun(
-          spaces(style -> style.withWithin(style.getWithin().withMethodDeclarationParentheses(true))),
+          spaces(style -> style.withWithin(style.getWithin().withMethodDeclarationParentheses(true))
+              .withBeforeParentheses(style.getBeforeParentheses().withMethodDeclaration(true))
+          ),
           java(
             """
               class Test {
-                  void foo(    /*comment*/ int x    ) {
-                  }
-                  void bar(    int y    /*comment*/    ) {
+                  void  /*c1*/   foo  /*c2*/   (  /*c3*/   int x, int y  /*c4*/   ) {
                   }
               }
               """,
             """
               class Test {
-                  void foo(    /*comment*/ int x ) {
+                  void  /*c1*/   foo  /*c2*/ (  /*c3*/   int x, int y  /*c4*/ ) {
                   }
-                  void bar( int y    /*comment*/    ) {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withinMethodDeclarationParenthesesTrueWithComment() {
+        rewriteRun(
+          spaces(style -> style.withWithin(style.getWithin().withMethodDeclarationParentheses(true))),
+          java(
+            """
+              class Test {
+                  void foo(    /*c1*/    int x    ) {
+                  }
+                  void bar(    int y    /*c2*/    ) {
+                  }
+                  void baz(    /*c3*/    int z    /*c4*/    ) {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void foo(    /*c1*/    int x ) {
+                  }
+                  void bar( int y    /*c2*/ ) {
+                  }
+                  void baz(    /*c3*/    int z    /*c4*/ ) {
                   }
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.format;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.Tree;
@@ -105,6 +106,28 @@ class SpacesTest implements RewriteTest {
             """
               class Test {
                   void method1 () {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method1() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled
+    @Test
+    void beforeParensMethodDeclarationFalse2() {
+        rewriteRun(
+          spaces(style -> style.withBeforeParentheses(style.getBeforeParentheses().withMethodDeclaration(false))),
+          java(
+            """
+              class Test {
+                  void method1    () {
                   }
               }
               """,
@@ -2377,6 +2400,28 @@ class SpacesTest implements RewriteTest {
         );
     }
 
+    @Disabled
+    @Test
+    void withinMethodDeclarationParenthesesTrue2() {
+        rewriteRun(
+          spaces(style -> style.withWithin(style.getWithin().withMethodDeclarationParentheses(true))),
+          java(
+            """
+              class Test {
+                  public void foo(int x, int y    ) {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  public void foo( int x, int y ) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void withinMethodDeclarationParenthesesFalse() {
         rewriteRun(
@@ -3317,9 +3362,9 @@ class SpacesTest implements RewriteTest {
               class Test {
                   void foo() {
                       Map<String,String> m = new HashMap<String,String>();
-                      Test.<String,Integer>bar();
+                      Test.<String,Integer>bar(1,2);
                   }
-                  static <A, B> void bar() {
+                  static <A,B> void bar(int x,int y) {
                   }
               }
               """,
@@ -3330,9 +3375,9 @@ class SpacesTest implements RewriteTest {
               class Test {
                   void foo() {
                       Map<String, String> m = new HashMap<String, String>();
-                      Test.<String, Integer>bar();
+                      Test.<String, Integer>bar(1, 2);
                   }
-                  static <A, B> void bar() {
+                  static <A, B> void bar(int x, int y) {
                   }
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
@@ -88,8 +88,6 @@ class SpacesTest implements RewriteTest {
         );
     }
 
-    void method1    /*comment*/ () {
-    }
     @Test
     void beforeParensMethodDeclarationTrueWithComment() {
         rewriteRun(


### PR DESCRIPTION
Issue: https://github.com/openrewrite/rewrite/issues/2681
### Issue
1. For spaces in method declaration, after the method name and before parentheses, there is a space style [BeforeParentheses.methodDeclaration](https://github.com/openrewrite/rewrite/blob/19df599e6612b1f2dfbe5cf57704eab7f4ee66ff/rewrite-java/src/main/java/org/openrewrite/java/style/SpacesStyle.java#L40), an example [here](https://github.com/openrewrite/rewrite/blob/c98e8a12cf41ec29536e3c65c6eacbe2c91cece5/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java#L101).
However, this case is not supported well.
```java
class Test {
    void method1    () {
    }
}
```
```
expected: 
  "class Test {
      void method1() {
      }
  }"
 but was: 
  "class Test {
      void method1    () {
      }
  }"
```
3. For spaces in the argument list, there is a space style [methodDeclarationParentheses](https://github.com/openrewrite/rewrite/blob/19df599e6612b1f2dfbe5cf57704eab7f4ee66ff/rewrite-java/src/main/java/org/openrewrite/java/style/SpacesStyle.java#L109), an example is [here](https://github.com/openrewrite/rewrite/blob/c98e8a12cf41ec29536e3c65c6eacbe2c91cece5/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java#L2372).
However, it can not cover this case well.
```java
class Test {
    public void foo(    int y    ) {
    }
}
```
```
expected:
  class Test {
      public void foo( int y ) {
      }
  }
but was:
  class Test {
      public void foo(    int y    ) {
      }
  }
```

### Root cause
Currently, the `Space` recipe spaces limited transformation between one single white space and empty only, so if there are multiple white spaces. it's not supported.

### Solution
Enhanced to support multiple white spaces transformation, including comments.


### Spaces/Comments code mapping, attached here as a note
```java
<code>
void  /*c1*/   foo  /*c2*/   (  /*c3*/   int x, int y  /*c4*/   ) {}
<Mapping>
    ___________                                                     = method.name.identifier.prefix
    __                                                              = method.name.identifier.prefix.whitespace = "  "
        __                                                          = ((TextComment)method.name.identifier.prefix.comments.get(0)).text = "c1"
            ___                                                     = ((TextComment)method.name.identifier.prefix.comments.get(0)).suffix = "   "
                  ___________                                       = m.parameters.before
                  __                                                = m.parameters.before.whitespace
                    _________                                       = m.parameters.before.comments
                    _________                                       = m.parameters.before.comments.get(0)
                      __                                            = ((TextComment)m.parameters.before.comments.get(0)).text = "c2"
                          ___                                       = ((TextComment)m.parameters.before.comments.get(0)).suffix = "   "
                              __________________________________    = m.parameters.elements
                              ________________                      = JRightPadded | m.parameters.elements.get(0)
                              ___________                           = ((VariableDeclarations)m.parameters.elements.get(0).element).prefix
                              __                                    = ((Space)((VariableDeclarations)m.parameters.elements.get(0).element).prefix).whitespace = "  "
                                _________                           = ((Space)((VariableDeclarations)m.parameters.elements.get(0).element).prefix).comments
                                  __                                = ((TextComment)comments.get(0)).text = "c3"
                                      ___                           = ((TextComment)comments.get(0)).suffix = "   "
                                               _________________    = JRightPadded | m.parameters.elements.get(1)
                                                     ___________    = m.parameters.elements.get(1).after
                                                     __             = m.parameters.elements.get(1).after.whitespace
                                                         __         = ((TextComment)m.parameters.elements.get(1).after.comments.get(0)).text = "c4"
                                                             ___    = ((TextComment)m.parameters.elements.get(1).after.comments.get(0)).suffix = "   "
```



