### PR TITLE
Fix `J.Unary` side effects and `SemanticallyEqual`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/InstanceOfPatternMatchTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/InstanceOfPatternMatchTest.java
@@ -454,4 +454,34 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             }
         }
     }
+
+    @Nested
+    class Various {
+        @Nested
+        class Positive {
+            @Test
+            void unaryWithoutSideEffects() {
+                rewriteRun(
+                  version(
+                    java(
+                      """
+                        public class A {
+                            String test(Object o) {
+                                return ((Object) ("1" + ~1)) instanceof String ? ((String) ((Object) ("1" + ~1))).substring(1) : o.toString();
+                            }
+                        }
+                        """,
+                      """
+                        public class A {
+                            String test(Object o) {
+                                return ((Object) ("1" + ~1)) instanceof String s ? s.substring(1) : o.toString();
+                            }
+                        }
+                        """
+                    ), 17
+                  )
+                );
+            }
+        }
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5318,7 +5318,7 @@ public interface J extends Tree {
         @Override
         @Transient
         public List<J> getSideEffects() {
-            return expression.getSideEffects();
+            return getOperator().isModifying() ? singletonList(this) : expression.getSideEffects();
         }
 
         public enum Type {


### PR DESCRIPTION
The implementation of `J.Unary#getSideEffects()` should always return the expression itself as a side effect if it is a modifying unary operator (e.g. postfix `++`).

Also, while implementing a test for this indirectly via `InstanceOfPatternMatchTest` I noticed that `SemanticallyEqual` doesn't allow comparing `J.Parentheses` and `J.ControlParentheses` instances. This is problematic in the case of the `InstanceOfPatternMatch` recipe, as in the `instanceof` it would be the former and in the type cast the latter type.

Further, a few more deficiencies in `SemanticallyEqual` have been fixed.