### PR TITLE
Make `J.ParameterizedType#getType()` return a `JavaType.Parameterized`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1741,7 +1741,7 @@ public class GroovyParserVisitor {
                     type, null);
             if (type instanceof JavaType.Parameterized) {
                 return new J.ParameterizedType(randomId(), prefix, Markers.EMPTY, ident, visitTypeParameterizations(
-                        staticType((org.codehaus.groovy.ast.expr.Expression) expression).getGenericsTypes()));
+                        staticType((org.codehaus.groovy.ast.expr.Expression) expression).getGenericsTypes()), type);
             }
             return ident.withPrefix(prefix);
         }
@@ -1929,7 +1929,7 @@ public class GroovyParserVisitor {
 
         assert expr != null;
         if (classNode != null && classNode.isUsingGenerics() && !classNode.isGenericsPlaceHolder()) {
-            expr = new J.ParameterizedType(randomId(), EMPTY, Markers.EMPTY, (NameTree) expr, visitTypeParameterizations(classNode.getGenericsTypes()));
+            expr = new J.ParameterizedType(randomId(), EMPTY, Markers.EMPTY, (NameTree) expr, visitTypeParameterizations(classNode.getGenericsTypes()), typeMapping.type(classNode));
         }
         return expr.withPrefix(prefix);
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -1146,7 +1146,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 expression = expression.withAfter(after);
                 expressions.add(expression);
             }
-            return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, id, JContainer.build(expressions));
+            return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, id, JContainer.build(expressions), typeMapping.type(node));
         }
     }
 }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1077,7 +1077,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitParameterizedType(ParameterizedTypeTree node, Space fmt) {
-        return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, convert(node.getType()), convertTypeParameters(node.getTypeArguments()));
+        return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, convert(node.getType()), convertTypeParameters(node.getTypeArguments()), typeMapping.type(node));
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -1147,7 +1147,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 expression = expression.withAfter(after);
                 expressions.add(expression);
             }
-            return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, id, JContainer.build(expressions));
+            return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, id, JContainer.build(expressions), typeMapping.type(node));
         }
     }
 }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1137,7 +1137,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitParameterizedType(ParameterizedTypeTree node, Space fmt) {
-        return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, convert(node.getType()), convertTypeParameters(node.getTypeArguments()));
+        return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, convert(node.getType()), convertTypeParameters(node.getTypeArguments()), typeMapping.type(node));
     }
 
     @Override

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -1070,7 +1070,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                 expression = expression.withAfter(after);
                 expressions.add(expression);
             }
-            return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, id, JContainer.build(expressions));
+            return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, id, JContainer.build(expressions), typeMapping.type(node));
         }
     }
 }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1074,7 +1074,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitParameterizedType(ParameterizedTypeTree node, Space fmt) {
-        return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, convert(node.getType()), convertTypeParameters(node.getTypeArguments()));
+        return new J.ParameterizedType(randomId(), fmt, Markers.EMPTY, convert(node.getType()), convertTypeParameters(node.getTypeArguments()), typeMapping.type(node));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
@@ -81,7 +81,8 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
                         Space.EMPTY,
                         Markers.EMPTY,
                         impl,
-                        JContainer.build(Space.EMPTY, elements, Markers.EMPTY)
+                        JContainer.build(Space.EMPTY, elements, Markers.EMPTY),
+                        new JavaType.Parameterized(null, interfaceType, typeParameters.stream().map(Expression::getType).collect(Collectors.toList()))
                 );
 
                 c = c.withImplements(ListUtils.concat(c.getImplements(), typedImpl));

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypes.java
@@ -152,7 +152,8 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
                             space,
                             Markers.EMPTY,
                             identifier,
-                            typeParameters
+                            typeParameters,
+                            new JavaType.Parameterized(null, fq, fq.getTypeParameters())
                     );
 
                 } else {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseCollectionInterfaces.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseCollectionInterfaces.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.cleanup;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
@@ -134,7 +133,11 @@ public class UseCollectionInterfaces extends Recipe {
                                         newType.getClassName(),
                                         newType,
                                         null);
-                                typeExpression = parameterizedType.withClazz(returnType);
+                                JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
+                                typeExpression = parameterizedType.withClazz(returnType)
+                                        .withType(javaType != null ? javaType.withType(newType) :
+                                                new JavaType.Parameterized(null, newType, null)
+                                        );
                             }
                             m = m.withReturnTypeExpression(typeExpression);
                         }
@@ -181,7 +184,11 @@ public class UseCollectionInterfaces extends Recipe {
                                     newType,
                                     null
                             );
-                            typeExpression = parameterizedType.withClazz(returnType);
+                            JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
+                            typeExpression = parameterizedType.withClazz(returnType)
+                                    .withType(javaType != null ? javaType.withType(newType) :
+                                            new JavaType.Parameterized(null, newType, null)
+                                    );
                         }
 
                         mv = mv.withTypeExpression(typeExpression);

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseLambdaForFunctionalInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UseLambdaForFunctionalInterface.java
@@ -66,7 +66,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                     n.getBody().getStatements().size() == 1 &&
                     n.getBody().getStatements().get(0) instanceof J.MethodDeclaration &&
                     n.getClazz() != null) {
-                    JavaType.Class type = TypeUtils.asClass(n.getClazz().getType());
+                    JavaType.@Nullable FullyQualified type = TypeUtils.asFullyQualified(n.getClazz().getType());
                     if (type != null && type.getKind().equals(JavaType.Class.Kind.Interface)) {
                         JavaType.Method sam = null;
                         for (JavaType.Method method : type.getMethods()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
@@ -22,7 +22,6 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
 
 import java.util.HashSet;
@@ -107,7 +106,7 @@ public class FindFieldsOfType extends Recipe {
     private static boolean hasElementType(@Nullable JavaType type, String fullyQualifiedName) {
         if (type instanceof JavaType.Array) {
             return hasElementType(((JavaType.Array) type).getElemType(), fullyQualifiedName);
-        } else if (type instanceof JavaType.Class) {
+        } else if (type instanceof JavaType.FullyQualified) {
             return fullyQualifiedName.equals(((JavaType.FullyQualified) type).getFullyQualifiedName());
         } else if (type instanceof JavaType.GenericTypeVariable) {
             JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -4273,6 +4273,11 @@ public interface J extends Tree {
         @Nullable
         JContainer<Expression> typeParameters;
 
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
+
         @Nullable
         public List<Expression> getTypeParameters() {
             return typeParameters == null ? null : typeParameters.getElements();
@@ -4280,20 +4285,6 @@ public interface J extends Tree {
 
         public ParameterizedType withTypeParameters(@Nullable List<Expression> typeParameters) {
             return getPadding().withTypeParameters(JContainer.withElementsNullable(this.typeParameters, typeParameters));
-        }
-
-        @Override
-        public JavaType getType() {
-            return clazz.getType();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public ParameterizedType withType(@Nullable JavaType type) {
-            if (type == clazz.getType()) {
-                return this;
-            }
-            return withClazz(clazz.withType(type));
         }
 
         @Override
@@ -4337,7 +4328,7 @@ public interface J extends Tree {
             }
 
             public ParameterizedType withTypeParameters(@Nullable JContainer<Expression> typeParameters) {
-                return t.typeParameters == typeParameters ? t : new ParameterizedType(t.id, t.prefix, t.markers, t.clazz, typeParameters);
+                return t.typeParameters == typeParameters ? t : new ParameterizedType(t.id, t.prefix, t.markers, t.clazz, typeParameters, t.type);
             }
         }
     }


### PR DESCRIPTION
This changes `J.ParameterizedType#getType()` to return a `JavaType.Parameterized` rather than always a `JavaType.Class` object by adding an explicit `type` field to the class which needs to be kept in sync with changes made to the LST.

Some recipes had to be changed as a consequence of this refactoring.