### PR TITLE
Fix validation failure of GradleWrapper caused by case-sensitive distribution type string

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -59,15 +59,10 @@ public class GradleWrapper {
 
         //noinspection unchecked
         return new Validated.Both(
-                Validated.test("distributionType", "must be a valid distribution type", distributionTypeName, dt -> {
-                    try {
-                        DistributionType.valueOf(dt);
-                        return true;
-                    } catch (Throwable e) {
-                        return false;
-                    }
-                }),
-                Semver.validate(version, null)
+            Validated.test("distributionType", "must be a valid distribution type", distributionTypeName,
+                dt -> Arrays.stream(DistributionType.values())
+                    .anyMatch(type -> type.name().equalsIgnoreCase(dt))),
+            Semver.validate(version, null)
         ) {
             GradleWrapper wrapper;
 
@@ -148,7 +143,8 @@ public class GradleWrapper {
     }
 
     public enum DistributionType {
-        Bin, All
+        Bin,
+        All
     }
 
     @Value

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddGradleWrapperTest.java
@@ -66,6 +66,7 @@ class AddGradleWrapperTest implements RewriteTest {
               recipeList:
                 - org.openrewrite.gradle.AddGradleWrapper:
                     version: "7.4.2"
+                    distribution: bin
               """.getBytes()
           ),
           "org.openrewrite.test.AddGradleWrapper"

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/GradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/GradleWrapperTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.gradle.util;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Validated;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,7 +25,10 @@ public class GradleWrapperTest {
 
     @Test
     void wrapper() {
-        GradleWrapper gw = GradleWrapper.validate(new InMemoryExecutionContext(), "7.x", "bin", null).getValue();
+        Validated validated = GradleWrapper.validate(new InMemoryExecutionContext(), "7.x", "bin", null);
+        assertThat(validated.isValid()).isTrue();
+
+        GradleWrapper gw = validated.getValue();
         assertThat(gw).isNotNull();
         assertThat(gw.getVersion()).startsWith("7.");
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/GradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/GradleWrapperTest.java
@@ -24,12 +24,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GradleWrapperTest {
 
     @Test
-    void wrapper() {
+    void validateDistributionTypeBin() {
         Validated validated = GradleWrapper.validate(new InMemoryExecutionContext(), "7.x", "bin", null);
-        assertThat(validated.isValid()).isTrue();
-
         GradleWrapper gw = validated.getValue();
+        assertThat(validated.isValid()).isTrue();
         assertThat(gw).isNotNull();
         assertThat(gw.getVersion()).startsWith("7.");
+        assertThat(gw.getDistributionInfos().getDownloadUrl()).endsWith("-bin.zip");
+    }
+
+    @Test
+    void validateDistributionTypeAll() {
+        Validated validated = GradleWrapper.validate(new InMemoryExecutionContext(), "6.x", "all", null);
+        GradleWrapper gw = validated.getValue();
+        assertThat(validated.isValid()).isTrue();
+        assertThat(gw).isNotNull();
+        assertThat(gw.getVersion()).startsWith("6.");
+        assertThat(gw.getDistributionInfos().getDownloadUrl()).endsWith("-all.zip");
+    }
+
+    @Test
+    void validateWithDistributionNull() {
+        Validated validated = GradleWrapper.validate(new InMemoryExecutionContext(), "7.x", null, null);
+        GradleWrapper gw = validated.getValue();
+        assertThat(validated.isValid()).isTrue();
+        assertThat(gw).isNotNull();
+        assertThat(gw.getVersion()).startsWith("7.");
+        assertThat(gw.getDistributionInfos().getDownloadUrl()).endsWith("-bin.zip");
     }
 }


### PR DESCRIPTION
issue: https://github.com/openrewrite/rewrite/issues/2746

`GradleWrapper.validate() ` returns an invalid if the input distribution is `bin`, but in the validation, it's expected to be `Bin` which is case-sensitive. Change to parse enums in a case-insensitive way.

error message: 
```
Recipe validation error in distributionType: must be a valid distribution type
```