### PR TITLE
Print stacktrace on IllegalArgumentException in JGit

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -184,7 +184,10 @@ public class GitProvenance implements Marker {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (IllegalArgumentException | GitAPIException e) {
-            e.printStackTrace();
+            // Silently ignore if the project directory is not a git repository
+            if (!"requireGitDirOrWorkTree".equals(e.getStackTrace()[0].getMethodName())) {
+                e.printStackTrace();
+            }
             return null;
         }
     }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -184,6 +184,7 @@ public class GitProvenance implements Marker {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (IllegalArgumentException | GitAPIException e) {
+            e.printStackTrace();
             return null;
         }
     }

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.marker.ci.JenkinsBuildEnvironment;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -76,6 +78,19 @@ class GitProvenanceTest {
             GitProvenance git = GitProvenance.fromProjectDirectory(projectDir, null);
             assertThat(git).isNotNull();
             assertThat(git.getBranch()).isEqualTo("main");
+        }
+    }
+
+    @Test
+    void nonGitNoStacktrace(@TempDir Path projectDir) throws GitAPIException {
+        PrintStream standardErr = System.err;
+        ByteArrayOutputStream captor = new ByteArrayOutputStream();
+        try {
+            System.setErr(new PrintStream(captor));
+            assertThat(GitProvenance.fromProjectDirectory(projectDir, null)).isNull();
+            assertThat(captor.toString()).doesNotContain("jgit");
+        } finally {
+            System.setErr(standardErr);
         }
     }
 


### PR DESCRIPTION
Exceptions where hidden, making it tough to debug in Graal where an IllegalArgumentException wraps a NoSuchMethodException.