### PR TITLE
Fix handling of generics in `InstanceOfPatternMatch`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/InstanceOfPatternMatchTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/InstanceOfPatternMatchTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
 
-@SuppressWarnings({"RedundantCast", "DataFlowIssue", "ConstantValue", "CastCanBeRemovedNarrowingVariableType", "ClassInitializerMayBeStatic"})
+@SuppressWarnings({"rawtypes", "unchecked", "RedundantCast", "DataFlowIssue", "ConstantValue", "CastCanBeRemovedNarrowingVariableType", "ClassInitializerMayBeStatic"})
 class InstanceOfPatternMatchTest implements RewriteTest {
 
     @Override
@@ -454,4 +454,80 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             }
         }
     }
+
+    @Nested
+    class Generics {
+        @Nested
+        class Positive {
+            @Test
+            void rawInstanceOfAndWildcardParameterizedCast() {
+                rewriteRun(
+                  version(
+                    java(
+                        """
+                        import java.util.List;
+                        public class A {
+                            Object test(Object o) {
+                                return o instanceof List ? ((List<?>) o).get(0) : o.toString();
+                            }
+                        }
+                        """,
+                        """
+                        import java.util.List;
+                        public class A {
+                            Object test(Object o) {
+                                return o instanceof List l ? l.get(0) : o.toString();
+                            }
+                        }
+                        """
+                    ), 17)
+                );
+            }
+            @Test
+            void rawInstanceOfAndObjectParameterizedCast() {
+              rewriteRun(
+                version(
+                  java(
+                    """
+                      import java.util.List;
+                      public class A {
+                          Object test(Object o) {
+                              return o instanceof List ? ((List<Object>) o).get(0) : o.toString();
+                          }
+                      }
+                      """,
+                    """
+                      import java.util.List;
+                      public class A {
+                          Object test(Object o) {
+                              return o instanceof List l ? l.get(0) : o.toString();
+                          }
+                      }
+                      """
+                  ), 17)
+              );
+            }
+        }
+        @Nested
+        class Negative {
+            @Test
+            void rawInstanceOfAndParameterizedCast() {
+                rewriteRun(
+                  version(
+                    java(
+                      """
+                        import java.util.List;
+                        public class A {
+                            String test(Object o) {
+                                return o instanceof List ? ((List<String>) o).get(0) : o.toString();
+                            }
+                        }
+                        """
+                    ), 17
+                  )
+                );
+            }
+        }
+    }
+
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
@@ -39,7 +39,11 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
     }
 
     public ImplementInterface(J.ClassDeclaration scope, String interfaze, @Nullable List<Expression> typeParameters) {
-        this(scope, JavaType.ShallowClass.build(interfaze), typeParameters);
+        this(scope, ListUtils.nullIfEmpty(typeParameters) != null ?
+                new JavaType.Parameterized(null, JavaType.ShallowClass.build(interfaze), typeParameters.stream().map(Expression::getType).collect(Collectors.toList()))
+                : JavaType.ShallowClass.build(interfaze),
+                typeParameters
+        );
     }
 
     public ImplementInterface(J.ClassDeclaration scope, JavaType.FullyQualified interfaceType) {
@@ -82,7 +86,7 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
                         Markers.EMPTY,
                         impl,
                         JContainer.build(Space.EMPTY, elements, Markers.EMPTY),
-                        new JavaType.Parameterized(null, interfaceType, typeParameters.stream().map(Expression::getType).collect(Collectors.toList()))
+                        interfaceType
                 );
 
                 c = c.withImplements(ListUtils.concat(c.getImplements(), typedImpl));

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/InstanceOfPatternMatch.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/InstanceOfPatternMatch.java
@@ -155,7 +155,7 @@ public class InstanceOfPatternMatch extends Recipe {
             JavaType type = toJavaType((TypedTree) instanceOf.getClazz());
 
             Optional<ExpressionAndType> existing = instanceOfs.keySet().stream()
-                    .filter(k -> k.getType().equals(type)
+                    .filter(k -> TypeUtils.isAssignableTo(type, k.getType())
                             && SemanticallyEqual.areEqual(k.getExpression(), expression))
                     .findAny();
             if (!existing.isPresent()) {
@@ -170,7 +170,7 @@ public class InstanceOfPatternMatch extends Recipe {
             JavaType type = toJavaType(typeCast.getClazz().getTree());
 
             Optional<ExpressionAndType> match = instanceOfs.keySet().stream()
-                    .filter(k -> k.getType().equals(type)
+                    .filter(k -> TypeUtils.isAssignableTo(type, k.getType())
                             && SemanticallyEqual.areEqual(k.getExpression(), expression))
                     .findAny();
             if (match.isPresent()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoDoubleBraceInitialization.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/NoDoubleBraceInitialization.java
@@ -163,9 +163,14 @@ public class NoDoubleBraceInitialization extends Recipe {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
-                if (mi.getMethodType() != null && TypeUtils.isAssignableTo(identifier.getFieldType(), mi.getMethodType().getDeclaringType())) {
-                    if (mi.getSelect() == null
-                            || (mi.getSelect() instanceof J.Identifier && "this".equals(((J.Identifier) mi.getSelect()).getSimpleName()))) {
+                if (mi.getMethodType() != null && identifier.getFieldType() != null && mi.getSelect() == null
+                        || (mi.getSelect() instanceof J.Identifier && "this".equals(((J.Identifier) mi.getSelect()).getSimpleName()))) {
+                    JavaType rawFieldType = identifier.getFieldType().getType();
+                    rawFieldType = rawFieldType instanceof JavaType.Parameterized ? ((JavaType.Parameterized) rawFieldType).getType() : rawFieldType;
+                    JavaType rawMethodDeclaringType = mi.getMethodType().getDeclaringType();
+                    rawMethodDeclaringType = rawMethodDeclaringType instanceof JavaType.Parameterized ? ((JavaType.Parameterized) rawMethodDeclaringType).getType() : rawMethodDeclaringType;
+
+                    if (TypeUtils.isAssignableTo(rawFieldType, rawMethodDeclaringType)) {
                         return mi.withSelect(identifier);
                     }
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -19,8 +19,11 @@ import org.openrewrite.internal.lang.Nullable;
 
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 public class TypeUtils {
+    private static final JavaType.Class TYPE_OBJECT = JavaType.ShallowClass.build("java.lang.Object");
+
     private TypeUtils() {
     }
 
@@ -156,11 +159,26 @@ public class TypeUtils {
             }
             if (to == from) {
                 return true;
+            } else if (to instanceof JavaType.Parameterized) {
+                JavaType.Parameterized toParameterized = (JavaType.Parameterized) to;
+                if (!(from instanceof JavaType.Parameterized)) {
+                    return toParameterized.getTypeParameters().stream().allMatch(p -> isAssignableTo(p, TYPE_OBJECT));
+                }
+                JavaType.Parameterized fromParameterized = (JavaType.Parameterized) from;
+                List<JavaType> toParameters = toParameterized.getTypeParameters();
+                List<JavaType> fromParameters = fromParameterized.getTypeParameters();
+                int parameterCount = toParameters.size();
+                return parameterCount == fromParameters.size() &&
+                        isAssignableTo(toParameterized.getType(), fromParameterized.getType()) &&
+                        IntStream.range(0, parameterCount).allMatch(i -> isAssignableTo(toParameters.get(i), fromParameters.get(i)));
             } else if (to instanceof JavaType.FullyQualified) {
                 JavaType.FullyQualified toFq = (JavaType.FullyQualified) to;
                 return isAssignableTo(toFq.getFullyQualifiedName(), from);
             } else if (to instanceof JavaType.GenericTypeVariable) {
                 JavaType.GenericTypeVariable genericTo = (JavaType.GenericTypeVariable) to;
+                if (genericTo.getBounds().isEmpty()) {
+                    return true;
+                }
                 for (JavaType bound : genericTo.getBounds()) {
                     if (isAssignableTo(bound, from)) {
                         return true;


### PR DESCRIPTION
Both the types in the `instanceof` and the type cast expression can use generics or not. The recipe must be able to deal with this correctly by checking the type assignability.
