### PR TITLE
Improve `ListUtils.flatMap()` to return equaled reference if no change is made

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -18,6 +18,7 @@ package org.openrewrite.internal;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -149,7 +150,7 @@ public final class ListUtils {
 
         List<T> newLs = ls;
         boolean widened = false;
-        List<T> outputLs = new ArrayList<>();
+        List<T> outputLs = new ArrayList<>(ls.size());
 
         for (int i = 0; i < ls.size(); i++) {
             T tree = ls.get(i);
@@ -159,11 +160,18 @@ public final class ListUtils {
                 outputLs.add( (T) newTreeOrTrees);
             } else {
                 if (newTreeOrTrees instanceof Iterable) {
-                    //noinspection unchecked
-                    Iterable<T> it = (Iterable<T>) newTreeOrTrees;
-                    List<T> outLs = new ArrayList<>();
-                    for (T t : it) {
-                        outLs.add(t);
+                    List<T> outLs;
+
+                    if (newTreeOrTrees instanceof Collection) {
+                        //noinspection unchecked
+                        outLs = new ArrayList<>((Collection<T>) newTreeOrTrees);
+                    } else {
+                        outLs = new ArrayList<>();
+                        //noinspection unchecked
+                        Iterable<T> it = (Iterable<T>) newTreeOrTrees;
+                        for (T t : it) {
+                            outLs.add(t);
+                        }
                     }
 
                     outputLs.addAll(outLs);

--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -163,8 +161,10 @@ public final class ListUtils {
                 if (newTreeOrTrees instanceof Iterable) {
                     //noinspection unchecked
                     Iterable<T> it = (Iterable<T>) newTreeOrTrees;
-                    List<T> outLs = StreamSupport.stream(it.spliterator(), false)
-                        .collect(Collectors.toList());
+                    List<T> outLs = new ArrayList<>();
+                    for (T t : it) {
+                        outLs.add(t);
+                    }
 
                     outputLs.addAll(outLs);
 

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +29,13 @@ class ListUtilsTest {
         var l = List.of(1.0, 2.0, 3.0);
         assertThat(ListUtils.flatMap(l, l2 -> l2.intValue() % 2 == 0 ? List.of(2.0, 2.1, 2.2) : l2))
           .containsExactly(1.0, 2.0, 2.1, 2.2, 3.0);
+    }
+
+    @Test
+    void flatMapWithNoChangeShouldHaveReferenceEquality() {
+        var before = List.of(1, 2, 3);
+        var after = ListUtils.flatMap(before, Collections::singletonList);
+        assertThat(before == after).isTrue();
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -35,7 +35,7 @@ class ListUtilsTest {
     void flatMapWithNoChangeShouldHaveReferenceEquality() {
         var before = List.of(1, 2, 3);
         var after = ListUtils.flatMap(before, Collections::singletonList);
-        assertThat(before == after).isTrue();
+        assertThat(before).isSameAs(after);
     }
 
     @Test


### PR DESCRIPTION
I found a defect in `ListUtils.flatMap()`.
When there is no change made, it should return an equaled reference.
I need this feature to fix the applicability test issue (with widened files).

Example case 
```java
    @Test
    void flatMapWithNoChangeShouldHaveReferenceEquality() {
        var before = List.of(1, 2, 3);
        var after = ListUtils.flatMap(before, Collections::singletonList);
        assertThat(before).isSameAs(after);
    }
```