### PR TITLE
Improve the equality check in `ListUtils#flatMap()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -18,6 +18,7 @@ package org.openrewrite.internal;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -117,7 +118,9 @@ public final class ListUtils {
             //noinspection ConstantConditions
             return ls;
         }
+
         List<T> newLs = ls;
+        boolean nullEncountered = false;
         for (int i = 0; i < ls.size(); i++) {
             T tree = ls.get(i);
             T newTree = map.apply(i, tree);
@@ -127,9 +130,10 @@ public final class ListUtils {
                 }
                 newLs.set(i, newTree);
             }
+            nullEncountered |= newTree == null;
         }
 
-        if (newLs != ls) {
+        if (newLs != ls && nullEncountered) {
             //noinspection StatementWithEmptyBody
             while (newLs.remove(null)) ;
         }
@@ -188,8 +192,17 @@ public final class ListUtils {
         }
 
         if (newLs != ls) {
-            //noinspection StatementWithEmptyBody
-            while (newLs.remove(null)) ;
+            boolean identical = newLs.size() == ls.size();
+            for (int i = newLs.size() - 1; i >= 0; i--) {
+                T newElem = newLs.get(i);
+                identical = identical && newElem == ls.get(i);
+                if (newElem == null) {
+                    newLs.remove(i);
+                }
+            }
+            if (identical) {
+                newLs = ls;
+            }
         }
 
         return newLs;

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -15,46 +15,90 @@
  */
 package org.openrewrite.internal;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ListUtilsTest {
 
-    @Test
-    void flatMap() {
-        var l = List.of(1.0, 2.0, 3.0);
-        assertThat(ListUtils.flatMap(l, l2 -> l2.intValue() % 2 == 0 ? List.of(2.0, 2.1, 2.2) : l2))
-          .containsExactly(1.0, 2.0, 2.1, 2.2, 3.0);
+    @Nested
+    class FlatMap {
+        @Test
+        void flatMap() {
+            var l = List.of(1.0, 2.0, 3.0);
+            assertThat(ListUtils.flatMap(l, l2 -> l2.intValue() % 2 == 0 ? List.of(2.0, 2.1, 2.2) : l2))
+              .containsExactly(1.0, 2.0, 2.1, 2.2, 3.0);
+        }
+
+        @Test
+        void flatMapWithNoChangeShouldHaveReferenceEquality() {
+            var before = Arrays.asList(1, 2, 3);
+            var after = ListUtils.flatMap(before, Collections::singletonList);
+            assertThat(after).isSameAs(before);
+        }
+
+        @Test
+        void flatMapWithNoChangeShouldHaveReferenceEqualityIncludingNulls() {
+            var before = Arrays.asList(1, null, 3);
+            var after = ListUtils.flatMap(before, Collections::singletonList);
+            assertThat(after).isSameAs(before);
+        }
+
+        @Test
+        void replaceSingleWithMultipleAtPosition0() {
+            var l = List.of(1);
+            assertThat(ListUtils.flatMap(l, l2 -> List.of(2, 3)))
+              .containsExactly(2, 3);
+        }
+
+        @Test
+        void removeSingleItem() {
+            var l = List.of(1, 2, 3);
+            assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? null : l1))
+              .containsExactly(1, 3);
+        }
+
+        @Test
+        void replaceItemWithCollectionThenRemoveNextItem() {
+            var l = List.of(2, 0);
+            assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? List.of(10, 11) : null))
+              .containsExactly(10, 11);
+        }
+
+        @Test
+        void removeByAddingEmptyCollection() {
+            var l = List.of(2, 0);
+            assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? List.of(10, 11) : List.of()))
+              .containsExactly(10, 11);
+        }
     }
 
-    @Test
-    void replaceSingleWithMultipleAtPosition0() {
-        var l = List.of(1);
-        assertThat(ListUtils.flatMap(l, l2 -> List.of(2, 3)))
-          .containsExactly(2, 3);
-    }
-
-    @Test
-    void removeSingleItem() {
-        var l = List.of(1, 2, 3);
-        assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? null : l1))
-          .containsExactly(1, 3);
-    }
-
-    @Test
-    void replaceItemWithCollectionThenRemoveNextItem() {
-        var l = List.of(2, 0);
-        assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? List.of(10, 11) : null))
-          .containsExactly(10, 11);
-    }
-
-    @Test
-    void removeByAddingEmptyCollection() {
-        var l = List.of(2, 0);
-        assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? List.of(10, 11) : List.of()))
-          .containsExactly(10, 11);
+    @Nested
+    class Map {
+        @Test
+        void identityMap() {
+            var l = Arrays.asList(1, 2, 3);
+            assertThat(ListUtils.map(l, (i, e) -> e)).isSameAs(l);
+        }
+        @Test
+        void identityMapWithNulls() {
+            var l = Arrays.asList(1, null, 3);
+            assertThat(ListUtils.map(l, (i, e) -> e)).isSameAs(l);
+        }
+        @Test
+        void removeElements() {
+            var l = Arrays.asList(1, 2, 3);
+            assertThat(ListUtils.map(l, (i, e) -> i % 2 == 0 ? null : e)).isEqualTo(List.of(2));
+        }
+        @Test
+        void removeElementsWithNulls() {
+            var l = Arrays.asList(0, 1, 2, null, 4, 5);
+            assertThat(ListUtils.map(l, (i, e) -> i == 4 ? null : e)).isEqualTo(List.of(0, 1, 2, 5));
+        }
     }
 }


### PR DESCRIPTION
In case the mapping function returned an `Iterable` for one or more elements, the `flatMap()` method will now return the input list if the elements are all identical.
