### PR TITLE
A proposal change of `listUtil.flatMap()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -18,6 +18,7 @@ package org.openrewrite.internal;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -149,7 +150,7 @@ public final class ListUtils {
 
         List<T> newLs = ls;
         boolean widened = false;
-        List<T> outputLs = new ArrayList<>();
+        List<T> outputLs = new ArrayList<>(ls.size());
 
         for (int i = 0; i < ls.size(); i++) {
             T tree = ls.get(i);
@@ -159,11 +160,18 @@ public final class ListUtils {
                 outputLs.add( (T) newTreeOrTrees);
             } else {
                 if (newTreeOrTrees instanceof Iterable) {
-                    //noinspection unchecked
-                    Iterable<T> it = (Iterable<T>) newTreeOrTrees;
-                    List<T> outLs = new ArrayList<>();
-                    for (T t : it) {
-                        outLs.add(t);
+                    List<T> outLs;
+
+                    if (newTreeOrTrees instanceof Collection) {
+                        //noinspection unchecked
+                        outLs = new ArrayList<>((Collection<T>) newTreeOrTrees);
+                    } else {
+                        outLs = new ArrayList<>();
+                        //noinspection unchecked
+                        Iterable<T> it = (Iterable<T>) newTreeOrTrees;
+                        for (T t : it) {
+                            outLs.add(t);
+                        }
                     }
 
                     outputLs.addAll(outLs);

--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -163,8 +161,10 @@ public final class ListUtils {
                 if (newTreeOrTrees instanceof Iterable) {
                     //noinspection unchecked
                     Iterable<T> it = (Iterable<T>) newTreeOrTrees;
-                    List<T> outLs = StreamSupport.stream(it.spliterator(), false)
-                        .collect(Collectors.toList());
+                    List<T> outLs = new ArrayList<>();
+                    for (T t : it) {
+                        outLs.add(t);
+                    }
 
                     outputLs.addAll(outLs);
 

--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -154,7 +154,12 @@ public final class ListUtils {
         for (int i = 0; i < ls.size(); i++) {
             T tree = ls.get(i);
             List<T> newTreeOrTrees = flatMap.apply(i, tree);
-            outputLs.addAll(newTreeOrTrees);
+
+            if (newTreeOrTrees == null) {
+                widened = true;
+            } else {
+                outputLs.addAll(newTreeOrTrees);
+            }
 
             if (!widened) {
                 if (newTreeOrTrees.size() == 1) {

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +29,13 @@ class ListUtilsTest {
         var l = List.of(1.0, 2.0, 3.0);
         assertThat(ListUtils.flatMap(l, l2 -> l2.intValue() % 2 == 0 ? List.of(2.0, 2.1, 2.2) : l2))
           .containsExactly(1.0, 2.0, 2.1, 2.2, 3.0);
+    }
+
+    @Test
+    void flatMapWithNoChangeShouldHaveReferenceEquality() {
+        var before = List.of(1, 2, 3);
+        var after = ListUtils.flatMap(before, Collections::singletonList);
+        assertThat(before == after).isTrue();
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -35,7 +35,7 @@ class ListUtilsTest {
     void flatMapWithNoChangeShouldHaveReferenceEquality() {
         var before = List.of(1, 2, 3);
         var after = ListUtils.flatMap(before, Collections::singletonList);
-        assertThat(before == after).isTrue();
+        assertThat(before).isSameAs(after);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -17,8 +17,10 @@ package org.openrewrite.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,8 +29,16 @@ class ListUtilsTest {
     @Test
     void flatMap() {
         var l = List.of(1.0, 2.0, 3.0);
-        assertThat(ListUtils.flatMap(l, l2 -> l2.intValue() % 2 == 0 ? List.of(2.0, 2.1, 2.2) : l2))
+        assertThat(ListUtils.flatMap(l, l2 -> l2.intValue() % 2 == 0 ? List.of(2.0, 2.1, 2.2) : List.of(l2)))
           .containsExactly(1.0, 2.0, 2.1, 2.2, 3.0);
+    }
+
+    @Test
+    void flatMapList() {
+        var before = List.of(List.of(1, 2), List.of(3, 4));
+        var after = ListUtils.flatMap2(before,
+          list -> Collections.singletonList(list.stream().map(n -> n * 2).collect(Collectors.toList())));
+        assertThat(after).containsExactly(List.of(2, 4), List.of(6, 8));
     }
 
     @Test
@@ -48,7 +58,7 @@ class ListUtilsTest {
     @Test
     void removeSingleItem() {
         var l = List.of(1, 2, 3);
-        assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? null : l1))
+        assertThat(ListUtils.flatMap(l, l1 -> l1.equals(2) ? null : List.of(l1)))
           .containsExactly(1, 3);
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ListUtilsTest.java
@@ -36,7 +36,7 @@ class ListUtilsTest {
     @Test
     void flatMapList() {
         var before = List.of(List.of(1, 2), List.of(3, 4));
-        var after = ListUtils.flatMap2(before,
+        var after = ListUtils.flatMap(before,
           list -> Collections.singletonList(list.stream().map(n -> n * 2).collect(Collectors.toList())));
         assertThat(after).containsExactly(List.of(2, 4), List.of(6, 8));
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -444,12 +444,12 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             if (i == description.size() - 1) {
                 if (desc instanceof Javadoc.Text) {
                     Javadoc.Text text = (Javadoc.Text) desc;
-                    return text.withText(text.getText());
+                    return Collections.singletonList(text.withText(text.getText()));
                 } else {
                     return ListUtils.concat(desc, endBrace());
                 }
             }
-            return desc;
+            return Collections.singletonList(desc);
         });
 
         return new Javadoc.Index(
@@ -830,7 +830,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     return ListUtils.concat(sum, endBrace());
                 }
             }
-            return sum;
+            return Collections.singletonList(sum);
         });
 
         return new Javadoc.Summary(

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -444,12 +444,12 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             if (i == description.size() - 1) {
                 if (desc instanceof Javadoc.Text) {
                     Javadoc.Text text = (Javadoc.Text) desc;
-                    return text.withText(text.getText());
+                    return Collections.singletonList(text.withText(text.getText())) ;
                 } else {
                     return ListUtils.concat(desc, endBrace());
                 }
             }
-            return desc;
+            return Collections.singletonList(desc);
         });
 
         return new Javadoc.Index(
@@ -830,7 +830,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     return ListUtils.concat(sum, endBrace());
                 }
             }
-            return sum;
+            return Collections.singletonList(sum);
         });
 
         return new Javadoc.Summary(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ExtractInterfaceTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ExtractInterfaceTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -42,9 +43,11 @@ class ExtractInterfaceTest implements RewriteTest {
 
         @Override
         protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
-            return ListUtils.flatMap(before, b ->
-              ExtractInterface.extract((JavaSourceFile) b,
-                "org.openrewrite.interfaces.ITest"));
+            return ListUtils.flatMap(before, b -> {
+                List<JavaSourceFile> ljs = ExtractInterface.extract((JavaSourceFile) b,
+                  "org.openrewrite.interfaces.ITest");
+                return ljs.stream().map(s -> (SourceFile) s).collect(Collectors.toList());
+            });
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -153,7 +153,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
                     return unfoldStarImport(impoort, otherTypesInPackageUsed);
                 }
             }
-            return impoort;
+            return Collections.singletonList(impoort);
         }));
 
         if (c != cu && c.getPackageDeclaration() == null && c.getImports().isEmpty() &&
@@ -164,7 +164,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
         return c;
     }
 
-    private Object unfoldStarImport(J.Import starImport, Set<String> otherImportsUsed) {
+    private List<J.Import> unfoldStarImport(J.Import starImport, Set<String> otherImportsUsed) {
         List<J.Import> unfoldedImports = new ArrayList<>(otherImportsUsed.size());
         int i = 0;
         for (String other : otherImportsUsed) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CatchClauseOnlyRethrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/CatchClauseOnlyRethrows.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
@@ -68,7 +69,7 @@ public class CatchClauseOnlyRethrows extends Recipe {
                             return ListUtils.map(aTry.getBody().getStatements(), tryStat -> autoFormat(tryStat, ctx, getCursor()));
                         }
                     }
-                    return statement;
+                    return Collections.singletonList(statement);
                 }));
             }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MinimumSwitchCases.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MinimumSwitchCases.java
@@ -105,7 +105,7 @@ public class MinimumSwitchCases extends Recipe {
                 return block.withStatements(ListUtils.flatMap(block.getStatements(), (statement) -> {
                     Statement visited = (Statement) visit(statement, executionContext, getCursor());
                     if (!(visited instanceof J.Switch) || !visited.getMarkers().findFirst(DefaultOnly.class).isPresent()) {
-                        return visited;
+                        return Collections.singletonList(visited);
                     }
                     // Unwrap the contents of the default block, discarding the break statement if one exists
                     J.Case defaultCase = (J.Case) ((J.Switch) visited).getCases().getStatements().get(0);

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MultipleVariableDeclarationsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MultipleVariableDeclarationsVisitor.java
@@ -25,6 +25,7 @@ import org.openrewrite.marker.Markers;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
@@ -36,11 +37,11 @@ public class MultipleVariableDeclarationsVisitor extends JavaIsoVisitor<Executio
 
         return b.withStatements(ListUtils.flatMap(b.getStatements(), statement -> {
             if(!(statement instanceof J.VariableDeclarations)) {
-                return statement;
+                return Collections.singletonList(statement);
             }
             J.VariableDeclarations mv = (J.VariableDeclarations) statement;
             if(mv.getVariables().size() <= 1) {
-                return mv;
+                return Collections.singletonList(statement);
             }
 
             List<J.VariableDeclarations> newDecls = new ArrayList<>(mv.getVariables().size());
@@ -65,7 +66,9 @@ public class MultipleVariableDeclarationsVisitor extends JavaIsoVisitor<Executio
                 vd = autoFormat(vd, ctx, getCursor());
                 newDecls.add(vd);
             }
-            return newDecls;
+            return newDecls.stream()
+                .map(nc -> (Statement) nc)
+                .collect(Collectors.toList());
         }));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MultipleVariableDeclarationsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MultipleVariableDeclarationsVisitor.java
@@ -66,9 +66,8 @@ public class MultipleVariableDeclarationsVisitor extends JavaIsoVisitor<Executio
                 vd = autoFormat(vd, ctx, getCursor());
                 newDecls.add(vd);
             }
-            return newDecls.stream()
-                .map(nc -> (Statement) nc)
-                .collect(Collectors.toList());
+
+            return new ArrayList<>(newDecls);
         }));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/RemoveUnneededBlock.java
@@ -23,6 +23,8 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 
+import java.util.Collections;
+
 @Incubating(since = "7.21.0")
 public class RemoveUnneededBlock extends Recipe {
     @Override
@@ -60,7 +62,7 @@ public class RemoveUnneededBlock extends Recipe {
             // Else perform the flattening on this block.
             return block.withStatements(ListUtils.flatMap(bl.getStatements(), stmt -> {
                 if (!(stmt instanceof J.Block)) {
-                    return stmt;
+                    return Collections.singletonList(stmt);
                 }
                 J.Block nested = (J.Block) stmt;
                 return ListUtils.map(nested.getStatements(), inlinedStmt -> maybeAutoFormat(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryCatch.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryCatch.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -54,7 +55,7 @@ public class UnnecessaryCatch extends Recipe {
                             return ListUtils.map(aTry.getBody().getStatements(), tryStat -> autoFormat(tryStat, ctx, getCursor()));
                         }
                     }
-                    return statement;
+                    return Collections.singletonList(statement);
                 }));
             }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnwrapRepeatableAnnotations.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnwrapRepeatableAnnotations.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.search.FindRepeatableAnnotations;
 import org.openrewrite.java.tree.J;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class UnwrapRepeatableAnnotations extends Recipe {
@@ -94,7 +95,7 @@ public class UnwrapRepeatableAnnotations extends Recipe {
                         }
                     }.visit(a, 0);
 
-                    return unwrapped.isEmpty() ? a : unwrapped;
+                    return unwrapped.isEmpty() ? Collections.singletonList(a) : unwrapped;
                 });
             }
         };

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -24,10 +24,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
@@ -128,7 +125,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                         return ListUtils.concat(statement, gen);
                                 }
                             }
-                            return statement;
+                            return Collections.singletonList(statement);
                         }));
                     }
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -276,7 +276,7 @@ public class ImportLayoutStyle implements JavaStyle {
         return ListUtils.flatMap(originalImports, (i, anImport) -> {
             if (starFold.get() && i >= starFoldFrom.get() && i < starFoldTo.get()) {
                 return i == starFoldFrom.get() ?
-                        finalToAdd /* only add the star import once */ :
+                        Collections.singletonList(finalToAdd) /* only add the star import once */ :
                         null;
             } else if (finalAfter != null && anImport.getElement().isScope(finalAfter.getElement())) {
                 if (starFold.get()) {
@@ -284,7 +284,7 @@ public class ImportLayoutStyle implements JavaStyle {
                     if (starFoldFrom.get() == starFoldTo.get()) {
                         return Arrays.asList(finalToAdd, finalAfter);
                     } else {
-                        return finalAfter;
+                        return Collections.singletonList(finalAfter);
                     }
                 } else if (isNewBlock.get()) {
                     return anImport.getElement().isStatic() && !finalToAdd.getElement().isStatic() ?
@@ -295,7 +295,7 @@ public class ImportLayoutStyle implements JavaStyle {
             } else if (i == originalImports.size() - 1 && (finalAfter == null)) {
                 return Arrays.asList(anImport, finalToAdd);
             }
-            return anImport;
+            return Collections.singletonList(anImport);
         });
     }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
@@ -29,6 +29,8 @@ import org.openrewrite.xml.tree.Xml;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -63,7 +65,11 @@ public class RemoveOwaspSuppressions extends Recipe {
             if (!new XPathMatcher("/suppressions").matches(getCursor()) || t.getContent() == null) {
                 return t;
             }
-            return t.withContent(ListUtils.flatMap(t.getContent(), (i, c) -> isPastDueSuppression(c) ? null : c));
+//            List<? extends Content> lc =  ListUtils.flatMap(t.getContent(),
+//                (i, c) -> isPastDueSuppression(c) ? null : Collections.singletonList(c));
+            List<? extends Content> lc =  ListUtils.map(t.getContent(),
+                c -> isPastDueSuppression(c) ? null : c);
+            return t.withContent(lc);
         }
 
         private boolean isPastDueSuppression(Content content) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
@@ -29,8 +29,6 @@ import org.openrewrite.xml.tree.Xml;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -65,9 +63,7 @@ public class RemoveOwaspSuppressions extends Recipe {
             if (!new XPathMatcher("/suppressions").matches(getCursor()) || t.getContent() == null) {
                 return t;
             }
-            List<? extends Content> lc =  ListUtils.map(t.getContent(),
-                c -> isPastDueSuppression(c) ? null : c);
-            return t.withContent(lc);
+            return t.withContent(ListUtils.map(t.getContent(), c -> isPastDueSuppression(c) ? null : c));
         }
 
         private boolean isPastDueSuppression(Content content) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
@@ -65,8 +65,6 @@ public class RemoveOwaspSuppressions extends Recipe {
             if (!new XPathMatcher("/suppressions").matches(getCursor()) || t.getContent() == null) {
                 return t;
             }
-//            List<? extends Content> lc =  ListUtils.flatMap(t.getContent(),
-//                (i, c) -> isPastDueSuppression(c) ? null : Collections.singletonList(c));
             List<? extends Content> lc =  ListUtils.map(t.getContent(),
                 c -> isPastDueSuppression(c) ? null : c);
             return t.withContent(lc);


### PR DESCRIPTION
## Just a proposal here.

Want to address this problem the original one can not cover.
for the method 
```
public static <T> List<T> flatMap(@Nullable List<T> ls, BiFunction<Integer, T, Object> flatMap)
```

The `Object` type could produce ambiguity,  for example:
if `T` is a `List` type or any `Collection` type,  then `Object` may be a `List`, and it will be flattened inside, which would not be expected.
An example is like this 
```java
    @Test
    void flatMapList() {
        var before = List.of(List.of(1, 2), List.of(3, 4));
        var after = ListUtils.flatMap(before,
          list -> list.stream().map(n -> n * 2).collect(Collectors.toList()));
        assertThat(after).containsExactly(List.of(2, 4), List.of(6, 8));
    }
```
```
expected
  [[2, 4], [6, 8]]
but was
  [2, 4, 6, 8]
```
To address this, propose changing the method declaration to 
```
public static <T> List<T> flatMap(@Nullable List<T> ls, BiFunction<Integer, T, List<T>> flatMap)
```
