### PR TITLE
Fix a defect of `RewriteTest.rewriteRun()`  that cannot detect unexpected newly generated files

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
@@ -162,7 +162,7 @@ class AppendToTextFileTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2796")
     @Test
-    void missingUnexpectedGeneratedFiles() {
+    void missingExpectedGeneratedFiles() {
         assertThrows(AssertionError.class, () ->
           rewriteRun(
             spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")

--- a/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.text;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
@@ -153,6 +154,48 @@ class AppendToTextFileTest implements RewriteTest {
               content2
               """,
             spec -> spec.path("file2.txt").noTrim()
+          )
+        );
+    }
+
+    // This test is just to demonstrate RewriteRun defect, it's expected to fail since new file `file1.txt` generated but pass.
+    // todo, kunli, to be removed after this PR.
+    @Disabled("Expected to be failed since new file generated")
+    @Test
+    void demonstrateRewriteRunDefect() {
+        rewriteRun(
+          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
+            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+          text(
+            "existing2",
+            """
+              preamble2
+              content2
+              """,
+            spec -> spec.path("file2.txt").noTrim()
+          )
+        );
+    }
+
+    @Test
+    void changeAndCreatedFilesIfNeeded() {
+        rewriteRun(
+          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
+            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+          text(
+            "existing2",
+            """
+              preamble2
+              content2
+              """,
+            spec -> spec.path("file2.txt").noTrim()
+          ),
+          text(
+            null,
+            """
+              preamble1
+              content1
+              """
           )
         );
     }

--- a/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
@@ -17,12 +17,14 @@ package org.openrewrite.text;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
 import java.util.function.Supplier;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openrewrite.test.SourceSpecs.text;
 
 class AppendToTextFileTest implements RewriteTest {
@@ -158,25 +160,25 @@ class AppendToTextFileTest implements RewriteTest {
         );
     }
 
-    // This test is just to demonstrate RewriteRun defect, it's expected to fail since new file `file1.txt` generated but pass.
-    // todo, kunli, to be removed after this PR.
-    @Disabled("Expected to be failed since new file generated")
+    @Issue("https://github.com/openrewrite/rewrite/issues/2796")
     @Test
-    void demonstrateRewriteRunDefect() {
-        rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
-            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
-          text(
-            "existing2",
-            """
-              preamble2
-              content2
-              """,
-            spec -> spec.path("file2.txt").noTrim()
-          )
-        );
+    void missingUnexpectedGeneratedFiles() {
+        assertThrows(AssertionError.class, () ->
+          rewriteRun(
+            spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
+              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+            text(
+              "existing2",
+              """
+                preamble2
+                content2
+                """,
+              spec -> spec.path("file2.txt").noTrim()
+            )
+          ));
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/2796")
     @Test
     void changeAndCreatedFilesIfNeeded() {
         rewriteRun(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddGradleWrapperTest.java
@@ -119,6 +119,7 @@ class AddGradleWrapperTest implements RewriteTest {
           }).expectedCyclesThatMakeChanges(1),
           other("", spec -> spec.path("gradlew")),
           other("", spec -> spec.path("gradlew.bat")),
+          other("", spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")),
           buildGradle("")
         );
     }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -332,7 +332,7 @@ public interface RewriteTest extends SourceSpecs {
         }
 
         Collection<SourceSpec<?>> expectedNewSources = Collections.newSetFromMap(new IdentityHashMap<>());
-        Collection<Result> expectedNewResults = Collections.newSetFromMap(new IdentityHashMap<>());;
+        Collection<Result> expectedNewResults = Collections.newSetFromMap(new IdentityHashMap<>());
 
         for (SourceSpec<?> sourceSpec : sourceSpecs) {
             if (sourceSpec.before == null) {

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -460,6 +460,7 @@ public interface RewriteTest extends SourceSpecs {
                 } else if (result.getBefore() == null
                     && !(result.getAfter() instanceof Remote)
                     && !expectedNewResults.contains(result)
+                    && testMethodSpec.afterRecipes.isEmpty()
                 ) {
                     // falsely added files detected.
                     fail("The recipe added a source file \"" + result.getAfter().getSourcePath()

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -332,6 +332,8 @@ public interface RewriteTest extends SourceSpecs {
         }
 
         Collection<SourceSpec<?>> expectedNewSources = Collections.newSetFromMap(new IdentityHashMap<>());
+        Collection<Result> expectedNewResults = Collections.newSetFromMap(new IdentityHashMap<>());;
+
         for (SourceSpec<?> sourceSpec : sourceSpecs) {
             if (sourceSpec.before == null) {
                 expectedNewSources.add(sourceSpec);
@@ -352,6 +354,7 @@ public interface RewriteTest extends SourceSpecs {
 
                     if (result.getAfter() != null && sourceSpec.getSourcePath().equals(result.getAfter().getSourcePath())) {
                         expectedNewSources.remove(sourceSpec);
+                        expectedNewResults.add(result);
                         assertThat(result.getBefore())
                                 .as("Expected a new file for the source path but there was an existing file already present: " +
                                     sourceSpec.getSourcePath())
@@ -376,6 +379,7 @@ public interface RewriteTest extends SourceSpecs {
                     String expected = trimIndentPreserveCRLF(sourceSpec.after.apply(actual));
                     if (actual.equals(expected)) {
                         expectedNewSources.remove(sourceSpec);
+                        expectedNewResults.add(result);
                         //noinspection unchecked
                         ((Consumer<SourceFile>) sourceSpec.afterRecipe).accept(result.getAfter());
                         if (sourceSpec.sourcePath != null) {
@@ -450,10 +454,16 @@ public interface RewriteTest extends SourceSpecs {
                         }
                     }
 
-
                     //noinspection unchecked
                     ((Consumer<SourceFile>) sourceSpec.afterRecipe).accept(result.getAfter());
                     continue nextSourceFile;
+                } else if (result.getBefore() == null
+                    && !(result.getAfter() instanceof Remote)
+                    && !expectedNewResults.contains(result)
+                ) {
+                    // falsely added files detected.
+                    fail("The recipe added a source file \"" + result.getAfter().getSourcePath()
+                        + "\" that was not expected.");
                 }
             }
 


### PR DESCRIPTION
Fixes #2796

I found a defect that `RewriteTest.rewriteRun()` cannot detect unexpected newly generated files.
An example test is
```java
    @Test
    void demonstrateRewriteRunDefect() {
        rewriteRun(
          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
          text(
            "existing2",
            """
              preamble2
              content2
              """,
            spec -> spec.path("file2.txt").noTrim()
          )
        );
    }
```
 Recipe `AppendToTextFile` is expected to create new files `file1.txt` here, so the expected results are
```diff
Results = 

diff --git a/file1.txt b/file1.txt
new file mode 100644
index 0000000..0ece344
--- /dev/null
+++ b/file1.txt
@@ -0,0 +1,2 @@ org.openrewrite.text.AppendToTextFile
+preamble1
+content1

diff --git a/file2.txt b/file2.txt
index 2647aa3..d9b1872 100644
--- a/file2.txt
+++ b/file2.txt
@@ -1 +1,2 @@ org.openrewrite.text.AppendToTextFile
-existing2
\ No newline at end of file
+preamble2
+content2
```

The above test should fail since `file1.txt` is generated and should be detected, but it didn't and passed.
