### PR TITLE
Fix type errors in a few before sources of tests

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -340,7 +340,8 @@ class RemoveUnusedImportsTest implements RewriteTest {
               class A {
                  Collection<Integer> c;
                  Set<Integer> s = new HashSet<>();
-                 List<String> l = singletonList("a","b","c");
+                 Map<String, String> m = new HashMap<>();
+                 List<String> l = new ArrayList<>();
               }
               """
           )
@@ -832,7 +833,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
               import static java.util.Collections.*;
               
               class Test {
-                  ConcurrentHashMap<String, String> m = emptyMap();
+                  ConcurrentHashMap<String, String> m = new ConcurrentHashMap(emptyMap());
               }
               """
           )
@@ -1194,7 +1195,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
               class A {
                  Collection<Integer> c = emptyList();
                  Set<Integer> s = emptySet();
-                 List<String> l = singletonList("c","b","a");
+                 List<String> l = List.of("c","b","a");
                  Iterator<Short> i = emptyIterator();
                  Entry<String, Integer> entry;
               }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ExplicitLambdaArgumentTypesTest.java
@@ -62,6 +62,7 @@ class ExplicitLambdaArgumentTypesTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import java.util.List;
               import java.util.function.Consumer;
 
               class Test {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/InstanceOfPatternMatchTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/InstanceOfPatternMatchTest.java
@@ -237,7 +237,7 @@ class InstanceOfPatternMatchTest implements RewriteTest {
                         public class A {
                             void test(Object o) {
                                 if (o instanceof String) {
-                                    System.out.println(s);
+                                    System.out.println(o);
                                 }
                             }
                         }
@@ -255,7 +255,7 @@ class InstanceOfPatternMatchTest implements RewriteTest {
                         public class A {
                             void test(Object o) {
                                 if (o instanceof String) {
-                                    System.out.println(s);
+                                    System.out.println(o);
                                 } else {
                                     System.out.println((String) s);
                                 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RemoveUnusedPrivateMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RemoveUnusedPrivateMethodsTest.java
@@ -91,7 +91,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                       @MethodSource("sourceExample")
                       void test(String input) {
                       }
-                      private Stream<Arguments> sourceExample() {
+                      private Stream<Object> sourceExample() {
                           return null;
                       }
                   }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCaseTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RenamePrivateFieldsToCamelCaseTest.java
@@ -75,9 +75,9 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
                       private final String _var = "";
                       private void a() {
                           if (true) {
-                              Thread t = new Thread(){
+                              Thread t = new Thread() {
                                   public void run() {
-                                      String var = _val;
+                                      String var = "a";
                                   }
                               };
                           }


### PR DESCRIPTION
Unless a test case explicitly tests that a recipe behaves correctly in the presence of unresolved type references or the recipe is purely syntactic (e.g. formatting), it makes sense if all type references can be resolved, as otherwise the test may inadvertently be incorrect.
