### PR TITLE
Add `JavaType.FullyQualified.Kind.RECORD`

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -245,18 +245,19 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
         return clazz;
     }
 
-    private JavaType.Class.Kind getKind(Symbol.ClassSymbol sym) {
-        JavaType.Class.Kind kind;
-        if ((sym.flags_field & KIND_BITMASK_ENUM) != 0) {
-            kind = JavaType.Class.Kind.Enum;
-        } else if ((sym.flags_field & KIND_BITMASK_ANNOTATION) != 0) {
-            kind = JavaType.Class.Kind.Annotation;
-        } else if ((sym.flags_field & KIND_BITMASK_INTERFACE) != 0) {
-            kind = JavaType.Class.Kind.Interface;
-        } else {
-            kind = JavaType.Class.Kind.Class;
+    private JavaType.FullyQualified.Kind getKind(Symbol.ClassSymbol sym) {
+        switch (sym.getKind()) {
+            case ENUM:
+                return JavaType.FullyQualified.Kind.Enum;
+            case ANNOTATION_TYPE:
+                return JavaType.FullyQualified.Kind.Annotation;
+            case INTERFACE:
+                return JavaType.FullyQualified.Kind.Interface;
+            case RECORD:
+                return JavaType.FullyQualified.Kind.Record;
+            default:
+                return JavaType.FullyQualified.Kind.Class;
         }
-        return kind;
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RemoveUnusedLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/RemoveUnusedLocalVariablesTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.test.RewriteTest;
 import java.util.UUID;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
 
 @SuppressWarnings({
   "ConstantConditions",
@@ -937,14 +938,7 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
     @Test
     void recordCompactConstructor() {
         rewriteRun(
-          spec -> spec.beforeRecipe(cu -> {
-              var javaRuntimeVersion = System.getProperty("java.runtime.version");
-              var javaVendor = System.getProperty("java.vm.vendor");
-              if (new JavaVersion(UUID.randomUUID(), javaRuntimeVersion, javaVendor, javaRuntimeVersion, javaRuntimeVersion).getMajorVersion() != 17) {
-                  spec.recipe(Recipe.noop());
-              }
-          }),
-          java(
+          version(java(
             """
               public record MyRecord(
                  boolean bar,
@@ -957,7 +951,7 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
                 }
               }
               """
-          )
+          ), 17)
         );
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -289,7 +289,8 @@ public interface JavaType {
             Class,
             Enum,
             Interface,
-            Annotation
+            Annotation,
+            Record
         }
     }
 


### PR DESCRIPTION
Add a new enum constant `JavaType.FullyQualified.Kind.RECORD` for `JavaType.Class` instances representing records. This is required so that  `FindMissingTypes.FindMissingTypesVisitor#visitClassDeclaration()` doesn't report an error (with message `J.ClassDeclaration kind Record does not match the kind in its type information Class`).
