### PR TITLE
Fix the replacement coordinates for unary expressions

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/AvoidBoxedBooleanExpressionsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/AvoidBoxedBooleanExpressionsTest.java
@@ -61,6 +61,30 @@ public class AvoidBoxedBooleanExpressionsTest implements RewriteTest {
     }
 
     @Test
+    void unaryNotInIfCondition() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  boolean test(Boolean b) {
+                      if (!b) return false;
+                      return true;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  boolean test(Boolean b) {
+                      if (Boolean.FALSE.equals(b)) return false;
+                      return true;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void guardAgainstNpeUnaryExpressions() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/CoordinateBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/CoordinateBuilder.java
@@ -246,6 +246,31 @@ public abstract class CoordinateBuilder {
         }
     }
 
+    public static class Unary extends Statement {
+        Unary(J.Unary tree) {
+            super(tree);
+        }
+
+        @Override
+        JavaCoordinates after(Space.Location location) {
+            return after(isModifying() ? Space.Location.STATEMENT_PREFIX : Space.Location.EXPRESSION_PREFIX);
+        }
+
+        @Override
+        public JavaCoordinates before() {
+            return before(isModifying() ? Space.Location.STATEMENT_PREFIX : Space.Location.EXPRESSION_PREFIX);
+        }
+
+        @Override
+        public JavaCoordinates replace() {
+            return replace(isModifying() ? Space.Location.STATEMENT_PREFIX : Space.Location.EXPRESSION_PREFIX);
+        }
+
+        private boolean isModifying() {
+            return ((J.Unary) tree).getOperator().isModifying();
+        }
+    }
+
     public static class Package extends Statement {
         Package(J.Package tree) {
             super(tree);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5303,7 +5303,7 @@ public interface J extends Tree {
         @Override
         @Transient
         public CoordinateBuilder.Statement getCoordinates() {
-            return new CoordinateBuilder.Statement(this);
+            return new CoordinateBuilder.Unary(this);
         }
 
         @Override


### PR DESCRIPTION
A unary expression (like e.g. `!b`) cannot be used as a statement on its own like modifying unary expressions (like `i++`) can. As a result the `JavaTemplate` must use a corresponding coordinate when replacing a unary expression, as otherwise the Java code produced by the template compiler is incorrect.

This problem affects multiple recipes. So far `CompareEnumsWithEqualityOperator` and `AvoidBoxedBooleanExpressionsTest` have been identified.