### PR TITLE
Java parser partial reset

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
 
 import java.lang.reflect.Constructor;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -42,6 +43,12 @@ public class Java11Parser implements JavaParser {
     @Override
     public JavaParser reset() {
         delegate.reset();
+        return this;
+    }
+
+    @Override
+    public JavaParser reset(Collection<URI> cus) {
+        delegate.reset(cus);
         return this;
     }
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -285,6 +285,19 @@ public class ReloadableJava11Parser implements JavaParser {
         return this;
     }
 
+    @Override
+    public JavaParser reset(Collection<URI> uris) {
+        if (!uris.isEmpty()) {
+            compilerLog.reset(uris);
+        }
+        pfm.flush();
+        Check.instance(context).newRound();
+        Annotate.instance(context).newRound();
+        Enter.instance(context).newRound();
+        Modules.instance(context).newRound();
+        return this;
+    }
+
     public void setClasspath(Collection<Path> classpath) {
         this.classpath = classpath;
     }
@@ -345,6 +358,15 @@ public class ReloadableJava11Parser implements JavaParser {
 
         public void reset() {
             sourceMap.clear();
+        }
+
+        public void reset(Collection<URI> uris) {
+            for (Iterator<JavaFileObject> itr = sourceMap.keySet().iterator(); itr.hasNext();) {
+                JavaFileObject f = itr.next();
+                if (uris.contains(f.toUri())) {
+                    itr.remove();
+                }
+            }
         }
     }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
 
 import java.lang.reflect.Constructor;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
@@ -41,6 +42,12 @@ public class Java17Parser implements JavaParser {
     @Override
     public JavaParser reset() {
         delegate.reset();
+        return this;
+    }
+
+    @Override
+    public JavaParser reset(Collection<URI> cus) {
+        delegate.reset(cus);
         return this;
     }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.tree.J;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
@@ -47,6 +48,12 @@ public class Java8Parser implements JavaParser {
     @Override
     public JavaParser reset() {
         delegate.reset();
+        return this;
+    }
+
+    @Override
+    public JavaParser reset(Collection<URI> cus) {
+        delegate.reset(cus);
         return this;
     }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -255,6 +255,15 @@ class ReloadableJava8Parser implements JavaParser {
     }
 
     @Override
+    public JavaParser reset(Collection<URI> uris) {
+        if (!uris.isEmpty()) {
+            compilerLog.reset(uris);
+        }
+        pfm.flush();
+        return this;
+    }
+
+    @Override
     public void setClasspath(Collection<Path> classpath) {
         this.classpath = classpath;
     }
@@ -304,6 +313,15 @@ class ReloadableJava8Parser implements JavaParser {
 
         public void reset() {
             sourceMap.clear();
+        }
+
+        public void reset(Collection<URI> uris) {
+            for (Iterator<JavaFileObject> itr = sourceMap.keySet().iterator(); itr.hasNext();) {
+                JavaFileObject f = itr.next();
+                if (uris.contains(f.toUri())) {
+                    itr.remove();
+                }
+            }
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -266,6 +266,8 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
      */
     JavaParser reset();
 
+    JavaParser reset(Collection<URI> uris);
+
     /**
      * Changes the classpath on the parser. Intended for use in multiple pass parsing, where we want to keep the
      * compiler symbol table intact for type attribution on later parses, i.e. for maven multi-module projects.


### PR DESCRIPTION
Partial reset of the JavaParser to avoid exception urging to call `reset()`