### PR TITLE
`MethodParamPad` no longer formats entire method body

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -58,6 +58,11 @@ public interface SourceFile extends Tree {
         return NamedStyles.merge(style, getMarkers().findAll(NamedStyles.class));
     }
 
+    default <S extends Style> S getStyle(Class<S> style, S defaultStyle) {
+        S s = getStyle(style);
+        return s == null ? defaultStyle : s;
+    }
+
     default <P> byte[] printAllAsBytes(P p) {
         return printAll(p).getBytes(getCharset() == null ? StandardCharsets.UTF_8 : getCharset());
     }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/OmitParenthesesFormat.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/OmitParenthesesFormat.java
@@ -23,6 +23,8 @@ import org.openrewrite.groovy.style.OmitParenthesesStyle;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.JavaSourceFile;
 
+import java.util.Optional;
+
 public class OmitParenthesesFormat extends Recipe {
     @Override
     public String getDisplayName() {
@@ -42,10 +44,7 @@ public class OmitParenthesesFormat extends Recipe {
     private static class OmitParenthesesFromCompilationUnitStyle extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext ctx) {
-            OmitParenthesesStyle style = ((SourceFile) cu).getStyle(OmitParenthesesStyle.class);
-            if (style == null) {
-                style = OmitParenthesesStyle.DEFAULT;
-            }
+            OmitParenthesesStyle style = Optional.ofNullable(((SourceFile) cu).getStyle(OmitParenthesesStyle.class)).orElse(OmitParenthesesStyle.DEFAULT);
             if(style.getLastArgumentLambda()) {
                 doAfterVisit(new OmitParenthesesForLastArgumentLambda().getVisitor());
             }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/MethodParamPadTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/MethodParamPadTest.java
@@ -308,6 +308,22 @@ class MethodParamPadTest implements RewriteTest {
         );
     }
 
+    @SuppressWarnings("StatementWithEmptyBody")
+    @Test
+    void bodyNotFormatted() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  void test() {
+                      for  (int i=0;i<10;i++) {}
+                  }
+              }
+              """
+          )
+        );
+    }
+
     private static Consumer<SourceSpec<J.CompilationUnit>> autoFormatIsIdempotent() {
         return spec -> spec.afterRecipe(cu ->
           assertThat(new AutoFormatVisitor<>().visit(cu, 0)).isEqualTo(cu));

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPad.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.cleanup;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.SourceFile;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.format.SpacesVisitor;
 import org.openrewrite.java.style.*;
@@ -46,19 +45,11 @@ public class MethodParamPad extends Recipe {
         SpacesStyle spacesStyle;
         MethodParamPadStyle methodParamPadStyle;
 
-        @Nullable
-        EmptyForInitializerPadStyle emptyForInitializerPadStyle;
-
-        @Nullable
-        EmptyForIteratorPadStyle emptyForIteratorPadStyle;
-
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile javaSourceFile, ExecutionContext ctx) {
             SourceFile cu = (SourceFile)javaSourceFile;
             spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
             methodParamPadStyle = cu.getStyle(MethodParamPadStyle.class) == null ? Checkstyle.methodParamPadStyle() : cu.getStyle(MethodParamPadStyle.class);
-            emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
-            emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
 
             spacesStyle = spacesStyle.withBeforeParentheses(
                     spacesStyle.getBeforeParentheses()
@@ -78,7 +69,7 @@ public class MethodParamPad extends Recipe {
                         )
                 );
             }
-            md = (J.MethodDeclaration)new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, md).visitNonNull(md, ctx);
+            md = (J.MethodDeclaration)new SpacesVisitor<>(spacesStyle, null, null, md.getParameters().get(0)).visitNonNull(md, ctx);
             return md;
         }
 
@@ -92,7 +83,7 @@ public class MethodParamPad extends Recipe {
                         )
                 );
             }
-            mi = (J.MethodInvocation)new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, mi).visitNonNull(mi, ctx);
+            mi = (J.MethodInvocation)new SpacesVisitor<>(spacesStyle, null, null, mi).visitNonNull(mi, ctx);
             return mi;
         }
 
@@ -106,7 +97,7 @@ public class MethodParamPad extends Recipe {
                         )
                 );
             }
-            nc = (J.NewClass)new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, nc).visitNonNull(nc, ctx);
+            nc = (J.NewClass)new SpacesVisitor<>(spacesStyle, null, null, nc).visitNonNull(nc, ctx);
             return nc;
         }
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/MethodParamPad.java
@@ -24,6 +24,8 @@ import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 
+import java.util.Optional;
+
 public class MethodParamPad extends Recipe {
     @Override
     public String getDisplayName() {
@@ -48,8 +50,8 @@ public class MethodParamPad extends Recipe {
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile javaSourceFile, ExecutionContext ctx) {
             SourceFile cu = (SourceFile)javaSourceFile;
-            spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
-            methodParamPadStyle = cu.getStyle(MethodParamPadStyle.class) == null ? Checkstyle.methodParamPadStyle() : cu.getStyle(MethodParamPadStyle.class);
+            spacesStyle = Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces());
+            methodParamPadStyle = Optional.ofNullable(cu.getStyle(MethodParamPadStyle.class)).orElse(Checkstyle.methodParamPadStyle());
 
             spacesStyle = spacesStyle.withBeforeParentheses(
                     spacesStyle.getBeforeParentheses()
@@ -69,7 +71,8 @@ public class MethodParamPad extends Recipe {
                         )
                 );
             }
-            md = (J.MethodDeclaration)new SpacesVisitor<>(spacesStyle, null, null, md.getParameters().get(0)).visitNonNull(md, ctx);
+            md = (J.MethodDeclaration)new SpacesVisitor<>(spacesStyle, null, null, md.getParameters().get(0))
+                    .visitNonNull(md, ctx, getCursor().getParentTreeCursor().fork());
             return md;
         }
 
@@ -83,7 +86,8 @@ public class MethodParamPad extends Recipe {
                         )
                 );
             }
-            mi = (J.MethodInvocation)new SpacesVisitor<>(spacesStyle, null, null, mi).visitNonNull(mi, ctx);
+            mi = (J.MethodInvocation)new SpacesVisitor<>(spacesStyle, null, null, mi)
+                    .visitNonNull(mi, ctx, getCursor().getParentTreeCursor().fork());
             return mi;
         }
 
@@ -97,7 +101,8 @@ public class MethodParamPad extends Recipe {
                         )
                 );
             }
-            nc = (J.NewClass)new SpacesVisitor<>(spacesStyle, null, null, nc).visitNonNull(nc, ctx);
+            nc = (J.NewClass)new SpacesVisitor<>(spacesStyle, null, null, nc)
+                    .visitNonNull(nc, ctx, getCursor().getParentTreeCursor().fork());
             return nc;
         }
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
@@ -48,8 +48,8 @@ public class TypecastParenPad extends Recipe {
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile javaSourceFile, ExecutionContext ctx) {
             SourceFile cu = (SourceFile)javaSourceFile;
-            spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
-            typecastParenPadStyle = cu.getStyle(TypecastParenPadStyle.class) == null ? Checkstyle.typecastParenPadStyle() : cu.getStyle(TypecastParenPadStyle.class);
+            spacesStyle = cu.getStyle(SpacesStyle.class, IntelliJ.spaces());
+            typecastParenPadStyle = cu.getStyle(TypecastParenPadStyle.class, Checkstyle.typecastParenPadStyle()) ;
 
             spacesStyle = spacesStyle.withWithin(spacesStyle.getWithin().withTypeCastParentheses(typecastParenPadStyle.getSpace()));
             return super.visitJavaSourceFile((JavaSourceFile)cu, ctx);
@@ -58,7 +58,8 @@ public class TypecastParenPad extends Recipe {
         @Override
         public J.TypeCast visitTypeCast(J.TypeCast typeCast, ExecutionContext ctx) {
             J.TypeCast tc = super.visitTypeCast(typeCast, ctx);
-            tc = (J.TypeCast) new SpacesVisitor<>(spacesStyle, null, null, tc).visitNonNull(tc, ctx);
+            tc = (J.TypeCast) new SpacesVisitor<>(spacesStyle, null, null, tc)
+                    .visitNonNull(tc, ctx, getCursor().getParentTreeCursor().fork());
             return tc;
         }
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
@@ -24,6 +24,8 @@ import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 
+import java.util.Optional;
+
 public class TypecastParenPad extends Recipe {
     @Override
     public String getDisplayName() {
@@ -48,8 +50,8 @@ public class TypecastParenPad extends Recipe {
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile javaSourceFile, ExecutionContext ctx) {
             SourceFile cu = (SourceFile)javaSourceFile;
-            spacesStyle = cu.getStyle(SpacesStyle.class, IntelliJ.spaces());
-            typecastParenPadStyle = cu.getStyle(TypecastParenPadStyle.class, Checkstyle.typecastParenPadStyle()) ;
+            spacesStyle = Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces());
+            typecastParenPadStyle = Optional.ofNullable(cu.getStyle(TypecastParenPadStyle.class)).orElse(Checkstyle.typecastParenPadStyle());
 
             spacesStyle = spacesStyle.withWithin(spacesStyle.getWithin().withTypeCastParentheses(typecastParenPadStyle.getSpace()));
             return super.visitJavaSourceFile((JavaSourceFile)cu, ctx);

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/TypecastParenPad.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.cleanup;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.SourceFile;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.format.SpacesVisitor;
 import org.openrewrite.java.style.*;
@@ -46,19 +45,11 @@ public class TypecastParenPad extends Recipe {
         SpacesStyle spacesStyle;
         TypecastParenPadStyle typecastParenPadStyle;
 
-        @Nullable
-        EmptyForInitializerPadStyle emptyForInitializerPadStyle;
-
-        @Nullable
-        EmptyForIteratorPadStyle emptyForIteratorPadStyle;
-
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile javaSourceFile, ExecutionContext ctx) {
             SourceFile cu = (SourceFile)javaSourceFile;
             spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
             typecastParenPadStyle = cu.getStyle(TypecastParenPadStyle.class) == null ? Checkstyle.typecastParenPadStyle() : cu.getStyle(TypecastParenPadStyle.class);
-            emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
-            emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
 
             spacesStyle = spacesStyle.withWithin(spacesStyle.getWithin().withTypeCastParentheses(typecastParenPadStyle.getSpace()));
             return super.visitJavaSourceFile((JavaSourceFile)cu, ctx);
@@ -67,7 +58,7 @@ public class TypecastParenPad extends Recipe {
         @Override
         public J.TypeCast visitTypeCast(J.TypeCast typeCast, ExecutionContext ctx) {
             J.TypeCast tc = super.visitTypeCast(typeCast, ctx);
-            doAfterVisit(new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle, tc));
+            tc = (J.TypeCast) new SpacesVisitor<>(spacesStyle, null, null, tc).visitNonNull(tc, ctx);
             return tc;
         }
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -49,9 +49,9 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
 
     public SpacesVisitor(SpacesStyle style, @Nullable EmptyForInitializerPadStyle emptyForInitializerPadStyle, @Nullable EmptyForIteratorPadStyle emptyForIteratorPadStyle, @Nullable Tree stopAfter) {
         this.style = style;
-        this.stopAfter = stopAfter;
         this.emptyForInitializerPadStyle = emptyForInitializerPadStyle;
         this.emptyForIteratorPadStyle = emptyForIteratorPadStyle;
+        this.stopAfter = stopAfter;
     }
 
     <T extends J> T spaceBefore(T j, boolean spaceBefore) {
@@ -1206,7 +1206,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
     @Override
     public J postVisit(J tree, P p) {
         if (stopAfter != null && stopAfter.isScope(tree)) {
-            getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, "stop", true);
+            getCursor().getRoot().putMessage("stop", true);
         }
         return super.postVisit(tree, p);
     }


### PR DESCRIPTION
The `MethodParamPad` recipe now uses the first method parameter (or corresponding `J.Empty` marker if there are none) as the stop criterion for the `SpacesVisitor` rather than the method declaration itself.

To get this to work in the context of the `MethodParamPad` the `SpacesVisitor` had to be changed to add the stop message to the root cursor, since when visiting a subtree there is not necessarily any cursor for the source file node.
