### PR TITLE
Allow Recipes to influence later Recipe Applicability

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -19,6 +19,8 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.filter.RecipeApplicableTest;
+import org.openrewrite.filter.RecipeSingleSourceApplicableTest;
 import org.openrewrite.internal.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Generated;
@@ -192,6 +194,14 @@ public interface RecipeScheduler {
         }
 
         try {
+            for (RecipeApplicableTest test : ctx.getMessage(RecipeApplicableTest.class.getSimpleName(), Collections.<RecipeApplicableTest>emptySet())) {
+                recipe.addApplicableTest(test.getTest(recipe));
+            }
+
+            for (RecipeSingleSourceApplicableTest test : ctx.getMessage(RecipeSingleSourceApplicableTest.class.getSimpleName(), Collections.<RecipeSingleSourceApplicableTest>emptySet())) {
+                recipe.addSingleSourceApplicableTest(test.getTest(recipe));
+            }
+
             if (!recipe.getApplicableTests().isEmpty()) {
                 boolean anySourceMatch = false;
                 for (S s : before) {

--- a/rewrite-core/src/main/java/org/openrewrite/filter/RecipeApplicableTest.java
+++ b/rewrite-core/src/main/java/org/openrewrite/filter/RecipeApplicableTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.filter;
+
+import org.openrewrite.*;
+
+/**
+ * A {@link Recipe#getApplicableTests()} test to be applied to {@link Recipe} executions.
+ * </p>
+ * <b>Note: Heavily Incubating</b>
+ * </p>
+ * </p>
+ * To use this class properly, use {@link #addToExecutionContext}.
+ */
+@Incubating(since = "7.36.0")
+@FunctionalInterface
+public interface RecipeApplicableTest {
+
+    /**
+     * The test should implement the specification described on {@link Recipe#getApplicableTest()}.
+     *
+     * @param recipe The current {@link Recipe} the {@link Recipe#getApplicableTest()} is being applied to.
+     *               This will be the same as {@link ExecutionContext#getCurrentRecipe()}.
+     * @return A tree visitor that performs an applicability test.
+     */
+    TreeVisitor<?, ExecutionContext> getTest(Recipe recipe);
+
+    /**
+     * Adds a {@link RecipeApplicableTest} to the {@link ExecutionContext} so the {@link RecipeScheduler} will
+     * configure all <i>future</i> {@link Recipe} executions.
+     * </p>
+     * This allows any {@link Recipe} to influence the behavior/applicability of all future {@link Recipe} executions.
+     * </p>
+     * This method is best invoked within the {@link Recipe#visit} method.
+     */
+    static void addToExecutionContext(ExecutionContext ctx, RecipeApplicableTest test) {
+        ctx.putMessageInSet(RecipeApplicableTest.class.getSimpleName(), test);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/filter/RecipeSingleSourceApplicableTest.java
+++ b/rewrite-core/src/main/java/org/openrewrite/filter/RecipeSingleSourceApplicableTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.filter;
+
+import org.openrewrite.*;
+
+/**
+ * A {@link Recipe#getSingleSourceApplicableTest()} test to be applied to {@link Recipe} executions.
+ * </p>
+ * <b>Note: Heavily Incubating</b>
+ * </p>
+ * </p>
+ * To use this class properly, use {@link #addToExecutionContext}.
+ */
+@Incubating(since = "7.36.0")
+@FunctionalInterface
+public interface RecipeSingleSourceApplicableTest {
+
+    /**
+     * The test should implement the specification described on {@link Recipe#getSingleSourceApplicableTest()}.
+     *
+     * @param recipe The current {@link Recipe} the {@link Recipe#getSingleSourceApplicableTest()} is being applied to. This will be the same as {@link ExecutionContext#getCurrentRecipe()}.
+     * @return A tree visitor that performs an applicability test.
+     */
+    TreeVisitor<?, ExecutionContext> getTest(Recipe recipe);
+
+    /**
+     * Adds a {@link RecipeSingleSourceApplicableTest} to the {@link ExecutionContext} so the {@link RecipeScheduler} will
+     * configure all <i>future</i> {@link Recipe} executions.
+     * </p>
+     * This allows any {@link Recipe} to influence the behavior/applicability of all future {@link Recipe} executions.
+     * </p>
+     * This method is best invoked within the {@link Recipe#visit} method.
+     */
+    static void addToExecutionContext(ExecutionContext ctx, RecipeSingleSourceApplicableTest test) {
+        ctx.putMessageInSet(RecipeSingleSourceApplicableTest.class.getSimpleName(), test);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/filter/package-info.java
+++ b/rewrite-core/src/main/java/org/openrewrite/filter/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.filter;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/filter/SourceApplicabilityFilterTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/filter/SourceApplicabilityFilterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.filter;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.CompositeRecipe;
+import org.openrewrite.java.search.FindMethods;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.SourceSpecs.dir;
+
+public class SourceApplicabilityFilterTest {
+    @Language("java")
+    private static final String PRODUCTION_INITIAL = """
+      class Production {
+        Production() {
+          System.out.println("Hello World!");
+        }
+      }
+      """;
+
+    @Language("java")
+    private static final String PRODUCTION_SEARCH_RESULT = """
+      class Production {
+        Production() {
+          /*~~>*/System.out.println("Hello World!");
+        }
+      }
+      """;
+
+    @Language("java")
+    private static final String TEST_INITIAL = """
+      class Test {
+        Test() {
+          System.out.println("Hello World!");
+        }
+      }
+      """;
+
+    @Language("java")
+    private static final String TEST_SEARCH_RESULT = """
+      class Test {
+        Test() {
+          /*~~>*/System.out.println("Hello World!");
+        }
+      }
+      """;
+
+    @Nested
+    class AllSourceTest implements RewriteTest {
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new CompositeRecipe()
+              .doNext(new SourceApplicabilityFilter(SourceApplicabilityFilter.Target.ALL_SOURCE))
+              .doNext(new FindMethods("java.io.PrintStream println(..)", true, "none")));
+        }
+
+        @Test
+        void justProduction() {
+            rewriteRun(
+              dir("src/main/java/org/openrewrite/java/", java(PRODUCTION_INITIAL, PRODUCTION_SEARCH_RESULT))
+            );
+        }
+
+        @Test
+        void justTest() {
+            rewriteRun(
+              dir("src/test/java/org/openrewrite/java/", java(TEST_INITIAL, TEST_SEARCH_RESULT))
+            );
+        }
+
+        @Test
+        void productionAndTest() {
+            rewriteRun(
+              dir("src/main/java/org/openrewrite/java/", java(PRODUCTION_INITIAL, PRODUCTION_SEARCH_RESULT)),
+              dir("src/test/java/org/openrewrite/java/", java(TEST_INITIAL, TEST_SEARCH_RESULT))
+            );
+        }
+    }
+
+    @Nested
+    class AllSourceIfDetectedInNonTestTest implements RewriteTest {
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new CompositeRecipe()
+              .doNext(new SourceApplicabilityFilter(SourceApplicabilityFilter.Target.ALL_SOURCE_IF_DETECTED_IN_NON_TEST))
+              .doNext(new FindMethods("java.io.PrintStream println(..)", true, "none")));
+        }
+
+        @Test
+        void justProduction() {
+            rewriteRun(
+              dir("src/main/java/org/openrewrite/java/", java(PRODUCTION_INITIAL, PRODUCTION_SEARCH_RESULT))
+            );
+        }
+
+        @Test
+        void justTest() {
+            rewriteRun(
+              dir("src/test/java/org/openrewrite/java/", java(TEST_INITIAL))
+            );
+        }
+
+        @Test
+        void productionAndTest() {
+            rewriteRun(
+              dir("src/main/java/org/openrewrite/java/", java(PRODUCTION_INITIAL, PRODUCTION_SEARCH_RESULT)),
+              dir("src/test/java/org/openrewrite/java/", java(TEST_INITIAL, TEST_SEARCH_RESULT))
+            );
+        }
+    }
+
+    @Nested
+    class NonTestSourceTest implements RewriteTest {
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new CompositeRecipe()
+              .doNext(new SourceApplicabilityFilter(SourceApplicabilityFilter.Target.NON_TEST_SOURCE))
+              .doNext(new FindMethods("java.io.PrintStream println(..)", true, "none")));
+        }
+
+        @Test
+        void justProduction() {
+            rewriteRun(
+              dir("src/main/java/org/openrewrite/java/", java(PRODUCTION_INITIAL, PRODUCTION_SEARCH_RESULT))
+            );
+        }
+
+        @Test
+        void justTest() {
+            rewriteRun(
+              dir("src/test/java/org/openrewrite/java/", java(TEST_INITIAL))
+            );
+        }
+
+        @Test
+        void productionAndTest() {
+            rewriteRun(
+              dir("src/main/java/org/openrewrite/java/", java(PRODUCTION_INITIAL, PRODUCTION_SEARCH_RESULT)),
+              dir("src/test/java/org/openrewrite/java/", java(TEST_INITIAL))
+            );
+        }
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/filter/SourceApplicabilityFilter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/filter/SourceApplicabilityFilter.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.filter;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.filter.RecipeApplicableTest;
+import org.openrewrite.filter.RecipeSingleSourceApplicableTest;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Heavily Incubating
+ */
+@Incubating(since = "7.36.0")
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class SourceApplicabilityFilter extends Recipe {
+
+    @AllArgsConstructor
+    enum Target {
+        AllSource(Target.ALL_SOURCE),
+        AllSourceWhenNonTestDetected(Target.ALL_SOURCE_IF_DETECTED_IN_NON_TEST),
+        NonTestSource(Target.NON_TEST_SOURCE);
+
+        static final String ALL_SOURCE = "All Source";
+        static final String ALL_SOURCE_IF_DETECTED_IN_NON_TEST = "All Source if detected in Non Test Source";
+        static final String NON_TEST_SOURCE = "Non-Test Source";
+
+        private static Target fromString(@Nullable String target) {
+            if (target == null) {
+                return NonTestSource;
+            }
+            switch (target) {
+                case ALL_SOURCE:
+                    return AllSource;
+                case ALL_SOURCE_IF_DETECTED_IN_NON_TEST:
+                    return AllSourceWhenNonTestDetected;
+                default:
+                    return NonTestSource;
+            }
+        }
+
+        private final String description;
+    }
+
+    @Option(
+            displayName = "Target",
+            description = "Specify whether all recipes scheduled in this run should apply to all sources or only non-test sources. Defaults to non-test sources.",
+            required = false,
+            valid = {
+                    Target.ALL_SOURCE,
+                    Target.ALL_SOURCE_IF_DETECTED_IN_NON_TEST,
+                    Target.NON_TEST_SOURCE
+            },
+            example = Target.ALL_SOURCE
+    )
+    String target;
+
+    @Override
+    public String getDisplayName() {
+        return "Source Applicability Filter";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Filters the set of sources all future recipes will be applied to.";
+    }
+
+    @Override
+    protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
+        Target target = Target.fromString(getTarget());
+        if (Target.AllSource.equals(target)) {
+            // No filtering required
+            return super.visit(before, ctx);
+        }
+
+        if (Target.AllSourceWhenNonTestDetected.equals(target)) {
+            // Must find one case of a non-test source file that is modified before applying the recipe to all
+            RecipeApplicableTest.addToExecutionContext(ctx, recipe -> new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                    // If the target is Non Test Source, and this is a test source file, skip it.
+                    if (isTestSource(cu.getSourcePath())) {
+                        return cu;
+                    }
+                    boolean allMatch = true;
+                    for (TreeVisitor<?, ExecutionContext> applicableTest : recipe.getSingleSourceApplicableTests()) {
+                        if (applicableTest.visit(cu, ctx, getCursor().getParentOrThrow()) == cu) {
+                            allMatch = false;
+                            break;
+                        }
+                    }
+                    if (allMatch) {
+                        // Unfortunately, this couples the Applicable Test to the Recipe visitor, which could be expensive.
+                        // However, it guarantees that at least one non-test source file will be modified before attempting to apply it to the entire tree.
+                        return (J.CompilationUnit) getVisitor(recipe).visitNonNull(cu, executionContext, getCursor().getParentOrThrow());
+                    }
+                    return cu;
+                }
+            });
+        }
+
+        if (Target.NonTestSource.equals(target)) {
+            // Must not apply the change to any test source files
+            RecipeSingleSourceApplicableTest.addToExecutionContext(ctx, recipe -> new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                    if (isTestSource(cu.getSourcePath())) {
+                        return cu;
+                    } else {
+                        return SearchResult.found(cu);
+                    }
+                }
+            });
+        }
+        return super.visit(before, ctx);
+    }
+
+    private static TreeVisitor<?, ExecutionContext> getVisitor(Recipe recipe) {
+        try {
+            Method getVisitor = Recipe.class.getDeclaredMethod("getVisitor");
+            getVisitor.setAccessible(true);
+            //noinspection unchecked
+            return (TreeVisitor<?, ExecutionContext>) getVisitor.invoke(recipe);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static boolean isTestSource(Path path) {
+        return path.getFileSystem().getPathMatcher("glob:**/test/**").matches(path);
+    }
+}


### PR DESCRIPTION
This is a proposal based upon a discussion here:
https://linuxfoundation.slack.com/archives/C04HR6EJ38D/p1674840301966909

This allows any Recipe to influence the applicability test of later Recipes that are executed.

This allows Recipes to provide filter logic without requiring custom filter logic in every later recipe.

This PR obviously needs tests, but it demonstrates the general idea behind the proposal.