### PR TITLE
Fix `IsEmptyCallOnCollections` in for loop control

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.cleanup.IndexOfReplaceableByContains;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -114,7 +115,7 @@ class JavaTemplateTest implements RewriteTest {
 
     @SuppressWarnings({"RedundantOperationOnEmptyContainer"})
     @Test
-    void replaceForEachControlVariable() {
+    void replaceForEachControlVariableType() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
               @Override
@@ -145,6 +146,80 @@ class JavaTemplateTest implements RewriteTest {
               class T {
                   void m() {
                       for (Object s : new ArrayList<String>()) {}
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceForEachControlIterable() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.ForEachLoop.Control visitForEachControl(J.ForEachLoop.Control control, ExecutionContext executionContext) {
+                  control = super.visitForEachControl(control, executionContext);
+                  Expression iterable = control.getIterable();
+                  if ( !TypeUtils.isOfClassType(iterable.getType(), "java.lang.String"))
+                      return control;
+                  iterable = iterable.withTemplate(
+                    JavaTemplate.builder(this::getCursor, "new Object[0]")
+                      .build(),
+                    iterable.getCoordinates().replace()
+                  );
+                  return control.withIterable(iterable);
+              }
+          })),
+          java(
+            """
+              class T {
+                  void m() {
+                      for (Object o : new String[0]) {}
+                  }
+              }
+              """,
+            """
+              class T {
+                  void m() {
+                      for (Object o : new Object[0]) {}
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceBinaryExpression() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.Binary visitBinary(J.Binary binary, ExecutionContext executionContext) {
+                  binary = super.visitBinary(binary, executionContext);
+                  if (binary.getLeft() instanceof J.Literal lit && lit.getValue().equals(42)) {
+                      lit = lit.withTemplate(
+                        JavaTemplate.builder(this::getCursor, "43")
+                          .build(),
+                        lit.getCoordinates().replace()
+                      );
+                      return binary.withLeft(lit);
+                  }
+                  return binary;
+              }
+          })),
+          java(
+            """
+              class T {
+                  boolean m() {
+                      return 42 == 0x2A;
+                  }
+              }
+              """,
+            """
+              class T {
+                  boolean m() {
+                      return 43 == 0x2A;
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/IsEmptyCallOnCollections.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/IsEmptyCallOnCollections.java
@@ -15,15 +15,12 @@
  */
 package org.openrewrite.java.cleanup;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -79,8 +76,8 @@ public class IsEmptyCallOnCollections extends Recipe {
                             if (COLLECTION_SIZE.matches(maybeSizeCallMethod)) {
                                 String op = binary.getOperator() == J.Binary.Type.Equal ? "" : "!";
                                 return (maybeSizeCallMethod.getSelect() == null ?
-                                        maybeSizeCallMethod.withTemplate(isEmptyNoReceiver, maybeSizeCallMethod.getCoordinates().replace(), op) :
-                                        maybeSizeCallMethod.withTemplate(isEmpty, maybeSizeCallMethod.getCoordinates().replace(), op, maybeSizeCallMethod.getSelect())
+                                        binary.withTemplate(isEmptyNoReceiver, binary.getCoordinates().replace(), op) :
+                                        binary.withTemplate(isEmpty, binary.getCoordinates().replace(), op, maybeSizeCallMethod.getSelect())
                                 ).withPrefix(binary.getPrefix());
                             }
                         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -224,7 +224,10 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitExpression(Expression expression, Integer p) {
                 if (loc.equals(EXPRESSION_PREFIX) && expression.isScope(insertionPoint)) {
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(substitutedTemplate))
+                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                                    new Cursor(getCursor(), insertionPoint),
+                                    substitutedTemplate,
+                                    loc))
                             .withPrefix(expression.getPrefix()), p);
                 }
                 return expression;
@@ -233,7 +236,10 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitFieldAccess(J.FieldAccess fa, Integer p) {
                 if (loc.equals(FIELD_ACCESS_PREFIX) && fa.isScope(insertionPoint)) {
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(substitutedTemplate))
+                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                                    new Cursor(getCursor(), insertionPoint),
+                                    substitutedTemplate,
+                                    loc))
                             .withPrefix(fa.getPrefix()), p);
                 }
                 return super.visitFieldAccess(fa, p);
@@ -243,7 +249,10 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             public J visitIdentifier(J.Identifier ident, Integer p) {
                 // ONLY for backwards compatibility, otherwise the same as expression replacement
                 if (loc.equals(IDENTIFIER_PREFIX) && ident.isScope(insertionPoint)) {
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(substitutedTemplate))
+                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                                    new Cursor(getCursor(), insertionPoint),
+                                    substitutedTemplate,
+                                    loc))
                             .withPrefix(ident.getPrefix()), p);
                 }
                 return super.visitIdentifier(ident, p);


### PR DESCRIPTION
Uses `JavaTemplate` to replace the `J.Binary` rather than the `J.MethodInvocation` as that is also what is the intention.

Fixes #2813