### PR TITLE
`UnnecessaryExplicitTypeArguments`: Don't apply to `var` variables

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArgumentsTest.java
@@ -129,4 +129,24 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1211")
+    @Test
+    void assignedToVar() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+
+              public class Test {
+              
+                  List<String> test() {
+                      var l = List.<String> of("x");
+                      return l;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArgumentsTest.java
@@ -130,7 +130,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1211")
+    @Issue("https://github.com/openrewrite/rewrite/issues/2818')
     @Test
     void assignedToVar() {
         rewriteRun(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArgumentsTest.java
@@ -130,7 +130,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2818')
+    @Issue("https://github.com/openrewrite/rewrite/issues/2818")
     @Test
     void assignedToVar() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArguments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryExplicitTypeArguments.java
@@ -68,6 +68,12 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                     } else if (enclosing instanceof Expression) {
                         enclosingType = ((Expression) enclosing).getType();
                     } else if (enclosing instanceof NameTree) {
+                        if (enclosing instanceof J.VariableDeclarations.NamedVariable) {
+                            J.VariableDeclarations decl = getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
+                            if (decl.getTypeExpression() instanceof J.Identifier && "var".equals(((J.Identifier) decl.getTypeExpression()).getSimpleName())) {
+                                return m;
+                            }
+                        }
                         enclosingType = ((NameTree) enclosing).getType();
                     } else if (enclosing instanceof J.Return) {
                         Object e = getCursor().dropParentUntil(p -> p instanceof J.MethodDeclaration || p instanceof J.Lambda).getValue();


### PR DESCRIPTION
When the initializer of a `var` declared variable calls a method with type arguments, these arguments should not be removed, as otherwise the type cannot be deduced and the Java code doesn't compile.

Fixes: #2818
