### PR TITLE
Consistently use OpenRewrite nullness annotations

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
@@ -15,9 +15,9 @@
  */
 package org.openrewrite.internal;
 
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
 import org.openrewrite.config.*;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.lang.annotation.Annotation;
@@ -191,7 +191,7 @@ public class RecipeIntrospectionUtils {
         }
     }
 
-    @NotNull
+    @NonNull
     private static RecipeIntrospectionException getRecipeIntrospectionException(Class<?> recipeClass, ReflectiveOperationException e) {
         return new RecipeIntrospectionException("Unable to call primary constructor for Recipe " + recipeClass, e);
     }

--- a/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
@@ -17,13 +17,9 @@ package org.openrewrite.text;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.jetbrains.annotations.Nullable;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
@@ -15,9 +15,9 @@
  */
 package org.openrewrite.config;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.NonNull;
 
 import java.net.URI;
 import java.util.Collection;
@@ -110,7 +110,7 @@ public class CategoryTreeTest {
         assertThat(categoryTree.getRecipe("org.openrewrite.MyRecipe")).isNotNull();
     }
 
-    @NotNull
+    @NonNull
     private static RecipeDescriptor recipeDescriptor(String packageName) {
         return new RecipeDescriptor(packageName + ".MyRecipe",
           "My recipe", "", emptySet(), null, emptyList(),

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -24,7 +24,6 @@ import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.ast.stmt.*;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.transform.stc.StaticTypesMarker;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.FileAttributes;
@@ -32,6 +31,7 @@ import org.openrewrite.groovy.marker.*;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.EncodingDetectingInputStream;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.ImplicitReturn;
@@ -1835,7 +1835,7 @@ public class GroovyParserVisitor {
         int column;
 
         @Override
-        public int compareTo(@NotNull GroovyParserVisitor.LineColumn lc) {
+        public int compareTo(@NonNull GroovyParserVisitor.LineColumn lc) {
             return line != lc.line ? line - lc.line : column - lc.column;
         }
     }

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -19,11 +19,11 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.FileAttributes;
 import org.openrewrite.hcl.internal.grammar.HCLParser;
 import org.openrewrite.hcl.internal.grammar.HCLParserBaseVisitor;
 import org.openrewrite.hcl.tree.*;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
@@ -373,7 +373,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
         });
     }
 
-    @NotNull
+    @NonNull
     private List<Expression> visitHeredocTemplateExpressions(List<HCLParser.HeredocTemplatePartContext> ctx) {
         List<Expression> expressions = new ArrayList<>(ctx.size());
         for (HCLParser.HeredocTemplatePartContext part : ctx) {
@@ -584,7 +584,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
         return quotedTemplate;
     }
 
-    @NotNull
+    @NonNull
     private List<Expression> visitTemplateExpressions(List<HCLParser.QuotedTemplatePartContext> ctx) {
         List<Expression> expressions = new ArrayList<>(ctx.size());
         for (HCLParser.QuotedTemplatePartContext part : ctx) {
@@ -660,7 +660,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
         });
     }
 
-    @NotNull
+    @NonNull
     private Hcl.Identifier visitIdentifier(TerminalNode identifier) {
         Hcl.Identifier ident = new Hcl.Identifier(randomId(), Space.format(prefix(identifier)),
                 Markers.EMPTY, identifier.getText());

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
@@ -19,8 +19,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 import org.intellij.lang.annotations.Language;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.search.UsesField;
 import org.openrewrite.java.tree.*;
@@ -107,7 +107,7 @@ public class ChangeStaticFieldToMethod extends Recipe {
                 return ident;
             }
 
-            @NotNull
+            @NonNull
             private J useNewMethod(TypeTree tree) {
                 String newClass = newClassName == null ? oldClassName : newClassName;
 
@@ -128,7 +128,7 @@ public class ChangeStaticFieldToMethod extends Recipe {
                         method.withMethodType(method.getMethodType().withReturnType(tree.getType()));
             }
 
-            @NotNull
+            @NonNull
             private JavaTemplate makeNewMethod(String newClass, Cursor statementCursor) {
 
                 String packageName = StringUtils.substringBeforeLast(newClass, ".");

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -16,10 +16,9 @@
 package org.openrewrite.java;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.java.cleanup.UnnecessaryParentheses;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.tree.Expression;
@@ -63,7 +62,7 @@ public class RemoveObjectsIsNull extends Recipe {
             return m;
         }
 
-        @NotNull
+        @NonNull
         private Expression replace(ExecutionContext executionContext, J.MethodInvocation m, String pattern) {
             JavaTemplate template = JavaTemplate.builder(this::getCursor, pattern).build();
             Expression e = m.getArguments().get(0);

--- a/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlowSummaryDotVisualizer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlowSummaryDotVisualizer.java
@@ -16,7 +16,7 @@
 package org.openrewrite.java.controlflow;
 
 import lombok.Value;
-import org.jetbrains.annotations.NotNull;
+import org.openrewrite.internal.lang.NonNull;
 
 import java.util.Comparator;
 import java.util.IdentityHashMap;
@@ -112,7 +112,7 @@ final class ControlFlowSummaryDotVisualizer implements ControlFlowDotFileGenerat
                 .comparingInt(NodeToNodeText::comparingType)
                 .thenComparing(NodeToNodeText::getNodeText);
 
-        @NotNull ControlFlowNode node;
+        @NonNull ControlFlowNode node;
         String nodeText;
 
         NodeToNodeText(ControlFlowNode node) {
@@ -132,7 +132,7 @@ final class ControlFlowSummaryDotVisualizer implements ControlFlowDotFileGenerat
          * This makes the test output consistent, even if the order of the nodes changes.
          */
         @Override
-        public int compareTo(@NotNull NodeToNodeText o) {
+        public int compareTo(@NonNull NodeToNodeText o) {
             if (this.equals(o)) {
                 return 0;
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeTabsOrSpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeTabsOrSpacesVisitor.java
@@ -15,10 +15,10 @@
  */
 package org.openrewrite.java.format;
 
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
@@ -68,7 +68,7 @@ public class NormalizeTabsOrSpacesVisitor<P> extends JavaIsoVisitor<P> {
         }));
     }
 
-    @NotNull
+    @NonNull
     private String normalizeAfterFirstNewline(String text) {
         int firstNewline = text.indexOf('\n');
         if (firstNewline >= 0 && firstNewline != text.length() - 1) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.tree.*;
 
@@ -396,7 +396,7 @@ public class RawPom {
         return profiles;
     }
 
-    @NotNull
+    @NonNull
     private List<MavenRepository> mapRepositories(@Nullable RawRepositories rawRepositories) {
         List<MavenRepository> pomRepositories = emptyList();
         if (rawRepositories != null) {

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -16,13 +16,13 @@
 package org.openrewrite.test;
 
 import org.assertj.core.api.SoftAssertions;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SourceSet;
 import org.openrewrite.quark.Quark;
@@ -506,7 +506,7 @@ public interface RewriteTest extends SourceSpecs {
         return new InMemoryExecutionContext(t -> fail("Failed to parse sources or run recipe", t));
     }
 
-    @NotNull
+    @NonNull
     @Override
     default Iterator<SourceSpec<?>> iterator() {
         return new Iterator<SourceSpec<?>>() {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpacesVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpacesVisitor.java
@@ -15,9 +15,9 @@
  */
 package org.openrewrite.xml.format;
 
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.style.TabsAndIndentsStyle;
@@ -38,7 +38,7 @@ public class NormalizeTabsOrSpacesVisitor<P> extends XmlIsoVisitor<P> {
         this.stopAfter = stopAfter;
     }
 
-    @NotNull
+    @NonNull
     private String normalizeAfterFirstNewline(String text) {
         int firstNewline = text.indexOf('\n');
         if (firstNewline >= 0 && firstNewline != text.length() - 1) {


### PR DESCRIPTION
If IDEA hasn't been configured appropriately, sometimes the JetBrains nullness annotations slip in.
