### PR TITLE
Add first simple ArchUnit tests

### DIFF
--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     }
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-java-test"))
+    testImplementation("com.tngtech.archunit:archunit:1.0.1")
 
     // For use in ClassGraphTypeMappingTest
     testRuntimeOnly("org.eclipse.persistence:org.eclipse.persistence.core:3.0.2")

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-java-test"))
     testImplementation("com.tngtech.archunit:archunit:1.0.1")
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.0.1")
 
     // For use in ClassGraphTypeMappingTest
     testRuntimeOnly("org.eclipse.persistence:org.eclipse.persistence.core:3.0.2")

--- a/rewrite-java/src/main/java/org/openrewrite/java/ai/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ai/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.openrewrite.java.ai;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.openrewrite.java.table;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/test/java/org/openrewrite/java/OpenRewriteArchitectureTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/OpenRewriteArchitectureTest.java
@@ -17,36 +17,31 @@ package org.openrewrite.java;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaPackage;
-import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.*;
-import org.junit.jupiter.api.Test;
 import org.openrewrite.internal.lang.NonNullApi;
 
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.all;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noCodeUnits;
 
+@AnalyzeClasses(packages = "org.openrewrite.java", importOptions = ImportOption.DoNotIncludeTests.class)
 public class OpenRewriteArchitectureTest {
-    JavaClasses importedClasses = new ClassFileImporter()
-      .withImportOption(new ImportOption.DoNotIncludeTests())
-      .importPackages("org.openrewrite.java");
 
-    @Test
-    void packageInfo() {
+    @ArchTest
+    public static final ArchRule packageInfo =
         all(packages("org.openrewrite.java"))
           .that(doNot(name("org.openrewrite.java.internal.grammar")))
-          .should(containAnAnnotatedPackageInfo())
-          .check(importedClasses);
-    }
+          .should(containAnAnnotatedPackageInfo());
 
-    @Test
-    void nullness() {
+    @ArchTest
+    public static final ArchRule nullness =
         noCodeUnits()
           .should().beAnnotatedWith("org.jetbrains.annotations.NotNull")
-          .orShould().beAnnotatedWith("org.jetbrains.annotations.Nullable")
-          .check(importedClasses);
-    }
+          .orShould().beAnnotatedWith("org.jetbrains.annotations.Nullable");
 
     private static ClassesTransformer<JavaPackage> packages(String basePackage) {
         return new AbstractClassesTransformer<>("packages") {

--- a/rewrite-java/src/test/java/org/openrewrite/java/OpenRewriteArchitectureTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/OpenRewriteArchitectureTest.java
@@ -69,12 +69,10 @@ public class OpenRewriteArchitectureTest {
         }.and(new ArchCondition<>("be annotated with @NonNullApi") {
             @Override
             public void check(JavaPackage javaPackage, ConditionEvents events) {
-                if (javaPackage.tryGetPackageInfo().isPresent()) {
-                    if (!javaPackage.getPackageInfo().isAnnotatedWith(NonNullApi.class)) {
-                        String message = String.format("Package '%s' is not annotated as @NonNullApi", javaPackage.getName());
-                        events.add(SimpleConditionEvent.violated(javaPackage, message));
-                    }
-                }
+                javaPackage.tryGetPackageInfo()
+                        .filter(packageInfo -> !packageInfo.isAnnotatedWith(NonNullApi.class))
+                        .ifPresent(packageInfo -> events.add(SimpleConditionEvent.violated(javaPackage,
+                                String.format("Package '%s' is not annotated as @NonNullApi", javaPackage.getName()))));
             }
         });
     }

--- a/rewrite-java/src/test/java/org/openrewrite/java/OpenRewriteArchitectureTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/OpenRewriteArchitectureTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaPackage;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.*;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.lang.NonNullApi;
+
+import static com.tngtech.archunit.base.DescribedPredicate.doNot;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+
+public class OpenRewriteArchitectureTest {
+    JavaClasses importedClasses = new ClassFileImporter()
+      .withImportOption(new ImportOption.DoNotIncludeTests())
+      .importPackages("org.openrewrite.java");
+
+    @Test
+    void packageInfo() {
+        all(packages("org.openrewrite.java"))
+          .that(doNot(name("org.openrewrite.java.internal.grammar")))
+          .should(containAnAnnotatedPackageInfo())
+          .check(importedClasses);
+    }
+
+    @Test
+    void nullness() {
+        noCodeUnits()
+          .should().beAnnotatedWith("org.jetbrains.annotations.NotNull")
+          .orShould().beAnnotatedWith("org.jetbrains.annotations.Nullable")
+          .check(importedClasses);
+    }
+
+    private static ClassesTransformer<JavaPackage> packages(String basePackage) {
+        return new AbstractClassesTransformer<>("packages") {
+            @Override
+            public Iterable<JavaPackage> doTransform(JavaClasses classes) {
+                return classes.getPackage(basePackage).getSubpackagesInTree();
+            }
+        };
+    }
+
+    private static ArchCondition<JavaPackage> containAnAnnotatedPackageInfo() {
+        return new ArchCondition<JavaPackage>("contain a package-info") {
+            @Override
+            public void check(JavaPackage javaPackage, ConditionEvents events) {
+                if (javaPackage.tryGetPackageInfo().isEmpty()) {
+                    String message = String.format("Package '%s' does not contain a package-info", javaPackage.getName());
+                    events.add(SimpleConditionEvent.violated(javaPackage, message));
+                }
+            }
+        }.and(new ArchCondition<>("be annotated with @NonNullApi") {
+            @Override
+            public void check(JavaPackage javaPackage, ConditionEvents events) {
+                if (javaPackage.tryGetPackageInfo().isPresent()) {
+                    if (!javaPackage.getPackageInfo().isAnnotatedWith(NonNullApi.class)) {
+                        String message = String.format("Package '%s' is not annotated as @NonNullApi", javaPackage.getName());
+                        events.add(SimpleConditionEvent.violated(javaPackage, message));
+                    }
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
ArchUnit can be used to enforce certain architectural constraints. Typically, these get checked by the build system by executing them as tests (using JUnit).

This first set of tests only applies to `rewrite-java` and only checks that all Java packages have a `package-info.java` including a `@NonNullApi` annotation and that the JetBrains nullness annotations are not used.
