### PR TITLE
Add recipe to replace Stream.toList() with Stream.collect()

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollectTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+class ReplaceStreamToListWithCollectTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceStreamToListWithCollect());
+    }
+
+    @Test
+    void replacesToList() {
+        rewriteRun(
+          version(
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().toList();
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().collect(Collectors.toList());
+                  }
+              }
+              """),
+            16));
+    }
+
+    @Test
+    void preservesFormatting() {
+        rewriteRun(
+          version(
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          .toList();
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          .collect(Collectors.toList());
+                  }
+              }
+              """),
+            16));
+    }
+
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollectTest.java
@@ -61,7 +61,7 @@ class ReplaceStreamToListWithCollectTest implements RewriteTest {
     }
 
     @Test
-    void preservesFormatting() {
+    void formatting() {
         rewriteRun(
           version(
             java(
@@ -86,6 +86,41 @@ class ReplaceStreamToListWithCollectTest implements RewriteTest {
               class Example {
                   public void test() {
                       Stream.of()
+                          .collect(Collectors.toList());
+                  }
+              }
+              """),
+            16));
+    }
+
+    @Test
+    void comment() {
+        rewriteRun(
+          version(
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          // Convert to list
+                          .toList();
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          // Convert to list
                           .collect(Collectors.toList());
                   }
               }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollect.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.Applicability;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+import java.time.Duration;
+
+public class ReplaceStreamToListWithCollect extends Recipe {
+
+    private static final MethodMatcher STREAM_TO_LIST = new MethodMatcher("java.util.stream.Stream toList()");
+
+    @Override
+    public String getDisplayName() {
+        return "Replace Stream.toList() with Stream.collect(Collectors.toList())";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace Java 16 Stream.toList() with Java 11 Stream.collect(Collectors.toList()).";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return Applicability.and(new UsesJavaVersion<>(16),
+                new UsesMethod<>(STREAM_TO_LIST));
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+
+            private final JavaTemplate template = JavaTemplate
+                    .builder(this::getCursor, "#{any(java.util.stream.Stream)}.collect(Collectors.toList())")
+                    .imports("java.util.stream.Collectors")
+                    .build();
+
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation result = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (STREAM_TO_LIST.matches(method)) {
+                    result = result
+                            .withTemplate(template, result.getCoordinates().replace(), result.getSelect())
+                            .withPrefix(result.getPrefix());
+                    maybeAddImport("java.util.stream.Collectors");
+                }
+                return result;
+            }
+
+        };
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceStreamToListWithCollect.java
@@ -65,9 +65,12 @@ public class ReplaceStreamToListWithCollect extends Recipe {
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation result = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (STREAM_TO_LIST.matches(method)) {
+                    J.MethodInvocation newMethod = result
+                            .withTemplate(template, result.getCoordinates().replace(), result.getSelect());
                     result = result
-                            .withTemplate(template, result.getCoordinates().replace(), result.getSelect())
-                            .withPrefix(result.getPrefix());
+                            .withName(newMethod.getName())
+                            .withMethodType(newMethod.getMethodType())
+                            .withArguments(newMethod.getArguments());
                     maybeAddImport("java.util.stream.Collectors");
                 }
                 return result;


### PR DESCRIPTION
We use the recipe to downgrade Java 17 code to Java 11. I'm not sure whether it could be useful for somebody else.

Anyway, could you please help to fix `preservesFormatting` test? :) How to preserve spacing within method invocation after template application?