### PR TITLE
Add `IsLikelyTest` and `IsLikelyNotTest` Recipes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -510,7 +510,7 @@ public class StringUtils {
     }
 
     /**
-     * See https://eclipse.org/aspectj/doc/next/progguide/semantics-pointcuts.html#type-patterns
+     * See <a href="https://eclipse.org/aspectj/doc/next/progguide/semantics-pointcuts.html#type-patterns">https://eclipse.org/aspectj/doc/next/progguide/semantics-pointcuts.html#type-patterns</a>
      * <p>
      * An embedded * in an identifier matches any sequence of characters, but
      * does not match the package (or inner-type) separator ".".

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/IsOrIsNotLikelyTestTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/IsOrIsNotLikelyTestTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.test.SourceSpecs.dir;
+
+public class IsOrIsNotLikelyTestTest {
+
+    private interface Base extends RewriteTest {
+        @Language("java")
+        String MAIN_INITIAL = """
+          class Main { }
+          """;
+
+        @Language("java")
+        String MAIN_SEARCH_RESULT = """
+          /*~~>*/class Main { }
+          """;
+
+        default SourceSpecs assertMainIsFound() {
+            return java(MAIN_INITIAL, MAIN_SEARCH_RESULT);
+        }
+
+        default SourceSpecs assertMainNoChanges() {
+            return java(MAIN_INITIAL);
+        }
+
+        @Language("java")
+        String TEST_INITIAL = """
+          class ATest { }
+          """;
+
+        @Language("java")
+        String TEST_SEARCH_RESULT = """
+          /*~~>*/class ATest { }
+          """;
+
+        @Language("java")
+        String JUNIT_TEST_INITIAL = """
+          import org.junit.jupiter.api.Test;
+                    
+          class TestTest {
+            @Test
+            void test() {}
+          }
+          """;
+
+        @Language("java")
+        String JUNIT_TEST_SEARCH_RESULT = """
+          /*~~>*/import org.junit.jupiter.api.Test;
+                    
+          class TestTest {
+            @Test
+            void test() {}
+          }
+          """;
+
+        default SourceSpecs assertTestIsFound() {
+            return dir("com/example",
+              java(TEST_INITIAL, TEST_SEARCH_RESULT),
+              java(JUNIT_TEST_INITIAL, JUNIT_TEST_SEARCH_RESULT)
+            );
+        }
+
+        default SourceSpecs assertTestNoChanges() {
+            return dir("com/example",
+              java(TEST_INITIAL),
+              java(JUNIT_TEST_INITIAL)
+            );
+        }
+
+        @SuppressWarnings("SpellCheckingInspection")
+        default SourceSpecs srcIntegTestJava(SourceSpecs... javaSources) {
+            return dir("src/integTest/java", spec -> sourceSet(spec, "integTest"), javaSources);
+        }
+
+        default SourceSpecs srcCompatibilityTestJava(SourceSpecs... javaSources) {
+            return dir("src/compatibility-test/java", spec -> sourceSet(spec, "compatibilityTest"), javaSources);
+        }
+    }
+
+    @Nested
+    class IsLikelyTestTest implements Base {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec
+              .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api"))
+              .recipe(new IsLikelyTest());
+        }
+
+        @Test
+        void testStandardMainAndTestSourceSet() {
+            rewriteRun(
+              srcMainJava(assertMainNoChanges()),
+              srcTestJava(assertTestIsFound())
+            );
+        }
+
+        @Test
+        @SuppressWarnings("SpellCheckingInspection")
+        void testStandardMainAndIntegTestSourceSet() {
+            rewriteRun(
+              srcMainJava(assertMainNoChanges()),
+              srcIntegTestJava(assertTestIsFound())
+            );
+        }
+
+        @Test
+        void testStandardMainAndCompatibilityTestSourceSet() {
+            rewriteRun(
+              srcMainJava(assertMainNoChanges()),
+              srcCompatibilityTestJava(assertTestIsFound())
+            );
+        }
+
+        @Test
+        void junitTestNotInTestSourceSet() {
+            rewriteRun(java(JUNIT_TEST_INITIAL, JUNIT_TEST_SEARCH_RESULT));
+        }
+    }
+
+    @Nested
+    class IsLikelyNotTestTest implements Base {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec
+              .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api"))
+              .recipe(new IsLikelyNotTest());
+        }
+
+        @Test
+        void testStandardMainAndTestSourceSet() {
+            rewriteRun(
+              srcMainJava(assertMainIsFound()),
+              srcTestJava(assertTestNoChanges())
+            );
+        }
+
+        @Test
+        @SuppressWarnings("SpellCheckingInspection")
+        void testStandardMainAndIntegTestSourceSet() {
+            rewriteRun(
+              srcMainJava(assertMainIsFound()),
+              srcIntegTestJava(assertTestNoChanges())
+            );
+        }
+
+        @Test
+        void testStandardMainAndCompatibilityTestSourceSet() {
+            rewriteRun(
+              srcMainJava(assertMainIsFound()),
+              srcCompatibilityTestJava(assertTestNoChanges())
+            );
+        }
+
+        @Test
+        void junitTestNotInTestSourceSet() {
+            rewriteRun(java(JUNIT_TEST_INITIAL));
+        }
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/IsLikelyNotTest.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/IsLikelyNotTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.openrewrite.*;
+
+@Incubating(since = "7.36.0")
+public class IsLikelyNotTest extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Find files that are likely not tests";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Sources that do not contain indicators of being, or being exclusively for the use in tests. " +
+                "This recipe is simply a negation of the `" + IsLikelyTest.class.getName() + "` recipe.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Applicability.not(new IsLikelyTest().getVisitor());
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/IsLikelyTest.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/IsLikelyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.marker.JavaSourceSet;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+@Incubating(since = "7.36.0")
+public class IsLikelyTest extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Find sources that are likely tests";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Sources that contain indicators of being, or being exclusively for the use in tests. " +
+                "This recipe is not exhaustive, but is intended to be a good starting point for finding test sources. " +
+                "Looks at the source set name, and types in use; for example looks for uses of JUnit & TestNG annotations/assertions.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Applicability.or(
+                new HasSourceSet("test").getVisitor(),
+                new HasSourceSetNameContainingTestVisitor<>(),
+                new UsesType<>("org.junit..*"), // Covers both JUnit 4 and 5
+                new UsesType<>("org.testng..*"),
+                new UsesType<>("org.hamcrest..*"),
+                new UsesType<>("org.mockito..*"),
+                new UsesType<>("org.powermock..*"),
+                new UsesType<>("org.assertj..*"),
+                new UsesType<>("spock.lang..*")
+        );
+    }
+
+    private static class HasSourceSetNameContainingTestVisitor<P> extends JavaIsoVisitor<P> {
+        @Override
+        public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, P p) {
+            if (cu.getMarkers().findFirst(JavaSourceSet.class)
+                    .filter(s -> s.getName().toLowerCase(Locale.ROOT).contains("test"))
+                    .isPresent()) {
+                return SearchResult.found(cu);
+            }
+            return cu;
+        }
+    }
+}


### PR DESCRIPTION
Enables applicability tests to be applied exclusively to, or excluding
test source.

Resolves https://github.com/openrewrite/rewrite/discussions/2849
Closes #2850

This enables the following which is exactly what is needed for security fixing vulnerabilities at-scale across OSS:
```yaml
---
type: specs.openrewrite.org/v1beta/recipe
name: com.example.FilteringTestSources
displayName: Filtering Test Sources Test
description: Only apply a `FindMethods` recipe to all sources when non-test sources are modified.
applicability:
  anySource:
  - org.openrewrite.java.search.IsLikelyNotTest
  - org.openrewrite.java.search.FindMethods: # Stand in for the security fix recipe to be executed
      methodPattern: "java.io.PrintStream println(..)"
recipeList:
  - org.openrewrite.java.search.FindMethods: # Stand in for the security fix recipe to be executed duplicate config from above
      methodPattern: "java.io.PrintStream println(..)"
```