### PR TITLE
Actually support `Recipe` in `addApplicableTest` & `addSingleSourceApplicableTest`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
  */
 public interface ExecutionContext {
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
+    String PARENT_RECIPE = "org.openrewrite.parentRecipe";
     String UNCAUGHT_EXCEPTION_COUNT = "org.openrewrite.uncaughtExceptionCount";
     String DATA_TABLES = "org.openrewrite.dataTables";
 
@@ -88,9 +89,24 @@ public interface ExecutionContext {
         putMessage(CURRENT_RECIPE, recipe);
     }
 
-    default Recipe getCurrentRecipe() {
-        //noinspection ConstantConditions
-        return getMessage(CURRENT_RECIPE);
+    /**
+     * @return The previous parent recipe.
+     * @implNote For use in the {@link RecipeScheduler} only.
+     */
+    @Nullable
+    @Incubating(since = "7.37.0")
+    default Recipe putParentRecipe(@Nullable Recipe recipe) {
+        Recipe previousParent = getMessage(PARENT_RECIPE);
+        putMessage(PARENT_RECIPE, recipe);
+        return previousParent;
+    }
+
+    /**
+     * The recipe that scheduled this recipe's execution via {@link Recipe#getApplicableTests()} or {@link Recipe#getSingleSourceApplicableTests()}.
+     */
+    @Incubating(since = "7.37.0")
+    default Optional<Recipe> getParentRecipe() {
+        return Optional.ofNullable(getMessage(PARENT_RECIPE));
     }
 
     default int incrementAndGetUncaughtExceptionCount() {

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -18,6 +18,8 @@ package org.openrewrite;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.intellij.lang.annotations.Language;
 import org.openrewrite.config.DataTableDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
@@ -72,8 +74,8 @@ public abstract class Recipe implements Cloneable {
         }
     };
 
-    private transient List<TreeVisitor<?, ExecutionContext>> singleSourceApplicableTests;
-    private transient List<TreeVisitor<?, ExecutionContext>> applicableTests;
+    private transient List<Recipe> singleSourceApplicableTests;
+    private transient List<Recipe> applicableTests;
 
     @Nullable
     private transient List<DataTableDescriptor> dataTables;
@@ -96,6 +98,40 @@ public abstract class Recipe implements Cloneable {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return NOOP;
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    private static class AdHocRecipe extends Recipe {
+        @Language("markdown")
+        String displayName;
+        @Language("markdown")
+        String description;
+        TreeVisitor<?, ExecutionContext> visitor;
+
+        @Override
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return visitor;
+        }
+
+        @Nullable
+        static AdHocRecipe fromNullableVisitor(
+                @Language("markdown") String displayName,
+                @Language("markdown") String description,
+                @Nullable TreeVisitor<?, ExecutionContext> visitor
+        ) {
+            return visitor == null ? null : new AdHocRecipe(displayName, description, visitor);
         }
     }
 
@@ -230,7 +266,7 @@ public abstract class Recipe implements Cloneable {
      * particular source file. If multiple applicable tests configured, the final result of the applicable test depends
      * on all conditions being met, that is, a logical 'AND' relationship.
      * <p>
-     * To identify a {@link SourceFile} as applicable, the visitor should mark or change it at any level. Any mutation
+     * To identify a {@link SourceFile} as applicable, the {@link TreeVisitor} should mark or change it at any level. Any mutation
      * that the applicability test visitor makes on the tree will not be included in the results.
      * <p>
      *
@@ -238,6 +274,25 @@ public abstract class Recipe implements Cloneable {
      */
     @SuppressWarnings("unused")
     public Recipe addApplicableTest(TreeVisitor<?, ExecutionContext> test) {
+        return addApplicableTest(AdHocRecipe.fromNullableVisitor(
+                "Add applicable test for: " + getDisplayName(),
+                "Add applicable test for: " + getDescription(),
+                test
+        ));
+    }
+
+    /**
+     * A recipe can be configured with any number of applicable tests that can be used to determine whether it should run on a
+     * particular source file. If multiple applicable tests configured, the final result of the applicable test depends
+     * on all conditions being met, that is, a logical 'AND' relationship.
+     * <p>
+     * To identify a {@link SourceFile} as applicable, the {@link Recipe} should mark or change it at any level. Any mutation
+     * that the applicability test recipe makes on the tree will not be included in the results.
+     * <p>
+     *
+     * @return This recipe. Not the argument passed.
+     */
+    public Recipe addApplicableTest(Recipe test) {
         if (applicableTests == null) {
             applicableTests = new ArrayList<>(1);
         }
@@ -252,8 +307,15 @@ public abstract class Recipe implements Cloneable {
         dataTables.add(dataTableDescriptorFromDataTable(dataTable));
     }
 
-    public List<TreeVisitor<?, ExecutionContext>> getApplicableTests() {
-        List<TreeVisitor<?, ExecutionContext>> tests = ListUtils.concat(getApplicableTest(), applicableTests);
+    public List<Recipe> getApplicableTests() {
+        List<Recipe> tests = ListUtils.concat(
+                AdHocRecipe.fromNullableVisitor(
+                        "Applicable test for: " + getDisplayName(),
+                        "Applicable test for: " + getDescription(),
+                        getApplicableTest()
+                ),
+                applicableTests
+        );
         return tests == null ? emptyList() : tests;
     }
 
@@ -276,12 +338,31 @@ public abstract class Recipe implements Cloneable {
      * particular source file. If multiple applicable tests configured, the final result of the applicable test depends
      * on all conditions being met, that is, a logical 'AND' relationship.
      * <p>
-     * To identify a {@link SourceFile} as applicable, the visitor should mark or change it at any level. Any mutation
+     * To identify a {@link SourceFile} as applicable, the {@link TreeVisitor} should mark or change it at any level. Any mutation
      * that the applicability test visitor makes on the tree will not be included in the results.
      *
      * @return This recipe.
      */
+    @SuppressWarnings("unused")
     public Recipe addSingleSourceApplicableTest(TreeVisitor<?, ExecutionContext> test) {
+        return addSingleSourceApplicableTest(AdHocRecipe.fromNullableVisitor(
+                "Add single source applicable test for: " + getDisplayName(),
+                "Add single source applicable test for: " + getDescription(),
+                test
+        ));
+    }
+
+    /**
+     * A recipe can be configured with any number of applicable tests that can be used to determine whether it should run on a
+     * particular source file. If multiple applicable tests configured, the final result of the applicable test depends
+     * on all conditions being met, that is, a logical 'AND' relationship.
+     * <p>
+     * To identify a {@link SourceFile} as applicable, the {@link Recipe} should mark or change it at any level. Any mutation
+     * that the applicability test recipe makes on the tree will not be included in the results.
+     *
+     * @return This recipe. Not the argument passed.
+     */
+    public Recipe addSingleSourceApplicableTest(Recipe test) {
         if (singleSourceApplicableTests == null) {
             singleSourceApplicableTests = new ArrayList<>(1);
         }
@@ -289,8 +370,15 @@ public abstract class Recipe implements Cloneable {
         return this;
     }
 
-    public List<TreeVisitor<?, ExecutionContext>> getSingleSourceApplicableTests() {
-        List<TreeVisitor<?, ExecutionContext>> tests = ListUtils.concat(getSingleSourceApplicableTest(), singleSourceApplicableTests);
+    public List<Recipe> getSingleSourceApplicableTests() {
+        List<Recipe> tests = ListUtils.concat(
+                AdHocRecipe.fromNullableVisitor(
+                        "Single Source Applicable test for: " + getDisplayName(),
+                        "Single Source Applicable test for: " + getDescription(),
+                        getSingleSourceApplicableTest()
+                ),
+                singleSourceApplicableTests
+        );
         return tests == null ? emptyList() : tests;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -118,25 +118,14 @@ public class DeclarativeRecipe extends CompositeRecipe {
     private void configureByUse(RecipeUse use, Recipe recipe) {
         switch(use) {
             case SingleSourceApplicability:
-                addSingleSourceApplicableTest(getVisitor(recipe));
+                addSingleSourceApplicableTest(recipe);
                 break;
             case AnySourceApplicability:
-                addApplicableTest(getVisitor(recipe));
+                addApplicableTest(recipe);
                 break;
             case Recipe:
                 doNext(recipe);
                 break;
-        }
-    }
-
-    private TreeVisitor<?, ExecutionContext> getVisitor(Recipe recipe) {
-        try {
-            Method getVisitor = recipe.getClass().getDeclaredMethod("getVisitor");
-            getVisitor.setAccessible(true);
-            //noinspection unchecked
-            return (TreeVisitor<?, ExecutionContext>) getVisitor.invoke(recipe);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/marker/Markup.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/Markup.java
@@ -79,7 +79,7 @@ public interface Markup extends Marker {
 
     @Value
     @With
-    class Error implements Markup {
+    public class Error implements Markup {
         UUID id;
         Throwable exception;
 

--- a/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
@@ -44,7 +44,7 @@ public class FindAndReplace extends Recipe {
     Boolean regex;
 
     /**
-     * @deprecated Use {@link Recipe#addSingleSourceApplicableTest(TreeVisitor)} instead.
+     * @deprecated Use {@link Recipe#addSingleSourceApplicableTest(Recipe)} instead.
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
     @Option(displayName = "Optional file Matcher",

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DoesNotUseRewriteSkipTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DoesNotUseRewriteSkipTest.java
@@ -26,7 +26,7 @@ class DoesNotUseRewriteSkipTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ChangeType("java.util.List", "java.util.Collection", false)
-            .addSingleSourceApplicableTest(new DoesNotUseRewriteSkip().getVisitor()))
+            .addSingleSourceApplicableTest(new DoesNotUseRewriteSkip()))
           .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaRecipeLifecycleTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaRecipeLifecycleTest.java
@@ -127,8 +127,8 @@ public class JavaRecipeLifecycleTest {
         public void defaults(RecipeSpec spec) {
             spec.recipe(
               Recipe.noop()
-                .addApplicableTest(new HasSourceSet("main").getVisitor())
-                .addApplicableTest(createFindMethods().getVisitor())
+                .addApplicableTest(new HasSourceSet("main"))
+                .addApplicableTest(createFindMethods())
                 .doNext(createFindMethods())
             );
         }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RecipeExceptionDemonstrationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RecipeExceptionDemonstrationTest.java
@@ -83,7 +83,6 @@ class RecipeExceptionDemonstrationTest implements RewriteTest {
         );
     }
 
-    @Disabled(value = "The exception thrown in getSingleSourceApplicableTest() is caught by RecipeScheduler, so disable this.")
     @Test
     void singleSourceApplicableTest() {
         rewriteRun(
@@ -101,15 +100,13 @@ class RecipeExceptionDemonstrationTest implements RewriteTest {
                       list.add(42);
                   }
               }
-              """,
-            """
-              /*~~(Demonstrating an exception thrown on the single-source applicable test.)~~>*/import java.util.*;
-              class Test {
-                  void test(List<Integer> list) {
-                      list.add(42);
-                  }
-              }
               """
+          ),
+          text(
+            null,
+            "~~(Demonstrating an exception thrown on the single-source applicable test.)~~>" +
+              "Rewrite encountered an uncaught recipe error in org.openrewrite.java.RecipeExceptionDemonstration.",
+            spec -> spec.path("recipe-exception-1.txt")
           )
         );
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.Issue;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaParser;
-import org.openrewrite.test.AdHocRecipe;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class AddDependencyTest implements RewriteTest {
 
@@ -803,12 +803,22 @@ class AddDependencyTest implements RewriteTest {
     void rawVisitorDoesNotDuplicate() {
         rewriteRun(
           spec -> spec.recipe(
-            new AdHocRecipe("Add dependency",
-              "Uses AddDependencyVisitor directly to validate that it will not add a dependency multiple times",
-              false,
-              () -> new AddDependencyVisitor("com.google.guava", "guava", "29.0-jre",
-                null, "test",  null, null, null, null, null),
-              null)),
+            toRecipe()
+              .withDisplayName("Add dependency")
+              .withName("Uses AddDependencyVisitor directly to validate that it will not add a dependency multiple times")
+              .withGetVisitor(() -> new AddDependencyVisitor(
+                "com.google.guava",
+                "guava",
+                "29.0-jre",
+                null,
+                "test",
+                null,
+                null,
+                null,
+                null,
+                null
+              ))
+          ),
           mavenProject("project",
             srcTestJava(
               java(usingGuavaIntMath)

--- a/rewrite-test/src/main/java/org/openrewrite/test/AdHocRecipe.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/AdHocRecipe.java
@@ -53,6 +53,14 @@ public class AdHocRecipe extends Recipe {
     @With
     BiFunction<List<SourceFile>, ExecutionContext, List<SourceFile>> visit;
 
+    @Nullable
+    @With
+    Supplier<TreeVisitor<?, ExecutionContext>> getSingleSourceApplicableTest;
+
+    @Nullable
+    @With
+    Supplier<TreeVisitor<?, ExecutionContext>> getApplicableTest;
+
     public String getDisplayName() {
         return StringUtils.isBlank(displayName) ? "Ad hoc recipe" : displayName;
     }
@@ -74,5 +82,15 @@ public class AdHocRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return getVisitor.get();
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return getSingleSourceApplicableTest == null ? super.getSingleSourceApplicableTest() : getSingleSourceApplicableTest.get();
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return getApplicableTest == null ? super.getApplicableTest() : getApplicableTest.get();
     }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -47,11 +47,11 @@ import static org.openrewrite.internal.StringUtils.trimIndentPreserveCRLF;
 @SuppressWarnings("unused")
 public interface RewriteTest extends SourceSpecs {
     static AdHocRecipe toRecipe(Supplier<TreeVisitor<?, ExecutionContext>> visitor) {
-        return new AdHocRecipe(null, null, null, visitor, null);
+        return new AdHocRecipe(null, null, null, visitor, null, null, null);
     }
 
     static AdHocRecipe toRecipe() {
-        return new AdHocRecipe(null, null, null, () -> Recipe.NOOP, null);
+        return new AdHocRecipe(null, null, null, () -> Recipe.NOOP, null, null, null);
     }
 
     static AdHocRecipe toRecipe(Function<Recipe, TreeVisitor<?, ExecutionContext>> visitor) {


### PR DESCRIPTION
Recipes used in applicability tests will have their own applicability tests invoked now.

This means that expensive recipes with light `singleSourceApplicableTest` can be used without incurring a performance overhead of invoking the recipe visitor every time.
