### PR TITLE
Support `instanceof` pattern variables in `JavaTemplate`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateInstanceOfTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateInstanceOfTest.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.search.FindMissingTypes;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+import org.openrewrite.test.TypeValidation;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * These JavaTemplate tests are specific to the `instanceof` pattern matching syntax.
+ * The tests always perform the same substitution: Every `42` literal is replaced with a call to `s.length()`.
+ * The tests then contain `invalid` marker comments to indicate that the substitution is
+ * expected to result in a missing type error in that position and in the end the test
+ * cases validate that the actual and expected missing types are the same.
+ */
+class JavaTemplateInstanceOfTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        //noinspection DataFlowIssue
+        spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitLiteral(J.Literal literal, ExecutionContext executionContext) {
+                  return literal.getValue() == Integer.valueOf(42) ? literal.withTemplate(
+                    JavaTemplate.builder(this::getCursor, "s.length()")
+//                          .doBeforeParseTemplate(System.out::println)
+                      .build(),
+                    literal.getCoordinates().replace()
+                  ) : super.visitLiteral(literal, executionContext);
+              }
+          }))
+          // custom missing type validation
+          .typeValidationOptions(TypeValidation.none())
+          .afterRecipe(run -> run.getResults().forEach(r -> assertTypeAttribution((J) r.getAfter())));
+    }
+
+    @SuppressWarnings("PointlessBooleanExpression")
+    @Test
+    void replaceExpressionInNestedIfCondition() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (true || (o instanceof String s && 42 != 1)) {
+                            return /*invalid*/ 42;
+                        }
+                        return /*invalid*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings({"EmptyTryBlock", "finally", "ReturnInsideFinallyBlock"})
+    @Test
+    void elseWithEmptyTryAndReturnFromFinally() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (!(o instanceof String s)) {
+                            return /*invalid*/ 42;
+                        } else {
+                            try {
+                            } finally {
+                                return 42;
+                            }
+                        }
+                        return /*invalid*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings({"UnnecessaryBreak"})
+    @Test
+    void normallyCompletingLabeledBreak() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (!(o instanceof String s)) {
+                            return /*invalid*/ 42;
+                        } else {
+                            A: {
+                                break A;
+                            }
+                        }
+                        return 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void abnormallyCompletingLabeledBreak() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        A: {
+                            if (!(o instanceof String s)) {
+                                return /*invalid 1*/ 42;
+                            } else {
+                                System.out.println(42);
+                                break A;
+                            }
+                            return /*invalid 2*/ 42;
+                        }
+                        return /*invalid 3*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceInThenWithReturn() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (o instanceof String s) {
+                            return 42;
+                        } else {
+                            System.out.println(/*invalid*/ 42);
+                        }
+                        return /*invalid*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceInUnbracedBlocks() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (o instanceof String s)
+                            return 42;
+                        else
+                            System.out.println(/*invalid*/ 42);
+                        return /*invalid*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceInThenWithoutReturn() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (o instanceof String s) {
+                            System.out.println(42);
+                        } else {
+                            System.out.println(/*invalid*/ 42);
+                        }
+                        return /*invalid*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceInThenWithReturnInElse() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        if (o instanceof String s) {
+                            System.out.println(42);
+                        } else {
+                            return /*invalid*/ 42;
+                        }
+                        return 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceInElse() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          System.out.println(42);
+                      }
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings("UnnecessaryReturnStatement")
+    @Test
+    void replaceInElseWithAnonymousClass() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          new Runnable() {
+                              public void run() {
+                                  System.out.println(42);
+                                  return;
+                              }
+                          };
+                      }
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings("UnnecessaryReturnStatement")
+    @Test
+    void replaceInElseWithLambda() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          Runnable r = () -> {
+                              System.out.println(42);
+                              return;
+                          };
+                      }
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceAfterIf() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          System.out.println(42);
+                      }
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings({"SwitchStatementWithTooFewBranches", "EnhancedSwitchMigration", "DataFlowIssue"})
+    @Test
+    void incompleteSwitch() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          switch (true) {
+                              case true:
+                                  return 42;
+                          }
+                      }
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings({"SwitchStatementWithTooFewBranches", "EnhancedSwitchMigration", "DataFlowIssue"})
+    @Test
+    void completeSwitch() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          switch (true) {
+                              case true:
+                              default:
+                                  return 42;
+                          }
+                      }
+                      return /*invalid*/ 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void tryCatchWithoutRethrow() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          try {
+                              return 42;
+                          } catch (RuntimeException ignore) {
+                          }
+                      }
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings("CaughtExceptionImmediatelyRethrown")
+    @Test
+    void tryCatchWithRethrow() {
+        rewriteRun(
+          templatedJava17(
+            """
+              class T {
+                  Object m(Object o) {
+                      if (!(o instanceof String s)) {
+                          return /*invalid*/ 42;
+                      } else {
+                          try {
+                              return 42;
+                          } catch (RuntimeException e) {
+                              throw e;
+                          }
+                      }
+                      return /*invalid*/ 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings({"ConditionalExpressionWithIdenticalBranches", "PointlessBooleanExpression", "ConstantValue"})
+    @Test
+    void replaceTernaryCondition() {
+        rewriteRun(
+          templatedJava17(
+            """
+                class T {
+                    Object m(Object o) {
+                        return o instanceof String s && 42 > 0 ? 42 : /*invalid*/ 42;
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    private SourceSpecs templatedJava17(@Language("java") String before) {
+        return version(java(
+          before,
+          before.replaceAll("\\b42\\b", "s.length()")
+        ), 17);
+    }
+
+    @SuppressWarnings("SuspiciousMethodCalls")
+    static void assertTypeAttribution(J sf) {
+        List<FindMissingTypes.MissingTypeResult> missingTypes = FindMissingTypes.findMissingTypes(sf);
+        Map<J, Cursor> expectedMissing = new LinkedHashMap<>();
+        Map<J, Cursor> actualMissing = new LinkedHashMap<>();
+        new JavaIsoVisitor<Integer>() {
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, Integer ignore) {
+                if (tree instanceof J j) {
+                    if (j.getComments().stream().anyMatch(c -> c instanceof TextComment t && t.getText().startsWith("invalid"))) {
+                        expectedMissing.put(j, getCursor());
+                    }
+                    if (missingTypes.stream().anyMatch(t -> t.getJ().isScope(j))) {
+                        actualMissing.put(j, getCursor());
+                    }
+                }
+                return super.visit(tree, ignore);
+            }
+        }.visit(sf, 0);
+
+        for (var entry : new HashMap<>(actualMissing).entrySet()) {
+            if (expectedMissing.containsKey(entry.getKey())) {
+                actualMissing.remove(entry.getKey());
+                expectedMissing.remove(entry.getKey());
+                continue;
+            }
+            for (Cursor cursor = entry.getValue(); cursor.getParent() != null; cursor = cursor.getParent()) {
+                if (expectedMissing.containsKey(cursor.getValue())) {
+                    actualMissing.remove(entry.getKey());
+                    expectedMissing.remove(cursor.getValue());
+                    break;
+                }
+            }
+        }
+        if (!expectedMissing.isEmpty()) {
+            fail("Expected missing types not found:\n" + expectedMissing.entrySet().stream()
+              .map(e -> {
+                  String path = e.getValue().getPathAsStream().filter(J.class::isInstance).map(t -> t.getClass().getSimpleName()).collect(Collectors.joining("->"));
+                  return path + ": " + e.getKey().printTrimmed(new InMemoryExecutionContext(), e.getValue().getParentOrThrow());
+              })
+              .collect(Collectors.joining("\n")));
+        }
+        if (!actualMissing.isEmpty()) {
+            fail("Unexpected missing types found:\n" + actualMissing.entrySet().stream()
+              .map(e -> {
+                  String path = e.getValue().getPathAsStream().filter(J.class::isInstance).map(t -> t.getClass().getSimpleName()).collect(Collectors.joining("->"));
+                  return path + ": " + e.getKey().printTrimmed(new InMemoryExecutionContext(), e.getValue().getParentOrThrow());
+              })
+              .collect(Collectors.joining("\n")));
+        }
+
+    }
+}

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     }
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-java-test"))
+    testRuntimeOnly(project(":rewrite-java-17"))
     testImplementation("com.tngtech.archunit:archunit:1.0.1")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.0.1")
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -43,8 +43,7 @@ import static java.util.Collections.newSetFromMap;
 public class BlockStatementTemplateGenerator {
     private static final String TEMPLATE_COMMENT = "__TEMPLATE__";
     private static final String STOP_COMMENT = "__TEMPLATE_STOP__";
-    static final String EXPR_STATEMENT_PARAM = "" +
-                                               "class __P__ {" +
+    static final String EXPR_STATEMENT_PARAM = "class __P__ {" +
                                                "  static native <T> T p();" +
                                                "  static native <T> T[] arrp();" +
                                                "  static native boolean booleanp();" +
@@ -56,8 +55,7 @@ public class BlockStatementTemplateGenerator {
                                                "  static native short shortp();" +
                                                "  static native float floatp();" +
                                                "}";
-    private static final String METHOD_INVOCATION_STUBS = "" +
-                                                          "class __M__ {" +
+    private static final String METHOD_INVOCATION_STUBS = "class __M__ {" +
                                                           "  static native Object any(Object o);" +
                                                           "  static native <T> Object anyT();" +
                                                           "}";
@@ -81,7 +79,7 @@ public class BlockStatementTemplateGenerator {
                         after.append('}');
                     }
 
-                    template(next(cursor), cursor.getValue(), before, after, newSetFromMap(new IdentityHashMap<>()));
+                    template(next(cursor), cursor.getValue(), before, after, newSetFromMap(new IdentityHashMap<>()), cursor.getValue());
 
                     return before.toString().trim() + "\n/*" + TEMPLATE_COMMENT + "*/" + template + "/*" + STOP_COMMENT + "*/" + "\n" + after;
                 });
@@ -160,7 +158,7 @@ public class BlockStatementTemplateGenerator {
     }
 
     @SuppressWarnings("ConstantConditions")
-    private void template(Cursor cursor, J prior, StringBuilder before, StringBuilder after, Set<J> templated) {
+    private void template(Cursor cursor, J prior, StringBuilder before, StringBuilder after, Set<J> templated, J toReplace) {
         templated.add(cursor.getValue());
         J j = cursor.getValue();
         if (j instanceof JavaSourceFile) {
@@ -192,16 +190,7 @@ public class BlockStatementTemplateGenerator {
                 J.MethodDeclaration m = (J.MethodDeclaration) parent;
 
                 // variable declarations up to the point of insertion
-                assert m.getBody() != null;
-                for (Statement statement : m.getBody().getStatements()) {
-                    if (referToSameElement(prior, statement)) {
-                        break;
-                    } else if (statement instanceof J.VariableDeclarations) {
-                        before.insert(0, "\n" +
-                                         variable((J.VariableDeclarations) statement, true, cursor) +
-                                         ";\n");
-                    }
-                }
+                addLeadingVariableDeclarations(cursor, prior, m.getBody(), before, toReplace);
 
                 if (m.getReturnTypeExpression() != null && !JavaType.Primitive.Void
                         .equals(m.getReturnTypeExpression().getType())) {
@@ -215,19 +204,11 @@ public class BlockStatementTemplateGenerator {
                                          .withLeadingAnnotations(emptyList())
                                          .withPrefix(Space.EMPTY)
                                          .printTrimmed(cursor).trim() + '{');
-            } else if (parent instanceof J.Block || parent instanceof J.Lambda) {
+            } else if (parent instanceof J.Block || parent instanceof J.Lambda || parent instanceof J.Label || parent instanceof Loop) {
                 J.Block b = (J.Block) j;
 
                 // variable declarations up to the point of insertion
-                for (Statement statement : b.getStatements()) {
-                    if (referToSameElement(prior, statement)) {
-                        break;
-                    } else if (statement instanceof J.VariableDeclarations) {
-                        before.insert(0, "\n" +
-                                         variable((J.VariableDeclarations) statement, true, cursor) +
-                                         ";\n");
-                    }
-                }
+                addLeadingVariableDeclarations(cursor, prior, b, before, toReplace);
 
                 before.insert(0, "{\n");
                 if (b.isStatic()) {
@@ -314,10 +295,12 @@ public class BlockStatementTemplateGenerator {
             }
         } else if (j instanceof J.ForLoop) {
             J.ForLoop f = (J.ForLoop) j;
-            insertControlWithBlock(f.getBody(), before, after, () -> before.insert(0,
-                    f.withBody(null).withPrefix(Space.EMPTY)
-                            .withControl(f.getControl().withCondition(null).withUpdate(emptyList()))
-                            .printTrimmed(cursor).trim()));
+            if (referToSameElement(prior, f.getBody())) {
+                insertControlWithBlock(f.getBody(), before, after, () -> before.insert(0,
+                        f.withBody(null).withPrefix(Space.EMPTY)
+                                .withControl(f.getControl().withCondition(null).withUpdate(emptyList()))
+                                .printTrimmed(cursor).trim()));
+            }
         } else if (j instanceof J.ForEachLoop.Control) {
             J.ForEachLoop.Control c = (J.ForEachLoop.Control) j;
             if (c.getVariable() == prior) {
@@ -394,10 +377,47 @@ public class BlockStatementTemplateGenerator {
         } else if (j instanceof J.If) {
             J.If iff = (J.If) j;
             if (referToSameElement(prior, iff.getIfCondition())) {
-                insertControlWithBlock(iff.getThenPart(), before, after, () -> {
-                    before.insert(0, "Object __b" + cursor.getPathAsStream().count() + "__ =");
-                    after.append(";");
-                });
+                String condition = PatternVariables.simplifiedPatternVariableCondition(iff.getIfCondition().getTree(), toReplace);
+                if (condition != null) {
+                    int splitIdx = condition.indexOf('§');
+                    before.insert(0, "if (" + condition.substring(0, splitIdx) + '(');
+                    after.append(')').append(condition.substring(splitIdx + 1)).append(") {}");
+                } else {
+                    insertControlWithBlock(iff.getThenPart(), before, after, () -> {
+                        before.insert(0, "Object __b" + cursor.getPathAsStream().count() + "__ =");
+                        after.append(";");
+                    });
+                }
+            } else {
+                String condition = PatternVariables.simplifiedPatternVariableCondition(iff.getIfCondition().getTree(), toReplace);
+                if (condition != null) {
+                    if (referToSameElement(prior, iff.getThenPart())) {
+                        insertControlWithBlock(iff.getThenPart(), before, after, () ->
+                                before.insert(0, "if (" + condition + ") "));
+                    } else if (referToSameElement(prior, iff.getElsePart())) {
+                        insertControlWithBlock(iff.getElsePart().getBody(), before, after, () ->
+                                before.insert(0, "if (" + condition + ") {} else "));
+                    }
+                }
+            }
+        } else if (j instanceof J.Ternary) {
+            J.Ternary ternary = (J.Ternary) j;
+            if (referToSameElement(prior, ternary.getCondition())) {
+                String condition = PatternVariables.simplifiedPatternVariableCondition(ternary.getCondition(), toReplace);
+                if (condition != null) {
+                    int splitIdx = condition.indexOf('§');
+                    before.insert(0, condition.substring(0, splitIdx) + '(');
+                    after.append(')').append(condition.substring(splitIdx + 1))
+                            .append(" ? ").append(ternary.getTruePart().printTrimmed(cursor).trim())
+                            .append(" : ").append(ternary.getFalsePart().printTrimmed(cursor).trim());
+                }
+            } else if (referToSameElement(prior, ternary.getTruePart())) {
+                String condition = PatternVariables.simplifiedPatternVariableCondition(ternary.getCondition(), toReplace);
+                before.insert(0, condition + " ? ");
+                after.append(" : ").append(ternary.getFalsePart().printTrimmed(cursor).trim());
+            } else if (referToSameElement(prior, ternary.getFalsePart())) {
+                String condition = PatternVariables.simplifiedPatternVariableCondition(ternary.getCondition(), toReplace);
+                before.insert(0, condition + " ? " + ternary.getTruePart().printTrimmed(cursor).trim() + " : ");
             }
         } else if (j instanceof J.WhileLoop) {
             J.WhileLoop wl = (J.WhileLoop) j;
@@ -419,7 +439,36 @@ public class BlockStatementTemplateGenerator {
         } else if (j instanceof J.EnumValueSet) {
             after.append(";");
         }
-        template(next(cursor), j, before, after, templated);
+        template(next(cursor), j, before, after, templated, toReplace);
+    }
+
+    private void addLeadingVariableDeclarations(Cursor cursor, J current, J.Block containingBlock, StringBuilder before, J toReplace) {
+        for (Statement statement : containingBlock.getStatements()) {
+            if (referToSameElement(current, statement)) {
+                break;
+            }
+            if (statement instanceof J.Label) {
+                statement = ((J.Label) statement).getStatement();
+            }
+            if (statement instanceof J.VariableDeclarations) {
+                before.insert(0, "\n" +
+                                 variable((J.VariableDeclarations) statement, true, cursor) +
+                                 ";\n");
+            } else if (statement instanceof J.If) {
+                J.If iff = (J.If) statement;
+                String condition = PatternVariables.simplifiedPatternVariableCondition(iff.getIfCondition().getTree(), toReplace);
+                if (condition != null) {
+                    boolean thenNeverCompletesNormally = PatternVariables.neverCompletesNormally(iff.getThenPart());
+                    boolean elseNeverCompletesNormally = iff.getElsePart() != null && PatternVariables.neverCompletesNormally(iff.getElsePart().getBody());
+                    if (thenNeverCompletesNormally || elseNeverCompletesNormally) {
+                        StringBuilder ifStatement = new StringBuilder("if (").append(condition).append(") {");
+                        ifStatement.append(thenNeverCompletesNormally ? " throw new RuntimeException(); }" : " }");
+                        ifStatement.append(elseNeverCompletesNormally ? " else { throw new RuntimeException(); }" : " else { }");
+                        before.insert(0, ifStatement);
+                    }
+                }
+            }
+        }
     }
 
     private void insertControlWithBlock(J body, StringBuilder before, StringBuilder after, Runnable insertion) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/PatternVariables.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/PatternVariables.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.template;
+
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Loop;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class PatternVariables {
+
+    private static final String DEFAULT_LABEL = "!";
+
+    private static class ResultCollector {
+        final StringBuilder builder = new StringBuilder();
+        boolean instanceOfFound;
+    }
+
+    @Nullable
+    static String simplifiedPatternVariableCondition(Expression condition, @Nullable J toReplace) {
+        ResultCollector resultCollector = new ResultCollector();
+        simplifiedPatternVariableCondition0(condition, toReplace, resultCollector);
+        return resultCollector.instanceOfFound ? resultCollector.builder.toString() : null;
+    }
+
+    private static boolean simplifiedPatternVariableCondition0(J expr, @Nullable J toReplace, ResultCollector collector) {
+        if (expr == toReplace) {
+            collector.builder.append('§');
+            return true;
+        }
+
+        if (expr instanceof J.Parentheses) {
+            J.Parentheses<?> parens = (J.Parentheses<?>) expr;
+            collector.builder.append('(');
+            try {
+                return simplifiedPatternVariableCondition0(parens.getTree(), toReplace, collector);
+            } finally {
+                collector.builder.append(')');
+            }
+        } else if (expr instanceof J.Unary) {
+            J.Unary unary = (J.Unary) expr;
+            switch (unary.getOperator()) {
+                case PostIncrement: {
+                    boolean found = simplifiedPatternVariableCondition0(unary.getExpression(), toReplace, collector);
+                    collector.builder.append("++");
+                    return found;
+                }
+                case PostDecrement: {
+                    boolean found = simplifiedPatternVariableCondition0(unary.getExpression(), toReplace, collector);
+                    collector.builder.append("--");
+                    return found;
+                }
+                case PreIncrement:
+                    collector.builder.append("++");
+                    break;
+                case PreDecrement:
+                    collector.builder.append("--");
+                    break;
+                case Positive:
+                    collector.builder.append('+');
+                    break;
+                case Negative:
+                    collector.builder.append('-');
+                    break;
+                case Complement:
+                    collector.builder.append('~');
+                    break;
+                case Not:
+                    collector.builder.append('!');
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected unary operator: " + unary.getOperator());
+            }
+            return simplifiedPatternVariableCondition0(unary.getExpression(), toReplace, collector);
+        } else if (expr instanceof J.Binary) {
+            J.Binary binary = (J.Binary) expr;
+            int length = collector.builder.length();
+            boolean result = simplifiedPatternVariableCondition0(binary.getLeft(), toReplace, collector);
+            switch (binary.getOperator()) {
+                case Addition:
+                    collector.builder.append('+');
+                    break;
+                case Subtraction:
+                    collector.builder.append('-');
+                    break;
+                case Multiplication:
+                    collector.builder.append('*');
+                    break;
+                case Division:
+                    collector.builder.append('/');
+                    break;
+                case Modulo:
+                    collector.builder.append('%');
+                    break;
+                case LessThan:
+                    collector.builder.append('<');
+                    break;
+                case GreaterThan:
+                    collector.builder.append('>');
+                    break;
+                case LessThanOrEqual:
+                    collector.builder.append("<=");
+                    break;
+                case GreaterThanOrEqual:
+                    collector.builder.append(">=");
+                    break;
+                case Equal:
+                    collector.builder.append("==");
+                    break;
+                case NotEqual:
+                    collector.builder.append("!=");
+                    break;
+                case BitAnd:
+                    collector.builder.append('&');
+                    break;
+                case BitOr:
+                    collector.builder.append('|');
+                    break;
+                case BitXor:
+                    collector.builder.append('^');
+                    break;
+                case LeftShift:
+                    collector.builder.append("<<");
+                    break;
+                case RightShift:
+                    collector.builder.append(">>");
+                    break;
+                case UnsignedRightShift:
+                    collector.builder.append(">>>");
+                    break;
+                case Or:
+                    collector.builder.append("||");
+                    break;
+                case And:
+                    collector.builder.append("&&");
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected binary operator: " + binary.getOperator());
+            }
+            result |= simplifiedPatternVariableCondition0(binary.getRight(), toReplace, collector);
+            if (!result) {
+                switch (binary.getOperator()) {
+                    case LessThan:
+                    case GreaterThan:
+                    case LessThanOrEqual:
+                    case GreaterThanOrEqual:
+                    case Equal:
+                    case NotEqual:
+                    case Or:
+                    case And:
+                        collector.builder.setLength(length);
+                        collector.builder.append("true");
+                        return false;
+                }
+            }
+            return result;
+        } else if (expr instanceof J.InstanceOf) {
+            J.InstanceOf instanceOf = (J.InstanceOf) expr;
+            if (instanceOf.getPattern() != null) {
+                collector.builder.append("((Object)null) instanceof ").append(instanceOf.getClazz()).append(' ').append(instanceOf.getPattern());
+                collector.instanceOfFound = true;
+                return true;
+            }
+            collector.builder.append("true");
+        } else if (expr instanceof J.Literal) {
+            J.Literal literal = (J.Literal) expr;
+            collector.builder.append(literal.getValue());
+        } else if (expr instanceof Expression) {
+            collector.builder.append("null");
+        }
+        return false;
+    }
+
+    static boolean neverCompletesNormally(Statement statement) {
+        return neverCompletesNormally0(statement, new HashSet<>());
+    }
+
+    private static boolean neverCompletesNormally0(@Nullable Statement statement, Set<String> labelsToIgnore) {
+        if (statement instanceof J.Return || statement instanceof J.Throw) {
+            return true;
+        } else if (statement instanceof J.Break) {
+            J.Break breakStatement = (J.Break) statement;
+            return breakStatement.getLabel() != null && !labelsToIgnore.contains(breakStatement.getLabel().getSimpleName())
+                    || breakStatement.getLabel() == null && !labelsToIgnore.contains(DEFAULT_LABEL);
+        } else if (statement instanceof J.Continue) {
+            J.Continue continueStatement = (J.Continue) statement;
+            return continueStatement.getLabel() != null && !labelsToIgnore.contains(continueStatement.getLabel().getSimpleName())
+                    || continueStatement.getLabel() == null && !labelsToIgnore.contains(DEFAULT_LABEL);
+        } else if (statement instanceof J.Block) {
+            return neverCompletesNormally0(getLastStatement(statement), labelsToIgnore);
+        } else if (statement instanceof Loop) {
+            Loop loop = (Loop) statement;
+            return neverCompletesNormallyIgnoringLabel(loop.getBody(), DEFAULT_LABEL, labelsToIgnore);
+        } else if (statement instanceof J.If) {
+            J.If if_ = (J.If) statement;
+            return if_.getElsePart() != null
+                    && neverCompletesNormally0(if_.getThenPart(), labelsToIgnore)
+                    && neverCompletesNormally0(if_.getElsePart().getBody(), labelsToIgnore);
+        } else if (statement instanceof J.Switch) {
+            J.Switch switch_ = (J.Switch) statement;
+            if (switch_.getCases().getStatements().isEmpty()) {
+                return false;
+            }
+            Statement defaultCase = null;
+            for (Statement case_ : switch_.getCases().getStatements()) {
+                if (!neverCompletesNormallyIgnoringLabel(case_, DEFAULT_LABEL, labelsToIgnore)) {
+                    return false;
+                }
+                if (case_ instanceof J.Case) {
+                    Expression elem = ((J.Case) case_).getPattern();
+                    if (elem instanceof J.Identifier && ((J.Identifier) elem).getSimpleName().equals("default")) {
+                        defaultCase = case_;
+                    }
+                }
+            }
+            return neverCompletesNormallyIgnoringLabel(defaultCase, DEFAULT_LABEL, labelsToIgnore);
+        } else if (statement instanceof J.Case) {
+            J.Case case_ = (J.Case) statement;
+            if (case_.getStatements().isEmpty()) {
+                // fallthrough to next case
+                return true;
+            }
+            return neverCompletesNormally0(getLastStatement(case_), labelsToIgnore);
+        } else if (statement instanceof J.Try) {
+            J.Try try_ = (J.Try) statement;
+            if (try_.getFinally() != null && !try_.getFinally().getStatements().isEmpty()
+                    && neverCompletesNormally0(try_.getFinally(), labelsToIgnore)) {
+                return true;
+            }
+            boolean bodyHasExit = false;
+            if (!try_.getBody().getStatements().isEmpty()
+                    && !(bodyHasExit = neverCompletesNormally0(try_.getBody(), labelsToIgnore))) {
+                return false;
+            }
+            for (J.Try.Catch catch_ : try_.getCatches()) {
+                if (!neverCompletesNormally0(catch_.getBody(), labelsToIgnore)) {
+                    return false;
+                }
+            }
+            return bodyHasExit;
+        } else if (statement instanceof J.Synchronized) {
+            return neverCompletesNormally0(((J.Synchronized) statement).getBody(), labelsToIgnore);
+        } else if (statement instanceof J.Label) {
+            String label = ((J.Label) statement).getLabel().getSimpleName();
+            Statement labeledStatement = ((J.Label) statement).getStatement();
+            return neverCompletesNormallyIgnoringLabel(labeledStatement, label, labelsToIgnore);
+        }
+        return false;
+    }
+
+    private static boolean neverCompletesNormallyIgnoringLabel(@Nullable Statement statement, String label, Set<String> labelsToIgnore) {
+        boolean added = labelsToIgnore.add(label);
+        try {
+            return neverCompletesNormally0(statement, labelsToIgnore);
+        } finally {
+            if (added) {
+                labelsToIgnore.remove(label);
+            }
+        }
+    }
+
+    @Nullable
+    private static Statement getLastStatement(Statement statement) {
+        if (statement instanceof J.Block) {
+            List<Statement> statements = ((J.Block) statement).getStatements();
+            return statements.isEmpty() ? null : getLastStatement(statements.get(statements.size() - 1));
+        } else if (statement instanceof J.Case) {
+            List<Statement> statements = ((J.Case) statement).getStatements();
+            return statements.isEmpty() ? null : getLastStatement(statements.get(statements.size() - 1));
+        } else if (statement instanceof Loop) {
+            return getLastStatement(((Loop) statement).getBody());
+        }
+        return statement;
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/template/PatternVariablesTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/template/PatternVariablesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.template;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.internal.template.PatternVariables.simplifiedPatternVariableCondition;
+
+class PatternVariablesTest {
+
+    private final JavaParser parser = JavaParser.fromJavaVersion().build();
+
+    @Test
+    void none() {
+        String condition = simplify("o == null");
+        assertThat(condition).isNull();
+    }
+
+    @Test
+    void simple() {
+        String condition = simplify("o instanceof String s");
+        assertThat(condition).isEqualTo("((Object)null) instanceof String s");
+    }
+
+    @Test
+    void multiple() {
+        String condition = simplify("(o instanceof String s && s.length() > 0) || (o instanceof Integer i && i > 0)");
+        assertThat(condition).isEqualTo("(((Object)null) instanceof String s&&true)||(((Object)null) instanceof Integer i&&true)");
+    }
+
+    @Test
+    void binaryOr() {
+        String condition = simplify("o instanceof String s || 1 > 0 || o instanceof Integer i || 1 > 0");
+        assertThat(condition).isEqualTo("((Object)null) instanceof String s||true||((Object)null) instanceof Integer i||true");
+    }
+
+    @Test
+    void collapseNested() {
+        String condition = simplify("1 > 2 && (o.hasCode() == 0 || 1 == 2) || o instanceof String s");
+        assertThat(condition).isEqualTo("true||((Object)null) instanceof String s");
+    }
+
+    @Test
+    void unaryNot() {
+        String condition = simplify("!(o instanceof String s || true)");
+        assertThat(condition).isEqualTo("!(((Object)null) instanceof String s||true)");
+    }
+
+    private @Nullable String simplify(String condition) {
+        @Language("java")
+        String source = """
+                class Test {
+                    void test(Object o) {
+                        if ($condition) {
+                            System.out.println(s);
+                        }
+                    }
+                }
+                """.replace("$condition", condition);
+        J.CompilationUnit cu = parser.parse(source).get(0);
+        J.MethodDeclaration method = (J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0);
+        @SuppressWarnings("DataFlowIssue") J.If ifStatement = (J.If) method.getBody().getStatements().get(0);
+        return simplifiedPatternVariableCondition(ifStatement.getIfCondition().getTree(), null);
+    }
+}


### PR DESCRIPTION
Using `instanceof` pattern matching an `if` statement can declare local variables which can be dereferenced in the condition itself, in the `then` block, the `else` block, or also in successor statements to the `if` statement. Therefore, it is important that `JavaTemplate` keeps these `instanceof` pattern matching expressions when generating the stub to extract the type attributed substitution of a template.

For any `if` statements which contain `instanceof` pattern variables the `if` statement is added in a reduced form to the stub. The flow scoping rules of the pattern variables require the then and else blocks to retain the same "completes normally" characteristics as in the original code, as this influences the scope of the pattern variable.

Additionally this PR fixes a few other minor problems with the stub generation in the `JavaTemplate` engine. Specifically, any variables declared in the same block as the element to be replaced, but preceding it, are now also generated into the stub. This was also the case before, but didn't work in the context of loops or labeled blocks.

Finally, `J.Ternary` expressions with pattern variables in the condition are also supported.

Fixes: #2820
