### PR TITLE
Use CI_SERVER_HOST to get GitLab host name

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/GitlabBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/GitlabBuildEnvironment.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import java.util.function.UnaryOperator;
 
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.marker.OperatingSystemProvenance.hostname;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -41,7 +40,7 @@ public class GitlabBuildEnvironment implements BuildEnvironment {
                 randomId(),
                 environment.apply("CI_BUILD_ID"),
                 environment.apply("CI_JOB_URL"),
-                hostname(),
+                environment.apply("CI_SERVER_HOST"),
                 environment.apply("CI_BUILD_NAME")
         );
     }


### PR DESCRIPTION
As per https://docs.gitlab.com/ee/ci/variables/predefined_variables.html

Because GraalVM has issues resolving hostname.
```
JNA: Problems loading core IDs: java.lang.Object
Exception in thread "main" java.lang.NoClassDefFoundError: java/lang/Object
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.functions.JNIFunctions.FindClass(JNIFunctions.java:343)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNIOnLoadFunctionPointer.invoke(JNILibraryInitializer.java)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNILibraryInitializer.callOnLoadFunction(JNILibraryInitializer.java:71)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNILibraryInitializer.initialize(JNILibraryInitializer.java:132)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibrarySupport.addLibrary(NativeLibrarySupport.java:174)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibrarySupport.loadLibrary0(NativeLibrarySupport.java:130)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibrarySupport.loadLibraryAbsolute(NativeLibrarySupport.java:89)
	at java.base@19.0.1/java.lang.ClassLoader.loadLibrary(ClassLoader.java:57)
	at java.base@19.0.1/java.lang.Runtime.load0(Runtime.java:785)
	at java.base@19.0.1/java.lang.System.load(System.java:2011)
	at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:1045)
	at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:1015)
	at com.sun.jna.Native.<clinit>(Native.java:221)
	at org.openrewrite.marker.ci.POSIXUtil.<clinit>(POSIXUtil.java:23)
	at org.openrewrite.marker.OperatingSystemProvenance.hostname(OperatingSystemProvenance.java:69)
	at org.openrewrite.marker.ci.GitlabBuildEnvironment.build(GitlabBuildEnvironment.java:44)
	at org.openrewrite.marker.ci.BuildEnvironment.build(BuildEnvironment.java:30)
	at org.openrewrite.marker.GitProvenanceBuilder.fromProjectDirectory(GitProvenanceBuilder.java:23)
```