### PR TITLE
fix: Fix a bug of recipe FinalizePrivateFields with multiple constructors

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizePrivateFieldsTest.java
@@ -449,6 +449,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
+    @Disabled("Multi constructors ignored")
+    @Issue("https://github.com/openrewrite/rewrite/issues/2865")
     @Test
     void fieldAssignedIndirectlyInAllAlternateConstructors() {
         rewriteRun(
@@ -813,6 +815,27 @@ class FinalizePrivateFieldsTest implements RewriteTest {
                   void func() {
                       B b = new B();
                       b.setNum(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2865")
+    void additionalConstructorIgnored() {
+        rewriteRun(
+          java(
+            """
+              class Reproducer {
+                  private String potentiallyFinal;
+
+                  Reproducer(String potentiallyFinal) {
+                      this.potentiallyFinal = potentiallyFinal;
+                  }
+
+                  Reproducer() {
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizePrivateFields.java
@@ -70,6 +70,11 @@ public class FinalizePrivateFields extends Recipe {
                     return classDecl;
                 }
 
+                // skip if a class has multi constructor methods
+                if (getConstructorCount(classDecl) > 1) {
+                    return classDecl;
+                }
+
                 List<J.VariableDeclarations.NamedVariable> privateFields = collectPrivateFields(classDecl);
                 Map<JavaType.Variable, Integer> privateFieldAssignCountMap = privateFields.stream()
                     .filter(v -> v.getVariableType() != null)
@@ -131,6 +136,16 @@ public class FinalizePrivateFields extends Recipe {
             .map(J.VariableDeclarations::getVariables)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
+    }
+
+    private static int getConstructorCount(J.ClassDeclaration classDecl) {
+        return (int) classDecl.getBody()
+            .getStatements()
+            .stream()
+            .filter(statement -> statement instanceof J.MethodDeclaration)
+            .map(J.MethodDeclaration.class::cast)
+            .filter(J.MethodDeclaration::isConstructor)
+            .count();
     }
 
     private static class CollectPrivateFieldsAssignmentCounts extends JavaIsoVisitor<Map<JavaType.Variable, Integer>> {


### PR DESCRIPTION
fixes #2865 
fixes #2869 
Fix a bug in recipe `FinalizePrivateFields` with multiple constructors, if any constructor does not initialize a field, it can not be final.
### Solution:
Skip rewriting if a class has multiple constructors.