### PR TITLE
fix: an edge case of grouping in `ChainStringBuilderAppendCalls` recipe

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
@@ -72,7 +72,7 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
     }
 
     @Test
-    void groupedObjectsConcatenation() {
+    void groupedStringsConcatenation() {
         rewriteRun(
           java(
             """
@@ -90,6 +90,32 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
                       StringBuilder sb = new StringBuilder();
                       String op = "+";
                       sb.append("A" + "B" + "C").append(op).append("D" + "E");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void correctlyGroupConcatenations() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  void method1() {
+                      StringBuilder sb = new StringBuilder();
+                      String op = "+";
+                      sb.append(op + 1 + 2 + "A" + "B" + 'x');
+                  }
+              }
+              """,
+            """
+              class A {
+                  void method1() {
+                      StringBuilder sb = new StringBuilder();
+                      String op = "+";
+                      sb.append(op).append(1).append(2).append("A" + "B").append('x');
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
@@ -81,7 +81,8 @@ public class ChainStringBuilderAppendCalls extends Recipe {
                     List<Expression> groups = new ArrayList<>();
                     List<Expression> group = new ArrayList<>();
                     for (Expression exp : flattenExpressions) {
-                        if (exp instanceof J.Literal) {
+                        if (exp instanceof J.Literal
+                            && (((J.Literal) exp).getType() == JavaType.Primitive.String)) {
                             group.add(exp);
                         } else {
                             addToGroups(group, groups);


### PR DESCRIPTION
To fix an edge case of incorrectly grouping in `ChainStringBuilderAppendCalls`.

address comments [here](https://github.com/openrewrite/rewrite/pull/2882#discussion_r1115023005)

For example:

```java
sb.append(op + 'a' + 'b')
```
can not rewrite to 
```java
sb.append(op).append('a' + 'b') 
```
(where op is a variable of type String).

but should be 
```java
sb.append(op).append('a').append('b')
```