### PR TITLE
Remove the gradle-api from being shaded into rewrite-gradle.

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -1,8 +1,5 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("org.openrewrite.build.language-library")
-    id("org.openrewrite.build.shadow")
     id("groovy")
 }
 
@@ -17,25 +14,17 @@ repositories {
 
 dependencies {
     api(project(":rewrite-core"))
-    api(project(":rewrite-groovy"))
+    api(project(":rewrite-groovy")) {
+        exclude("org.codehaus.groovy", "groovy")
+    }
     api(project(":rewrite-maven"))
     api("org.jetbrains:annotations:latest.release")
     compileOnly(project(":rewrite-test"))
     implementation(project(":rewrite-properties"))
-    implementation("org.codehaus.groovy:groovy:latest.release")
     implementation("org.openrewrite.gradle.tooling:model:latest.release")
 
-    compileOnly("org.gradle:gradle-base-services:latest.release")
-    compileOnly("org.gradle:gradle-core-api:latest.release")
-    compileOnly("org.gradle:gradle-language-groovy:latest.release")
-    compileOnly("org.gradle:gradle-language-java:latest.release")
-    compileOnly("org.gradle:gradle-logging:latest.release")
-    compileOnly("org.gradle:gradle-messaging:latest.release")
-    compileOnly("org.gradle:gradle-native:latest.release")
-    compileOnly("org.gradle:gradle-process-services:latest.release")
-    compileOnly("org.gradle:gradle-resources:latest.release")
-    compileOnly("org.gradle:gradle-testing-base:latest.release")
-    compileOnly("org.gradle:gradle-testing-jvm:latest.release")
+    compileOnly("org.codehaus.groovy:groovy:latest.release")
+    compileOnly(gradleApi())
 
     compileOnly("com.gradle:gradle-enterprise-gradle-plugin:latest.release")
 
@@ -47,33 +36,14 @@ dependencies {
         // because gradle-api fatjars this implementation already
         exclude("ch.qos.logback", "logback-classic")
     }
-    testImplementation(project(":rewrite-maven"))
     testImplementation("com.squareup.okhttp3:mockwebserver:4.+")
 
-    testRuntimeOnly("org.gradle:gradle-base-services:latest.release")
-    testRuntimeOnly("org.gradle:gradle-core-api:latest.release")
-    testRuntimeOnly("org.gradle:gradle-language-groovy:latest.release")
-    testRuntimeOnly("org.gradle:gradle-language-java:latest.release")
-    testRuntimeOnly("org.gradle:gradle-logging:latest.release")
-    testRuntimeOnly("org.gradle:gradle-messaging:latest.release")
-    testRuntimeOnly("org.gradle:gradle-native:latest.release")
-    testRuntimeOnly("org.gradle:gradle-process-services:latest.release")
-    testRuntimeOnly("org.gradle:gradle-resources:latest.release")
-    testRuntimeOnly("org.gradle:gradle-testing-base:latest.release")
-    testRuntimeOnly("org.gradle:gradle-testing-jvm:latest.release")
+    testRuntimeOnly("org.codehaus.groovy:groovy:latest.release")
+    testRuntimeOnly(gradleApi())
     testRuntimeOnly("com.gradle:gradle-enterprise-gradle-plugin:latest.release")
     testRuntimeOnly("com.google.guava:guava:latest.release")
     testRuntimeOnly(project(":rewrite-java-17"))
     testRuntimeOnly("org.projectlombok:lombok:latest.release")
-}
-
-tasks.withType<ShadowJar> {
-    exclude("org/slf4j/impl/**.class")
-    exclude("org/gradle/internal/logging/slf4j/**.class")
-    dependencies {
-        include(dependency("org.gradle:"))
-        include(dependency("com.gradle:"))
-    }
 }
 
 // This seems to be the only way to get the groovy compiler to emit java-8 compatible bytecode

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
@@ -41,7 +41,7 @@ public class Assertions {
     }
 
     private static final Parser.Builder gradleParser = GradleParser.builder()
-            .setGroovyParser(GroovyParser.builder().logCompilationWarningsAndErrors(true));
+            .groovyParser(GroovyParser.builder().logCompilationWarningsAndErrors(true));
 
     public static SourceSpecs buildGradle(@Language("groovy") @Nullable String before) {
         return buildGradle(before, s -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
@@ -15,9 +15,6 @@
  */
 package org.openrewrite.gradle;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.gradle.internal.DefaultImportsCustomizer;
@@ -98,9 +95,6 @@ public class GradleParser implements Parser<G.CompilationUnit> {
         return new Builder();
     }
 
-    @Accessors(chain=true)
-    @Setter
-    @Getter
     public static class Builder extends Parser.Builder {
         protected GroovyParser.Builder groovyParser = GroovyParser.builder();
 
@@ -112,6 +106,24 @@ public class GradleParser implements Parser<G.CompilationUnit> {
 
         public Builder() {
             super(G.CompilationUnit.class);
+        }
+
+        public Builder groovyParser(GroovyParser.Builder groovyParser) {
+            this.groovyParser = groovyParser;
+            return this;
+        }
+
+        /**
+         * @deprecated Use {@code groovyParser(GroovyParser.Builder)} instead.
+         */
+        @Deprecated//(since = "7.37.0", forRemoval = true)
+        public Builder setGroovyParser(GroovyParser.Builder groovyParser) {
+            return groovyParser(groovyParser);
+        }
+
+        @Deprecated//(since = "7.37.0", forRemoval = true)
+        public GroovyParser.Builder getGroovyParser() {
+            return groovyParser;
         }
 
         public Builder buildscriptClasspath(Collection<Path> classpath) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
@@ -24,8 +24,10 @@ import org.openrewrite.gradle.internal.DefaultImportsCustomizer;
 import org.openrewrite.groovy.GroovyParser;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaParser;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,14 +37,9 @@ public class GradleParser implements Parser<G.CompilationUnit> {
     private final GroovyParser buildParser;
     private final GroovyParser settingsParser;
 
+    @Deprecated//(since = "7.37.0", forRemoval = true)
     public GradleParser(GroovyParser.Builder groovyParser) {
         GroovyParser.Builder base = groovyParser;
-        try {
-            base = groovyParser.classpath("gradle-core-api", "gradle-language-groovy", "gradle-language-java", "gradle-resources",
-                    "gradle-testing-base", "gradle-testing-jvm", "gradle-enterprise-gradle-plugin");
-        } catch (IllegalArgumentException e) {
-            // when gradle API has been fatjared into the rewrite-gradle distribution
-        }
         this.buildParser = GroovyParser.builder(base)
                 .compilerCustomizers(
                         new DefaultImportsCustomizer(),
@@ -50,6 +47,24 @@ public class GradleParser implements Parser<G.CompilationUnit> {
                 )
                 .build();
         this.settingsParser = GroovyParser.builder(base)
+                .compilerCustomizers(
+                        new DefaultImportsCustomizer(),
+                        config -> config.setScriptBaseClass("RewriteSettings")
+                )
+                .build();
+    }
+
+    private GradleParser(Builder builder) {
+        GroovyParser.Builder base = builder.groovyParser;
+        this.buildParser = GroovyParser.builder(base)
+                .classpath(builder.buildscriptClasspath)
+                .compilerCustomizers(
+                        new DefaultImportsCustomizer(),
+                        config -> config.setScriptBaseClass("RewriteGradleProject")
+                )
+                .build();
+        this.settingsParser = GroovyParser.builder(base)
+                .classpath(builder.settingsClasspath)
                 .compilerCustomizers(
                         new DefaultImportsCustomizer(),
                         config -> config.setScriptBaseClass("RewriteSettings")
@@ -89,12 +104,38 @@ public class GradleParser implements Parser<G.CompilationUnit> {
     public static class Builder extends Parser.Builder {
         protected GroovyParser.Builder groovyParser = GroovyParser.builder();
 
+        @Nullable
+        private Collection<Path> buildscriptClasspath = JavaParser.runtimeClasspath();
+
+        @Nullable
+        private Collection<Path> settingsClasspath = JavaParser.runtimeClasspath();
+
         public Builder() {
             super(G.CompilationUnit.class);
         }
 
+        public Builder buildscriptClasspath(Collection<Path> classpath) {
+            this.buildscriptClasspath = classpath;
+            return this;
+        }
+
+        public Builder buildscriptClasspath(String... classpath) {
+            this.buildscriptClasspath = JavaParser.dependenciesFromClasspath(classpath);
+            return this;
+        }
+
+        public Builder settingsClasspath(Collection<Path> classpath) {
+            this.settingsClasspath = classpath;
+            return this;
+        }
+
+        public Builder settingsClasspath(String... classpath) {
+            this.settingsClasspath = JavaParser.dependenciesFromClasspath(classpath);
+            return this;
+        }
+
         public GradleParser build() {
-            return new GradleParser(groovyParser);
+            return new GradleParser(this);
         }
 
         @Override

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -481,7 +481,7 @@ public class GroovyParserVisitor {
                 );
                 cursor += param.getName().length();
 
-                org.codehaus.groovy.ast.expr.Expression defaultValue = param.getDefaultValue();
+                org.codehaus.groovy.ast.expr.Expression defaultValue = param.getInitialExpression();
                 if (defaultValue != null) {
                     paramName = paramName.withElement(paramName.getElement().getPadding()
                             .withInitializer(new JLeftPadded<>(


### PR DESCRIPTION
This enables better alignment in terms of type attribution by utilizing the Gradle, Groovy, and (future) Kotlin versions as provided by the executing Gradle wrapper.