### PR TITLE
fix: a tricky edge case of chain StringBuilder.append() calls

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
@@ -107,7 +107,10 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
                       StringBuilder sb = new StringBuilder();
                       String op = "+";
                       sb.append(op + 1 + 2 + "A" + "B" + 'x');
+                      sb.append(1 + 2 + op + 3 + 4);
+                      sb.append(1 + 2 + name() + 3 + 4);
                   }
+                  String name() { return "name"; }
               }
               """,
             """
@@ -116,7 +119,10 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
                       StringBuilder sb = new StringBuilder();
                       String op = "+";
                       sb.append(op).append(1).append(2).append("A" + "B").append('x');
+                      sb.append(1 + 2).append(op).append(3).append(4);
+                      sb.append(1 + 2).append(name()).append(3).append(4);
                   }
+                  String name() { return "name"; }
               }
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
@@ -80,13 +80,31 @@ public class ChainStringBuilderAppendCalls extends Recipe {
                     // group expressions
                     List<Expression> groups = new ArrayList<>();
                     List<Expression> group = new ArrayList<>();
+                    boolean appendToString = false;
                     for (Expression exp : flattenExpressions) {
-                        if (exp instanceof J.Literal
-                            && (((J.Literal) exp).getType() == JavaType.Primitive.String)) {
-                            group.add(exp);
+                        if (appendToString) {
+                            if (exp instanceof J.Literal
+                                && (((J.Literal) exp).getType() == JavaType.Primitive.String)
+                            ) {
+                                group.add(exp);
+                            } else {
+                                addToGroups(group, groups);
+                                groups.add(exp);
+                            }
                         } else {
-                            addToGroups(group, groups);
-                            groups.add(exp);
+                            if (exp instanceof J.Literal
+                                && (((J.Literal) exp).getType() == JavaType.Primitive.String)) {
+                                addToGroups(group, groups);
+                                appendToString = true;
+                            }  else if ((exp instanceof J.Identifier || exp instanceof J.MethodInvocation) && exp.getType() != null) {
+                                JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(exp.getType());
+                                if (fullyQualified != null && fullyQualified.getFullyQualifiedName().equals("java.lang.String")) {
+                                    addToGroups(group, groups);
+                                    appendToString = true;
+                                }
+                            }
+                            group.add(exp);
+
                         }
                     }
                     addToGroups(group, groups);


### PR DESCRIPTION
Fix a tricky edge case of grouping when chaining `StringBuilder.append()` calls.

Example:
```java
StringBuilder sb = new StringBuilder();
String op = "+";
sb.append(1 + 2 + op + 3 + 4);
```

can not transform to 
```java
StringBuilder sb = new StringBuilder();
String op = "+";
sb.append(1).append(2).append(op).append(3).append(4);
```
but should be 
```java
StringBuilder sb = new StringBuilder();
String op = "+";
sb.append(1 + 2).append(op).append(3).append(4);
```