### PR TITLE
recipe: Replace deprecated `Runtime.Exec()` methods

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethodsTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReplaceDeprecatedRuntimeExecMethodsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceDeprecatedRuntimeExecMethods());
+    }
+
+    @Test
+    void rawString() {
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+
+              class A {
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec("ls -al");
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+
+              class A {
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec(new String[]{"ls", "-al"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void stringVariableAsInput() {
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+
+              class B {
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      String command = "ls -al";
+                      Process process = runtime.exec(command);
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+
+              class B {
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      String command = "ls -al";
+                      Process process = runtime.exec(command.split(" "));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodInvocationAsInput() {
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+
+              class B {
+                  String command() {
+                      return "ls -al";
+                  }
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec(command());
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+
+              class B {
+                  String command() {
+                      return "ls -al";
+                  }
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec(command().split(" "));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void concatenatedRawStringsAsInput() {
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+
+              class A {
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec("ls" + " " + "-a" + " " + "-l");
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+
+              class A {
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec(new String[]{"ls", "-a", "-l"});
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void concatenatedObjectsAsInput() {
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+
+              class B {
+                  String options = "-a -l";
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec("ls" + " " + options);
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+
+              class B {
+                  String options = "-a -l";
+                  void method() throws IOException {
+                      Runtime runtime = Runtime.getRuntime();
+                      Process process = runtime.exec(("ls" + " " + options).split(" "));
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethodsTest.java
@@ -28,42 +28,6 @@ class ReplaceDeprecatedRuntimeExecMethodsTest implements RewriteTest {
         spec.recipe(new ReplaceDeprecatedRuntimeExecMethods());
     }
 
-
-    @Test
-    void debug() {
-        rewriteRun(
-          version(
-            java(
-              """
-                import java.io.File;
-                import java.io.IOException;
-
-                class A {
-                    void method() throws IOException {
-                        Runtime runtime = Runtime.getRuntime();
-                        String[] envp = { "E1=1", "E2=2"};
-                        File dir = new File("/tmp");
-                        Process process3 = runtime.exec("ls -a -l", envp, dir);
-                    }
-                }
-                """,
-              """
-                import java.io.File;
-                import java.io.IOException;
-
-                class A {
-                    void method() throws IOException {
-                        Runtime runtime = Runtime.getRuntime();
-                        String[] envp = { "E1=1", "E2=2"};
-                        File dir = new File("/tmp");
-                        Process process3 = runtime.exec(new String[]{"ls", "-a", "-l"}, envp, dir);
-                    }
-                }
-                """
-            ), 18)
-        );
-    }
-
     @Test
     void rawString() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
@@ -176,7 +176,7 @@ public class ChainStringBuilderAppendCalls extends Recipe {
         }
     }
 
-    private static boolean flatAdditiveExpressions(Expression expression, List<Expression> expressionList) {
+    public static boolean flatAdditiveExpressions(Expression expression, List<Expression> expressionList) {
         if (expression instanceof J.Binary) {
             J.Binary b = (J.Binary) expression;
             if (b.getOperator() != J.Binary.Type.Addition) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
@@ -100,14 +100,25 @@ public class ReplaceDeprecatedRuntimeExecMethods extends Recipe {
                         // replace argument to 'command.split(" ")'
                         JavaTemplate template = JavaTemplate.builder(
                             this::getCursor, "#{any(java.lang.Runtime)}.exec(#{any(java.lang.String)}.split(\" \"))").build();
-                        Expression splitSelect = m.getArguments().get(0);
+                        JavaTemplate template2 = JavaTemplate.builder(
+                            this::getCursor, "#{any(java.lang.Runtime)}.exec(#{any(java.lang.String)}.split(\" \"), #{anyArray(java.lang.String)})").build();
+                        JavaTemplate template3 = JavaTemplate.builder(
+                            this::getCursor, "#{any(java.lang.Runtime)}.exec(#{any(java.lang.String)}.split(\" \"), #{anyArray(java.lang.String)}, #{any(java.io.File)})").build();
 
+                        Expression splitSelect = m.getArguments().get(0);
                         if (!(splitSelect instanceof J.Identifier)
                             && !(splitSelect instanceof J.Literal)
                             && !(splitSelect instanceof J.MethodInvocation)) {
                             splitSelect = ReplaceStringBuilderWithString.wrapExpression(splitSelect);
                         }
-                        return m.withTemplate(template, m.getCoordinates().replace(), m.getSelect(), splitSelect);
+
+                        if (RUNTIME_EXEC_CMD.matches(m)) {
+                            return m.withTemplate(template, m.getCoordinates().replace(), m.getSelect(), splitSelect);
+                        } else if (RUNTIME_EXEC_CMD_ENVP.matches(m) ) {
+                            return m.withTemplate(template2, m.getCoordinates().replace(), m.getSelect(), splitSelect, m.getArguments().get(1));
+                        } else if (RUNTIME_EXEC_CMD_ENVP_FILE.matches(m)) {
+                            return m.withTemplate(template3, m.getCoordinates().replace(), m.getSelect(), splitSelect, m.getArguments().get(1), m.getArguments().get(2));
+                        }
                     }
                 }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
@@ -61,8 +61,7 @@ public class ReplaceDeprecatedRuntimeExecMethods extends Recipe {
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
-                                                            ExecutionContext executionContext) {
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, executionContext);
 
                 if (RUNTIME_EXEC_CMD.matches(m) || RUNTIME_EXEC_CMD_ENVP.matches(m) || RUNTIME_EXEC_CMD_ENVP_FILE.matches(m)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
@@ -106,9 +106,9 @@ public class ReplaceDeprecatedRuntimeExecMethods extends Recipe {
                             this::getCursor, "#{any(java.lang.Runtime)}.exec(#{any(java.lang.String)}.split(\" \"), #{anyArray(java.lang.String)}, #{any(java.io.File)})").build();
 
                         Expression splitSelect = m.getArguments().get(0);
-                        if (!(splitSelect instanceof J.Identifier)
-                            && !(splitSelect instanceof J.Literal)
-                            && !(splitSelect instanceof J.MethodInvocation)) {
+                        if (!(splitSelect instanceof J.Identifier) && 
+                            !(splitSelect instanceof J.Literal) &&
+                            !(splitSelect instanceof J.MethodInvocation)) {
                             splitSelect = ReplaceStringBuilderWithString.wrapExpression(splitSelect);
                         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDeprecatedRuntimeExecMethods.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReplaceDeprecatedRuntimeExecMethods extends Recipe {
+    private static final MethodMatcher RUNTIME_EXEC = new MethodMatcher("java.lang.Runtime exec(String)");
+
+
+    @Override
+    public String getDisplayName() {
+        return "Replace Deprecated Runtime.Exec() methods";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace Runtime.exec(String) methods to use exec(String[]) instead because the former is deprecated " +
+               "after java 18 and no longer recommended for use by the Java documentation.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(3);
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesJavaVersion<>(18);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            ExecutionContext executionContext) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, executionContext);
+
+                if (RUNTIME_EXEC.matches(m)) {
+                    Expression command = m.getArguments().get(0);
+                    List<Expression> commands = new ArrayList<>();
+                    boolean flattenAble= ChainStringBuilderAppendCalls.flatAdditiveExpressions(command, commands);
+
+                    StringBuilder sb = new StringBuilder();
+                    if (flattenAble) {
+                        for (Expression e : commands) {
+                            if (e instanceof J.Literal && ((J.Literal) e).getType() == JavaType.Primitive.String) {
+                                sb.append(((J.Literal) e).getValue());
+                            } else {
+                                flattenAble = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (flattenAble) {
+                        String[] cmds = sb.toString().split(" ");
+                        String templateCode = String.format("#{any(java.lang.Runtime)}.exec(new String[] {%s})", toStringArguments(cmds));
+                        JavaTemplate template = JavaTemplate.builder(
+                            this::getCursor, templateCode).build();
+                        return m.withTemplate(template, m.getCoordinates().replace(), m.getSelect());
+                    } else {
+                        // replace argument to 'command.split(" ")'
+                        JavaTemplate template = JavaTemplate.builder(
+                            this::getCursor, "#{any(java.lang.Runtime)}.exec(#{any(java.lang.String)}.split(\" \"))").build();
+                        Expression splitSelect = m.getArguments().get(0);
+
+                        if (!(splitSelect instanceof J.Identifier)
+                            && !(splitSelect instanceof J.Literal)
+                            && !(splitSelect instanceof J.MethodInvocation)) {
+                            splitSelect = ReplaceStringBuilderWithString.wrapExpression(splitSelect);
+                        }
+
+                        return m.withTemplate(template, m.getCoordinates().replace(), m.getSelect(), splitSelect);
+                    }
+                }
+
+                return m;
+            }
+        };
+    }
+
+    private static String toStringArguments(String[] cmds) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < cmds.length; i++) {
+            String token = cmds[i];
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append("\"")
+                .append(token)
+                .append("\"");
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Closes https://github.com/openrewrite/rewrite-migrate-java/issues/159

Replace `Runtime.exec(String)` methods to use exec(String[]) instead because the former is deprecated after java 18 and no longer recommended for use by the Java documentation.

Example:
Before
```java
Process process1 = runtime.exec("ls -a -l");
Process process2 = runtime.exec("ls -a -l", envp);
Process process3 = runtime.exec("ls -a -l", envp, dir);
Process process4 = runtime.exec(command);
Process process5 = runtime.exec(command, envp);
Process process6 = runtime.exec(command, envp, dir);
```
After
```java
Process process1 = runtime.exec(new String[]{"ls", "-a", "-l"});
Process process2 = runtime.exec(new String[]{"ls", "-a", "-l"}, envp);
Process process3 = runtime.exec(new String[]{"ls", "-a", "-l"}, envp, dir);
Process process4 = runtime.exec(command.split(" "));
Process process5 = runtime.exec(command.split(" "), envp);
Process process6 = runtime.exec(command.split(" "), envp, dir);
```

