### PR TITLE
GitProvenance Support for non build environments without .git config

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -24,8 +24,7 @@ import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.treewalk.WorkingTreeOptions;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.marker.ci.BuildEnvironment;
-import org.openrewrite.marker.ci.JenkinsBuildEnvironment;
+import org.openrewrite.marker.ci.*;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -139,50 +138,91 @@ public class GitProvenance implements Marker {
 
     /**
      * @param projectDir       The project directory.
-     * @param buildEnvironment In detached head scenarios, the branch is best
+     * @param environment In detached head scenarios, the branch is best
      *                         determined from a {@link BuildEnvironment} marker if possible.
      * @return A marker containing git provenance information.
      */
-    public static @Nullable GitProvenance fromProjectDirectory(Path projectDir, @Nullable BuildEnvironment buildEnvironment) {
-        Repository repository = null;
-        try {
-            repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build();
-            String branch = null;
-            String changeset = getChangeset(repository);
+    public static @Nullable GitProvenance fromProjectDirectory(Path projectDir, @Nullable BuildEnvironment environment) {
 
+        if (environment != null) {
+            if(environment instanceof JenkinsBuildEnvironment) {
+                JenkinsBuildEnvironment jenkinsBuildEnvironment = (JenkinsBuildEnvironment) environment;
+                try (Repository repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build()) {
+                    String branch = jenkinsBuildEnvironment.getLocalBranch()  != null
+                            ? jenkinsBuildEnvironment.getLocalBranch()
+                            :  localBranchName(repository, jenkinsBuildEnvironment.getBranch());
+                    return fromGitConfig(repository, branch, getChangeset(repository));
+                } catch (IllegalArgumentException | GitAPIException e) {
+                    // Silently ignore if the project directory is not a git repository
+                    printRequireGitDirOrWorkTreeException(e);
+                    return null;
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            } else {
+                try {
+                    return environment.buildGitProvenance();
+                } catch (IncompleteGitConfigException e) {
+                    return fromGitConfig(projectDir);
+                }
+            }
+        } else {
+            return fromGitConfig(projectDir);
+        }
+    }
+
+    private static void printRequireGitDirOrWorkTreeException(Exception e) {
+        if (!"requireGitDirOrWorkTree".equals(e.getStackTrace()[0].getMethodName())) {
+            e.printStackTrace();
+        }
+    }
+
+    private static GitProvenance fromGitConfig(Path projectDir) {
+        String branch = null;
+        try (Repository repository = new RepositoryBuilder().findGitDir(projectDir.toFile()).build()) {
+            String changeset = getChangeset(repository);
             if (!repository.getBranch().equals(changeset)) {
                 branch = repository.getBranch();
-            } else if (buildEnvironment instanceof JenkinsBuildEnvironment) {
-                JenkinsBuildEnvironment jenkins = (JenkinsBuildEnvironment) buildEnvironment;
-                branch = jenkins.getLocalBranch() != null ?
-                        jenkins.getLocalBranch() :
-                        localBranchName(repository, jenkins.getBranch());
             }
+            return fromGitConfig(repository, branch, changeset);
+        } catch (IllegalArgumentException e) {
+            printRequireGitDirOrWorkTreeException(e);
+            return null;
+        }catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private static GitProvenance fromGitConfig(Repository repository, @Nullable String branch, String changeset) {
+        if (branch == null) {
+            branch = resolveBranchFromGitConfig(repository);
+        }
+        return new GitProvenance(randomId(), getOrigin(repository), branch, changeset,
+                getAutocrlf(repository), getEOF(repository));
+    }
 
-            if (branch == null) {
-                try (Git git = Git.open(repository.getDirectory())) {
-                    ObjectId commit = repository.resolve(Constants.HEAD);
-                    Map<ObjectId, String> branchesByCommit = git.nameRev().addPrefix("refs/heads/").add(commit).call();
-                    if (branchesByCommit.containsKey(commit)) {
-                        // detached head but _not_ a shallow clone
-                        branch = branchesByCommit.get(commit);
-                    } else {
-                        // detached head and _also_ a shallow clone
-                        branchesByCommit = git.nameRev().add(commit).call();
-                        branch = localBranchName(repository, branchesByCommit.get(commit));
-                    }
-                    if (branch != null) {
-                        if (branch.contains("^")) {
-                            branch = branch.substring(0, branch.indexOf('^'));
-                        } else if (branch.contains("~")) {
-                            branch = branch.substring(0, branch.indexOf('~'));
-                        }
+    @Nullable
+    static String resolveBranchFromGitConfig(Repository repository) {
+        String branch = null;
+        try {
+            try (Git git = Git.open(repository.getDirectory())) {
+                ObjectId commit = repository.resolve(Constants.HEAD);
+                Map<ObjectId, String> branchesByCommit = git.nameRev().addPrefix("refs/heads/").add(commit).call();
+                if (branchesByCommit.containsKey(commit)) {
+                    // detached head but _not_ a shallow clone
+                    branch = branchesByCommit.get(commit);
+                } else {
+                    // detached head and _also_ a shallow clone
+                    branchesByCommit = git.nameRev().add(commit).call();
+                    branch = localBranchName(repository, branchesByCommit.get(commit));
+                }
+                if (branch != null) {
+                    if (branch.contains("^")) {
+                        branch = branch.substring(0, branch.indexOf('^'));
+                    } else if (branch.contains("~")) {
+                        branch = branch.substring(0, branch.indexOf('~'));
                     }
                 }
             }
-
-            return new GitProvenance(randomId(), getOrigin(repository), branch, changeset,
-                    getAutocrlf(repository), getEOF(repository));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (IllegalArgumentException | GitAPIException e) {
@@ -191,15 +231,9 @@ public class GitProvenance implements Marker {
                 e.printStackTrace();
             }
             return null;
-        } finally {
-            if(repository != null) {
-                try {
-                    repository.close();
-                } catch (Throwable e) {
-                    // Suppress
-                }
-            }
         }
+        return branch;
+
     }
 
     @Nullable

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/BuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/BuildEnvironment.java
@@ -16,6 +16,7 @@
 package org.openrewrite.marker.ci;
 
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.GitProvenance;
 import org.openrewrite.marker.Marker;
 
 import java.util.function.UnaryOperator;
@@ -24,11 +25,14 @@ public interface BuildEnvironment extends Marker {
 
     @Nullable
     static BuildEnvironment build(UnaryOperator<String> environment) {
-        if (environment.apply("BUILD_NUMBER") != null && environment.apply("JOB_NAME") != null) {
+        if (environment.apply("CUSTOM_CI") != null) {
+            return CustomBuildEnvironment.build(environment);
+        } else if (environment.apply("BUILD_NUMBER") != null && environment.apply("JOB_NAME") != null) {
             return JenkinsBuildEnvironment.build(environment);
         } else if (environment.apply("GITLAB_CI") != null) {
             return GitlabBuildEnvironment.build(environment);
-        } else if (environment.apply("CI") != null && environment.apply("GITHUB_ACTION") != null && environment.apply("GITHUB_RUN_ID") != null) {
+        } else if (environment.apply("CI") != null && environment.apply("GITHUB_ACTION") != null
+                && environment.apply("GITHUB_RUN_ID") != null) {
             return GithubActionsBuildEnvironment.build(environment);
         } else if (environment.apply("DRONE") != null) {
             return DroneBuildEnvironment.build(environment);
@@ -37,7 +41,10 @@ public interface BuildEnvironment extends Marker {
         } else if (environment.apply("TRAVIS") != null) {
             return TravisBuildEnvironment.build(environment);
         }
-
         return null;
     }
+
+    GitProvenance buildGitProvenance() throws IncompleteGitConfigException;
+
+
 }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/CircleCiBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/CircleCiBuildEnvironment.java
@@ -18,6 +18,8 @@ package org.openrewrite.marker.ci;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.marker.GitProvenance;
 
 import java.util.UUID;
 import java.util.function.UnaryOperator;
@@ -36,13 +38,35 @@ public class CircleCiBuildEnvironment implements BuildEnvironment {
     String host;
     String job;
 
+    String branch;
+
+    String repositoryURL;
+
+    String sha1;
+
+    String tag;
+
     public static CircleCiBuildEnvironment build(UnaryOperator<String> environment) {
         return new CircleCiBuildEnvironment(
                 randomId(),
                 environment.apply("CIRCLE_BUILD_NUM"),
                 environment.apply("CIRCLE_BUILD_URL"),
                 hostname(),
-                environment.apply("CIRCLE_JOB")
+                environment.apply("CIRCLE_JOB"),
+                environment.apply("CIRCLE_BRANCH"),
+                environment.apply("CIRCLE_REPOSITORY_URL"),
+                environment.apply("CIRCLE_SHA1"),
+                environment.apply("CIRCLE_TAG")
         );
+    }
+
+    @Override
+    public GitProvenance buildGitProvenance() throws IncompleteGitConfigException {
+        if (StringUtils.isBlank(repositoryURL) || StringUtils.isBlank(sha1) || (
+                StringUtils.isBlank(branch)&& StringUtils.isBlank(tag))) {
+            throw new IncompleteGitConfigException();
+        }
+        return new GitProvenance(UUID.randomUUID(), repositoryURL, StringUtils.isBlank(branch)? tag : branch,
+                sha1, null, null);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/CustomBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/CustomBuildEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,38 +28,30 @@ import static org.openrewrite.Tree.randomId;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class GitlabBuildEnvironment implements BuildEnvironment {
+public class CustomBuildEnvironment implements BuildEnvironment{
     @With
     UUID id;
+    String cloneURL;
+    String ref;
+    String sha;
 
-    String buildId;
-    String buildUrl;
-    String host;
-    String job;
-    String ciRepositoryUrl;
-    String ciCommitRefName;
-    String ciCommitSha;
-
-    public static GitlabBuildEnvironment build(UnaryOperator<String> environment) {
-        return new GitlabBuildEnvironment(
+    public static CustomBuildEnvironment build(UnaryOperator<String> environment) {
+        return new CustomBuildEnvironment(
                 randomId(),
-                environment.apply("CI_BUILD_ID"),
-                environment.apply("CI_JOB_URL"),
-                environment.apply("CI_SERVER_HOST"),
-                environment.apply("CI_BUILD_NAME"),
-                environment.apply("CI_REPOSITORY_URL"),
-                environment.apply("CI_COMMIT_REF_NAME"),
-                environment.apply("CI_COMMIT_SHA")
-        );
+                environment.apply("CUSTOM_GIT_CLONE_URL"),
+                environment.apply("CUSTOM_GIT_REF"),
+                environment.apply("CUSTOM_GIT_SHA"));
     }
 
     @Override
     public GitProvenance buildGitProvenance() throws IncompleteGitConfigException {
-        if (StringUtils.isBlank(ciRepositoryUrl)
-                || StringUtils.isBlank(ciCommitRefName)
-                || StringUtils.isBlank(ciCommitSha)) {
+        if (StringUtils.isBlank(cloneURL)
+                || StringUtils.isBlank(ref)
+                || StringUtils.isBlank(sha)) {
             throw new IncompleteGitConfigException();
+        } else {
+            return new GitProvenance(UUID.randomUUID(), cloneURL, ref, sha, null, null);
         }
-        return new GitProvenance(UUID.randomUUID(), ciRepositoryUrl, ciCommitRefName, ciCommitSha, null, null);
     }
+
 }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/GithubActionsBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/GithubActionsBuildEnvironment.java
@@ -18,6 +18,8 @@ package org.openrewrite.marker.ci;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.marker.GitProvenance;
 
 import java.util.UUID;
 import java.util.function.UnaryOperator;
@@ -29,11 +31,15 @@ import static org.openrewrite.Tree.randomId;
 public class GithubActionsBuildEnvironment implements BuildEnvironment {
     @With
     UUID id;
-
     String buildNumber;
     String buildId;
     String host;
     String job;
+    String apiURL; //https://api.github.com
+    String repository; //e.g octocat/Hello-World
+    String ghRef; //// refs/pull/<pr_number>/merge or refs/heads/<branch_name>
+    String sha;
+    String headRef;
 
     public static GithubActionsBuildEnvironment build(UnaryOperator<String> environment) {
         return new GithubActionsBuildEnvironment(
@@ -41,11 +47,35 @@ public class GithubActionsBuildEnvironment implements BuildEnvironment {
                 environment.apply("GITHUB_RUN_NUMBER"),
                 environment.apply("GITHUB_RUN_ID"),
                 environment.apply("GITHUB_SERVER_URL"),
-                environment.apply("GITHUB_ACTION")
+                environment.apply("GITHUB_ACTION"),
+                environment.apply("GITHUB_API_URL"),
+                environment.apply("GITHUB_REPOSITORY"),
+                environment.apply("GITHUB_REF"),
+                environment.apply("GITHUB_SHA"),
+                environment.apply("GITHUB_HEAD_REF")
         );
     }
 
-    public String getBuildUrl() {
-        return host + "/" + buildId;
+    @Override
+    public GitProvenance buildGitProvenance() throws IncompleteGitConfigException {
+        String host = getApiURL().replaceFirst("api\\.", "");
+        String gitRef = getGhRef();
+        if (gitRef.startsWith("refs/pull")) {
+            gitRef = getHeadRef();
+        } else {
+            gitRef = gitRef.replaceFirst("refs/heads/", "");
+        }
+        if (StringUtils.isBlank(ghRef)
+                || StringUtils.isBlank(host)
+                || StringUtils.isBlank(repository)
+                || StringUtils.isBlank(sha)) {
+            throw new IncompleteGitConfigException(
+                    String.format("Invalid GitHub environment with host: %s, branch: %s, " +
+                    "repository: %s, sha: %s", host, ghRef, repository, sha));
+        }
+
+        return new GitProvenance(UUID.randomUUID(), host + "/" + getRepository()
+                + ".git", gitRef, getSha(), null, null);
     }
+
 }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/IncompleteGitConfigException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/IncompleteGitConfigException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.marker.ci;
+
+public class IncompleteGitConfigException extends Exception {
+
+    public IncompleteGitConfigException(){
+        super();
+    }
+    public IncompleteGitConfigException(String format) {
+        super(format);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/JenkinsBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/JenkinsBuildEnvironment.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.GitProvenance;
 
 import java.util.UUID;
 import java.util.function.UnaryOperator;
@@ -61,5 +62,10 @@ public class JenkinsBuildEnvironment implements BuildEnvironment {
                 environment.apply("GIT_LOCAL_BRANCH"),
                 environment.apply("GIT_BRANCH")
         );
+    }
+
+    @Override
+    public GitProvenance buildGitProvenance() throws IncompleteGitConfigException {
+        throw new IncompleteGitConfigException();
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/TravisBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/TravisBuildEnvironment.java
@@ -18,6 +18,7 @@ package org.openrewrite.marker.ci;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.marker.GitProvenance;
 
 import java.util.UUID;
 import java.util.function.UnaryOperator;
@@ -30,12 +31,17 @@ import static org.openrewrite.marker.OperatingSystemProvenance.hostname;
 public class TravisBuildEnvironment implements BuildEnvironment {
     @With
     UUID id;
-
     String buildNumber;
     String buildId;
     String buildUrl;
     String host;
     String job;
+    String branch;
+    String commit;
+
+    String repoSlug;
+
+    String tag;
 
     public static TravisBuildEnvironment build(UnaryOperator<String> environment) {
         return new TravisBuildEnvironment(
@@ -44,7 +50,17 @@ public class TravisBuildEnvironment implements BuildEnvironment {
                 environment.apply("TRAVIS_BUILD_ID"),
                 environment.apply("TRAVIS_BUILD_WEB_URL"),
                 hostname(),
-                environment.apply("TRAVIS_REPO_SLUG")
+                environment.apply("TRAVIS_REPO_SLUG"),
+                environment.apply("TRAVIS_BRANCH"),
+                environment.apply("TRAVIS_COMMIT"),
+                environment.apply("TRAVIS_REPO_SLUG"),
+                environment.apply("TRAVIS_TAG")
         );
+    }
+
+    @Override
+    public GitProvenance buildGitProvenance() throws IncompleteGitConfigException {
+        //travis generates the .config directory and it is not possible to obtain the clone URL from any env
+        throw new IncompleteGitConfigException();
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.openrewrite.marker.ci.JenkinsBuildEnvironment;
+import org.openrewrite.marker.ci.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,6 +37,8 @@ import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -255,6 +257,83 @@ class GitProvenanceTest {
         assumeTrue(GitProvenance.fromProjectDirectory(projectDir.resolve("workspace"), null) != null);
         assertThat(GitProvenance.fromProjectDirectory(projectDir.resolve("workspace"), null).getBranch())
           .isEqualTo("main");
+    }
+
+    @Test
+    void supportsGitHubActions(@TempDir Path projectDir) {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("GITHUB_API_URL", "https://api.github.com");
+        envVars.put("GITHUB_REPOSITORY", "octocat/Hello-World");
+        envVars.put("GITHUB_REF", "refs/heads/main");
+        envVars.put("GITHUB_SHA", "287364287357");
+        envVars.put("GITHUB_HEAD_REF", "");
+
+        GitProvenance prov = GitProvenance.fromProjectDirectory(projectDir,
+          GithubActionsBuildEnvironment.build(var -> envVars.get(var)));
+        assertThat(prov != null);
+        assertThat(prov.getOrigin()).isEqualTo("https://github.com/octocat/Hello-World.git");
+        assertThat(prov.getBranch()).isEqualTo("main");
+        assertThat(prov.getChange()).isEqualTo("287364287357");
+    }
+
+    @Test
+    void supportsCustomBuildEnvironment(@TempDir Path projectDir) {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("CUSTOM_GIT_CLONE_URL", "https://github.com/octocat/Hello-World.git");
+        envVars.put("CUSTOM_GIT_REF", "main");
+        envVars.put("CUSTOM_GIT_SHA", "287364287357");
+
+        GitProvenance prov = GitProvenance.fromProjectDirectory(projectDir,
+          CustomBuildEnvironment.build(var -> envVars.get(var)));
+
+        assertThat(prov != null);
+        assertThat(prov.getOrigin()).isEqualTo("https://github.com/octocat/Hello-World.git");
+        assertThat(prov.getBranch()).isEqualTo("main");
+        assertThat(prov.getChange()).isEqualTo("287364287357");
+    }
+
+    @Test
+    void supportsGitLab(@TempDir Path projectDir) {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("CI_REPOSITORY_URL", "https://github.com/octocat/Hello-World.git");
+        envVars.put("CI_COMMIT_REF_NAME", "main");
+        envVars.put("CI_COMMIT_SHA", "287364287357");
+
+        GitProvenance prov = GitProvenance.fromProjectDirectory(projectDir,
+          GitlabBuildEnvironment.build(var -> envVars.get(var)));
+
+        assertThat(prov != null);
+        assertThat(prov.getOrigin()).isEqualTo("https://github.com/octocat/Hello-World.git");
+        assertThat(prov.getBranch()).isEqualTo("main");
+        assertThat(prov.getChange()).isEqualTo("287364287357");
+    }
+
+    @Test
+    void supportsDrone(@TempDir Path projectDir) {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("DRONE_BRANCH", "main");
+        envVars.put("DRONE_TAG", "");
+        envVars.put("DRONE_REMOTE_URL", "https://github.com/octocat/Hello-World.git");
+        envVars.put("DRONE_COMMIT_SHA", "287364287357");
+
+        GitProvenance prov = GitProvenance.fromProjectDirectory(projectDir,
+          DroneBuildEnvironment.build(var -> envVars.get(var)));
+
+        assertThat(prov != null);
+        assertThat(prov.getOrigin()).isEqualTo("https://github.com/octocat/Hello-World.git");
+        assertThat(prov.getBranch()).isEqualTo("main");
+        assertThat(prov.getChange()).isEqualTo("287364287357");
+    }
+
+    @Test
+    void supportsTravis(@TempDir Path projectDir) throws Exception {
+        try (Git g = Git.init().setDirectory(projectDir.toFile()).setInitialBranch("main").call()) {
+            Map<String, String> envVars = new HashMap<>();
+            TravisBuildEnvironment buildEnvironment = TravisBuildEnvironment.build(var -> envVars.get(var));
+            GitProvenance git = GitProvenance.fromProjectDirectory(projectDir, buildEnvironment);
+            assertThat(git).isNotNull();
+            assertThat(git.getBranch()).isEqualTo("main");
+        }
     }
 
     void runCommand(Path workingDir, String command) {


### PR DESCRIPTION
Currently, GitProvenance is mainly calculated using the information that is inside the .git config. Only there is a special behavior when Jenkins is the BuildEnvironment.

However, there is no .git config in GitLab, GitHub and Drone when a repository is checkout and the required Git metadata is on environment variables.

Therefore, this patch adds `BuildEnvironment#buildGitProvenance()` to force an implementation for CI BuildEnvironments. If they need .git config information, such as Jenkins or Travis, they throw `IncompleteGitConfigException`.

A new CustomBuildEnvironment class has also been added to support the use case of fetching external repositories from a GitHub repository.