### PR TITLE
Support for git fecth with depth > 0 from BuildEnv

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -160,10 +160,16 @@ public class GitProvenance implements Marker {
                     throw new UncheckedIOException(e);
                 }
             } else {
-                try {
-                    return environment.buildGitProvenance();
-                } catch (IncompleteGitConfigException e) {
+                if (new RepositoryBuilder().findGitDir(projectDir.toFile()).getGitDir().exists()) {
+                    //it has been cloned with --depth > 0
                     return fromGitConfig(projectDir);
+                } else {
+                    //there is not .git config
+                    try {
+                        return environment.buildGitProvenance();
+                    } catch (IncompleteGitConfigException e) {
+                        return fromGitConfig(projectDir);
+                    }
                 }
             }
         } else {

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -26,6 +26,7 @@ import org.eclipse.jgit.treewalk.WorkingTreeOptions;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.ci.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -160,7 +161,8 @@ public class GitProvenance implements Marker {
                     throw new UncheckedIOException(e);
                 }
             } else {
-                if (new RepositoryBuilder().findGitDir(projectDir.toFile()).getGitDir().exists()) {
+                File gitDir = new RepositoryBuilder().findGitDir(projectDir.toFile()).getGitDir();
+                if (gitDir != null && gitDir.exists()) {
                     //it has been cloned with --depth > 0
                     return fromGitConfig(projectDir);
                 } else {


### PR DESCRIPTION
In GitHub, you can fetch repositories with a particular "depth". This creates a .config file with the Git metadata required to publish repositories.

Specially, this is useful for cases where the repository that is fetched is not the same than the one that runs GitHub Actions.