### PR TITLE
chore: suppress `com.fasterxml.jackson` version

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
 
     implementation("io.quarkus.gizmo:gizmo:1.0.+")
 
-    api("com.fasterxml.jackson.core:jackson-databind")
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
-    api("com.fasterxml.jackson.module:jackson-module-parameter-names")
+    api("com.fasterxml.jackson.core:jackson-databind:2.14.0")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.14.0")
+    api("com.fasterxml.jackson.module:jackson-module-parameter-names:2.14.0")
     implementation("net.java.dev.jna:jna-platform:latest.release")
 
     // Pinning okhttp while waiting on 5.0.0

--- a/rewrite-groovy/build.gradle.kts
+++ b/rewrite-groovy/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
     api("org.jetbrains:annotations:latest.release")
 
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-java-test"))

--- a/rewrite-hcl/build.gradle.kts
+++ b/rewrite-hcl/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
     implementation("org.xerial.snappy:snappy-java:1.1.8.4")
 
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     implementation("io.github.fastfilter:fastfilter:latest.release")
 

--- a/rewrite-json/build.gradle.kts
+++ b/rewrite-json/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     api(project(":rewrite-xml"))
     api("org.jetbrains:annotations:latest.release")
 
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 
@@ -19,10 +19,10 @@ dependencies {
     // FIXME: switch to `latest.release`
     // when https://github.com/resilience4j/resilience4j/issues/1472 is resolved
     implementation("io.github.resilience4j:resilience4j-retry:1.7.0")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
-    implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.14.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.14.0")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.0")
 
     // needed by AddDependency
     implementation(project(":rewrite-java"))

--- a/rewrite-properties/build.gradle.kts
+++ b/rewrite-properties/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-protobuf/build.gradle.kts
+++ b/rewrite-protobuf/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -9,6 +9,6 @@ dependencies {
     api("org.junit.jupiter:junit-jupiter-params:latest.release")
 
     implementation("org.assertj:assertj-core:latest.release")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.14.0")
     implementation("org.slf4j:slf4j-api:1.7.36")
 }

--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-yaml/build.gradle.kts
+++ b/rewrite-yaml/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
 dependencies {
     api(project(":rewrite-core"))
     api("org.jetbrains:annotations:latest.release")
-    api("com.fasterxml.jackson.core:jackson-annotations")
+    api("com.fasterxml.jackson.core:jackson-annotations:2.14.0")
 
     compileOnly(project(":rewrite-test"))
 


### PR DESCRIPTION
This is to address dependency vulnerability report https://github.com/moderneinc/dependency-vulnerability-reports/issues/491


jackson-coreFound versions: 2.13.4, 2.14.2, 2.14.3, 2.12.7 | rewrite-cloud-suitability-analyzer, rewrite-maven-plugin, rewrite-quarkus, rewrite-recipe-markdown-generator, rewrite-recommendations | maven/com.fasterxml.jackson.core/jackson-core@2.13.4maven/com.fasterxml.jackson.core/jackson-core@2.14.2maven/com.fasterxml.jackson.core/jackson-core@2.14.3-SNAPSHOTmaven/com.fasterxml.jackson.core/jackson-core@2.12.7 | HIGH
-- | -- | -- | --

```
One or more dependencies were identified with known vulnerabilities in rewrite-recipe-markdown-generator:

jackson-core-2.14.2.jar (pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.2, cpe:2.3:a:fasterxml:jackson-modules-java8:2.14.2:*:*:*:*:*:*:*, cpe:2.3:a:json-java_project:json-java:2.14.2:*:*:*:*:*:*:*) : CVE-2022-45688
jackson-core-2.14.3-SNAPSHOT.jar (pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.3-SNAPSHOT, cpe:2.3:a:fasterxml:jackson-modules-java8:2.14.3:snapshot:*:*:*:*:*:*, cpe:2.3:a:json-java_project:json-java:2.14.3:snapshot:*:*:*:*:*:*) : CVE-2022-45688
```

`2.14.2` is the latest version of `com.fasterxml.jackson` and has vulnerabilities, so change to using `2.14.0`.