### PR TITLE
Run `rewrite-java-security` with core changes immediately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,36 @@ jobs:
       ossrh_token: ${{ secrets.OSSRH_TOKEN }}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+  test-downstream:
+    strategy:
+      fail-fast: false
+      matrix:
+        repository: [ rewrite-java-security , rewrite-spring, rewrite-migrate-java ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: rewrite
+          fetch-depth: 0
+      - name: Checkout ${{ matrix.repository }} repo
+        uses: actions/checkout@v3
+        with:
+          repository: openrewrite/${{ matrix.repository }}
+          path: ${{ matrix.repository }}
+          fetch-depth: 0
+      - name: Setup Java
+        uses: actions/setup-java@v3.10.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --console=plain --info --stacktrace --warning-mode=all --no-daemon --include-build ../rewrite build
+          build-root-directory: ${{ matrix.repository }}
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+


### PR DESCRIPTION
This will help detect any API breaking changes that the
`rewrite` tests don't cover but `rewrite-java-security` catches.

Example: https://github.com/openrewrite/rewrite-java-security/issues/83
