### PR TITLE
fix: fix a bug when replacing StringBuilder to strings if the constructor has parameters

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceStringBuilderWithStringTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceStringBuilderWithStringTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.cleanup;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -125,6 +126,39 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
               class A {
                   void foo() {
                       int len = ("A" + "B").length();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2930")
+    @Test
+    void withConstructor() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  void method() {
+                      String key1 = new StringBuilder(10).append("_").append("a").toString();
+                      String key2 = new StringBuilder(name()).append("_").append("a").toString();
+                      String key3 = new StringBuilder("m").append("_").append("a").toString();
+                  }
+                  String name() {
+                      return "name";
+                  }
+              }
+              """,
+            """
+              class A {
+                  void method() {
+                      String key1 = "_" + "a";
+                      String key2 = name() + "_" + "a";
+                      String key3 = "m" + "_" + "a";
+                  }
+                  String name() {
+                      return "name";
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceStringBuilderWithString.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceStringBuilderWithString.java
@@ -131,8 +131,14 @@ public class ReplaceStringBuilderWithString extends Recipe {
             }
         }
 
-        return select instanceof J.NewClass
-               && TypeUtils.isOfClassType(((J.NewClass) select).getClazz().getType(), "java.lang.StringBuilder");
+        if (select instanceof J.NewClass && TypeUtils.isOfClassType(((J.NewClass) select).getClazz().getType(), "java.lang.StringBuilder")) {
+            J.NewClass nc = (J.NewClass) select;
+            if (nc.getArguments().size() == 1 && TypeUtils.isString(nc.getArguments().get(0).getType())) {
+                arguments.add(nc.getArguments().get(0));
+            }
+            return true;
+        }
+        return false;
     }
 
     public static J.Parentheses getParenthesesTemplate() {


### PR DESCRIPTION
fixes #2930

Add handling for two `StringBuilder` constructors with String as a parameter and ignore the capacity one. 