### PR TITLE
ci: enable gradle build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: gradle
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
See https://github.com/actions/setup-java#caching-packages-dependencies