### PR TITLE
Allow matching an LST subtree against a `JavaTemplate`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateMatchTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateMatchTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class JavaTemplateMatchTest implements RewriteTest {
+
+    @SuppressWarnings("ConstantValue")
+    @Test
+    void matchBinary() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              private final JavaTemplate template = JavaTemplate.builder(this::getCursor, "1 == #{any(int)}").build();
+
+              @Override
+              public J visitBinary(J.Binary binary, ExecutionContext ctx) {
+                  return template.matches(binary) ? SearchResult.found(binary) : super.visitBinary(binary, ctx);
+              }
+          })),
+          java(
+            """
+              class Test {
+                  boolean b1 = 1 == 2;
+                  boolean b2 = 1 == 3;
+
+                  boolean b3 = 2 == 1;
+              }
+              """,
+            """
+              class Test {
+                  boolean b1 = /*~~>*/1 == 2;
+                  boolean b2 = /*~~>*/1 == 3;
+
+                  boolean b3 = 2 == 1;
+              }
+              """
+          ));
+    }
+
+    @Test
+    @SuppressWarnings({"UnnecessaryCallToStringValueOf", "RedundantCast"})
+    void matchCompatibleTypes() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              private final JavaTemplate template = JavaTemplate.builder(this::getCursor, "#{any(long)}").build();
+
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  return template.matches(method) ? SearchResult.found(method) : super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          java(
+            """
+              class Test {
+                  void m() {
+                      System.out.println(new Object().hashCode());
+                      System.out.println((int) new Object().hashCode());
+                      System.out.println(Long.parseLong("123"));
+                      System.out.println(String.valueOf(Long.parseLong("123")));
+
+                      System.out.println(new Object());
+                      System.out.println(1L);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void m() {
+                      System.out.println(/*~~>*/new Object().hashCode());
+                      System.out.println((int) /*~~>*/new Object().hashCode());
+                      System.out.println(/*~~>*/Long.parseLong("123"));
+                      System.out.println(String.valueOf(/*~~>*/Long.parseLong("123")));
+
+                      System.out.println(new Object());
+                      System.out.println(1L);
+                  }
+              }
+              """)
+        );
+    }
+
+    @Test
+    void dontMatchOverloads() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              private final JavaTemplate template = JavaTemplate.builder(this::getCursor, "#{any(java.lang.StringBuilder)}.append(#{any(int)})").build();
+
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  return template.matches(method) ? SearchResult.found(method) : super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          java(
+            """
+              class Test {
+                  void m(StringBuilder sb, int i, long l) {
+                      sb.append(i);
+                      sb.append(1);
+                      sb.append(1 + 1);
+                      sb.append(1 + 'c');
+
+                      sb.append((short) 1);
+                      sb.append(l);
+                      sb.append(1L);
+                      sb.append((long) 1);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void m(StringBuilder sb, int i, long l) {
+                      /*~~>*/sb.append(i);
+                      /*~~>*/sb.append(1);
+                      /*~~>*/sb.append(1 + 1);
+                      /*~~>*/sb.append(1 + 'c');
+
+                      sb.append((short) 1);
+                      sb.append(l);
+                      sb.append(1L);
+                      sb.append((long) 1);
+                  }
+              }
+              """)
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -17,12 +17,14 @@ package org.openrewrite.java;
 
 import lombok.Value;
 import org.openrewrite.Cursor;
+import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.template.JavaTemplateJavaExtension;
 import org.openrewrite.java.internal.template.JavaTemplateParser;
 import org.openrewrite.java.internal.template.Substitutions;
+import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaCoordinates;
 import org.openrewrite.java.tree.Space.Location;
@@ -50,6 +52,10 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         this.onAfterVariableSubstitution = onAfterVariableSubstitution;
         this.parameterCount = StringUtils.countOccurrences(code, "#{");
         this.templateParser = new JavaTemplateParser(parser, onAfterVariableSubstitution, onBeforeParseTemplate, imports);
+    }
+
+    public String getCode() {
+        return code;
     }
 
     @Override
@@ -105,6 +111,11 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         return (J2) new JavaTemplateJavaExtension(templateParser, substitutions, substitutedTemplate, coordinates, parentCursorRef, parentScope)
                 .getMixin()
                 .visit(changing, 0, parentCursor);
+    }
+
+    @Incubating(since = "7.38.0")
+    public boolean matches(J tree) {
+        return SemanticallyEqual.matchesTemplate(this, tree);
     }
 
     public static Builder builder(Supplier<Cursor> parentScope, String code) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -36,7 +36,8 @@ public class TypeUtils {
 
     public static boolean fullyQualifiedNamesAreEqual(@Nullable String fqn1, @Nullable String fqn2) {
         if (fqn1 != null && fqn2 != null) {
-            return fqn1.replace("$", ".").equals(fqn2.replace("$", "."));
+            return fqn1.equals(fqn2) || fqn1.length() == fqn2.length()
+                    && fqn1.replace("$", ".").equals(fqn2.replace("$", "."));
         }
         return fqn1 == null && fqn2 == null;
     }
@@ -212,6 +213,49 @@ public class TypeUtils {
                 for (JavaType bound : genericFrom.getBounds()) {
                     if (isAssignableTo(to, bound)) {
                         return true;
+                    }
+                }
+            } else if (from instanceof JavaType.Primitive) {
+                JavaType.Primitive fromPrimitive = (JavaType.Primitive) from;
+                JavaType.Primitive toPrimitive = JavaType.Primitive.fromKeyword(to);
+                if (fromPrimitive == toPrimitive) {
+                    return true;
+                } else if (fromPrimitive == JavaType.Primitive.Boolean) {
+                    return false;
+                } else if (toPrimitive != null) {
+                    switch (toPrimitive) {
+                        case Char:
+                            return fromPrimitive == JavaType.Primitive.Byte;
+                        case Short:
+                            switch (fromPrimitive) {
+                                case Byte:
+                                case Char:
+                                    return true;
+                            }
+                            return false;
+                        case Int:
+                            switch (fromPrimitive) {
+                                case Byte:
+                                case Char:
+                                case Short:
+                                    return true;
+                            }
+                            return false;
+                        case Long:
+                            switch (fromPrimitive) {
+                                case Byte:
+                                case Char:
+                                case Short:
+                                case Int:
+                                    return true;
+                            }
+                            return false;
+                        case Float:
+                            return fromPrimitive != JavaType.Primitive.Double;
+                        case Double:
+                            return true;
+                        default:
+                            return false;
                     }
                 }
             } else if (from instanceof JavaType.Variable) {


### PR DESCRIPTION
`JavaTemplate` offers a new `matches(J)` method which can be used to check if the given tree matches the receiving `JavaTemplate`. This uses `SemanticallyEqual#matchesTemplate()` and will check if the tree at the cursor is identical to the tree represented by the template.

The template can also contain `#{any(...)}` parameters, which require the input subtree to contain a typed subtree at the given location with a type compatible to the type of the template parameter.