### PR TITLE
fix: fix a template error for an edge case of recipe `PrimitiveWrapperClassConstructorToValueOf`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/PrimitiveWrapperClassConstructorToValueOfTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/PrimitiveWrapperClassConstructorToValueOfTest.java
@@ -32,6 +32,35 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
         spec.recipe(new PrimitiveWrapperClassConstructorToValueOf());
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/2945")
+    @Test
+    void ternaryWithBinary() {
+        rewriteRun(
+          java(
+            """
+              import java.util.concurrent.TimeUnit;
+              class A {
+                  void method(Long time) {
+                      Long timeoutValue = (time == null)
+                          ? new Long(0)
+                          : time + TimeUnit.MICROSECONDS.convert(60, TimeUnit.MINUTES);
+                  }
+              }
+              """,
+            """
+              import java.util.concurrent.TimeUnit;
+              class A {
+                  void method(Long time) {
+                      Long timeoutValue = (time == null)
+                          ? Long.valueOf(0)
+                          : time + TimeUnit.MICROSECONDS.convert(60, TimeUnit.MINUTES);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void integerValueOf() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -110,6 +110,18 @@ public class BlockStatementTemplateGenerator {
                     return (J) tree;
                 }
 
+                if (getCursor().getValue() instanceof JLeftPadded) {
+                    JLeftPadded lp = (JLeftPadded) getCursor().getValue();
+                    if (lp.getBefore() != null && lp.getBefore().getComments() != null) {
+                        for (Comment comment : lp.getBefore().getComments()) {
+                            if (comment instanceof TextComment && ((TextComment) comment).getText().equals(STOP_COMMENT)) {
+                                done = true;
+                                return (J) tree;
+                            }
+                        }
+                    }
+                }
+
                 if (expected.isInstance(tree)) {
                     @SuppressWarnings("unchecked") J2 t = (J2) tree;
 


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite/issues/2945

### Root cause: 
Given an edge case with `J.Ternary` combined with `J.Binary`  like this
```java
Long timeoutValue = (time == null)
    ? new Long(0)
    : time + TimeUnit.MICROSECONDS.convert(60, TimeUnit.MINUTES);
```
the template is like
```java
Long timeoutValue=null ?
/*__TEMPLATE__*/Long.valueOf(__P__./*__p0__*/longp())/*__TEMPLATE_STOP__*/
 : time + TimeUnit.MICROSECONDS.convert(60, TimeUnit.MINUTES);
```

`/*__TEMPLATE_STOP__*/ ` can not be captured successfully.
Change the code to provide a way to be able to capture it.

![Screen Shot 2023-03-08 at 7 16 45 PM](https://user-images.githubusercontent.com/122563761/223915502-cd6de0b5-8fe4-4d3d-8dce-c74bb85111f7.png)


