### PR TITLE
Add a new `@Primitive` annotation for `JavaTemplate#compile()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/template/Primitive.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/template/Primitive.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.template;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Primitive {
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/template/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/template/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.openrewrite.java.template;
+
+import org.openrewrite.internal.lang.NonNullApi;


### PR DESCRIPTION
When using `JavaTemplate#compile()` to build a template based on a Java lambda, there needs to be a way to create templates which refer to primitive template parameters.

Since the SAM types (`F0` through `F10`) don't allow for this, instead add an `@Primitive` annotation type with source retention. Any parameter annotated with this on the lambda will in the generated template string use the corresponding primitive type instead (e.g. `#{any(int)}`).
