### PR TITLE
Updated ChangeType to change types in java island grammars.

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/java/cleanup/ChangeTypeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/java/cleanup/ChangeTypeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.groovy.Assertions.groovy;
+
+public class ChangeTypeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ChangeType("a.b.Original", "x.y.Target", true));
+    }
+
+    @SuppressWarnings("GrPackage")
+    @Test
+    void changeImport() {
+        rewriteRun(
+          groovy(
+            """
+            package a.b
+            class Original {}
+            """),
+          groovy(
+            """
+            import a.b.Original
+            
+            class A {
+                Original type
+            }
+            """,
+            """
+            import x.y.Target
+            
+            class A {
+                Target type
+            }
+            """
+          )
+        );
+    }
+
+    @SuppressWarnings("GrPackage")
+    @Test
+    void changeType() {
+        rewriteRun(
+          groovy(
+            """
+            package a.b
+            class Original {}
+            """),
+          groovy(
+            """
+            class A {
+                a.b.Original type
+            }
+            """,
+            """
+            class A {
+                x.y.Target type
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void changeDefinition() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("file", "newFile", false)),
+          groovy(
+            """
+            class file {
+            }
+            """,
+            """
+            class newFile {
+            }
+            """,
+            spec -> spec.path("file.groovy").afterRecipe(cu ->
+              assertThat(TypeUtils.isOfClassType(cu.getClasses().get(0).getType(), "newFile")).isTrue())
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -19,7 +19,6 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
-import org.openrewrite.PathUtils;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -270,7 +269,6 @@ class ChangeTypeTest implements RewriteTest {
         rewriteRun(
           java(a1),
           java(a2),
-
           java(
             """
               import a.A1;
@@ -1267,29 +1265,8 @@ class ChangeTypeTest implements RewriteTest {
               public class NoMatch {
               }
               """,
-            spec -> spec.path("a/b/Original.java")
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/1904")
-    @Test
-    void onlyChangeTypeMissingPublicModifier() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangeType("a.b.Original", "x.y.Target", false)),
-          java(
-            """
-              package a.b;
-              class Original {
-              }
-              """,
-            """
-              package x.y;
-              class Target {
-              }
-              """,
             spec -> spec.path("a/b/Original.java").afterRecipe(cu ->
-              assertThat(TypeUtils.isOfClassType(cu.getClasses().get(0).getType(), "x.y.Target")).isTrue())
+              assertThat("a/b/Original.java").isEqualTo(cu.getSourcePath().toString()))
           )
         );
     }
@@ -1310,8 +1287,10 @@ class ChangeTypeTest implements RewriteTest {
               public class Target {
               }
               """,
-            spec -> spec.path("a/b/NoMatch.java").afterRecipe(cu ->
-              assertThat(TypeUtils.isOfClassType(cu.getClasses().get(0).getType(), "x.y.Target")).isTrue())
+            spec -> spec.path("a/b/NoMatch.java").afterRecipe(cu -> {
+              assertThat("a/b/NoMatch.java").isEqualTo(cu.getSourcePath().toString());
+              assertThat(TypeUtils.isOfClassType(cu.getClasses().get(0).getType(), "x.y.Target")).isTrue();
+            })
           )
         );
     }
@@ -1332,8 +1311,10 @@ class ChangeTypeTest implements RewriteTest {
               public class Target {
               }
               """,
-            spec -> spec.path("a/b/Original.java").afterRecipe(cu ->
-              assertThat(cu.getSourcePath().toString()).isEqualTo(PathUtils.separatorsToSystem("x/y/Target.java")))
+            spec -> spec.path("a/b/Original.java").afterRecipe(cu -> {
+                assertThat("x/y/Target.java").isEqualTo(cu.getSourcePath().toString());
+                assertThat(TypeUtils.isOfClassType(cu.getClasses().get(0).getType(), "x.y.Target")).isTrue();
+            })
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -26,7 +26,6 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.SearchResult;
 
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
@@ -119,7 +118,8 @@ public class ChangePackage extends Recipe {
 
                 for (J.Import anImport : c.getImports()) {
                     if (anImport.getPackageName().equals(changingTo) && !anImport.isStatic()) {
-                        c = new RemoveImport<ExecutionContext>(anImport.getTypeName(), true).visitJavaSourceFile(c, ctx);
+                        c = (JavaSourceFile) new RemoveImport<ExecutionContext>(anImport.getTypeName(), true).visit(c, ctx, getCursor());
+                        assert c != null;
                     }
                 }
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -17,7 +17,9 @@ package org.openrewrite.java;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
+import org.openrewrite.SourceFile;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.FormatFirstClassPrefix;
 import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.java.style.IntelliJ;
@@ -51,117 +53,122 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
     }
 
     @Override
-    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, P p) {
+    public @Nullable J preVisit(J tree, P p) {
+        J j = tree;
+        if (tree instanceof JavaSourceFile) {
+            JavaSourceFile cu = (JavaSourceFile) tree;
+            ImportLayoutStyle importLayoutStyle = Optional.ofNullable(((SourceFile) cu).getStyle(ImportLayoutStyle.class))
+                    .orElse(IntelliJ.importLayout());
 
-        ImportLayoutStyle importLayoutStyle = Optional.ofNullable(cu.getStyle(ImportLayoutStyle.class))
-                .orElse(IntelliJ.importLayout());
+            boolean typeUsed = false;
+            Set<String> otherTypesInPackageUsed = new TreeSet<>();
 
-        boolean typeUsed = false;
-        Set<String> otherTypesInPackageUsed = new TreeSet<>();
-
-        Set<String> methodsAndFieldsUsed = new HashSet<>();
-        Set<String> otherMethodsAndFieldsInTypeUsed = new TreeSet<>();
-        Set<String> originalImports = new HashSet<>();
-        for (J.Import cuImport : cu.getImports()) {
-            if (cuImport.getQualid().getType() != null) {
-                originalImports.add(((JavaType.FullyQualified) cuImport.getQualid().getType()).getFullyQualifiedName().replace("$", "."));
+            Set<String> methodsAndFieldsUsed = new HashSet<>();
+            Set<String> otherMethodsAndFieldsInTypeUsed = new TreeSet<>();
+            Set<String> originalImports = new HashSet<>();
+            for (J.Import cuImport : cu.getImports()) {
+                if (cuImport.getQualid().getType() != null) {
+                    originalImports.add(((JavaType.FullyQualified) cuImport.getQualid().getType()).getFullyQualifiedName().replace("$", "."));
+                }
             }
-        }
 
-        for (JavaType.Variable variable : cu.getTypesInUse().getVariables()) {
-            JavaType.FullyQualified fq = TypeUtils.asFullyQualified(variable.getOwner());
-            if (fq != null && (TypeUtils.fullyQualifiedNamesAreEqual(fq.getFullyQualifiedName(), type)
-                    || TypeUtils.fullyQualifiedNamesAreEqual(fq.getFullyQualifiedName(), owner))) {
-                methodsAndFieldsUsed.add(variable.getName());
+            for (JavaType.Variable variable : cu.getTypesInUse().getVariables()) {
+                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(variable.getOwner());
+                if (fq != null && (TypeUtils.fullyQualifiedNamesAreEqual(fq.getFullyQualifiedName(), type)
+                        || TypeUtils.fullyQualifiedNamesAreEqual(fq.getFullyQualifiedName(), owner))) {
+                    methodsAndFieldsUsed.add(variable.getName());
+                }
             }
-        }
 
-        for (JavaType.Method method : cu.getTypesInUse().getUsedMethods()) {
-            if (method.hasFlags(Flag.Static)) {
-                String declaringType = method.getDeclaringType().getFullyQualifiedName();
-                if (TypeUtils.fullyQualifiedNamesAreEqual(declaringType, type)) {
-                    methodsAndFieldsUsed.add(method.getName());
-                } else if (declaringType.equals(owner)) {
-                    if (method.getName().equals(type.substring(type.lastIndexOf('.') + 1))) {
+            for (JavaType.Method method : cu.getTypesInUse().getUsedMethods()) {
+                if (method.hasFlags(Flag.Static)) {
+                    String declaringType = method.getDeclaringType().getFullyQualifiedName();
+                    if (TypeUtils.fullyQualifiedNamesAreEqual(declaringType, type)) {
                         methodsAndFieldsUsed.add(method.getName());
-                    } else {
-                        otherMethodsAndFieldsInTypeUsed.add(method.getName());
+                    } else if (declaringType.equals(owner)) {
+                        if (method.getName().equals(type.substring(type.lastIndexOf('.') + 1))) {
+                            methodsAndFieldsUsed.add(method.getName());
+                        } else {
+                            otherMethodsAndFieldsInTypeUsed.add(method.getName());
+                        }
                     }
                 }
             }
-        }
 
-        for (JavaType javaType : cu.getTypesInUse().getTypesInUse()) {
-            if (javaType instanceof JavaType.FullyQualified) {
-                JavaType.FullyQualified fullyQualified = (JavaType.FullyQualified) javaType;
-                if (TypeUtils.fullyQualifiedNamesAreEqual(fullyQualified.getFullyQualifiedName(), type)) {
-                    typeUsed = true;
-                } else if (TypeUtils.fullyQualifiedNamesAreEqual(fullyQualified.getFullyQualifiedName(), owner)
-                        || TypeUtils.fullyQualifiedNamesAreEqual(fullyQualified.getPackageName(), owner)) {
-                    if (!originalImports.contains(fullyQualified.getFullyQualifiedName().replace("$", "."))) {
-                        otherTypesInPackageUsed.add(fullyQualified.getClassName());
+            for (JavaType javaType : cu.getTypesInUse().getTypesInUse()) {
+                if (javaType instanceof JavaType.FullyQualified) {
+                    JavaType.FullyQualified fullyQualified = (JavaType.FullyQualified) javaType;
+                    if (TypeUtils.fullyQualifiedNamesAreEqual(fullyQualified.getFullyQualifiedName(), type)) {
+                        typeUsed = true;
+                    } else if (TypeUtils.fullyQualifiedNamesAreEqual(fullyQualified.getFullyQualifiedName(), owner)
+                            || TypeUtils.fullyQualifiedNamesAreEqual(fullyQualified.getPackageName(), owner)) {
+                        if (!originalImports.contains(fullyQualified.getFullyQualifiedName().replace("$", "."))) {
+                            otherTypesInPackageUsed.add(fullyQualified.getClassName());
+                        }
                     }
                 }
             }
-        }
 
-        J.CompilationUnit c = cu;
+            JavaSourceFile c = cu;
 
-        boolean keepImport = !force && (typeUsed || !otherTypesInPackageUsed.isEmpty() && type.endsWith(".*"));
-        AtomicReference<Space> spaceForNextImport = new AtomicReference<>();
-        c = c.withImports(ListUtils.flatMap(c.getImports(), impoort -> {
-            if (spaceForNextImport.get() != null) {
-                impoort = impoort.withPrefix(spaceForNextImport.get());
-                spaceForNextImport.set(null);
-            }
+            boolean keepImport = !force && (typeUsed || !otherTypesInPackageUsed.isEmpty() && type.endsWith(".*"));
+            AtomicReference<Space> spaceForNextImport = new AtomicReference<>();
+            c = c.withImports(ListUtils.flatMap(c.getImports(), impoort -> {
+                if (spaceForNextImport.get() != null) {
+                    impoort = impoort.withPrefix(spaceForNextImport.get());
+                    spaceForNextImport.set(null);
+                }
 
-            String typeName = impoort.getTypeName();
-            if (impoort.isStatic()) {
-                String imported = impoort.getQualid().getSimpleName();
-                if (TypeUtils.fullyQualifiedNamesAreEqual(typeName + "." + imported, type) && (force || !methodsAndFieldsUsed.contains(imported))) {
-                    // e.g. remove java.util.Collections.emptySet when type is java.util.Collections.emptySet
-                    spaceForNextImport.set(impoort.getPrefix());
-                    return null;
-                } else if ("*".equals(imported) && (TypeUtils.fullyQualifiedNamesAreEqual(typeName, type)
-                        || TypeUtils.fullyQualifiedNamesAreEqual(typeName + type.substring(type.lastIndexOf('.')), type))) {
-                    if (methodsAndFieldsUsed.isEmpty() && otherMethodsAndFieldsInTypeUsed.isEmpty()) {
+                String typeName = impoort.getTypeName();
+                if (impoort.isStatic()) {
+                    String imported = impoort.getQualid().getSimpleName();
+                    if (TypeUtils.fullyQualifiedNamesAreEqual(typeName + "." + imported, type) && (force || !methodsAndFieldsUsed.contains(imported))) {
+                        // e.g. remove java.util.Collections.emptySet when type is java.util.Collections.emptySet
                         spaceForNextImport.set(impoort.getPrefix());
                         return null;
-                    } else if (!isPackageAlwaysFolded(importLayoutStyle.getPackagesToFold(), impoort) &&
-                            methodsAndFieldsUsed.size() + otherMethodsAndFieldsInTypeUsed.size() < importLayoutStyle.getNameCountToUseStarImport()) {
-                        methodsAndFieldsUsed.addAll(otherMethodsAndFieldsInTypeUsed);
-                        return unfoldStarImport(impoort, methodsAndFieldsUsed);
+                    } else if ("*".equals(imported) && (TypeUtils.fullyQualifiedNamesAreEqual(typeName, type)
+                            || TypeUtils.fullyQualifiedNamesAreEqual(typeName + type.substring(type.lastIndexOf('.')), type))) {
+                        if (methodsAndFieldsUsed.isEmpty() && otherMethodsAndFieldsInTypeUsed.isEmpty()) {
+                            spaceForNextImport.set(impoort.getPrefix());
+                            return null;
+                        } else if (!isPackageAlwaysFolded(importLayoutStyle.getPackagesToFold(), impoort) &&
+                                methodsAndFieldsUsed.size() + otherMethodsAndFieldsInTypeUsed.size() < importLayoutStyle.getNameCountToUseStarImport()) {
+                            methodsAndFieldsUsed.addAll(otherMethodsAndFieldsInTypeUsed);
+                            return unfoldStarImport(impoort, methodsAndFieldsUsed);
+                        }
+                    } else if (TypeUtils.fullyQualifiedNamesAreEqual(typeName, type) && !methodsAndFieldsUsed.contains(imported)) {
+                        // e.g. remove java.util.Collections.emptySet when type is java.util.Collections
+                        spaceForNextImport.set(impoort.getPrefix());
+                        return null;
                     }
-                } else if (TypeUtils.fullyQualifiedNamesAreEqual(typeName, type) && !methodsAndFieldsUsed.contains(imported)) {
-                    // e.g. remove java.util.Collections.emptySet when type is java.util.Collections
-                    spaceForNextImport.set(impoort.getPrefix());
+                } else if (!keepImport && TypeUtils.fullyQualifiedNamesAreEqual(typeName, type)) {
+                    if (impoort.getPrefix().isEmpty() || impoort.getPrefix().getLastWhitespace().chars().filter(s -> s == '\n').count() > 1) {
+                        spaceForNextImport.set(impoort.getPrefix());
+                    }
                     return null;
+                } else if (!keepImport && impoort.getPackageName().equals(owner) &&
+                        "*".equals(impoort.getClassName()) &&
+                        !isPackageAlwaysFolded(importLayoutStyle.getPackagesToFold(), impoort) &&
+                        otherTypesInPackageUsed.size() < importLayoutStyle.getClassCountToUseStarImport()) {
+                    if (otherTypesInPackageUsed.isEmpty()) {
+                        spaceForNextImport.set(impoort.getPrefix());
+                        return null;
+                    } else {
+                        return unfoldStarImport(impoort, otherTypesInPackageUsed);
+                    }
                 }
-            } else if (!keepImport && TypeUtils.fullyQualifiedNamesAreEqual(typeName, type)) {
-                if (impoort.getPrefix().isEmpty() || impoort.getPrefix().getLastWhitespace().chars().filter(s -> s == '\n').count() > 1) {
-                    spaceForNextImport.set(impoort.getPrefix());
-                }
-                return null;
-            } else if (!keepImport && impoort.getPackageName().equals(owner) &&
-                    "*".equals(impoort.getClassName()) &&
-                    !isPackageAlwaysFolded(importLayoutStyle.getPackagesToFold(), impoort) &&
-                    otherTypesInPackageUsed.size() < importLayoutStyle.getClassCountToUseStarImport()) {
-                if (otherTypesInPackageUsed.isEmpty()) {
-                    spaceForNextImport.set(impoort.getPrefix());
-                    return null;
-                } else {
-                    return unfoldStarImport(impoort, otherTypesInPackageUsed);
-                }
-            }
-            return impoort;
-        }));
+                return impoort;
+            }));
 
-        if (c != cu && c.getPackageDeclaration() == null && c.getImports().isEmpty() &&
-                c.getPrefix() == Space.EMPTY) {
-            doAfterVisit(new FormatFirstClassPrefix<>());
+            if (c != cu && c.getPackageDeclaration() == null && c.getImports().isEmpty() &&
+                    c.getPrefix() == Space.EMPTY) {
+                doAfterVisit(new FormatFirstClassPrefix<>());
+            }
+
+            j = c;
         }
 
-        return c;
+        return j;
     }
 
     private Object unfoldStarImport(J.Import starImport, Set<String> otherImportsUsed) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -32,7 +32,11 @@ public interface JavaSourceFile extends J {
 
     List<Import> getImports();
 
+    JavaSourceFile withImports(List<Import> imports);
+
     List<J.ClassDeclaration> getClasses();
+
+    JavaSourceFile withClasses(List<J.ClassDeclaration> classes);
 
     Space getEof();
 


### PR DESCRIPTION
Changes:
- ChangeType will operate on java island grammars like `G` and `K`.

TODO:
- ~~Revise ChangeType#visitCompilationUnit so that it does not handle imports.~~
- ~~Change imports in postVisit (equivalent to super.visitCompilationUnit).~~
- ~~Update ChangeClassDefinition to work across other J implementations.~~
- ~~Update `RemoveImport` / `AddImport` to work across `J` island grammars.~~
    - Issue: `visitCompilationUnit` will not be executed on other languages like `G` or `K.`
    - `SourceFile` does not have access to `typesInUse.`
    - `visitJavaSourceFile` is used to delegate to the language-specific `visitCompilationUnit.` So, overriding the method in place of `visitCompilationUnit` causes the `K` or `G` visitCompilationUnit not to be visited.
- ~~Implement `withImports` and `withClasses` on `G`.~~

Notes:
- Recipes like AddImport and ChangeType do not add imports from `java.lang`, other languages like Kotlin include additional classes on the classpath.

fixes #2961