### PR TITLE
Allow tests to configure default Java version for sources

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceTextBlockWithStringTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ReplaceTextBlockWithStringTest.java
@@ -19,433 +19,403 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.java.Assertions.*;
 
+@SuppressWarnings("UnnecessaryStringEscape")
 class ReplaceTextBlockWithStringTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new ReplaceTextBlockWithString());
+        spec.recipe(new ReplaceTextBlockWithString()).allSources(s -> s.markers(javaVersion(14)));
     }
 
     @Test
     void newLine() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "\\n";
+            }
+            """));
     }
 
     @Test
     void singleLine() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1\\n";
+            }
+            """));
     }
 
     @Test
     void singleLineNoNewLineAtEnd() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1\"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1\"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1";
+            }
+            """));
     }
 
     @Test
     void multipleLines() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1
-                          line2
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1
+                        line2
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1\\n" +
-                          "line2\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1\\n" +
+                        "line2\\n";
+            }
+            """));
     }
 
     @Test
     void multipleLinesNoNewLineAtEnd() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1
-                          line2\"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1
+                        line2\"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1\\n" +
-                          "line2";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1\\n" +
+                        "line2";
+            }
+            """));
     }
 
     @Test
     void indent() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1
-                              line2
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1
+                            line2
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1\\n" +
-                          "    line2\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1\\n" +
+                        "    line2\\n";
+            }
+            """));
     }
 
     @Test
     void startingEmptyLines() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
+            public class Test {
+                String str =
+                        \"\"\"
 
 
-                          line1
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+                        line1
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "\\n" +
-                          "\\n" +
-                          "line1\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "\\n" +
+                        "\\n" +
+                        "line1\\n";
+            }
+            """));
     }
 
     @Test
     void endingEmptyLines() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1
 
 
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1\\n" +
-                          "\\n" +
-                          "\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1\\n" +
+                        "\\n" +
+                        "\\n";
+            }
+            """));
     }
 
     @Test
     void middleEmptyLines() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          line1
+            public class Test {
+                String str =
+                        \"\"\"
+                        line1
 
 
-                          line2
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+                        line2
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "line1\\n" +
-                          "\\n" +
-                          "\\n" +
-                          "line2\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "line1\\n" +
+                        "\\n" +
+                        "\\n" +
+                        "line2\\n";
+            }
+            """));
     }
 
     @Test
     void assignmentAndBlockSameLine() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str = \"\"\"
-                          line1
-                          line2
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str = \"\"\"
+                        line1
+                        line2
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str = "line1\\n" +
-                          "line2\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str = "line1\\n" +
+                        "line2\\n";
+            }
+            """));
     }
 
     @Test
     void singleLineComment() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          // Comment
-                          \"\"\"
-                          line1
-                          line2
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        // Comment
+                        \"\"\"
+                        line1
+                        line2
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          // Comment
-                          "line1\\n" +
-                          "line2\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        // Comment
+                        "line1\\n" +
+                        "line2\\n";
+            }
+            """));
     }
 
     @Test
     void multiLineComment() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          /* Comment
-                           * Next line
-                           */
-                          \"\"\"
-                          line1
-                          line2
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        /* Comment
+                         * Next line
+                         */
+                        \"\"\"
+                        line1
+                        line2
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          /* Comment
-                           * Next line
-                           */
-                          "line1\\n" +
-                          "line2\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        /* Comment
+                         * Next line
+                         */
+                        "line1\\n" +
+                        "line2\\n";
+            }
+            """));
     }
 
     @Test
     void doubleQuote() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          "line1"
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        "line1"
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "\\"line1\\"\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "\\"line1\\"\\n";
+            }
+            """));
     }
 
     @Test
     void threeDoubleQuotes() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          \\"\\"\\"line1\\"\\"\\"
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        \\"\\"\\"line1\\"\\"\\"
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "\\"\\"\\"line1\\"\\"\\"\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "\\"\\"\\"line1\\"\\"\\"\\n";
+            }
+            """));
     }
 
     @Test
     void unicode() {
         rewriteRun(
-          version(
-            java(
-              """
-              package com.example;
+          java(
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          \"\"\"
-                          Γειά σου Κόσμε
-                          \"\"\";
-              }
-              """,
-              """
-              package com.example;
+            public class Test {
+                String str =
+                        \"\"\"
+                        Γειά σου Κόσμε
+                        \"\"\";
+            }
+            """,
+            """
+            package com.example;
 
-              public class Test {
-                  String str =
-                          "Γειά σου Κόσμε\\n";
-              }
-              """),
-            14));
+            public class Test {
+                String str =
+                        "Γειά σου Κόσμε\\n";
+            }
+            """));
     }
 
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -191,7 +191,7 @@ public class Assertions {
         return sourceSpec;
     }
 
-    private static JavaVersion javaVersion(int version) {
+    public static JavaVersion javaVersion(int version) {
         return javaVersions.computeIfAbsent(version, v ->
                 new JavaVersion(Tree.randomId(), "openjdk", "adoptopenjdk",
                         Integer.toString(v), Integer.toString(v)));

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -24,7 +24,6 @@ import org.openrewrite.*;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.YamlResourceLoader;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.quark.QuarkParser;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -87,14 +86,14 @@ public class RecipeSpec {
 
     List<UncheckedConsumer<RecipeRun>> afterRecipes = new ArrayList<>();
 
-    // The before and after here don't mean anything
-    SourceSpec<SourceFile> allSources = new SourceSpec<>(SourceFile.class, null, QuarkParser.builder(), "", null);
+    List<UncheckedConsumer<SourceSpec<?>>> allSources = new ArrayList<>();
 
     /**
      * Configuration that applies to all source file inputs.
      */
-    public SourceSpec<SourceFile> allSources() {
-        return allSources;
+    public RecipeSpec allSources(UncheckedConsumer<SourceSpec<?>> allSources) {
+        this.allSources.add(allSources);
+        return this;
     }
 
     public RecipeSpec recipe(Recipe recipe) {

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -24,6 +24,8 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SourceSet;
 import org.openrewrite.quark.Quark;
 import org.openrewrite.remote.Remote;
@@ -240,6 +242,12 @@ public interface RewriteTest extends SourceSpecs {
                 } else {
                     sourcePath = parser.sourcePathFromSourceText(sourceSpec.dir, beforeTrimmed);
                 }
+                for (UncheckedConsumer<SourceSpec<?>> consumer : testMethodSpec.allSources) {
+                    consumer.accept(sourceSpec);
+                }
+                for (UncheckedConsumer<SourceSpec<?>> consumer : testClassSpec.allSources) {
+                    consumer.accept(sourceSpec);
+                }
                 inputs.put(sourceSpec, new Parser.Input(sourcePath, () -> new ByteArrayInputStream(beforeTrimmed.getBytes(parser.getCharset(executionContext)))));
             }
 
@@ -255,18 +263,17 @@ public interface RewriteTest extends SourceSpecs {
 
             for (int i = 0; i < sourceFiles.size(); i++) {
                 SourceFile sourceFile = sourceFiles.get(i);
-                sourceFile = sourceFile.withMarkers(sourceFile.getMarkers().withMarkers(ListUtils.concatAll(
-                        sourceFile.getMarkers().getMarkers(), testClassSpec.allSources.markers)));
-                sourceFile = sourceFile.withMarkers(sourceFile.getMarkers().withMarkers(ListUtils.concatAll(
-                        sourceFile.getMarkers().getMarkers(), testMethodSpec.allSources.markers)));
+                Markers markers = sourceFile.getMarkers();
 
                 SourceSpec<?> nextSpec = sourceSpecIter.next();
-                sourceFile = sourceFile.withMarkers(sourceFile.getMarkers().withMarkers(ListUtils.concatAll(
-                        sourceFile.getMarkers().getMarkers(), nextSpec.markers)));
+                for (Marker marker : nextSpec.getMarkers()) {
+                    markers = markers.setByType(marker);
+                }
+                sourceFile = sourceFile.withMarkers(markers);
 
                 // Update the default 'main' SourceSet Marker added by the JavaParser with the specs sourceSetName
                 if (nextSpec.sourceSetName != null) {
-                    sourceFile = sourceFile.withMarkers((sourceFile.getMarkers().withMarkers(ListUtils.map(sourceFile.getMarkers().getMarkers(), m -> {
+                    sourceFile = sourceFile.withMarkers((markers.withMarkers(ListUtils.map(markers.getMarkers(), m -> {
                         if (m instanceof SourceSet) {
                             m = ((SourceSet) m).withName(nextSpec.sourceSetName);
                         }

--- a/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
@@ -25,6 +25,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.internal.ThrowingConsumer;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.test.internal.ThrowingUnaryOperator;
 
 import java.nio.file.Path;
@@ -87,7 +88,11 @@ public class SourceSpec<T extends SourceFile> implements SourceSpecs {
     @Nullable
     protected Path sourcePath;
 
-    protected final List<Marker> markers = new ArrayList<>();
+    protected Markers markers = Markers.EMPTY;
+
+    public List<Marker> getMarkers() {
+        return markers.getMarkers();
+    }
 
     @Nullable
     Path getSourcePath() {
@@ -122,7 +127,9 @@ public class SourceSpec<T extends SourceFile> implements SourceSpecs {
     }
 
     public SourceSpec<T> markers(Marker... markers) {
-        Collections.addAll(this.markers, markers);
+        for (Marker marker : markers) {
+            this.markers = this.markers.computeByType(marker, (existing, replacement) -> existing);
+        }
         return this;
     }
 


### PR DESCRIPTION
The `Assertions.javaVersion(int)` method is now public. Using this a `RewriteTest`-based test can now use `RecipeSpec.allSources()` to configure a default Java version for the sources:

```java
    @Override
    public void defaults(RecipeSpec spec) {
        spec.recipe(new ReplaceTextBlockWithString()).allSources(s -> s.markers(javaVersion(14)));
    }
```