### PR TITLE
Maven ChangePropertyKey

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.tree.ResolvedPom;
+import org.openrewrite.xml.ChangeTagNameVisitor;
+import org.openrewrite.xml.ChangeTagValueVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangePropertyKey extends Recipe {
+
+    @Option(displayName = "Old key",
+            description = "The old name of the property key to be replaced.",
+            example = "junit.version")
+    String oldKey;
+
+    @Option(displayName = "New key",
+            description = "The new property name to use.",
+            example = "version.org.junit")
+    String newKey;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Maven project property key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Changes the specified Maven project property key leaving the value intact.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new MavenVisitor<ExecutionContext>() {
+            @Override
+            public Xml visitDocument(Xml.Document document, ExecutionContext executionContext) {
+                String oldKeyAsProperty = "${" + oldKey + "}";
+                ResolvedPom pom = getResolutionResult().getPom();
+                if (pom.getProperties().containsKey(oldKey)) {
+                    return SearchResult.found(document);
+                }
+                if (pom.getRequestedDependencies().stream().anyMatch(d -> d.getVersion().contains(oldKeyAsProperty))) {
+                    return SearchResult.found(document);
+                }
+                if (pom.getDependencyManagement().stream().anyMatch(d -> d.getVersion().contains(oldKeyAsProperty))) {
+                    return SearchResult.found(document);
+                }
+                return document;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<Xml, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<ExecutionContext>() {
+            final String oldKeyAsProperty = "${" + oldKey + "}";
+            final String newKeyAsProperty = "${" + newKey + "}";
+
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                if (isPropertyTag() && oldKey.equals(tag.getName())) {
+                    doAfterVisit(new ChangeTagNameVisitor<>(tag, newKey));
+                }
+                if (oldKeyAsProperty.equals(tag.getValue().orElse(null))) {
+                    doAfterVisit(new ChangeTagValueVisitor<>(tag, newKeyAsProperty));
+                }
+                return super.visitTag(tag, ctx);
+            }
+        };
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
@@ -22,6 +22,8 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.tree.Dependency;
+import org.openrewrite.maven.tree.ResolvedManagedDependency;
 import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.xml.ChangeTagNameVisitor;
 import org.openrewrite.xml.ChangeTagValueVisitor;
@@ -61,11 +63,15 @@ public class ChangePropertyKey extends Recipe {
                 if (pom.getProperties().containsKey(oldKey)) {
                     return SearchResult.found(document);
                 }
-                if (pom.getRequestedDependencies().stream().anyMatch(d -> d.getVersion().contains(oldKeyAsProperty))) {
-                    return SearchResult.found(document);
+                for (Dependency dependency : pom.getRequestedDependencies()) {
+                    if (dependency.getVersion().contains(oldKeyAsProperty)) {
+                        return SearchResult.found(document);
+                    }
                 }
-                if (pom.getDependencyManagement().stream().anyMatch(d -> d.getVersion().contains(oldKeyAsProperty))) {
-                    return SearchResult.found(document);
+                for (ResolvedManagedDependency dependency : pom.getDependencyManagement()) {
+                    if (dependency.getVersion().contains(oldKeyAsProperty)) {
+                        return SearchResult.found(document);
+                    }
                 }
                 return document;
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
@@ -58,22 +58,8 @@ public class ChangePropertyKey extends Recipe {
         return new MavenVisitor<ExecutionContext>() {
             @Override
             public Xml visitDocument(Xml.Document document, ExecutionContext executionContext) {
-                String oldKeyAsProperty = "${" + oldKey + "}";
-                ResolvedPom pom = getResolutionResult().getPom();
-                if (pom.getProperties().containsKey(oldKey)) {
-                    return SearchResult.found(document);
-                }
-                for (Dependency dependency : pom.getRequestedDependencies()) {
-                    if (dependency.getVersion().contains(oldKeyAsProperty)) {
-                        return SearchResult.found(document);
-                    }
-                }
-                for (ResolvedManagedDependency dependency : pom.getDependencyManagement()) {
-                    if (dependency.getVersion().contains(oldKeyAsProperty)) {
-                        return SearchResult.found(document);
-                    }
-                }
-                return document;
+                // Scanning every tag's value is not an efficient applicable test, so just accept all maven files
+                return SearchResult.found(document);
             }
         };
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
@@ -45,7 +45,7 @@ public class ChangePropertyKey extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Change Maven project property key";
+        return "Rename Maven property key";
     }
 
     @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
@@ -50,7 +50,7 @@ public class ChangePropertyKey extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Changes the specified Maven project property key leaving the value intact.";
+        return "Rename the specified Maven project property key leaving the value unchanged.";
     }
 
     @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyKey.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.maven;
 
+import java.util.Optional;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
@@ -75,8 +77,12 @@ public class ChangePropertyKey extends Recipe {
                 if (isPropertyTag() && oldKey.equals(tag.getName())) {
                     doAfterVisit(new ChangeTagNameVisitor<>(tag, newKey));
                 }
-                if (oldKeyAsProperty.equals(tag.getValue().orElse(null))) {
-                    doAfterVisit(new ChangeTagValueVisitor<>(tag, newKeyAsProperty));
+                if (tag.getChildren().isEmpty()) {
+                    Optional<String> value = tag.getValue();
+                    if (value.isPresent() && value.get().contains(oldKeyAsProperty)) {
+                        String newValue = value.get().replace(oldKeyAsProperty, newKeyAsProperty);
+                        doAfterVisit(new ChangeTagValueVisitor<>(tag, newValue));
+                    }
                 }
                 return super.visitTag(tag, ctx);
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePropertyKeyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePropertyKeyTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class ChangePropertyKeyTest implements RewriteTest {
+    @Test
+    void propertyInDependency() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey("guava.version", "version.com.google.guava")),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <properties>
+                  <guava.version>29.0-jre</guava.version>
+                </properties>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>${guava.version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <properties>
+                  <version.com.google.guava>29.0-jre</version.com.google.guava>
+                </properties>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>${version.com.google.guava}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void propertyInDependencyManagement() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey("guava.version", "version.com.google.guava")),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <properties>
+                  <guava.version>29.0-jre</guava.version>
+                </properties>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.google.guava</groupId>
+                      <artifactId>guava</artifactId>
+                      <version>${guava.version}</version>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <properties>
+                  <version.com.google.guava>29.0-jre</version.com.google.guava>
+                </properties>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.google.guava</groupId>
+                      <artifactId>guava</artifactId>
+                      <version>${version.com.google.guava}</version>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void propertyInProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey("guava.version", "version.com.google.guava")),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <properties>
+                  <abc>value1</abc>
+                  <guava.version>29.0-jre</guava.version>
+                  <def>value1</def>
+                  <xyz>${guava.version}</xyz>
+                </properties>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <properties>
+                  <abc>value1</abc>
+                  <version.com.google.guava>29.0-jre</version.com.google.guava>
+                  <def>value1</def>
+                  <xyz>${version.com.google.guava}</xyz>
+                </properties>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePropertyKeyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePropertyKeyTest.java
@@ -137,10 +137,10 @@ class ChangePropertyKeyTest implements RewriteTest {
                 <modelVersion>4.0.0</modelVersion>
                  
                 <properties>
-                  <abc>value1</abc>
                   <guava.version>29.0-jre</guava.version>
-                  <def>value1</def>
-                  <xyz>${guava.version}</xyz>
+                  <abc>${guava.version}</abc>
+                  <def>prefix ${guava.version}</def>
+                  <xyz>${guava.version} suffix ${abc}</xyz>
                 </properties>
                 
                 <groupId>com.mycompany.app</groupId>
@@ -153,10 +153,10 @@ class ChangePropertyKeyTest implements RewriteTest {
                 <modelVersion>4.0.0</modelVersion>
                  
                 <properties>
-                  <abc>value1</abc>
                   <version.com.google.guava>29.0-jre</version.com.google.guava>
-                  <def>value1</def>
-                  <xyz>${version.com.google.guava}</xyz>
+                  <abc>${version.com.google.guava}</abc>
+                  <def>prefix ${version.com.google.guava}</def>
+                  <xyz>${version.com.google.guava} suffix ${abc}</xyz>
                 </properties>
                 
                 <groupId>com.mycompany.app</groupId>

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagNameVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagNameVisitor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import org.openrewrite.xml.tree.Xml;
+
+public class ChangeTagNameVisitor<P> extends XmlVisitor<P> {
+
+    private final Xml.Tag scope;
+    private final String newName;
+
+    public ChangeTagNameVisitor(Xml.Tag scope, String newName) {
+        this.scope = scope;
+        this.newName = newName;
+    }
+
+    @Override
+    public Xml visitTag(Xml.Tag tag, P p) {
+        Xml.Tag t = (Xml.Tag) super.visitTag(tag, p);
+        if (scope.isScope(t)) {
+            t = t.withName(newName);
+        }
+
+        return t;
+    }
+}


### PR DESCRIPTION
Enhancement to change a maven property key name.

Currently, OpenRewrite only support changing a maven property value, not a key.

- [X] Unit tests