### PR TITLE
fix results data table

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/table/SourcesFileResultsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/table/SourcesFileResultsTest.java
@@ -48,8 +48,10 @@ class SourcesFileResultsTest implements RewriteTest {
             .dataTable(SourcesFileResults.Row.class, rows -> {
                 assertThat(rows)
                   .as("This example runs a list of two recipes on a single source and expects to produce 3 " +
-                      "rows in the SourcesFileResults table, one is for the declarative recipe, another two are for two " +
-                      "recipes in the list.")
+                      "rows in the SourcesFileResults table, they are :" +
+                      "change #1 : the declarative recipe `AppendAndChangeText`" +
+                      "change #2 : `AppendToTextFile` recipe changes \"0\" to \"0 -> 2\"" +
+                      "change #3 : `FindAndReplace` recipe changes \"0 -> 2\" to \"1 -> 2\"")
                   .hasSize(3);
 
                 SourcesFileResults.Row row0 = rows.get(0);

--- a/rewrite-core/src/test/java/org/openrewrite/table/SourcesFileResultsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/table/SourcesFileResultsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.table;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.test.SourceSpecs.text;
+
+
+class SourcesFileResultsTest implements RewriteTest {
+    @Test
+    void twoResultsOnly() {
+        @Language("yaml")
+        String yamlRecipe = """
+          ---
+          type: specs.openrewrite.org/v1beta/recipe
+          name: org.openrewrite.AppendAndChangeText
+          displayName: Append and then change text
+          recipeList:
+              - org.openrewrite.text.AppendToTextFile:
+                  relativeFileName: "file.txt"
+                  content: " -> 2"
+                  preamble: "preamble"
+                  appendNewline : false
+                  existingFileStrategy: "continue"
+              - org.openrewrite.text.FindAndReplace:
+                  find: "0"
+                  replace: "1"
+          """;
+        rewriteRun(
+          spec -> spec.recipeFromYaml(yamlRecipe, "org.openrewrite.AppendAndChangeText")
+            .dataTable(SourcesFileResults.Row.class, rows -> {
+                assertThat(rows)
+                  .as("This example runs a list of two recipes on a single source and expects to produce 3 " +
+                      "rows in the SourcesFileResults table, one is for the declarative recipe, another two are for two " +
+                      "recipes in the list.")
+                  .hasSize(3);
+
+                SourcesFileResults.Row row0 = rows.get(0);
+                assertThat(row0.getRecipe()).isEqualTo("org.openrewrite.AppendAndChangeText");
+                SourcesFileResults.Row row1 = rows.get(1);
+                assertThat(row1.getRecipe()).isEqualTo("org.openrewrite.text.AppendToTextFile");
+                SourcesFileResults.Row row2 = rows.get(2);
+                assertThat(row2.getRecipe()).isEqualTo("org.openrewrite.text.FindAndReplace");
+            }),
+          text(
+            "0",
+            "1 -> 2",
+            spec -> spec.path("file.txt").noTrim()
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DataTableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DataTableTest.java
@@ -31,14 +31,14 @@ class DataTableTest implements RewriteTest {
           spec -> spec.recipe(RewriteTest.fromRuntimeClasspath("org.openrewrite.java.cleanup.CommonStaticAnalysis"))
             .dataTable(SourcesFileResults.Row.class, rows -> {
                 assertThat(rows)
-                  .as("Running recipe CommonStaticAnalysis on a two source files, if each file is changed " +
-                      "by recipe ReplaceStringBuilderWithString, so it should produce 4 rows in the SourcesFileResults " +
+                  .as("Running recipe CommonStaticAnalysis on two source files, if each file is changed " +
+                      "by recipe ReplaceStringBuilderWithString only, so it should produce 4 rows in the SourcesFileResults " +
                       "table, and they are : " +
-                      "row0 : file1 is changed by CommonStaticAnalysis" +
-                      "row1 : file1 is changed by ReplaceStringBuilderWithString" +
-                      "row2 : file2 is changed by CommonStaticAnalysis" +
-                      "row3 : file2 is changed by ReplaceStringBuilderWithString" +
-                      "file1,file2 order can be random."
+                      "row0 : file1 is changed by `CommonStaticAnalysis`" +
+                      "row1 : file1 is changed by `ReplaceStringBuilderWithString`" +
+                      "row2 : file2 is changed by `CommonStaticAnalysis`" +
+                      "row3 : file2 is changed by `ReplaceStringBuilderWithString`" +
+                      "file1,file2 order can be random in the results."
                       )
                   .hasSize(4);
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DataTableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DataTableTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.table.SourcesFileResults;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+
+
+class DataTableTest implements RewriteTest {
+
+    @Test
+    void resultsDataTable() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.fromRuntimeClasspath("org.openrewrite.java.cleanup.CommonStaticAnalysis"))
+            .dataTable(SourcesFileResults.Row.class, rows -> {
+                assertThat(rows)
+                  .as("Running recipe CommonStaticAnalysis on a two source files, if each file is changed only by " +
+                      "one recipe, so it should produce 4 rows in the SourcesFileResults table")
+                  .hasSize(4);
+
+                SourcesFileResults.Row row0 = rows.get(0);
+                assertThat(row0.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.CommonStaticAnalysis");
+                SourcesFileResults.Row row1 = rows.get(1);
+
+                assertThat(row1.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.ReplaceStringBuilderWithString");
+
+                SourcesFileResults.Row row2 = rows.get(2);
+                assertThat(row2.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.CommonStaticAnalysis");
+                SourcesFileResults.Row row3 = rows.get(3);
+                assertThat(row3.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.ReplaceStringBuilderWithString");
+
+                assertThat(row0.getSourcePath().equals("A.java") || row0.getSourcePath().equals("B.java")).isTrue();
+                assertThat(row2.getSourcePath().equals("A.java") || row2.getSourcePath().equals("B.java")).isTrue();
+                assertThat(row0.getSourcePath()).isEqualTo(row1.getSourcePath());
+                assertThat(row2.getSourcePath()).isEqualTo(row3.getSourcePath());
+                assertThat(row0.getSourcePath()).isNotEqualTo(row2.getSourcePath());
+            }),
+          java(
+            """
+              class A {
+                  void foo() {
+                      String s = new StringBuilder().append("A").append("B").toString();
+                  }
+              }
+              """,
+            """
+              class A {
+                  void foo() {
+                      String s = "A" + "B";
+                  }
+              }
+              """,
+            spec -> spec.path("A.java")
+          )
+          ,
+          java(
+            """
+              class B {
+                  void foo() {
+                      String s = new StringBuilder().append("A").append("B").toString();
+                  }
+              }
+              """,
+            """
+              class B {
+                  void foo() {
+                      String s = "A" + "B";
+                  }
+              }
+              """,
+            spec -> spec.path("B.java")
+          )
+        );
+    }
+
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DataTableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DataTableTest.java
@@ -31,16 +31,21 @@ class DataTableTest implements RewriteTest {
           spec -> spec.recipe(RewriteTest.fromRuntimeClasspath("org.openrewrite.java.cleanup.CommonStaticAnalysis"))
             .dataTable(SourcesFileResults.Row.class, rows -> {
                 assertThat(rows)
-                  .as("Running recipe CommonStaticAnalysis on a two source files, if each file is changed only by " +
-                      "one recipe, so it should produce 4 rows in the SourcesFileResults table")
+                  .as("Running recipe CommonStaticAnalysis on a two source files, if each file is changed " +
+                      "by recipe ReplaceStringBuilderWithString, so it should produce 4 rows in the SourcesFileResults " +
+                      "table, and they are : " +
+                      "row0 : file1 is changed by CommonStaticAnalysis" +
+                      "row1 : file1 is changed by ReplaceStringBuilderWithString" +
+                      "row2 : file2 is changed by CommonStaticAnalysis" +
+                      "row3 : file2 is changed by ReplaceStringBuilderWithString" +
+                      "file1,file2 order can be random."
+                      )
                   .hasSize(4);
 
                 SourcesFileResults.Row row0 = rows.get(0);
                 assertThat(row0.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.CommonStaticAnalysis");
                 SourcesFileResults.Row row1 = rows.get(1);
-
                 assertThat(row1.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.ReplaceStringBuilderWithString");
-
                 SourcesFileResults.Row row2 = rows.get(2);
                 assertThat(row2.getRecipe()).isEqualTo("org.openrewrite.java.cleanup.CommonStaticAnalysis");
                 SourcesFileResults.Row row3 = rows.get(3);
@@ -89,5 +94,4 @@ class DataTableTest implements RewriteTest {
           )
         );
     }
-
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSchedulerCheckingExpectedCycles.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSchedulerCheckingExpectedCycles.java
@@ -49,10 +49,12 @@ class RecipeSchedulerCheckingExpectedCycles implements RecipeScheduler {
             List<S> before,
             ExecutionContext ctx,
             @Nullable Map<UUID, Boolean> singleSourceApplicableTestResult,
-            Map<UUID, Stack<Recipe>> recipeThatAddedOrDeletedSourceFile
+            Map<UUID, Stack<Recipe>> recipeThatAddedOrDeletedSourceFile,
+            boolean isApplicableTest
     ) {
         ctx.putMessage("cyclesThatResultedInChanges", cyclesThatResultedInChanges);
-        List<S> afterList = delegate.scheduleVisit(runStats, recipeStack, before, ctx, singleSourceApplicableTestResult, recipeThatAddedOrDeletedSourceFile);
+        List<S> afterList = delegate.scheduleVisit(runStats, recipeStack, before, ctx, singleSourceApplicableTestResult,
+            recipeThatAddedOrDeletedSourceFile, isApplicableTest);
         if (afterList != before) {
             cyclesThatResultedInChanges++;
             if (cyclesThatResultedInChanges > expectedCyclesThatMakeChanges &&


### PR DESCRIPTION
This is an alternate solution to PR #2981 (has been reverted), but removed `Recipe#isApplicableTest()` method since any recipe can potentially be an applicability test and a recipe can know about itself, especially for yaml recipes, the applicability test are recipes but not wrapping of visitors, so that PR doesn't cover yaml recipes.

------------------------------------------------------------

Currently, the results data table `SourcesFileResults` has two problems:
1. Include results for only one file and missed others.
2. Include tons of `AdHocRecipe` which is an applicability test recipe, regardless of whether the recipe modifies the file or not.

This PR is intended to fix the above two problems.
Here is an example, run `CommonStaticAnalysis` against one repo, and got this result table.

![Screen Shot 2023-03-13 at 9 50 37 PM](https://user-images.githubusercontent.com/122563761/224896532-fc46ba09-c22e-41c1-ab87-e00c1227a68e.png)

```
sourcePath,afterSourcePath,parentRecipe,recipe
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java",,"org.openrewrite.java.cleanup.CommonStaticAnalysis"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.RenameMethodsNamedHashcodeEqualOrTostring"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.RenameMethodsNamedHashcodeEqualOrTostring","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.NoDoubleBraceInitialization"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.NoDoubleBraceInitialization","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.LambdaBlockToExpression"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.LambdaBlockToExpression","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.IsEmptyCallOnCollections"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.IsEmptyCallOnCollections","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.FixStringFormatExpressions"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.FixStringFormatExpressions","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.AtomicPrimitiveEqualsUsesGet"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.AtomicPrimitiveEqualsUsesGet","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.UpperCaseLiteralSuffixes"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.UpperCaseLiteralSuffixes","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.StringLiteralEquality"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.StringLiteralEquality","org.openrewrite.Recipe$AdHocRecipe"
github.com,Netflix/spectator,main,"spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","spectator-agent/src/main/java/com/netflix/spectator/agent/Agent.java","org.openrewrite.java.cleanup.CommonStaticAnalysis","org.openrewrite.java.cleanup.ReplaceLambdaWithMethodReference"

```
