### PR TITLE
POC: Create a Trait-Based Model for the AST

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Cursor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Cursor.java
@@ -235,7 +235,7 @@ public class Cursor {
     /**
      * Return the first parent of the current cursor which points to an AST element, or the root cursor if the current
      * cursor already points to the root AST element. This skips over non-tree Padding elements.
-     *
+     * </p>
      * If you do want to access Padding elements, use getParent() or getParentOrThrow(), which do not skip over these elements.
      *
      * @return a cursor which either points at the first non-padding parent of the current element

--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation("io.github.classgraph:classgraph:latest.release")
     testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")
+    testImplementation("com.tngtech.archunit:archunit-junit5:latest.release")
     testRuntimeOnly(project(":rewrite-java-17"))
     testRuntimeOnly("junit:junit:4.13.2") {
         because("Used for RemoveUnneededAssertionTest")

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/dataflow/FindLocalFlowPathsStringTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/dataflow/FindLocalFlowPathsStringTest.java
@@ -54,7 +54,8 @@ class FindLocalFlowPathsStringTest implements RewriteTest {
             public boolean isSource(Expression expr, Cursor cursor) {
                 if (expr instanceof J.Literal) {
                     return Objects.equals(((J.Literal) expr).getValue(), "42");
-                } else if (expr instanceof J.MethodInvocation) {
+                }
+                if (expr instanceof J.MethodInvocation) {
                     return ((J.MethodInvocation) expr).getName().getSimpleName().equals("source");
                 }
                 return false;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/TraitArchitectureTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/TraitArchitectureTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@AnalyzeClasses(packages = "org.openrewrite.java.trait")
+public class TraitArchitectureTest {
+
+    private static ArchCondition<JavaClass> haveExplicitlyDeclaredMethodWithName(Function<JavaClass, Optional<JavaMethod>> getMethod, String description) {
+        return new ArchCondition<>("must have equals(Object) method") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                Optional<JavaMethod> m = getMethod.apply(item);
+                if (m.isEmpty()) {
+                    String message = String.format(description, item.getFullName());
+                    events.add(SimpleConditionEvent.violated(item, message));
+                }
+            }
+        };
+    }
+
+    private static final ArchCondition<JavaClass> haveExplicitlyDeclaredEqualsMethod =
+        haveExplicitlyDeclaredMethodWithName(javaClass -> javaClass.tryGetMethod("equals", Object.class), "Class %s has no equals(Object) method declared");
+
+    private static final ArchCondition<JavaClass> haveExplicitlyDeclaredHashCodeMethod =
+        haveExplicitlyDeclaredMethodWithName(javaClass -> javaClass.tryGetMethod("hashCode"), "Class %s has no hashCode() method declared");
+
+    @ArchTest
+    public static final ArchRule topImplementationClassesMustOverrideEqualsAndHashCode =
+      classes().that().implement(Top.class)
+        .should(haveExplicitlyDeclaredEqualsMethod)
+        .andShould(haveExplicitlyDeclaredHashCodeMethod);
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/expr/VarAccessCreationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/expr/VarAccessCreationTest.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.expr;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+@SuppressWarnings("ALL")
+public class VarAccessCreationTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+            @Override
+            public J preVisit(J tree, ExecutionContext executionContext) {
+                return VarAccess.viewOf(getCursor())
+                  .map(var -> {
+                      assertNotNull(var.getVariable(), "VarAccess.getVariable() is null");
+                      assertTrue(var.getVariable().getVarAccesses().contains(var), "VarAccess.getVariable().getVarAccesses() does not contain this VarAccess");
+                      return SearchResult.foundMerging(tree, var.getName());
+                  })
+                  .orSuccess(tree);
+            }
+        })).cycles(1).expectedCyclesThatMakeChanges(1);
+    }
+
+    @Test
+    void searchResultsForVarAccessUnary() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test() {
+                      int i = 0;
+                      i++;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      int i = 0;
+                      /*~~(i)~~>*/i++;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForBinaryExpression() {
+        rewriteRun(
+          java("""
+              class Test {
+                  int test(int a, int b) {
+                      return a + b;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  int test(int a, int b) {
+                      return /*~~(a)~~>*/a + /*~~(b)~~>*/b;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForSubjectMethodInvocation() {
+        rewriteRun(
+          java("""
+              import java.util.function.Supplier;
+              class Test {
+                   void test(Supplier<Object> s) {
+                      s.get();
+                   }               
+              }
+              """,
+            """
+              import java.util.function.Supplier;
+              class Test {
+                   void test(Supplier<Object> s) {
+                      /*~~(s)~~>*/s.get();
+                   }               
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForNewClass() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object o) {
+                      Another a = new Another(o);
+                      Another.Inner i = a.new Inner(o);
+                  }
+              }
+              class Another {
+                  Another(Object o) {}
+                  
+                  class Inner {
+                      Inner(Object o) {}
+                  }
+                            
+              }
+              """,
+            """
+              class Test {
+                  void test(Object o) {
+                      Another a = new Another(/*~~(o)~~>*/o);
+                      Another.Inner i = /*~~(a)~~>*/a.new Inner(/*~~(o)~~>*/o);
+                  }
+              }
+              class Another {
+                  Another(Object o) {}
+                  
+                  class Inner {
+                      Inner(Object o) {}
+                  }
+                            
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForArgumentsMethodInvocation() {
+        rewriteRun(
+          java("""
+              import java.util.function.Consumer;
+              class Test {
+                  void test(Consumer<Object> c, Object value) {
+                      c.accept(value);
+                  }               
+              }
+              """,
+            """
+                  import java.util.function.Consumer;
+                  class Test {
+                      void test(Consumer<Object> c, Object value) {
+                          /*~~(c)~~>*/c.accept(/*~~(value)~~>*/value);
+                      }               
+                  }
+              """)
+        );
+    }
+
+    @Test
+    void searchResultsForParenthesesWrappedMethodInvocation() {
+        rewriteRun(
+          java("""
+              import java.util.function.Consumer;
+              class Test {
+                  void test(Consumer<Object> c, Object value) {
+                      (c).accept((value));
+                  }               
+              }
+              """,
+            """
+                  import java.util.function.Consumer;
+                  class Test {
+                      void test(Consumer<Object> c, Object value) {
+                          (/*~~(c)~~>*/c).accept((/*~~(value)~~>*/value));
+                      }               
+                  }
+              """)
+        );
+    }
+
+    @Test
+    void searchResultsForTeraryExpression() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object any, Object other) {
+                      Object o = any == null ? other : any;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(Object any, Object other) {
+                      Object o = /*~~(any)~~>*/any == null ? /*~~(other)~~>*/other : /*~~(any)~~>*/any;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForNamedVariableCreation() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object any) {
+                      Object o = any;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(Object any) {
+                      Object o = /*~~(any)~~>*/any;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForVariableReassignment() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object any) {
+                      Object o = new Object();
+                      o = any;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(Object any) {
+                      Object o = new Object();
+                      /*~~(o)~~>*/o = /*~~(any)~~>*/any;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForCast() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object any) {
+                      Integer o = (Integer) any;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(Object any) {
+                      Integer o = (Integer) /*~~(any)~~>*/any;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultForForEachLoop() {
+        rewriteRun(
+          java("""
+              import java.util.List;
+              class Test {
+                  void test(List<Object> any) {
+                      for(Object o : any) {
+                          System.out.println(o);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              class Test {
+                  void test(List<Object> any) {
+                      for(Object o : /*~~(any)~~>*/any) {
+                          System./*~~(out)~~>*/out.println(/*~~(o)~~>*/o);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForForLoop() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(int initial, boolean condition, Object any) {
+                      for(int i = initial; condition; i++) {
+                          System.out.println(any);
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int initial, boolean condition, Object any) {
+                      for(int i = /*~~(initial)~~>*/initial; /*~~(condition)~~>*/condition; /*~~(i)~~>*/i++) {
+                          System./*~~(out)~~>*/out.println(/*~~(any)~~>*/any);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForControlParentheses() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(boolean condition, Object any) {
+                      while(condition) {
+                          System.out.println(any);
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(boolean condition, Object any) {
+                      while(/*~~(condition)~~>*/condition) {
+                          System./*~~(out)~~>*/out.println(/*~~(any)~~>*/any);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForNewArray() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object first, Object second, int size) {
+                      Object[] o = new Object[] { first, second };
+                      Object[] o2 = new Object[size];
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(Object first, Object second, int size) {
+                      Object[] o = new Object[] { /*~~(first)~~>*/first, /*~~(second)~~>*/second };
+                      Object[] o2 = new Object[/*~~(size)~~>*/size];
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForArrayAccess() {
+        rewriteRun(
+          java("""
+              class Test {
+                  void test(Object[] any, int index) {
+                      Object o = any[index];
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(Object[] any, int index) {
+                      Object o = /*~~(any)~~>*/any[/*~~(index)~~>*/index];
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForAnnotations() {
+        rewriteRun(
+          java("""
+              class Test {
+                  private static final String FOO = "foo";
+                  @SuppressWarnings(FOO)
+                  void test() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  private static final String FOO = "foo";
+                  @SuppressWarnings(/*~~(FOO)~~>*/FOO)
+                  void test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForAnnotationsExlicitArgument() {
+        rewriteRun(
+          java("""
+              class Test {
+                  private static final String FOO = "foo";
+                  @SuppressWarnings(value = FOO)
+                  void test() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  private static final String FOO = "foo";
+                  @SuppressWarnings(value = /*~~(FOO)~~>*/FOO)
+                  void test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsForQualifiedClassLocalVariableAccess() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Object field;
+                  void test() {
+                      Object o = this.field;
+                  }
+              }
+              """,
+            """
+                class Test {
+                    Object field;
+                    void test() {
+                        Object o = this./*~~(field)~~>*/field;
+                    }
+                }
+                """
+          )
+        );
+    }
+
+    @Test
+    void searchResultsDoNotInclude() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          java("""
+            package org.openrewrite;
+            import java.util.function.Supplier;
+            class Test {
+                void test(Object any) {
+                    new Object();
+                    String.format("foo");
+                }
+            }
+            """
+          )
+        );
+    }
+
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/expr/VarAccessTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/expr/VarAccessTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.expr;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+@SuppressWarnings("ALL")
+public class VarAccessTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+            @Override
+            public J preVisit(J tree, ExecutionContext executionContext) {
+                return VarAccess.viewOf(getCursor())
+                  .map(var -> {
+                      assertNotNull(var.getName(), "VarAccess.getName() is null");
+                      assertNotNull(var.getVariable(), "VarAccess.getVariable() is null");
+                      return SearchResult.foundMerging(tree, var.getName() + " local:" + var.isLocal() + " l:" + var.isLValue() + " r:" + var.isRValue() + " q:" + var.hasQualifier());
+                  })
+                  .orSuccess(tree);
+            }
+        })).cycles(1).expectedCyclesThatMakeChanges(1);
+    }
+
+    @Test
+    void correctlyLabelsLocalVariables() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test(int a) {
+                      int i = a;
+                      i = 1;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int a) {
+                      int i = /*~~(a local:true l:false r:true q:false)~~>*/a;
+                      /*~~(i local:true l:true r:false q:false)~~>*/i = 1;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void correctlyLabelsLocalVariablesParenthesesWrapped() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test(int a) {
+                      int i = (a);
+                      (i) = 1;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int a) {
+                      int i = (/*~~(a local:true l:false r:true q:false)~~>*/a);
+                      (/*~~(i local:true l:true r:false q:false)~~>*/i) = 1;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void correctlyLabelsLocalVariablesDoubleParenthesesWrapped() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test(int a) {
+                      int i = ((a));
+                      ((i)) = 1;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int a) {
+                      int i = ((/*~~(a local:true l:false r:true q:false)~~>*/a));
+                      ((/*~~(i local:true l:true r:false q:false)~~>*/i)) = 1;
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/member/CallableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/member/CallableTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.member;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class CallableTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+            @Override
+            public J preVisit(J tree, ExecutionContext executionContext) {
+                return StaticInitializerMethod
+                  .viewOf(getCursor())
+                  .map(c -> SearchResult.foundMerging(tree, c.getName()))
+                  .bind(t -> InstanceInitializer.viewOf(getCursor())
+                    .map(c -> SearchResult.foundMerging(t, c.getName())))
+                  .orSuccess(t ->
+                    Method.viewOf(getCursor())
+                      .map(c -> SearchResult.foundMerging(tree, c.getName()))
+                      .orSuccess(tree));
+            }
+        })).cycles(1).expectedCyclesThatMakeChanges(1);
+    }
+
+    @Test
+    void searchResultsForCallables() {
+        rewriteRun(
+          java("""
+            class Test {
+                Test() {}
+                void test() {}
+            }
+            """,
+            """
+            class Test /*~~(<clinit>, <obinit>)~~>*/{
+                /*~~(Test)~~>*/Test() {}
+                /*~~(test)~~>*/void test() {}
+            }
+            """
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/FieldTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/FieldTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class FieldTest implements RewriteTest {
+
+    static Supplier<TreeVisitor<?, ExecutionContext>> visitVariable(
+      BiFunction<J.VariableDeclarations.NamedVariable, Cursor, J.VariableDeclarations.NamedVariable> visitor
+    ) {
+        return () -> new JavaIsoVisitor<>() {
+            @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(
+              J.VariableDeclarations.NamedVariable variable,
+              ExecutionContext executionContext
+            ) {
+                return super.visitVariable(visitor.apply(variable, getCursor()), executionContext);
+            }
+        };
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(visitVariable((variable, cursor) -> Field.viewOf(cursor).map(localVariableDecl -> {
+            assertNotNull(localVariableDecl.getName(), "LocalVariableDecl callable is null");
+            return SearchResult.found(variable);
+        }).orSuccess(variable))));
+    }
+
+    @Test
+    void parameters() {
+        rewriteRun(
+          java(
+            "abstract class Test { abstract void test(int i); }"
+          )
+        );
+    }
+
+    @Test
+    void localVariables() {
+        rewriteRun(
+          java("class Test { void test() { int i = 0; } }")
+        );
+    }
+
+    @Test
+    void fieldsInAnonymousInnerClasses() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      new Object() {
+                          static int i = 0;
+                          int j = 0;
+                      };
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      new Object() {
+                          static int /*~~>*/i = 0;
+                          int /*~~>*/j = 0;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldsInInnerClasses() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      class Potato {
+                          static int i = 0;
+                          int j = 0;
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      class Potato {
+                          static int /*~~>*/i = 0;
+                          int /*~~>*/j = 0;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/LocalVariableDeclTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/LocalVariableDeclTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class LocalVariableDeclTest implements RewriteTest {
+
+    static Supplier<TreeVisitor<?, ExecutionContext>> visitVariable(
+      BiFunction<J.VariableDeclarations.NamedVariable, Cursor, J.VariableDeclarations.NamedVariable> visitor
+    ) {
+        return () -> new JavaIsoVisitor<>() {
+            @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(
+              J.VariableDeclarations.NamedVariable variable,
+              ExecutionContext executionContext
+            ) {
+                return super.visitVariable(visitor.apply(variable, getCursor()), executionContext);
+            }
+        };
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(visitVariable((variable, cursor) -> LocalVariableDecl.viewOf(cursor).map(localVariableDecl -> {
+            assertNotNull(localVariableDecl.getCallable(), "LocalVariableDecl callable is null");
+            return SearchResult.found(variable);
+        }).orSuccess(variable))));
+    }
+
+    @Test
+    void testVariableVisit() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {
+                LocalVariableDecl p = LocalVariableDecl.viewOf(cursor).orSuccess(TraitErrors::doThrow);
+                assertEquals("i", p.getName(), "LocalVariableDecl name is incorrect");
+                assertEquals("test", p.getCallable().getName(), "Parameter callable name is incorrect");
+                return SearchResult.found(variable);
+            }
+          ))),
+          java(
+            "class Test { void test() { int i = 0; } }",
+            "class Test { void test() { int /*~~>*/i = 0; } }"
+          )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("ClassInitializerMayBeStatic")
+    void testVariableInInitBlock() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {
+                LocalVariableDecl p = LocalVariableDecl.viewOf(cursor).orSuccess(TraitErrors::doThrow);
+                assertEquals("i", p.getName(), "LocalVariableDecl name is incorrect");
+                assertEquals("<obinit>", p.getCallable().getName(), "Parameter callable name is incorrect");
+                return SearchResult.found(variable);
+            }
+          ))),
+          java(
+            "class Test { { int i = 0; } }",
+            "class Test { { int /*~~>*/i = 0; } }"
+          )
+        );
+    }
+
+    @Test
+    void testVariableInStaticInitBlock() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {
+                LocalVariableDecl p = LocalVariableDecl.viewOf(cursor).orSuccess(TraitErrors::doThrow);
+                assertEquals("i", p.getName(), "LocalVariableDecl name is incorrect");
+                assertEquals("<clinit>", p.getCallable().getName(), "Parameter callable name is incorrect");
+                return SearchResult.found(variable);
+            }
+          ))),
+          java(
+            "class Test { static { int i = 0; } }",
+            "class Test { static { int /*~~>*/i = 0; } }"
+          )
+        );
+    }
+
+    @Test
+    void doesNotFindStaticFields() {
+        rewriteRun(
+          java(
+            "class Test { static int i = 0; }"
+          )
+        );
+    }
+
+    @Test
+    void doesNotFindParameters() {
+        rewriteRun(
+          java(
+            "abstract class Test { abstract void test(int i); }"
+          )
+        );
+    }
+
+    @Test
+    void doesNotFindStaticFieldsInAnonymousInnerClasses() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      new Object() {
+                          static int i = 0;
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotFindStaticFieldsInInnerClasses() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      class Potato {
+                          static int i = 0;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/ParameterTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/ParameterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class ParameterTest implements RewriteTest {
+
+    static Supplier<TreeVisitor<?, ExecutionContext>> visitVariable(
+      BiFunction<J.VariableDeclarations.NamedVariable, Cursor, J.VariableDeclarations.NamedVariable> visitor
+    ) {
+        return () -> new JavaIsoVisitor<>() {
+            @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(
+              J.VariableDeclarations.NamedVariable variable,
+              ExecutionContext executionContext
+            ) {
+                return super.visitVariable(visitor.apply(variable, getCursor()), executionContext);
+            }
+        };
+    }
+
+    @Test
+    void testVariableVisit() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {
+                Parameter p = Parameter.viewOf(cursor).orSuccess(TraitErrors::doThrow);
+                assertEquals(0, p.getPosition(), "Parameter position is incorrect");
+                assertFalse(p.isVarArgs(), "Parameter isVarArgs is incorrect");
+                assertEquals("i", p.getName(), "Parameter name is incorrect");
+                assertEquals("test", p.getCallable().getName(), "Parameter callable name is incorrect");
+                return SearchResult.found(variable);
+            }
+          ))),
+          java(
+            "abstract class Test { abstract void test(int i); }",
+            "abstract class Test { abstract void test(int /*~~>*/i); }"
+          )
+        );
+    }
+
+    @Test
+    void testVariableVisitVarargs() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(visitVariable((variable, cursor) -> {
+                Parameter p = Parameter.viewOf(cursor).orSuccess(TraitErrors::doThrow);
+                assertEquals(0, p.getPosition(), "Parameter position is incorrect");
+                assertTrue(p.isVarArgs(), "Parameter isVarArgs is incorrect");
+                assertEquals("i", p.getName(), "Parameter name is incorrect");
+                assertEquals("test", p.getCallable().getName(), "Parameter callable name is incorrect");
+                return SearchResult.found(variable);
+            }
+          ))),
+          java(
+            "abstract class Test { abstract void test(int... i); }",
+            "abstract class Test { abstract void test(int... /*~~>*/i); }"
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/VariableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/trait/variable/VariableTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.trait.expr.VarAccess;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+@SuppressWarnings("UnusedAssignment")
+public class VariableTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+            private int variableIndex = 0;
+
+            @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext executionContext) {
+                return Variable.viewOf(getCursor()).map(v -> {
+                    int thisVariableIndex = variableIndex++;
+                    doAfterVisit(new JavaIsoVisitor<>() {
+                        @Override
+                        public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext executionContext) {
+                            return VarAccess
+                              .viewOf(getCursor()).map(var -> {
+                                  if (v.getVarAccesses().contains(var)) {
+                                      return SearchResult.foundMerging(
+                                        identifier,
+                                        v.getName() + ": " + thisVariableIndex
+                                      );
+                                  } else {
+                                      return identifier;
+                                  }
+                              })
+                              .orSuccess(identifier);
+                        }
+                    });
+
+                    return SearchResult.found(variable, v.getName() + ": " + thisVariableIndex);
+                }).orSuccess(variable);
+            }
+        })).cycles(1).expectedCyclesThatMakeChanges(1);
+    }
+
+    @Test
+    void correctlyLabelsLocalVariables() {
+        rewriteRun(
+          java(
+            """
+                class Test {
+                    void test(int a) {
+                        int i = a;
+                        i = 1;
+                    }
+                }
+                """,
+            """
+                class Test {
+                    void test(int /*~~(a: 0)~~>*/a) {
+                        int /*~~(i: 1)~~>*/i = /*~~(a: 0)~~>*/a;
+                        /*~~(i: 1)~~>*/i = 1;
+                    }
+                }
+                """
+          )
+        );
+    }
+
+    @Test
+    void correctlyLabelsLocalFields() {
+        rewriteRun(
+          java(
+            """
+                class Test {
+                    int i;
+                    void test(int a) {
+                        i = a;
+                    }
+                }
+                """,
+            """
+                class Test {
+                    int /*~~(i: 0)~~>*/i;
+                    void test(int /*~~(a: 1)~~>*/a) {
+                        /*~~(i: 0)~~>*/i = /*~~(a: 1)~~>*/a;
+                    }
+                }
+                """
+          )
+        );
+    }
+
+    @Test
+    void correctlyLabelsWhenVariableRedefined() {
+        rewriteRun(
+          java(
+            """
+                class Test {
+                    int i;
+                    void test(int i) {
+                        this.i = i;
+                    }
+                }
+                """,
+            """
+                class Test {
+                    int /*~~(i: 0)~~>*/i;
+                    void test(int /*~~(i: 1)~~>*/i) {
+                        this./*~~(i: 0)~~>*/i = /*~~(i: 1)~~>*/i;
+                    }
+                }
+                """
+          )
+        );
+    }
+
+
+
+    @Test
+    void correctlyLabelsSuperField() {
+        rewriteRun(
+          java(
+            """
+              class Parent {
+                  int i = 0;
+              }
+                                                        
+              class Child extends Parent {
+              
+                  void test() {
+                      super.i = 1;
+                  }
+              }
+              """,
+            """
+              class Parent {
+                  int /*~~(i: 0)~~>*/i = 0;
+              }
+                            
+              class Child extends Parent {
+               
+                  void test() {
+                      super./*~~(i: 0)~~>*/i = 1;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void correctlyLabelsWhenVariableReDefinedInParent() {
+        rewriteRun(
+          java(
+            """
+              class Parent {
+                  int i = 0;
+              }
+                                                        
+              class Child extends Parent {
+                  int i = 1;              
+              
+                  void test(int i) {
+                      System.out.println(i);
+                      System.out.println(this.i);
+                      System.out.println(super.i);
+                  }
+              }
+              """,
+            """
+              class Parent {
+                  int /*~~(i: 0)~~>*/i = 0;
+              }
+                            
+              class Child extends Parent {
+                  int /*~~(i: 1)~~>*/i = 1;
+               
+                  void test(int /*~~(i: 2)~~>*/i) {
+                      System.out.println(/*~~(i: 2)~~>*/i);
+                      System.out.println(this./*~~(i: 1)~~>*/i);
+                      System.out.println(super./*~~(i: 0)~~>*/i);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void correctlyLabelsWhenVariableRedefinedInThrow() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  int i = 1;
+                  
+                  void test() {
+                      try {
+                          System.out.println(i);
+                      } catch (RuntimeException i) {
+                          i.printStackTrace();
+                          System.out.println(this.i);
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  int /*~~(i: 0)~~>*/i = 1;
+              
+                  void test() {
+                      try {
+                          System.out.println(/*~~(i: 0)~~>*/i);
+                      } catch (RuntimeException /*~~(i: 1)~~>*/i) {
+                          /*~~(i: 1)~~>*/i.printStackTrace();
+                          System.out.println(this./*~~(i: 0)~~>*/i);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -67,5 +67,5 @@ tasks.withType<Javadoc> {
     //   symbol:   method onConstructor_()
     //   location: @interface AllArgsConstructor
     // 1 error
-    exclude("**/JavaParser**", "**/ChangeMethodTargetToStatic**")
+    exclude("**/JavaParser**", "**/ChangeMethodTargetToStatic**", "**/trait/**")
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/dataflow/DataFlowNode.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/dataflow/DataFlowNode.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dataflow;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.variable.Parameter;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public abstract class DataFlowNode {
+    final Cursor cursor;
+
+    abstract Optional<Expression> asExpression();
+
+    abstract Optional<Parameter> asParameter();
+
+    abstract <T> T map(Function<Expression, T> whenExpression, Function<Parameter, T> whenParameter);
+
+    public static DataFlowNode of(Cursor cursor) {
+        if (cursor.getValue() instanceof Expression) {
+            return new ExpressionDataFlowNode(cursor, cursor.getValue());
+        } else if (cursor.getValue() instanceof J.VariableDeclarations.NamedVariable) {
+            return new ParameterDataFlowNode(cursor, Parameter.viewOf(cursor).orSuccess(TraitErrors::doThrow));
+        } else {
+            throw new IllegalArgumentException("DataFlowNode can not be of type: " + cursor.getValue().getClass());
+        }
+    }
+}
+
+class ExpressionDataFlowNode extends DataFlowNode {
+    private final Expression expression;
+    ExpressionDataFlowNode(Cursor cursor, Expression expression) {
+        super(cursor);
+        this.expression = requireNonNull(expression, "expression");
+    }
+
+    @Override
+    Optional<Expression> asExpression() {
+        return Optional.of(expression);
+    }
+
+    @Override
+    Optional<Parameter> asParameter() {
+        return Optional.empty();
+    }
+
+    @Override
+    <T> T map(Function<Expression, T> whenExpression, Function<Parameter, T> whenParameter) {
+        requireNonNull(whenExpression, "whenExpression");
+        requireNonNull(whenParameter, "whenParameter");
+        return whenExpression.apply(expression);
+    }
+}
+
+class ParameterDataFlowNode extends DataFlowNode {
+    private final Parameter parameter;
+    ParameterDataFlowNode(Cursor cursor, Parameter parameter) {
+        super(cursor);
+        this.parameter = requireNonNull(parameter, "parameter");
+    }
+
+    @Override
+    Optional<Expression> asExpression() {
+        return Optional.empty();
+    }
+
+    @Override
+    Optional<Parameter> asParameter() {
+        return Optional.of(parameter);
+    }
+
+    @Override
+    <T> T map(Function<Expression, T> whenExpression, Function<Parameter, T> whenParameter) {
+        requireNonNull(whenExpression, "whenExpression");
+        requireNonNull(whenParameter, "whenParameter");
+        return whenParameter.apply(parameter);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Element.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+public interface Element extends Top {
+    String getName();
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Top.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Top.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait;
+
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Top is the root of the trait type hierarchy; it defines some default
+ * methods for equality.
+ */
+public interface Top {
+    /**
+     * @return An identifier that can be used to uniquely identify this element. Used for equality checking.
+     */
+    UUID getId();
+
+    static boolean equals(Top e1, @Nullable Object other) {
+        if (e1 == other) return true;
+        if (other == null || e1.getClass() != other.getClass()) return false;
+        Top e2 = (Top) other;
+        return e1.getId().equals(e2.getId());
+    }
+
+    static int hashCode(Top e) {
+        return 41 * e.getId().hashCode();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/TraitFactory.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/TraitFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
 
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+public interface TraitFactory <T extends Top> {
+    Validation<TraitErrors, T> viewOf(Cursor cursor);
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/Expr.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/Expr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait.expr;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import org.openrewrite.java.trait.Top;
 
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+/** A common super-class that represents all kinds of expressions. */
+public interface Expr extends Top {
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/InstanceAccess.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/InstanceAccess.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.expr;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.util.Either;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.tree.J;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A use of one of the keywords `this` or `super`, which may be qualified.
+ */
+public interface InstanceAccess extends Expr {
+
+    /**
+     * True if this instance access gets the value of `this`. That is, it is not
+     * an enclosing instance.
+     * This is never true for accesses in lambda expressions as they cannot access
+     * their own instance directly.
+     */
+    boolean isOwnInstanceAccess();
+
+    enum Factory implements TraitFactory<InstanceAccess> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, InstanceAccess> viewOf(Cursor cursor) {
+            return ThisAccess.viewOf(cursor)
+                    .map(t -> (InstanceAccess) t)
+                    .f()
+                    .bind(thisFail -> SuperAccess.viewOf(cursor)
+                            .map(s -> (InstanceAccess) s)
+                            .f()
+                            .bind(superFail -> Validation.fail(TraitErrors.semigroup.sum(thisFail, superFail))));
+        }
+    }
+
+    static Validation<TraitErrors, InstanceAccess> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+}
+
+@AllArgsConstructor
+class InstanceAccessBase implements InstanceAccess {
+    final Cursor cursor;
+    /**
+     * Either a {@link J.Identifier} or a {@link J.FieldAccess} representing the instance access.
+     */
+    final Either<J.Identifier, J.FieldAccess> expression;
+
+    @Override
+    public UUID getId() {
+        return expression.either(
+                J.Identifier::getId,
+                J.FieldAccess::getId
+        );
+    }
+
+    public String getName() {
+        return expression.either(
+                J.Identifier::getSimpleName,
+                fa -> fa.getName().getSimpleName()
+        );
+    }
+
+    @Override
+    public boolean isOwnInstanceAccess() {
+        // TODO: Implement this
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    static Validation<TraitErrors, InstanceAccessBase> viewOf(Cursor cursor) {
+        Objects.requireNonNull(cursor, "cursor must not be null");
+        Object maybeTree = cursor.getValue();
+        if (maybeTree instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) maybeTree;
+            if ("this".equals(fieldAccess.getName().getSimpleName()) || "super".equals(fieldAccess.getName().getSimpleName())) {
+                return Validation.success(new InstanceAccessBase(cursor, Either.right(fieldAccess)));
+            }
+        } else if (maybeTree instanceof J.Identifier) {
+            J.Identifier identifier = (J.Identifier) maybeTree;
+            if ("this".equals(identifier.getSimpleName()) || "super".equals(identifier.getSimpleName())) {
+                return Validation.success(new InstanceAccessBase(cursor, Either.left(identifier)));
+            }
+        }
+        return TraitErrors.invalidTraitCreationType(InstanceAccess.class, cursor, J.Identifier.class, J.FieldAccess.class);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/SuperAccess.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/SuperAccess.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.expr;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.Delegate;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+
+/**
+ * A use of the keyword `super`, which may be qualified.
+ * <p/>
+ * Such an expression allows access to super-class members of an enclosing instance.
+ * For example, `A.super.x`.
+ */
+public interface SuperAccess extends InstanceAccess {
+    enum Factory implements TraitFactory<SuperAccess> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, SuperAccess> viewOf(Cursor cursor) {
+            return InstanceAccessBase.viewOf(cursor)
+                    .bind(iab -> {
+                        if ("super".equals(iab.getName())) {
+                            return Validation.success(new SuperAccessBase(iab));
+                        } else {
+                            return TraitErrors.invalidTraitCreationError("Instance Access is not a Super Access");
+                        }
+                    });
+        }
+    }
+
+    static Validation<TraitErrors, SuperAccess> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+}
+
+@AllArgsConstructor
+class SuperAccessBase implements SuperAccess {
+    @Delegate
+    private final InstanceAccessBase delegate;
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/ThisAccess.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/ThisAccess.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.expr;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.Delegate;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.trait.Top;
+
+/**
+ * A use of the keyword `this`, which may be qualified.
+ * <p/>
+ * Such an expression allows access to an enclosing instance.
+ * For example, `A.this` refers to the enclosing instance
+ * of type `A`.
+ */
+public interface ThisAccess extends InstanceAccess {
+    enum Factory implements TraitFactory<ThisAccess> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, ThisAccess> viewOf(Cursor cursor) {
+            return InstanceAccessBase.viewOf(cursor)
+                    .bind(iab -> {
+                        if ("super".equals(iab.getName())) {
+                            return Validation.success(new ThisAccessBase(iab));
+                        } else {
+                            return TraitErrors.invalidTraitCreationError("Instance Access is not a This Access");
+                        }
+                    });
+        }
+    }
+
+    static Validation<TraitErrors, ThisAccess> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+}
+
+@AllArgsConstructor
+class ThisAccessBase implements ThisAccess {
+    @Delegate
+    private final InstanceAccessBase delegate;
+
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/VarAccess.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/VarAccess.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.expr;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.openrewrite.Cursor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.internal.MaybeParenthesesPair;
+import org.openrewrite.java.trait.member.FieldDeclaration;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.trait.variable.Field;
+import org.openrewrite.java.trait.variable.Variable;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+public interface VarAccess extends Expr {
+
+    String getName();
+
+    /** Gets the variable accessed by this variable access. */
+    Variable getVariable();
+
+
+    boolean hasQualifier();
+
+    Optional<Expr> getQualifier();
+
+    /**
+     * True if this access refers to a local variable or a field of
+     * the receiver of the enclosing method or constructor.
+     */
+    boolean isLocal();
+
+    /**
+     * Holds if this variable access is an l-value.
+     * </p>
+     * An l-value is a write access to a variable, which occurs as the destination of an assignment.
+     */
+    boolean isLValue();
+
+    /**
+     * Holds if this variable access is an r-value.
+     * </p>
+     * An r-value is a read access to a variable.
+     * In other words, it is a variable access that does _not_ occur as the destination of
+     * a simple assignment, but it may occur as the destination of a compound assignment
+     * or a unary assignment.
+     */
+    boolean isRValue();
+
+    enum Factory implements TraitFactory<VarAccess> {
+        F;
+        @Override
+        public Validation<TraitErrors, VarAccess> viewOf(Cursor cursor) {
+            if (cursor.getValue() instanceof J.Identifier) {
+                J.Identifier ident = cursor.getValue();
+                return VarAccessBase.viewOf(cursor, ident);
+            }
+            return TraitErrors.invalidTraitCreationType(VarAccess.class, cursor, J.Identifier.class);
+        }
+    }
+
+    static Validation<TraitErrors, VarAccess> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+
+    /**
+     * Better to use {@link Variable#getVarAccesses()} as the correct 'scope' can be difficult to determine.
+     */
+    static Collection<VarAccess> findAllInScope(Cursor scope, Variable variable) {
+        List<VarAccess> varAccesses = new ArrayList<>();
+        new JavaVisitor<List<VarAccess>>() {
+            @Override
+            public J visitIdentifier(J.Identifier ident, List<VarAccess> varAccesses) {
+                Validation<TraitErrors, VarAccess> varAccess = VarAccess.viewOf(getCursor());
+                if (varAccess.map(v -> v.getVariable().equals(variable)).orSuccess(false)) {
+                    varAccesses.add(varAccess.success());
+                }
+                return ident;
+            }
+        }.visit(scope.getValue(), varAccesses, scope.getParentOrThrow());
+        return varAccesses;
+    }
+}
+
+@AllArgsConstructor
+class VarAccessBase implements VarAccess {
+    private final Cursor cursor;
+    private final J.Identifier identifier;
+    @Getter(lazy = true, onMethod =  @__(@Override))
+    private final Variable variable = computeVariable(this, cursor, identifier);
+
+    @Override
+    public UUID getId() {
+        return identifier.getId();
+    }
+
+    @Override
+    public String getName() {
+        return identifier.getSimpleName();
+    }
+
+    @Override
+    public boolean hasQualifier() {
+        return cursor.getParentTreeCursor().getValue() instanceof J.FieldAccess;
+    }
+
+    @Override
+    public Optional<Expr> getQualifier() {
+        return InstanceAccess.viewOf(cursor.getParentTreeCursor()).map(e -> (Expr) e).toOptional();
+    }
+
+    @Override
+    public boolean isLocal() {
+        return true;
+    }
+
+    @Override
+    public boolean isLValue() {
+        MaybeParenthesesPair pair = MaybeParenthesesPair.from(cursor);
+        if (pair.getParent() instanceof J.Assignment) {
+            J.Assignment assignment = (J.Assignment) pair.getParent();
+            return assignment.getVariable() == pair.getTree();
+        }
+        if (pair.getParent() instanceof J.Unary) {
+            J.Unary unary = (J.Unary) pair.getParent();
+            return unary.getExpression() == pair.getTree();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isRValue() {
+        MaybeParenthesesPair pair = MaybeParenthesesPair.from(cursor);
+        if (pair.getParent() instanceof J.Assignment) {
+            J.Assignment assignment = (J.Assignment) pair.getParent();
+            return assignment.getVariable() != pair.getTree();
+        }
+        return true ;
+    }
+
+    private static Variable computeVariable(VarAccessBase varAccess, Cursor cursor, J.Identifier varAccessIdent) {
+        Cursor compilationUnit = cursor.dropParentUntil(J.CompilationUnit.class::isInstance);
+        AtomicBoolean found = new AtomicBoolean(false);
+        Variable[] closestVariable = new Variable[1];
+        new JavaVisitor<AtomicBoolean>() {
+            @Override
+            public J visitVariable(J.VariableDeclarations.NamedVariable variable, AtomicBoolean atomicBoolean) {
+                if (atomicBoolean.get()) {
+                    // We've already found the variable, so we don't need to keep looking.
+                    return variable;
+                }
+                if (variable.getName().getSimpleName().equals(varAccessIdent.getSimpleName())) {
+                    assert varAccess.identifier.getFieldType() != null;
+                    assert varAccess.identifier.getFieldType().getOwner() != null;
+                    assert variable.getName().getFieldType() != null;
+                    if (varAccess.identifier.getFieldType().getOwner().equals(variable.getName().getFieldType().getOwner())) {
+                        closestVariable[0] = Variable.viewOf(getCursor()).orSuccess(TraitErrors::doThrow);
+                    }
+                }
+                return super.visitVariable(variable, atomicBoolean);
+            }
+
+            @Override
+            public J visitIdentifier(J.Identifier ident, AtomicBoolean atomicBoolean) {
+                if (ident == varAccessIdent) {
+                    atomicBoolean.set(true);
+                }
+                return ident;
+            }
+        }.visit(compilationUnit.getValue(), found, compilationUnit.getParentOrThrow());
+        if (closestVariable[0] != null) {
+            return closestVariable[0];
+        }
+        if (varAccessIdent.getFieldType() != null) {
+            return FieldFromJavaTypeVariable.create(varAccessIdent.getFieldType(), cursor);
+        }
+        throw new IllegalStateException("Unable to find variable for " + varAccessIdent.getSimpleName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    static Validation<TraitErrors, VarAccess> viewOf(Cursor cursor, J.Identifier ident) {
+        assert cursor.getValue() == ident;
+
+        if ("this".equals(ident.getSimpleName())) {
+            return TraitErrors.invalidTraitCreationError("`this` is not a variable access");
+        } else if ("super".equals(ident.getSimpleName())) {
+            return TraitErrors.invalidTraitCreationError("`super` is not a variable access");
+        }
+
+        Cursor parent = cursor.getParentTreeCursor();
+        if (checkType(parent, J.VariableDeclarations.NamedVariable.class, parentNamedVariable -> parentNamedVariable.getName() == ident)) {
+            // The identifier getFieldType will not be null in this case.
+            return TraitErrors.invalidTraitCreationError("J.Identifier on the name side of a variable declaration is not a variable access");
+        }
+
+        if (ident.getFieldType() != null) {
+            return Validation.success(new VarAccessBase(cursor, ident));
+        }
+
+        // If the identifier is a new class name, those are not variable accesses.
+        if (checkType(parent, J.NewClass.class, parentNewClass -> parentNewClass.getClazz() == ident)) {
+            assert ident.getFieldType() == null;
+            return TraitErrors.invalidTraitCreationError("J.Identifier within a new class statement is not a variable access");
+        }
+        if (checkType(parent, J.MethodInvocation.class, parentMethodInvocation -> parentMethodInvocation.getName() == ident)) {
+            assert ident.getFieldType() == null;
+            return TraitErrors.invalidTraitCreationError("J.Identifier within a method invocation name is not a variable access");
+        }
+        if (checkType(parent, J.MethodDeclaration.class, parentMethodDeclaration -> parentMethodDeclaration.getName() == ident)) {
+            assert ident.getFieldType() == null;
+            return TraitErrors.invalidTraitCreationError("J.Identifier within a method declaration name is not a variable access");
+        }
+
+        // Special case for type casts, where the identifier is the class part of the type cast.
+        if (checkType(parent, J.ControlParentheses.class, parentControlParentheses ->
+                parentControlParentheses.getTree() == ident &&
+                        checkType(parent.getParentTreeCursor(), J.TypeCast.class, parentParentTypeCast -> parentParentTypeCast.getClazz() == parentControlParentheses))) {
+            assert ident.getFieldType() == null;
+            return TraitErrors.invalidTraitCreationError("J.Identifier within a type cast class part is not a variable access");
+        }
+        // Special case for annotations, where the left side of the assignment is the annotation field name, and not a variable access.
+        if (checkType(parent, J.Assignment.class, parentAssignment ->
+                parentAssignment.getVariable() == ident &&
+                        checkType(parent.getParentTreeCursor(), J.Annotation.class, parentParentAnnotation -> parentParentAnnotation.getArguments() != null && parentParentAnnotation.getArguments().contains(parentAssignment)))) {
+            assert ident.getFieldType() == null;
+            return TraitErrors.invalidTraitCreationError("J.Identifier within an annotation argument's argument label is not a variable access");
+        }
+
+        boolean isParentFieldAccess = checkType(parent, J.FieldAccess.class, parentFieldAccess -> parentFieldAccess.getName() == ident);
+        boolean isParentMethodAccess = checkType(parent, J.MethodInvocation.class, parentMethodInvocation -> parentMethodInvocation.getSelect() == ident);
+        if (ident.getFieldType() != null && isParentFieldAccess) {
+            return Validation.success(new VarAccessBase(cursor, ident));
+        }
+
+        if (ident.getFieldType() == null && (isParentFieldAccess || isParentMethodAccess)) {
+            // This logic may also be reached when type information is missing.
+            // With type information missing, we can't determine the difference between `field.format()` and `String.format()` here.
+            // So we'll just assume it isn't a variable access.
+            return TraitErrors.invalidTraitCreationError("J.Identifier within a field access is not a variable access, or type information is missing.");
+        }
+
+        if (checkType(parent, J.MethodInvocation.class, parentMethodInvocation -> parentMethodInvocation.getSelect() == ident || parentMethodInvocation.getArguments().contains(ident)) ||
+                checkType(parent, J.NewClass.class, parentNewClass -> parentNewClass.getEnclosing() == ident || parentNewClass.getArguments().contains(ident)) ||
+                checkType(parent, J.Parentheses.class, parentParentheses -> parentParentheses.getTree() == ident) ||
+                checkType(parent, J.Unary.class, parentUnary -> parentUnary.getExpression() == ident) ||
+                checkType(parent, J.Binary.class, parentBinary -> parentBinary.getLeft() == ident || parentBinary.getRight() == ident) ||
+                checkType(parent, J.VariableDeclarations.NamedVariable.class, parentNamedVariable -> parentNamedVariable.getInitializer() == ident) ||
+                checkType(parent, J.Assignment.class, parentAssignment -> parentAssignment.getVariable() == ident || parentAssignment.getAssignment() == ident) ||
+                checkType(parent, J.TypeCast.class, parentTypeCast -> parentTypeCast.getExpression() == ident) ||
+                checkType(parent, J.ControlParentheses.class, parentControlParentheses -> parentControlParentheses.getTree() == ident) ||
+                checkType(parent, J.ForEachLoop.Control.class, parentForEachLoopControl -> parentForEachLoopControl.getIterable() == ident) ||
+                checkType(parent, J.ForLoop.Control.class, parentForLoopControl -> parentForLoopControl.getCondition() == ident) ||
+                checkType(parent, J.NewArray.class, parentNewArray -> parentNewArray.getInitializer() != null && parentNewArray.getInitializer().contains(ident)) ||
+                checkType(parent, J.ArrayDimension.class, parentArrayDimension -> parentArrayDimension.getIndex() == ident) ||
+                checkType(parent, J.ArrayAccess.class, parentArrayAccess -> parentArrayAccess.getIndexed() == ident) ||
+                checkType(parent, J.Ternary.class, parentTernary -> parentTernary.getCondition() == ident ||
+                        parentTernary.getTruePart() == ident ||
+                        parentTernary.getFalsePart() == ident) ||
+                checkType(parent, J.Annotation.class, parentAnnotation -> parentAnnotation.getArguments() != null && parentAnnotation.getArguments().contains(ident))) {
+            return Validation.success(new VarAccessBase(cursor, ident));
+        }
+
+        // Check if the ident appears within an import or package statement. Those are not variable accesses.
+        if (cursor.getPathAsStream(o -> o instanceof J.Import || o instanceof J.Package).findAny().isPresent()) {
+            assert ident.getFieldType() == null;
+            return TraitErrors.invalidTraitCreationError("J.Identifier within an import or package statement is not a variable access");
+        }
+
+        // Catch all. Useful point for setting a breakpoint when debugging.
+        assert ident.getFieldType() == null : "J.Identifier is not a variable access, but probably should be: " + ident;
+        return TraitErrors.invalidTraitCreationError("J.Identifier is not a variable access");
+    }
+
+    static <T> boolean checkType(Cursor parent, Class<T> tClass, Predicate<T> predicate) {
+        Object tree = parent.getValue();
+        if (tClass.isInstance(tree)) {
+            return predicate.test(tClass.cast(tree));
+        }
+        return false;
+    }
+}
+
+
+@AllArgsConstructor
+class FieldFromJavaTypeVariable implements Field {
+    JavaType.Variable variable;
+    Cursor compilationUnitCursor;
+
+    @Override
+    public String getName() {
+        return variable.getName();
+    }
+
+    @Override
+    public UUID getId() {
+        return UUID.nameUUIDFromBytes(variable.toString().getBytes());
+    }
+
+    @Override
+    public Optional<FieldDeclaration> getDeclaration() {
+        return Optional.empty();
+    }
+
+    @Override
+    public @Nullable JavaType getType() {
+        return variable.getType();
+    }
+
+    @Override
+    public Collection<VarAccess> getVarAccesses() {
+        return VarAccess.findAllInScope(compilationUnitCursor, this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    static Field create(JavaType.Variable variable, Cursor anyCursor) {
+        return new FieldFromJavaTypeVariable(variable, anyCursor.dropParentUntil(J.CompilationUnit.class::isInstance));
+    }
+}
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/expr/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+@Incubating(since = "7.41.0")
+@NonNullApi
+package org.openrewrite.java.trait.expr;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
-}
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/internal/MaybeParenthesesPair.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/internal/MaybeParenthesesPair.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.internal;
+
+import lombok.Value;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.J;
+
+import java.util.Iterator;
+
+@Value
+public class MaybeParenthesesPair {
+    /**
+     * Might be a {@link org.openrewrite.java.tree.J.Parentheses} if navigation up the tree was required.
+     */
+    Tree tree;
+    /**
+     * The direct parent in the cursor tree that is a {@link Tree}.
+     */
+    Tree parent;
+
+    public static MaybeParenthesesPair from(Cursor cursor) {
+        final Object initial = cursor.getValue();
+        if (!(initial instanceof Tree)) {
+            throw new IllegalArgumentException("Cursor value must be a Tree");
+        }
+        Tree tree = cursor.getValue();
+        Tree parent;
+        Iterator<Object> treeIterable = cursor.getPath(it -> it instanceof Tree && it != initial);
+        if (treeIterable.hasNext()) {
+            parent = (Tree) treeIterable.next();
+        } else {
+            throw new IllegalArgumentException("Cursor must have a parent");
+        }
+        while (parent instanceof J.Parentheses && treeIterable.hasNext()) {
+            tree = parent;
+            parent = (Tree) treeIterable.next();
+        }
+        return new MaybeParenthesesPair(tree, parent);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/internal/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+@Incubating(since = "7.41.0")
+@NonNullApi
+package org.openrewrite.java.trait.internal;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
-}
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/Callable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/Callable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.trait.Element;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.trait.variable.Parameter;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * A method or constructor.
+ */
+public interface Callable extends Member {
+    @Nullable
+    JavaType getReturnType();
+
+    List<Parameter> getParameters();
+}
+
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/FieldDeclaration.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/FieldDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait.member;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+/** A field declaration that declares one or more class or instance fields. */
+public interface FieldDeclaration {
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/InitializerMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/InitializerMethod.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.member;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.trait.variable.Parameter;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * A compiler-generated initializer method (could be static or
+ * non-static), which is used to hold (static or non-static) field
+ * initializers, as well as explicit initializer blocks.
+ */
+public interface InitializerMethod extends Callable {
+
+    @Override
+    default @Nullable JavaType getReturnType() {
+        return JavaType.Primitive.Void;
+    }
+
+    /**
+     * Initializer methods have no parameters.
+     */
+    @Override
+    default List<Parameter> getParameters() {
+        return Collections.emptyList();
+    }
+}
+
+@AllArgsConstructor
+abstract class InitializerMethodBase implements InitializerMethod {
+    /**
+     * IMPORTANT: This cursor points to the {@link J.Block} that is the body of the class, NOT the initializer block.
+     * This is because the static/object initializer block may not be explicitly declared, and so the cursor would be null.
+     */
+    private final Cursor cursor;
+
+    @Override
+    public UUID getId() {
+        return cursor.<Tree>getValue().getId();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    static <V extends InitializerMethodBase> Validation<TraitErrors, V> genericViewOf(Cursor cursor, Function<Cursor, V> initializer, Class<V> clazz) {
+        Objects.requireNonNull(cursor, "cursor must not be null");
+        if (cursor.getValue() instanceof J.Block) {
+            Cursor parent = cursor.getParentTreeCursor();
+            if (parent.getValue() instanceof J.ClassDeclaration) {
+                J.ClassDeclaration classDecl = parent.getValue();
+                if (classDecl.getBody() != null && classDecl.getBody() == cursor.getValue()) {
+                    return Validation.success(initializer.apply(cursor));
+                }
+            }
+        }
+        return TraitErrors.invalidTraitCreationType(clazz, cursor, J.Block.class);
+    }
+}
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/InstanceInitializer.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/InstanceInitializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.member;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+
+/**
+ * An instance initializer is a method that contains field initializations
+ * and explicit instance initializer blocks.
+ */
+public class InstanceInitializer extends InitializerMethodBase {
+    InstanceInitializer(Cursor cursor) {
+        super(cursor);
+    }
+
+    @Override
+    public String getName() {
+        return "<obinit>";
+    }
+
+    public static Validation<TraitErrors, InstanceInitializer> viewOf(Cursor cursor) {
+        return InitializerMethodBase.genericViewOf(cursor, InstanceInitializer::new, InstanceInitializer.class);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/Member.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/Member.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait.member;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import org.openrewrite.java.trait.Element;
 
 /**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
+ * A common abstraction for type member declarations,
+ * including methods, constructors, fields, and nested types.
  */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+public interface Member extends Element {
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/Method.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/Method.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.trait.Element;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.trait.variable.Parameter;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.*;
+
+/** A method is a particular kind of callable. */
+public interface Method extends Callable {
+
+    static Validation<TraitErrors, Method> viewOf(Cursor cursor) {
+        if (cursor.getValue() instanceof J.MethodDeclaration) {
+            return Validation.success(new MethodDeclarationMethod(
+                    cursor,
+                    cursor.getValue()
+            ));
+        }
+        return TraitErrors.invalidTraitCreationType(Callable.class, cursor, J.MethodDeclaration.class);
+    }
+
+}
+@AllArgsConstructor
+class MethodDeclarationMethod implements Method {
+    Cursor cursor;
+
+    J.MethodDeclaration methodDeclaration;
+
+    @Getter(lazy = true, onMethod = @__(@Override))
+    private final List<Parameter> parameters = collectParameters(cursor, methodDeclaration);
+
+    @Override
+    public String getName() {
+        return methodDeclaration.getSimpleName();
+    }
+
+    @Override
+    public JavaType getReturnType() {
+        if (methodDeclaration.getReturnTypeExpression() == null) {
+            return JavaType.Primitive.Void;
+        }
+        return methodDeclaration.getReturnTypeExpression().getType();
+    }
+
+    @Override
+    public UUID getId() {
+        return methodDeclaration.getId();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    private static List<Parameter> collectParameters(Cursor cursor, J.MethodDeclaration methodDeclaration) {
+        assert cursor.getValue() == methodDeclaration;
+        List<Parameter> parameters = new ArrayList<>(methodDeclaration.getParameters().size());
+        new JavaVisitor<List<Parameter>>() {
+            {
+                // Correctly set the parent cursor for the parameters
+                setCursor(cursor);
+            }
+
+            @Override
+            public J visitVariable(J.VariableDeclarations.NamedVariable variable, List<Parameter> parameters) {
+                parameters.add(Parameter.viewOf(getCursor()).orSuccess(TraitErrors::doThrow));
+                return variable;
+            }
+        }.visit(methodDeclaration.getParameters(), parameters);
+        return Collections.unmodifiableList(parameters);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/StaticInitializerMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/StaticInitializerMethod.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.member;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+
+/**
+ * A static initializer is a method that contains all static
+ * field initializations and static initializer blocks.
+ */
+public class StaticInitializerMethod extends InitializerMethodBase {
+    private StaticInitializerMethod(Cursor cursor) {
+        super(cursor);
+    }
+
+    @Override
+    public String getName() {
+        return "<clinit>";
+    }
+
+    public static Validation<TraitErrors, StaticInitializerMethod> viewOf(Cursor cursor) {
+        return InitializerMethodBase.genericViewOf(cursor, StaticInitializerMethod::new, StaticInitializerMethod.class);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/member/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/member/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+@Incubating(since = "7.41.0")
+@NonNullApi
+package org.openrewrite.java.trait.member;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
-}
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Traits represent higher-level abstractions of Java syntax that are useful for writing recipes.
+ * </p>
+ * They offer APIs that allow users to write recipes that are more concise and easier to understand by offering
+ * APIs that hide the details of the underlying {@link org.openrewrite.Cursor} navigation.
+ * </p>
+ * The traits are modeled after CodeQL's representation of the Java syntax and the queries and predicates it provides.
+ */
+@Incubating(since = "7.41.0")
+@NonNullApi
+package org.openrewrite.java.trait;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/Either.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/Either.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.util;
+
+import java.util.function.Function;
+
+/**
+ * The <code>Either</code> type represents a value of one of two possible types (a disjoint union).
+ * The data constructors; <code>Left</code> and <code>Right</code> represent the two possible
+ * values. The <code>Either</code> type is often used as an alternative to
+ * <code>scala.Option</code> where <code>Left</code> represents failure (by convention) and
+ * <code>Right</code> is akin to <code>Some</code>.
+ *
+ * @version %build.number%
+ */
+public abstract class Either<A, B> {
+    private Either() {
+
+    }
+
+    /**
+     * Returns <code>true</code> if this either is a left, <code>false</code> otherwise.
+     *
+     * @return <code>true</code> if this either is a left, <code>false</code> otherwise.
+     */
+    public abstract boolean isLeft();
+
+    /**
+     * Returns <code>true</code> if this either is a right, <code>false</code> otherwise.
+     *
+     * @return <code>true</code> if this either is a right, <code>false</code> otherwise.
+     */
+    public abstract boolean isRight();
+
+    /**
+     * The catamorphism for either. Folds over this either breaking into left or right.
+     *
+     * @param left  The function to call if this is left.
+     * @param right The function to call if this is right.
+     * @return The reduced value.
+     */
+    public abstract <X> X either(final Function<A, X> left, final Function<B, X> right);
+
+    /**
+     * If this is a left, then return the left value in right, or vice versa.
+     *
+     * @return The value of this either swapped to the opposing side.
+     */
+    public final Either<B, A> swap() {
+        return either(right_(), left_());
+    }
+
+    private static final class Left<A, B> extends Either<A, B> {
+        private final A a;
+
+        Left(final A a) {
+            this.a = a;
+        }
+
+        public boolean isLeft() {
+            return true;
+        }
+
+        public boolean isRight() {
+            return false;
+        }
+
+        @Override
+        public <X> X either(Function<A, X> left, Function<B, X> right) {
+            return left.apply(a);
+        }
+    }
+
+    private static final class Right<A, B> extends Either<A, B> {
+        private final B b;
+
+        Right(final B b) {
+            this.b = b;
+        }
+
+        public boolean isLeft() {
+            return false;
+        }
+
+        public boolean isRight() {
+            return true;
+        }
+
+        @Override
+        public <X> X either(Function<A, X> left, Function<B, X> right) {
+            return right.apply(b);
+        }
+    }
+
+
+    /**
+     * Construct a left value of either.
+     *
+     * @param a The value underlying the either.
+     * @return A left value of either.
+     */
+    public static <A, B> Either<A, B> left(final A a) {
+        return new Left<>(a);
+    }
+
+    /**
+     * A function that constructs a left value of either.
+     *
+     * @return A function that constructs a left value of either.
+     */
+    public static <A, B> Function<A, Either<A, B>> left_() {
+        return Either::left;
+    }
+
+    /**
+     * A function that constructs a right value of either.
+     *
+     * @return A function that constructs a right value of either.
+     */
+    public static <A, B> Function<B, Either<A, B>> right_() {
+        return Either::right;
+    }
+
+    /**
+     * Construct a right value of either.
+     *
+     * @param b The value underlying the either.
+     * @return A right value of either.
+     */
+    public static <A, B> Either<A, B> right(final B b) {
+        return new Right<>(b);
+    }
+
+}
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/Semigroup.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/Semigroup.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.util;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Implementations must satisfy the law of associativity:
+ * <ul>
+ * <li><em>Associativity</em>; forall x. forall y. forall z. sum(sum(x, y), z) == sum(x, sum(y, z))</li>
+ * </ul>
+ */
+public final class Semigroup<A> {
+
+    /**
+     * Primitives functions of Semigroup: minimal definition and overridable methods.
+     */
+    public interface Definition<A> {
+
+        A append(A a1, A a2);
+
+        default Function<A, A> prepend(A a) {
+            return a2 -> append(a, a2);
+        }
+
+        default A multiply1p(int n, A a) {
+            if (n <= 0) {
+                return a;
+            }
+
+            A xTmp = a;
+            int yTmp = n;
+            A zTmp = a;
+            while (true) {
+                if ((yTmp & 1) == 1) {
+                    zTmp = append(xTmp, zTmp);
+                    if (yTmp == 1) {
+                        return zTmp;
+                    }
+                }
+                xTmp = append(xTmp, xTmp);
+                yTmp = (yTmp) >>> 1;
+            }
+        }
+
+        default Definition<A> dual() {
+            return new Definition<A>() {
+
+                @Override
+                public A append(A a1, A a2) {
+                    return Definition.this.append(a2, a1);
+                }
+
+                @Override
+                public A multiply1p(int n, A a) {
+                    return Definition.this.multiply1p(n, a);
+                }
+            };
+        }
+    }
+
+    /**
+     * Primitives functions of Semigroup: alternative minimal definition and overridable methods.
+     */
+    public interface AltDefinition<A> extends Definition<A> {
+        @Override
+        Function<A, A> prepend(A a);
+
+        @Override
+        default A append(A a1, A a2) {
+            return prepend(a1).apply(a2);
+        }
+    }
+
+    private final Definition<A> def;
+
+    private Semigroup(final Definition<A> def) {
+        this.def = def;
+    }
+
+    /**
+     * Sums the two given arguments.
+     *
+     * @param a1 A value to sum with another.
+     * @param a2 A value to sum with another.
+     * @return The of the two given arguments.
+     */
+    public A sum(final A a1, final A a2) {
+        return def.append(a1, a2);
+    }
+
+    /**
+     * Returns a function that sums the given value according to this semigroup.
+     *
+     * @param a1 The value to sum.
+     * @return A function that sums the given value according to this semigroup.
+     */
+    public Function<A, A> sum(final A a1) {
+        return def.prepend(a1);
+    }
+
+    /**
+     * Returns a function that sums according to this semigroup.
+     *
+     * @return A function that sums according to this semigroup.
+     */
+    public Function<A, Function<A, A>> sum() {
+        return def::prepend;
+    }
+
+    /**
+     * Returns a value summed <code>n + 1</code> times (
+     * <code>a + a + ... + a</code>) The default definition uses peasant
+     * multiplication, exploiting associativity to only require {@code O(log n)} uses of
+     * {@link #sum(Object, Object)}.
+     *
+     * @param n multiplier
+     * @param a the value to be reapeatly summed n + 1 times
+     * @return {@code a} summed {@code n} times. If {@code n <= 0}, returns
+     * {@code zero()}
+     */
+    public A multiply1p(int n, A a) {
+        return def.multiply1p(n, a);
+    }
+
+    public <B, C> Semigroup<C> compose(Semigroup<B> sb, final Function<C, B> b, final Function<C, A> a, final BiFunction<A, B, C> c) {
+        Definition<A> saDef = this.def;
+        Definition<B> sbDef = sb.def;
+        return semigroupDef(new Definition<C>() {
+
+            @Override
+            public C append(C c1, C c2) {
+                return c.apply(saDef.append(a.apply(c1), a.apply(c2)), sbDef.append(b.apply(c1), b.apply(c2)));
+            }
+
+            @Override
+            public Function<C, C> prepend(C c1) {
+                Function<A, A> prependA = saDef.prepend(a.apply(c1));
+                Function<B, B> prependB = sbDef.prepend(b.apply(c1));
+                return c2 -> c.apply(prependA.apply(a.apply(c2)), prependB.apply(b.apply(c2)));
+            }
+
+            @Override
+            public C multiply1p(int n, C c1) {
+                return c.apply(saDef.multiply1p(n, a.apply(c1)), sbDef.multiply1p(n, b.apply(c1)));
+            }
+        });
+    }
+
+    /**
+     * Constructs a semigroup from the given definition.
+     *
+     * @param def The definition to construct this semigroup with.
+     * @return A semigroup from the given definition.
+     */
+    public static <A> Semigroup<A> semigroupDef(final Definition<A> def) {
+        return new Semigroup<>(def);
+    }
+
+    /**
+     * Constructs a semigroup from the given definition.
+     *
+     * @param def The definition to construct this semigroup with.
+     * @return A semigroup from the given definition.
+     */
+    public static <A> Semigroup<A> semigroupDef(final AltDefinition<A> def) {
+        return new Semigroup<>(def);
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/TraitError.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/TraitError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait.util;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
 
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+@Value
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class TraitError {
+    String error;
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/TraitErrors.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/TraitErrors.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.util;
+
+import org.openrewrite.Cursor;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Immutable
+public final class TraitErrors implements Iterable<TraitError> {
+    private final List<TraitError> errors;
+
+    private TraitErrors(List<TraitError> errors) {
+        // Defensive copy
+        this.errors =
+                Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(errors, "errors cannot be null")));
+    }
+
+    @Override
+    public Iterator<TraitError> iterator() {
+        return errors.iterator();
+    }
+
+    public <V> V doThrow() {
+        throw new TraitErrorsException(this);
+    }
+
+    public String toString() {
+        return "TraitErrors: " + errors.stream()
+                .map(TraitError::getError)
+                .collect(Collectors.joining("\n\t- ", "\n\t- ", ""));
+    }
+
+    public static TraitErrors fromSingle(TraitError error) {
+        return new TraitErrors(Collections.singletonList(error));
+    }
+
+    public static TraitErrors fromSingleError(String error) {
+        return fromSingle(new TraitError(error));
+    }
+
+    public static <V> Validation<TraitErrors, V> invalidTraitCreationError(String error) {
+        return Validation.fail(TraitErrors.fromSingleError(error));
+    }
+
+    public static <V> Validation<TraitErrors, V> invalidTraitCreationType(Class<?> traitType, Cursor cursor, Class<?> expectedType) {
+        return Validation.fail(TraitErrors.fromSingleError(
+                traitType.getSimpleName() + " must be created from " + expectedType + " but was " + cursor.getValue().getClass()
+        ));
+    }
+
+    public static <V> Validation<TraitErrors, V> invalidTraitCreationType(Class<?> traitType, Cursor cursor, Class<?> expectedTypeFirst, Class<?> expectedTypeSecond) {
+        return Validation.fail(TraitErrors.fromSingleError(
+                traitType.getSimpleName() + " must be created from " + expectedTypeFirst + " or " + expectedTypeSecond + " but was " + cursor.getValue().getClass()
+        ));
+    }
+
+    public static Semigroup<TraitErrors> semigroup = Semigroup.semigroupDef((a, b) -> new TraitErrors(
+            Stream.concat(a.errors.stream(), b.errors.stream()).collect(Collectors.toList())
+    ));
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/TraitErrorsException.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/TraitErrorsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+package org.openrewrite.java.trait.util;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
+class TraitErrorsException extends RuntimeException {
+    TraitErrorsException(TraitErrors traitErrors) {
+        super(traitErrors.toString());
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/Validation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/Validation.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * @param <E> Failing type
+ * @param <V> Success type
+ */
+@Immutable
+public interface Validation<E, V> {
+    /**
+     * @return true if the validation is invalid, false otherwise
+     */
+    default boolean isFail() {
+        return !isSuccess();
+    }
+
+    /**
+     * @return true if the validation is successful, false otherwise
+     */
+    boolean isSuccess();
+
+    /**
+     * @return the failure if the validation is invalid, or an exception if the validation is valid
+     */
+    E fail();
+
+    /**
+     * @return the value if the validation is valid, or an exception if the validation is invalid
+     */
+    V success();
+
+    /**
+     * The catamorphism for validation. Folds over this validation breaking into left or right.
+     *
+     * @param fail    The function to call if this failed.
+     * @param success The function to call if this succeeded.
+     * @return The reduced value.
+     */
+    <X> X validation(final Function<E, X> fail, final Function<V, X> success);
+
+    /**
+     * Returns a failing projection of this validation.
+     *
+     * @return a failing projection of this validation.
+     */
+    default FailProjection<E, V> f() {
+        return new FailProjection<>(this);
+    }
+
+    default V orSuccess(V defaultValue) {
+        return isSuccess() ? success() : defaultValue;
+    }
+
+    default V orSuccess(Function<E, V> f) {
+        Objects.requireNonNull(f, "f cannot be null");
+        return isSuccess() ? success() : f.apply(fail());
+    }
+
+    default <A> Validation<E, A> map(Function<V, A> f) {
+        Objects.requireNonNull(f, "f cannot be null");
+        return isFail() ? fail(fail()) : success(f.apply(success()));
+    }
+
+    default <A> Validation<E, A> bind(Function<V, Validation<E, A>> f) {
+        Objects.requireNonNull(f, "f cannot be null");
+        return isSuccess() ? f.apply(success()) : fail(fail());
+    }
+
+    default <A> Validation<E, A> apply(final Validation<E, Function<V, A>> v) {
+        Objects.requireNonNull(v, "v cannot be null");
+        return v.bind(this::map);
+    }
+
+    default Optional<V> toOptional() {
+        return isSuccess() ? Optional.of(success()) : Optional.empty();
+    }
+
+    /**
+     * Function application on the successful side of this validation, or accumulating the errors on the failing side
+     * using the given semigroup should one or more be encountered.
+     *
+     * @param s The semigroup to accumulate errors with if
+     * @param v The validating function to apply.
+     * @return A failing validation if this or the given validation failed (with errors accumulated if both) or a
+     *         succeeding validation if both succeeded.
+     */
+    default <A> Validation<E, A> accumapply(final Semigroup<E> s, final Validation<E, Function<V, A>> v) {
+        return isFail() ?
+                Validation.fail(v.isFail() ?
+                        s.sum(v.fail(), fail()) :
+                        fail()) :
+                v.isFail() ?
+                        Validation.fail(v.fail()) :
+                        Validation.success(v.success().apply(success()));
+    }
+
+    /**
+     * Accumulates errors on the failing side of this or any given validation if one or more are encountered, or applies
+     * the given function if all succeeded and returns that value on the successful side.
+     *
+     * @param s  The semigroup to accumulate errors with if one or more validations fail.
+     * @param va The second validation to accumulate errors with if it failed.
+     * @param f  The function to apply if all validations have succeeded.
+     * @return A succeeding validation if all validations succeeded, or a failing validation with errors accumulated if
+     *         one or more failed.
+     */
+    default <A, B> Validation<E, B> accumulate(final Semigroup<E> s, final Validation<E, A> va, final Function<V, Function<A, B>> f) {
+        return va.accumapply(s, map(f));
+    }
+
+    static <E, V> Validation<E, V> success(V value) {
+        return new ValidationSuccess<>(value);
+    }
+
+    static <E, V> Validation<E, V> fail(E error) {
+        return new ValidationFail<>(error);
+    }
+
+    /**
+     * A failing projection of a validation.
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class FailProjection<E, T> {
+        private final Validation<E, T> v;
+        /**
+         * Returns the underlying validation.
+         *
+         * @return The underlying validation.
+         */
+        public Validation<E, T> validation() {
+            return v;
+        }
+
+        /**
+         * Returns the failing value or the given value.
+         *
+         * @param e The value to return if this is success.
+         * @return The failing value or the given value.
+         */
+        public E orFail(final Supplier<E> e) {
+            return v.isFail() ? v.fail() : e.get();
+        }
+
+        /**
+         * Returns the failing value or the given value.
+         *
+         * @param e The value to return if this is success.
+         * @return The failing value or the given value.
+         */
+        public E orFail(final E e) {
+            return orFail(() ->e);
+        }
+
+        /**
+         * The failing value or the application of the given function to the success value.
+         *
+         * @param f The function to execute on the success value.
+         * @return The failing value or the application of the given function to the success value.
+         */
+        public E on(final Function<T, E> f) {
+            return v.isFail() ? v.fail() : f.apply(v.success());
+        }
+
+        /**
+         * Maps the given function across the failing side of this validation.
+         *
+         * @param f The function to map.
+         * @return A new validation with the function mapped.
+         */
+        public <A> Validation<A, T> map(final Function<E, A> f) {
+            Objects.requireNonNull(f, "f cannot be null");
+            return v.isFail() ? Validation.fail(f.apply(v.fail())) : Validation.success(v.success());
+        }
+
+        /**
+         * Binds the given function across this validation's failing value if it has one.
+         *
+         * @param f The function to bind across this validation.
+         * @return A new validation value after binding.
+         */
+        public <A> Validation<A, T> bind(final Function<E, Validation<A, T>> f) {
+            return v.isFail() ? f.apply(v.fail()) : Validation.success(v.success());
+        }
+
+        /**
+         * Performs a bind across the validation, but ignores the element value in the function.
+         *
+         * @param v The validation value to apply in the final join.
+         * @return A new validation value after the final join.
+         */
+        public <A> Validation<A, T> sequence(final Validation<A, T> v) {
+            return bind(e1 -> v);
+        }
+
+
+        /**
+         * Function application on the failing value.
+         *
+         * @param v The validation of the function to apply on the failing value.
+         * @return The result of function application in validation.
+         */
+        public <A> Validation<A, T> apply(final Validation<Function<E, A>, T> v) {
+            return v.f().bind(this::map);
+        }
+
+    }
+
+}
+
+@ToString
+@EqualsAndHashCode
+final class ValidationSuccess<E, V> implements Validation<E, V> {
+    private final V value;
+
+    ValidationSuccess(V value) {
+        this.value = Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return true;
+    }
+
+    @Override
+    public E fail() {
+        throw new IllegalStateException("Cannot fail a successful validation");
+    }
+
+    @Override
+    public V success() {
+        return value;
+    }
+
+    @Override
+    public <X> X validation(Function<E, X> fail, Function<V, X> success) {
+        Objects.requireNonNull(fail, "fail cannot be null");
+        Objects.requireNonNull(success, "success cannot be null");
+        return success.apply(value);
+    }
+}
+
+@ToString
+@EqualsAndHashCode
+final class ValidationFail<E, V> implements Validation<E, V> {
+    private final E error;
+
+    ValidationFail(E error) {
+        this.error = Objects.requireNonNull(error, "error cannot be null");
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return false;
+    }
+
+    @Override
+    public E fail() {
+        return error;
+    }
+
+    @Override
+    public V success() {
+        throw new IllegalStateException("Cannot get the success value of a failed validation");
+    }
+
+    @Override
+    public <X> X validation(Function<E, X> fail, Function<V, X> success) {
+        Objects.requireNonNull(fail, "fail cannot be null");
+        Objects.requireNonNull(success, "success cannot be null");
+        return fail.apply(error);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/util/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+@Incubating(since = "7.41.0")
+@NonNullApi
+package org.openrewrite.java.trait.util;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
-}
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/Field.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/Field.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.trait.Element;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.expr.VarAccess;
+import org.openrewrite.java.trait.member.FieldDeclaration;
+import org.openrewrite.java.trait.member.Member;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * A class or instance field.
+ */
+public interface Field extends Member, Variable {
+    /**
+     * Gets the field declaration in which this field is declared.
+     * <p/>
+     * Note that this declaration is only available if the field occurs in source code.
+     */
+    Optional<FieldDeclaration> getDeclaration();
+
+    enum Factory implements TraitFactory<Field> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, Field> viewOf(Cursor cursor) {
+            if (cursor.getValue() instanceof J.VariableDeclarations.NamedVariable) {
+                Cursor maybeVariableDecl = cursor.getParentTreeCursor();
+                Cursor maybeBlock = maybeVariableDecl.getParentTreeCursor();
+                Cursor maybeClassDecl = maybeBlock.getParentTreeCursor();
+                if (maybeClassDecl.getValue() instanceof J.ClassDeclaration || maybeClassDecl.getValue() instanceof J.NewClass) {
+                    return Validation.success(new FieldFromCursor(cursor, cursor.getValue(), maybeBlock));
+                }
+                return TraitErrors.invalidTraitCreationError("Field must be declared in a class, interface, or anonymous class");
+            }
+            return TraitErrors.invalidTraitCreationType(Field.class, cursor, J.VariableDeclarations.NamedVariable.class);
+        }
+    }
+
+    static Validation<TraitErrors, Field> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+}
+
+@AllArgsConstructor
+class FieldFromCursor implements Field {
+    Cursor cursor;
+    J.VariableDeclarations.NamedVariable variable;
+    Cursor parentBlock;
+
+    @Override
+    public String getName() {
+        return variable.getSimpleName();
+    }
+
+    @Override
+    public UUID getId() {
+        return variable.getId();
+    }
+
+    @Override
+    public Optional<FieldDeclaration> getDeclaration() {
+        return Optional.empty();
+    }
+
+    @Override
+    public @Nullable JavaType getType() {
+        return variable.getType();
+    }
+
+    @Override
+    public Collection<VarAccess> getVarAccesses() {
+        // Searching starts at the J.CompilationUnit because we want to find all references to this field, within the file,
+        // not just within the class (which may contain multiple classes).
+        Cursor searchScope = parentBlock.dropParentUntil(J.CompilationUnit.class::isInstance);
+        return VarAccess.findAllInScope(searchScope, this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/LocalScopeVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/LocalScopeVariable.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.member.Callable;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+
+/** A locally scoped variable, that is, either a local variable or a parameter. */
+public interface LocalScopeVariable extends Variable {
+    Callable getCallable();
+
+    enum Factory implements TraitFactory<LocalScopeVariable> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, LocalScopeVariable> viewOf(Cursor cursor) {
+            Validation<TraitErrors, LocalScopeVariable> parameter = Parameter.viewOf(cursor).map(p -> p);
+            return parameter.f().bind(parameterFail -> {
+                Validation<TraitErrors, LocalScopeVariable> localVariableDecl = LocalVariableDecl.viewOf(cursor).map(l -> l);
+                return localVariableDecl.f().bind(localVariableDeclFail -> Validation.fail(TraitErrors.semigroup.sum(
+                        parameterFail,
+                        localVariableDeclFail
+                )));
+            });
+        }
+    }
+
+    static Validation<TraitErrors, LocalScopeVariable> viewOf(Cursor cursor) {
+        return LocalScopeVariable.Factory.F.viewOf(cursor);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/LocalVariableDecl.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/LocalVariableDecl.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.expr.VarAccess;
+import org.openrewrite.java.trait.member.Callable;
+import org.openrewrite.java.trait.member.InstanceInitializer;
+import org.openrewrite.java.trait.member.Method;
+import org.openrewrite.java.trait.member.StaticInitializerMethod;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.UUID;
+
+/**
+ * A local variable declaration
+ */
+public interface LocalVariableDecl extends LocalScopeVariable {
+
+    enum Factory implements TraitFactory<LocalVariableDecl> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, LocalVariableDecl> viewOf(Cursor cursor) {
+            if (cursor.getValue() instanceof J.VariableDeclarations.NamedVariable) {
+                return LocalVariableDeclBase.findNearestParentCallable(cursor)
+                        .map(callable -> new LocalVariableDeclBase(cursor, cursor.getValue(), callable));
+            }
+            return TraitErrors.invalidTraitCreationType(LocalVariableDecl.class, cursor, J.VariableDeclarations.class);
+        }
+    }
+
+    static Validation<TraitErrors, LocalVariableDecl> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+}
+
+@AllArgsConstructor
+class LocalVariableDeclBase implements LocalVariableDecl {
+    final Cursor cursor;
+    final J.VariableDeclarations.NamedVariable variable;
+    @Getter(onMethod = @__(@Override))
+    final Callable callable;
+
+    @Override
+    public String getName() {
+        return variable.getSimpleName();
+    }
+
+    @Override
+    public UUID getId() {
+        return variable.getId();
+    }
+
+    @Override
+    public @Nullable JavaType getType() {
+        return variable.getType();
+    }
+
+    @Override
+    public Collection<VarAccess> getVarAccesses() {
+        return VarAccess.findAllInScope(cursor.dropParentUntil(J.CompilationUnit.class::isInstance), this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    static Validation<TraitErrors, Callable> findNearestParentCallable(Cursor cursor) {
+        Iterator<Cursor> path = cursor.getPathAsCursors(c -> c.getValue() instanceof J);
+        Cursor previous = null;
+        while (path.hasNext()) {
+            Cursor c = path.next();
+            Tree t = c.getValue();
+            if (t instanceof J.ClassDeclaration || t instanceof J.NewClass) {
+                break;
+            }
+            if (t instanceof J.Block && J.Block.isStaticOrInitBlock(c)) {
+                J.Block block = (J.Block) t;
+                if (block.isStatic()) {
+                    return StaticInitializerMethod.viewOf(c.getParentTreeCursor()).map(m -> m);
+                } else {
+                    return InstanceInitializer.viewOf(c.getParentTreeCursor()).map(m -> m);
+                }
+            }
+            if (t instanceof J.MethodDeclaration) {
+                J.MethodDeclaration m = (J.MethodDeclaration) t;
+                assert previous != null : "previous should not be null";
+                if (m.getParameters().contains(previous.<Statement>getValue())) {
+                    break;
+                }
+            }
+            Validation<TraitErrors, Method> v = Method.viewOf(c);
+            if (v.isSuccess()) {
+                return v.map(m -> m);
+            }
+            previous = c;
+        }
+        return TraitErrors.invalidTraitCreationError("No parent Method found");
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/Parameter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/Parameter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+import org.openrewrite.Cursor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.trait.Top;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.expr.VarAccess;
+import org.openrewrite.java.trait.member.Callable;
+import org.openrewrite.java.trait.member.Method;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.*;
+
+/**
+ * Represents a parameter in a {@link org.openrewrite.java.tree.J.MethodDeclaration} or
+ * {@link org.openrewrite.java.tree.J.NewClass}.
+ */
+public interface Parameter extends LocalScopeVariable {
+
+    /**
+     * The zero indexed position of the parameter in the method declaration.
+     */
+    int getPosition();
+
+    boolean isVarArgs();
+
+    enum Factory implements TraitFactory<Parameter> {
+        F;
+        @Override
+        public Validation<TraitErrors, Parameter> viewOf(Cursor c) {
+            if (c.getValue() instanceof J.VariableDeclarations.NamedVariable) {
+                Cursor variableDeclarationsCursor = c.getParentTreeCursor();
+                Cursor methodDeclarationCursor = variableDeclarationsCursor.getParentTreeCursor();
+                return Method.viewOf(methodDeclarationCursor).map(callable ->  new ParameterBase(
+                        c,
+                        c.getValue(),
+                        callable,
+                        methodDeclarationCursor,
+                        methodDeclarationCursor.getValue()
+                ));
+            }
+            return TraitErrors.invalidTraitCreationType(Parameter.class, c, J.VariableDeclarations.NamedVariable.class);
+        }
+    }
+
+    static Validation<TraitErrors, Parameter> viewOf(Cursor c) {
+        return Factory.F.viewOf(c);
+    }
+}
+
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+class ParameterBase implements Parameter {
+    Cursor cursor;
+    J.VariableDeclarations.NamedVariable namedVariable;
+    @Getter(onMethod = @__(@Override))
+    Callable callable;
+    Cursor methodDeclarationCursor;
+    J.MethodDeclaration methodDeclaration;
+
+    @Override
+    public UUID getId() {
+        return namedVariable.getId();
+    }
+
+    @Override
+    public String getName() {
+        return namedVariable.getSimpleName();
+    }
+
+    @Override
+    public int getPosition() {
+        return callable.getParameters().indexOf(this);
+    }
+
+    @Override
+    public boolean isVarArgs() {
+        if (this.namedVariable.getVariableType() == null) {
+            throw new IllegalStateException("Variable type is null for " + this.namedVariable);
+        }
+        return this.namedVariable.getVariableType().hasFlags(Flag.Varargs);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Top.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Top.hashCode(this);
+    }
+
+    @Override
+    public JavaType getType() {
+        return namedVariable.getType();
+    }
+
+    @Override
+    public Collection<VarAccess> getVarAccesses() {
+        if (methodDeclaration.getBody() == null) {
+            return Collections.emptySet();
+        }
+        return VarAccess.findAllInScope(new Cursor(methodDeclarationCursor, methodDeclaration.getBody()), this);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/Variable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/Variable.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.trait.variable;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.trait.Element;
+import org.openrewrite.java.trait.TraitFactory;
+import org.openrewrite.java.trait.expr.VarAccess;
+import org.openrewrite.java.trait.util.TraitErrors;
+import org.openrewrite.java.trait.util.Validation;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.Collection;
+
+/**
+ * A variable is a field, a local variable or a parameter.
+ */
+public interface Variable extends Element {
+
+    @Nullable
+    JavaType getType();
+
+    /**
+     * Gets all access to this variable.
+     */
+    Collection<VarAccess> getVarAccesses();
+
+    enum Factory implements TraitFactory<Variable> {
+        F;
+
+        @Override
+        public Validation<TraitErrors, Variable> viewOf(Cursor cursor) {
+            Validation<TraitErrors, Variable> localScopeVariable = LocalScopeVariable.viewOf(cursor).map(l -> l);
+            return localScopeVariable.f().bind(localScopeVariableFail -> {
+                Validation<TraitErrors, Variable> field = Field.viewOf(cursor).map(f -> f);
+                return field.f().bind(fieldFail -> Validation.fail(TraitErrors.semigroup.sum(
+                        localScopeVariableFail,
+                        fieldFail
+                )));
+            });
+
+        }
+    }
+
+    static Validation<TraitErrors, Variable> viewOf(Cursor cursor) {
+        return Factory.F.viewOf(cursor);
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/variable/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite;
+@Incubating(since = "7.41.0")
+@NonNullApi
+package org.openrewrite.java.trait.variable;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-/**
- * This is a feature that is experimental and may yield a breaking change in a minor release.
- */
-@Documented
-@Target({ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
-public @interface Incubating {
-    String since();
-}
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2585,22 +2585,22 @@ public interface J extends Tree {
 
         @Nullable
         public J.Identifier getAlias() {
-            if(alias == null) {
+            if (alias == null) {
                 return null;
             }
             return alias.getElement();
         }
 
         public J.Import withAlias(@Nullable J.Identifier alias) {
-            if(this.alias == null) {
-                if(alias == null) {
+            if (this.alias == null) {
+                if (alias == null) {
                     return this;
                 }
                 return new J.Import(null, id, prefix, markers, statik, qualid, JLeftPadded
                         .build(alias)
                         .withBefore(Space.format(" ")));
             }
-            if(alias == null) {
+            if (alias == null) {
                 return new J.Import(null, id, prefix, markers, statik, qualid, null);
             }
             return getPadding().withAlias(this.alias.withElement(alias));
@@ -2665,7 +2665,7 @@ public interface J extends Tree {
                 String name = part.getSimpleName();
                 if (part.getTarget() instanceof J.Identifier) {
                     typeName.insert(0, ((Identifier) part.getTarget()).getSimpleName() +
-                                       "." + name);
+                            "." + name);
                     break;
                 } else {
                     part = (FieldAccess) part.getTarget();
@@ -3387,6 +3387,9 @@ public interface J extends Tree {
             return getAnnotations().withName(this.name.withIdentifier(name));
         }
 
+        /**
+         * Can be either a list of {@link VariableDeclarations}, when there are no parameters, a single {@link J.Empty}.
+         */
         JContainer<Statement> parameters;
 
         public List<Statement> getParameters() {
@@ -3395,6 +3398,20 @@ public interface J extends Tree {
 
         public MethodDeclaration withParameters(List<Statement> parameters) {
             return getPadding().withParameters(JContainer.withElements(this.parameters, parameters));
+        }
+
+        public List<VariableDeclarations> getParametersAsVariableDeclarations() {
+            List<VariableDeclarations> declarations = new ArrayList<>(getParameters().size());
+            for (Statement parameter : getParameters()) {
+                if (parameter instanceof VariableDeclarations) {
+                    declarations.add((VariableDeclarations) parameter);
+                } else if (parameter instanceof J.Empty) {
+                    // ignore
+                } else {
+                    throw new IllegalStateException("Unexpected parameter type: " + parameter.getClass());
+                }
+            }
+            return declarations;
         }
 
         @Nullable
@@ -3499,8 +3516,8 @@ public interface J extends Tree {
         @Override
         public String toString() {
             return "MethodDeclaration{" +
-                   (getMethodType() == null ? "unknown" : getMethodType()) +
-                   "}";
+                    (getMethodType() == null ? "unknown" : getMethodType()) +
+                    "}";
         }
 
         @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)


### PR DESCRIPTION
This AST allows API users to ask higher-level questions of the AST
without requiring custom cursor traversal and visitors.

Questions like:
 - What parameter index is this `J.VariableDeclarations.NamedVariable`?
 - What callable is this `Parameter` a part of?

Future questions that could be asked are things like:
 - Is this parameter effectively final?
 - Where is this parameter read from?

The model for the traits matches, as closely as possible, CodeQL's

From the documentation:

```java
/**
 * Traits represent higher-level abstractions of Java syntax that are useful for writing recipes.
 * </p>
 * They offer APIs that allow users to write recipes that are more concise and easier to understand by offering
 * APIs that hide the details of the underlying {@link org.openrewrite.Cursor} navigation.
 * </p>
 * The traits are modeled after CodeQL's representation of the Java syntax and the queries and predicates it provides.
 */
```
