### PR TITLE
Fix templating in presence of nested enums

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -881,4 +881,49 @@ class JavaTemplateTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void nestedEnums() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitBinary(J.Binary binary, ExecutionContext p) {
+                  return binary.withTemplate(JavaTemplate.builder(this::getCursor, "\"ab\"").build(),
+                      binary.getCoordinates().replace());
+              }
+          })),
+          java(
+            """
+              enum Outer {
+                  A, B;
+
+                  enum Inner {
+                      C, D
+                  }
+
+                  private final String s;
+
+                  Outer() {
+                      s = "a" + "b";
+                  }
+              }
+              """,
+            """
+              enum Outer {
+                  A, B;
+
+                  enum Inner {
+                      C, D
+                  }
+
+                  private final String s;
+
+                  Outer() {
+                      s = "ab";
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDuplicateStringLiterals.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceDuplicateStringLiterals.java
@@ -113,7 +113,7 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                             continue;
                         }
                         J.Literal replaceLiteral = ((J.Literal) duplicateLiteralsMap.get(valueOfLiteral).toArray()[0]).withId(Tree.randomId());
-                        String insertStatement = "private static final String " + variableName + " = #{any(String)}";
+                        String insertStatement = "private static final String " + variableName + " = #{any(String)};";
                         if (classDecl.getKind() == J.ClassDeclaration.Kind.Type.Enum) {
                             J.EnumValueSet enumValueSet = classDecl.getBody().getStatements().stream()
                                     .filter(it -> it instanceof J.EnumValueSet)


### PR DESCRIPTION
Simplifies the logic in `BlockStatementTemplateGenerator` for the generation of nested types, which had a problem with nested enums.
