### PR TITLE
Add new `contributors` resource type

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeContributionDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeContributionDescriptor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.config;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class RecipeContributionDescriptor {
+
+    String name;
+    List<RecipeContributor> contributors;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeContributor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeContributor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.config;
+
+import lombok.Value;
+
+@Value
+public class RecipeContributor {
+
+    String name;
+    String email;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
@@ -19,7 +19,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
 import org.openrewrite.Maintainer;
-import org.openrewrite.Recipe;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.net.URI;
@@ -55,6 +54,9 @@ public class RecipeDescriptor {
     List<DataTableDescriptor> dataTables;
 
     List<Maintainer> maintainers;
+
+    @With
+    List<RecipeContributor> contributors;
 
     URI source;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -73,7 +73,8 @@ public class YamlResourceLoader implements ResourceLoader {
         Recipe("specs.openrewrite.org/v1beta/recipe"),
         Style("specs.openrewrite.org/v1beta/style"),
         Category("specs.openrewrite.org/v1beta/category"),
-        Example("specs.openrewrite.org/v1beta/example");
+        Example("specs.openrewrite.org/v1beta/example"),
+        Contributors("specs.openrewrite.org/v1beta/contributors");
 
         private final String spec;
 
@@ -213,7 +214,7 @@ public class YamlResourceLoader implements ResourceLoader {
 
             List<Object> rawMaintainers = (List<Object>) r.getOrDefault("maintainers", emptyList());
             List<Maintainer> maintainers;
-            if(rawMaintainers.isEmpty()) {
+            if (rawMaintainers.isEmpty()) {
                 maintainers = emptyList();
             } else {
                 maintainers = new ArrayList<>(rawMaintainers.size());
@@ -438,4 +439,39 @@ public class YamlResourceLoader implements ResourceLoader {
                         (String) c.get("after"))
                 ).collect(toList());
     }
+
+    public Collection<RecipeContributionDescriptor> listRecipeContributionDescriptors() {
+        Collection<Map<String, Object>> resources = loadResources(ResourceType.Contributors);
+        List<RecipeContributionDescriptor> contributions = new ArrayList<>(resources.size());
+        for (Map<String, Object> r : resources) {
+            if (!r.containsKey("name")) {
+                continue;
+            }
+
+            String name = (String) r.get("name");
+
+            @SuppressWarnings("unchecked")
+            List<Object> rawContributors = (List<Object>) r.getOrDefault("contributors", emptyList());
+            List<RecipeContributor> contributors;
+            if (rawContributors.isEmpty()) {
+                contributors = emptyList();
+            } else {
+                contributors = new ArrayList<>(rawContributors.size());
+                for (Object rawContributor : rawContributors) {
+                    if (rawContributor instanceof Map) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> contributorMap = (Map<String, Object>) rawContributor;
+                        String contributorName = (String) contributorMap.get("name");
+                        String contributorEmail = (String) contributorMap.get("email");
+                        contributors.add(new RecipeContributor(contributorName, contributorEmail));
+                    }
+                }
+            }
+
+            contributions.add(new RecipeContributionDescriptor(name, contributors));
+        }
+
+        return contributions;
+    }
+
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
@@ -97,10 +97,11 @@ public class RecipeIntrospectionUtils {
         for (Recipe childRecipe : recipe.getRecipeList()) {
             recipeList.add(recipeDescriptorFromRecipe(childRecipe));
         }
+
         //noinspection deprecation
         return new RecipeDescriptor(recipe.getName(), recipe.getDisplayName(), recipe.getDescription(),
                 recipe.getTags(), recipe.getEstimatedEffortPerOccurrence(),
-                emptyList(), recipe.getLanguages(), recipeList, recipe.getDataTableDescriptors(), recipe.getMaintainers(), source);
+                emptyList(), recipe.getLanguages(), recipeList, recipe.getDataTableDescriptors(), recipe.getMaintainers(), emptyList(), source);
     }
 
     public static Constructor<?> getPrimaryConstructor(Class<?> recipeClass) {
@@ -149,7 +150,7 @@ public class RecipeIntrospectionUtils {
         //noinspection deprecation
         return new RecipeDescriptor(recipe.getName(), recipe.getDisplayName(),
                 recipe.getDescription(), recipe.getTags(), recipe.getEstimatedEffortPerOccurrence(),
-                options, recipe.getLanguages(), recipeList, recipe.getDataTableDescriptors(), recipe.getMaintainers(), recipeSource);
+                options, recipe.getLanguages(), recipeList, recipe.getDataTableDescriptors(), recipe.getMaintainers(), emptyList(), recipeSource);
     }
 
     public static Recipe constructRecipe(Class<?> recipeClass) {

--- a/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
@@ -114,7 +114,7 @@ class CategoryTreeTest {
     private static RecipeDescriptor recipeDescriptor(String packageName) {
         return new RecipeDescriptor(packageName + ".MyRecipe",
           "My recipe", "", emptySet(), null, emptyList(),
-          emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"));
+          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"));
     }
 
     @Test

--- a/rewrite-test/src/test/resources/META-INF/rewrite/contributors.yml
+++ b/rewrite-test/src/test/resources/META-INF/rewrite/contributors.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/contributors
+name: org.openrewrite.text.ChangeTextToJon
+contributors:
+  - name: Foo Bar
+    email: foo@bar.com
+  - name: Baz Qux
+    email: baz@qux.com
+---
+type: specs.openrewrite.org/v1beta/contributors
+name: org.openrewrite.text.HelloKotlin
+contributors:
+  - name: Nobody
+    email: not@here.com
+---
+type: specs.openrewrite.org/v1beta/contributors
+name: org.openrewrite.HelloJon
+contributors:
+  - name: Foo Bar
+    email: foo@bar.com


### PR DESCRIPTION
Introduces a new YAML resource type `specs.openrewrite.org/v1beta/contributors` which contains information regarding recipe contributors. These resources get loaded through the `ClasspathScanningLoader` and are used to augment the `RecipeDescriptor`s which get created for declarative and imperative recipes.
