### PR TITLE
Do not rely on Path.toUri().getPath()

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserInputFileObject.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserInputFileObject.java
@@ -112,8 +112,7 @@ public class ReloadableJava11ParserInputFileObject implements JavaFileObject {
     public boolean isNameCompatible(String simpleName, Kind kind) {
         String baseName = simpleName + kind.extension;
         return kind.equals(getKind())
-                && (baseName.equals(toUri().getPath())
-                || toUri().getPath().endsWith("/" + baseName));
+                && path.getFileName().toString().equals(baseName);
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserInputFileObject.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserInputFileObject.java
@@ -112,8 +112,7 @@ public class ReloadableJava17ParserInputFileObject implements JavaFileObject {
     public boolean isNameCompatible(String simpleName, Kind kind) {
         String baseName = simpleName + kind.extension;
         return kind.equals(getKind())
-                && (baseName.equals(toUri().getPath())
-                || toUri().getPath().endsWith("/" + baseName));
+                && path.getFileName().toString().equals(baseName);
     }
 
     @Override

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/Java8ParserInputFileObject.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/Java8ParserInputFileObject.java
@@ -111,8 +111,7 @@ public class Java8ParserInputFileObject implements JavaFileObject {
     public boolean isNameCompatible(String simpleName, Kind kind) {
         String baseName = simpleName + kind.extension;
         return kind.equals(getKind())
-                && (baseName.equals(toUri().getPath())
-                || toUri().getPath().endsWith("/" + baseName));
+                && path.getFileName().toString().equals(baseName);
     }
 
     @Override


### PR DESCRIPTION
Change `*ParserInputFileObject` classes to use `Path.getFileName()` instead of `Path.toUri().getPath()`.

The `*ParserInputFileObject` classes use `Path.toUri().getPath()` to check the last element of a path. This is both awkward and not guaranteed to work on non-default file systems. [Path#toUri](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Path.html#toUri()) makes no guarantees about the return value of `URI#getPath()` of the returned object. This breaks on the JAR file system and others. `Path.getFileName()` is a better option.

See also https://github.com/marschall/memoryfilesystem/issues/141