### PR TITLE
Generify `Validated` to `Validated<T>`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -427,8 +426,8 @@ public abstract class Recipe implements Cloneable {
         return recipeScheduler.scheduleRun(this, before, ctx, maxCycles, minCycles);
     }
 
-    public Validated validate(ExecutionContext ctx) {
-        Validated validated = validate();
+    public Validated<Object> validate(ExecutionContext ctx) {
+        Validated<Object> validated = validate();
 
         for (Recipe recipe : recipeList) {
             validated = validated.and(recipe.validate(ctx));
@@ -443,8 +442,8 @@ public abstract class Recipe implements Cloneable {
      *
      * @return A validated instance based using non-null/nullable annotations to determine which fields of the recipe are required.
      */
-    public Validated validate() {
-        Validated validated = Validated.none();
+    public Validated<Object> validate() {
+        Validated<Object> validated = Validated.none();
         List<Field> requiredFields = NullUtils.findNonNullFields(this.getClass());
         for (Field field : requiredFields) {
             try {

--- a/rewrite-core/src/main/java/org/openrewrite/ValidationException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ValidationException.java
@@ -35,14 +35,14 @@ public class ValidationException extends RuntimeException {
 
     private URI source;
 
-    public ValidationException(Validated validation) {
+    public ValidationException(Validated<?> validation) {
         this(validation, null);
     }
 
-    public ValidationException(Validated validation, @Nullable URI source) {
+    public ValidationException(Validated<?> validation, @Nullable URI source) {
         super(validation.failures().stream()
                 .map(invalid -> invalid.getProperty() + " was '" +
-                        (invalid.getValue() == null ? "null" : invalid.getValue()) +
+                        (invalid.getInvalidValue() == null ? "null" : invalid.getInvalidValue()) +
                         "' but it " + invalid.getMessage())
                 .collect(Collectors.joining(
                         "\n",

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeNamedStyles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeNamedStyles.java
@@ -26,18 +26,18 @@ import java.util.UUID;
 
 public class DeclarativeNamedStyles extends NamedStyles {
     @JsonIgnore
-    private Validated validation = Validated.none();
+    private Validated<Object> validation = Validated.none();
 
     public DeclarativeNamedStyles(UUID id, String name, String displayName, String description, Set<String> tags, Collection<Style> styles) {
         super(id, name, displayName, description, tags, styles);
     }
 
-    void addValidation(Validated validated) {
+    void addValidation(Validated<Object> validated) {
         validation = validation.and(validated);
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return validation;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -64,7 +64,7 @@ public class DeclarativeRecipe extends CompositeRecipe {
     private final List<Maintainer> maintainers;
 
     @JsonIgnore
-    private Validated validation = Validated.test("initialization",
+    private Validated<Object> validation = Validated.test("initialization",
             "initialize(..) must be called on DeclarativeRecipe prior to use.",
             this, r -> uninitializedRecipes.isEmpty());
 
@@ -136,12 +136,12 @@ public class DeclarativeRecipe extends CompositeRecipe {
         }
     }
 
-    public void addValidation(Validated validated) {
+    public void addValidation(Validated<Object> validated) {
         validation = validation.and(validated);
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return validation;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/CaretRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/CaretRange.java
@@ -46,7 +46,7 @@ public class CaretRange extends LatestRelease {
                 super.compare(currentVersion, version, lower) >= 0;
     }
 
-    public static Validated build(String pattern, @Nullable String metadataPattern) {
+    public static Validated<CaretRange> build(String pattern, @Nullable String metadataPattern) {
         Matcher matcher = CARET_RANGE_PATTERN.matcher(pattern);
         if (!matcher.matches()) {
             return Validated.invalid("caretRange", pattern, "not a caret range");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/DependencyMatcher.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/DependencyMatcher.java
@@ -47,7 +47,7 @@ public class DependencyMatcher {
         this.versionComparator = versionComparator;
     }
 
-    public static Validated build(String pattern) {
+    public static Validated<DependencyMatcher> build(String pattern) {
         String[] patternPieces = pattern.split(":");
         if(patternPieces.length < 2) {
             return Validated.invalid("pattern", pattern, "missing required components. Must specify at least groupId:artifactId");
@@ -57,7 +57,7 @@ public class DependencyMatcher {
         if(patternPieces.length < 3) {
             return Validated.valid("pattern", new DependencyMatcher(patternPieces[0], patternPieces[1], null));
         }
-        Validated validatedVersion;
+        Validated<? extends VersionComparator> validatedVersion;
 
         if (patternPieces[2].contains("/")) {
             String[] versionPieces = patternPieces[2].split("/");
@@ -69,7 +69,7 @@ public class DependencyMatcher {
             validatedVersion = Semver.validate(patternPieces[2], null);
         }
         if(validatedVersion.isInvalid()) {
-            return validatedVersion;
+            return validatedVersion.asInvalid();
         }
         return Validated.valid("pattern", new DependencyMatcher(patternPieces[0], patternPieces[1], validatedVersion.getValue()));
     }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/ExactVersion.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/ExactVersion.java
@@ -31,7 +31,7 @@ public class ExactVersion extends LatestRelease {
         return this.version.equals(version);
     }
 
-    public static Validated build(String pattern) {
+    public static Validated<ExactVersion> build(String pattern) {
         String versionOnly;
         int hyphenIndex = pattern.indexOf('-');
         if(hyphenIndex == -1) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/HyphenRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/HyphenRange.java
@@ -43,7 +43,7 @@ public class HyphenRange extends LatestRelease {
                 super.compare(currentVersion, version, lower) >= 0;
     }
 
-    public static Validated build(String pattern, @Nullable String metadataPattern) {
+    public static Validated<HyphenRange> build(String pattern, @Nullable String metadataPattern) {
         Matcher matcher = HYPHEN_RANGE_PATTERN.matcher(pattern);
         if (!matcher.matches()) {
             return Validated.invalid("hyphenRange", pattern, "not a hyphen range");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestPatch.java
@@ -26,8 +26,8 @@ public class LatestPatch implements VersionComparator {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        Validated validated = currentVersion == null ?
-                LatestRelease.build("latest.release", metadataPattern) :
+        Validated<? extends VersionComparator> validated = currentVersion == null ?
+                LatestRelease.buildLatestRelease("latest.release", metadataPattern) :
                 TildeRange.build("~" + Semver.majorVersion(currentVersion) + "." + Semver.minorVersion(currentVersion), metadataPattern);
 
         if (validated.isValid()) {
@@ -52,7 +52,7 @@ public class LatestPatch implements VersionComparator {
                 .compare(currentVersion, v1, v2);
     }
 
-    public static Validated build(String toVersion, @Nullable String metadataPattern) {
+    public static Validated<LatestPatch> build(String toVersion, @Nullable String metadataPattern) {
         return "latest.patch".equalsIgnoreCase(toVersion) ?
                 Validated.valid("latestPatch", new LatestPatch(metadataPattern)) :
                 Validated.invalid("latestPatch", toVersion, "not latest release");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -138,7 +138,7 @@ public class LatestRelease implements VersionComparator {
         return normalized1.compareTo(normalized2);
     }
 
-    public static Validated build(String toVersion, @Nullable String metadataPattern) {
+    public static Validated<LatestRelease> buildLatestRelease(String toVersion, @Nullable String metadataPattern) {
         return "latest.release".equalsIgnoreCase(toVersion) ?
                 Validated.valid("latestRelease", new LatestRelease(metadataPattern)) :
                 Validated.invalid("latestRelease", toVersion, "not latest release");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -23,14 +23,12 @@ import org.openrewrite.internal.lang.Nullable;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
-import static org.openrewrite.Validated.test;
-
 public class Semver {
     private Semver() {
     }
 
-    public static Validated validate(String toVersion, @Nullable String metadataPattern) {
-        return test(
+    public static Validated<VersionComparator> validate(String toVersion, @Nullable String metadataPattern) {
+        return Validated.<VersionComparator, String>testNone(
                 "metadataPattern",
                 "must be a valid regular expression",
                 metadataPattern, metadata -> {
@@ -43,7 +41,8 @@ public class Semver {
                         return false;
                     }
                 }
-        ).and(LatestRelease.build(toVersion, metadataPattern)
+        ).and(Validated.<VersionComparator>none()
+                .or(LatestRelease.buildLatestRelease(toVersion, metadataPattern))
                 .or(LatestPatch.build(toVersion, metadataPattern))
                 .or(HyphenRange.build(toVersion, metadataPattern))
                 .or(XRange.build(toVersion, metadataPattern))

--- a/rewrite-core/src/main/java/org/openrewrite/semver/SetRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/SetRange.java
@@ -47,7 +47,7 @@ public class SetRange extends LatestRelease {
 
     }
 
-    public static Validated build(String pattern, @Nullable String metadataPattern) {
+    public static Validated<SetRange> build(String pattern, @Nullable String metadataPattern) {
         Matcher matcher = SET_RANGE_PATTERN.matcher(pattern);
         if (!matcher.matches()) {
             return Validated.invalid("setRange", pattern, "not a set range");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
@@ -46,7 +46,7 @@ public class TildeRange extends LatestRelease {
                 super.compare(currentVersion, version, lower) >= 0;
     }
 
-    public static Validated build(String pattern, @Nullable String metadataPattern) {
+    public static Validated<TildeRange> build(String pattern, @Nullable String metadataPattern) {
         Matcher matcher = TILDE_RANGE_PATTERN.matcher(pattern);
         if (!matcher.matches()) {
             return Validated.invalid("tildeRange", pattern, "not a tilde range");

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -74,7 +74,7 @@ public class XRange extends LatestRelease {
         return gav.group(4) == null || !gav.group(4).equals(micro);
     }
 
-    public static Validated build(String pattern, @Nullable String metadataPattern) {
+    public static Validated<XRange> build(String pattern, @Nullable String metadataPattern) {
         Matcher matcher = X_RANGE_PATTERN.matcher(pattern);
         if (!matcher.matches() || !(pattern.contains("x") || pattern.contains("X") || pattern.contains("*"))) {
             return Validated.invalid("xRange", pattern, "not an x-range");

--- a/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
@@ -99,7 +99,7 @@ public class NamedStyles implements Marker {
                 mergedStyles);
     }
 
-    public Validated validate() {
+    public Validated<Object> validate() {
         return Validated.none();
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -112,8 +112,8 @@ public class AddDependency extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (version != null) {
             validated = validated.or(Semver.validate(version, versionPattern));
         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
@@ -72,7 +72,7 @@ public class AddDependencyVisitor extends GroovyIsoVisitor<ExecutionContext> {
             }
         }
 
-        Validated versionValidation = Semver.validate(version, versionPattern);
+        Validated<VersionComparator> versionValidation = Semver.validate(version, versionPattern);
         if (versionValidation.isValid()) {
             @Nullable VersionComparator versionComparator = versionValidation.getValue();
         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.toolingapi.OpenRewriteModelBuilder;
 import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.groovy.GroovyParser;
 import org.openrewrite.groovy.tree.G;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.OperatingSystemProvenance;
 import org.openrewrite.properties.tree.Properties;
@@ -48,7 +47,6 @@ import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.properties.Assertions.properties;
-import static org.openrewrite.test.SourceSpecs.*;
 
 public class Assertions {
 
@@ -82,7 +80,7 @@ public class Assertions {
                     }
 
                     if (version != null) {
-                        GradleWrapper gradleWrapper = requireNonNull(GradleWrapper.validate(new InMemoryExecutionContext(), version, distribution, null, null).getValue());
+                        GradleWrapper gradleWrapper = requireNonNull(GradleWrapper.validate(new InMemoryExecutionContext(), version, distribution, null).getValue());
                         Files.createDirectories(projectDir.resolve("gradle/wrapper/"));
                         Files.write(projectDir.resolve(GradleWrapper.WRAPPER_PROPERTIES_LOCATION), ("distributionBase=GRADLE_USER_HOME\n" +
                                 "distributionPath=wrapper/dists\n" +

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
@@ -76,7 +76,7 @@ public class ChangeDependencyArtifactId extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(DependencyMatcher.build(groupId + ":" + artifactId));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
@@ -75,7 +75,7 @@ public class ChangeDependencyClassifier extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(DependencyMatcher.build(groupId + ":" + artifactId));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyConfiguration.java
@@ -68,7 +68,7 @@ public class ChangeDependencyConfiguration extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(DependencyMatcher.build(groupId + ":" + artifactId));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyExtension.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyExtension.java
@@ -75,7 +75,7 @@ public class ChangeDependencyExtension extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(DependencyMatcher.build(groupId + ":" + artifactId));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
@@ -76,7 +76,7 @@ public class ChangeDependencyGroupId extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(DependencyMatcher.build(groupId + ":" + artifactId));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyVersion.java
@@ -79,7 +79,7 @@ public class ChangeDependencyVersion extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(DependencyMatcher.build(groupId + ":" + artifactId));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -16,11 +16,8 @@
 package org.openrewrite.gradle;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import lombok.experimental.NonFinal;
 import org.openrewrite.*;
 import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.internal.ListUtils;
@@ -43,9 +40,9 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.PathUtils.equalIgnoringSeparators;
 import static org.openrewrite.gradle.util.GradleWrapper.*;
+import static org.openrewrite.internal.StringUtils.isBlank;
 
 @Value
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 public class UpdateGradleWrapper extends Recipe {
 
@@ -74,12 +71,17 @@ public class UpdateGradleWrapper extends Recipe {
     @Nullable
     String distribution;
 
-    @NonFinal
-    Validated gradleWrapper;
+    private Validated<GradleWrapper> createGradleWrapperValidated(ExecutionContext ctx) {
+        return GradleWrapper.validate(ctx,
+                isBlank(version) ? "latest.release" : version,
+                distribution,
+                null
+        );
+    }
 
     @Override
-    public Validated validate(ExecutionContext ctx) {
-        return super.validate(ctx).and(GradleWrapper.validate(ctx, version, distribution, gradleWrapper, null));
+    public Validated<Object> validate(ExecutionContext ctx) {
+        return super.validate(ctx).and(createGradleWrapperValidated(ctx));
     }
 
     //NOTE: Using an explicit constructor here due to a bug that surfaces when running JavaDoc.
@@ -107,7 +109,7 @@ public class UpdateGradleWrapper extends Recipe {
                     return entry;
                 }
 
-                GradleWrapper gradleWrapper = requireNonNull(validate(context).getValue());
+                GradleWrapper gradleWrapper = requireNonNull(createGradleWrapperValidated(context).getValue());
 
                 // Typical example: https://services.gradle.org/distributions/gradle-7.4-all.zip
                 String currentDistributionUrl = entry.getValue().getText();
@@ -121,7 +123,7 @@ public class UpdateGradleWrapper extends Recipe {
 
     @Override
     protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
-        GradleWrapper gradleWrapper = validate(ctx).getValue();
+        GradleWrapper gradleWrapper = createGradleWrapperValidated(ctx).getValue();
         assert gradleWrapper != null;
 
         List<SourceFile> sourceFileList = ListUtils.map(before, sourceFile -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeLiteralDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeLiteralDependencyVersion.java
@@ -83,8 +83,8 @@ public class UpgradeLiteralDependencyVersion extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -71,7 +71,7 @@ public class UpgradePluginVersion extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Semver.validate(newVersion, versionPattern));
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/util/GradleWrapper.java
@@ -47,80 +47,53 @@ public class GradleWrapper {
     String version;
     DistributionInfos distributionInfos;
 
-    public static Validated validate(
+    public static Validated<GradleWrapper> validate(
             ExecutionContext ctx,
             String version,
             @Nullable String distribution,
-            @Nullable Validated cachedValidation,
-            @Nullable String repositoryUrl) {
-        if (cachedValidation != null) {
-            return cachedValidation;
-        }
+            @Nullable String repositoryUrl
+    ) {
         String distributionTypeName = distribution != null ? distribution : DistributionType.Bin.name().toLowerCase();
+        Validated<Object> validated =
+                Validated
+                        .testNone("distributionType", "must be a valid distribution type", distributionTypeName,
+                                dt -> Arrays.stream(DistributionType.values())
+                                        .anyMatch(type -> type.name().equalsIgnoreCase(dt)))
+                        .and(Semver.validate(version, null));
+        if (validated.isInvalid()) {
+            return validated.asInvalid();
+        }
         HttpSender httpSender = HttpSenderExecutionContextView.view(ctx).getHttpSender();
+        return Validated.lazy("", () -> create(distributionTypeName, version, repositoryUrl, httpSender));
+    }
 
-        //noinspection unchecked
-        return new Validated.Both(
-            Validated.test("distributionType", "must be a valid distribution type", distributionTypeName,
-                dt -> Arrays.stream(DistributionType.values())
-                    .anyMatch(type -> type.name().equalsIgnoreCase(dt))),
-            Semver.validate(version, null)
-        ) {
-            GradleWrapper wrapper;
+    private static GradleWrapper create(String distributionTypeName, String version, @Nullable String repositoryUrl, HttpSender httpSender) {
+        DistributionType distributionType = Arrays.stream(DistributionType.values())
+                .filter(dt -> dt.name().equalsIgnoreCase(distributionTypeName))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown distribution type " + distributionTypeName));
+        VersionComparator versionComparator = requireNonNull(Semver.validate(version, null).getValue());
 
-            @Override
-            public boolean isValid() {
-                if (!super.isValid()) {
-                    return false;
-                }
-                try {
-                    buildWrapper();
-                    return true;
-                } catch (Throwable t) {
-                    return false;
-                }
+        String gradleVersionsUrl = (repositoryUrl == null) ? "https://services.gradle.org/versions/all" : repositoryUrl;
+        try (HttpSender.Response resp = httpSender.send(httpSender.get(gradleVersionsUrl).build())) {
+            if (resp.isSuccessful()) {
+                List<GradleVersion> allVersions = new ObjectMapper()
+                        .registerModule(new ParameterNamesModule())
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .readValue(resp.getBody(), new TypeReference<List<GradleVersion>>() {
+                        });
+                GradleVersion gradleVersion = allVersions.stream()
+                        .filter(v -> versionComparator.isValid(null, v.version))
+                        .max((v1, v2) -> versionComparator.compare(null, v1.version, v2.version))
+                        .orElseThrow(() -> new IllegalStateException("Expected to find at least one Gradle wrapper version to select from."));
+
+                DistributionInfos infos = DistributionInfos.fetch(httpSender, distributionType, gradleVersion);
+                return new GradleWrapper(gradleVersion.version, infos);
             }
-
-            @Override
-            public GradleWrapper getValue() {
-                return buildWrapper();
-            }
-
-            private GradleWrapper buildWrapper() {
-                if (wrapper != null) {
-                    return wrapper;
-                }
-
-                DistributionType distributionType = Arrays.stream(DistributionType.values())
-                        .filter(dt -> dt.name().equalsIgnoreCase(distributionTypeName))
-                        .findAny()
-                        .orElseThrow(() -> new IllegalArgumentException("Unknown distribution type " + distributionTypeName));
-                VersionComparator versionComparator = requireNonNull(Semver.validate(version, null).getValue());
-
-                String gradleVersionsUrl = (repositoryUrl == null) ?  "https://services.gradle.org/versions/all" : repositoryUrl;
-                try (HttpSender.Response resp = httpSender.send(httpSender.get(gradleVersionsUrl).build())) {
-                    if (resp.isSuccessful()) {
-                        List<GradleVersion> allVersions = new ObjectMapper()
-                                .registerModule(new ParameterNamesModule())
-                                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                                .readValue(resp.getBody(), new TypeReference<List<GradleVersion>>() {
-                                });
-                        GradleVersion gradleVersion = allVersions.stream()
-                                .filter(v -> versionComparator.isValid(null, v.version))
-                                .max((v1, v2) -> versionComparator.compare(null, v1.version, v2.version))
-                                .orElseThrow(() -> new IllegalStateException("Expected to find at least one Gradle wrapper version to select from."));
-
-                        DistributionInfos infos = DistributionInfos.fetch(httpSender, distributionType, gradleVersion);
-                        wrapper = new GradleWrapper(gradleVersion.version, infos);
-                        return wrapper;
-                    }
-                    throw new IOException("Could not get Gradle versions at: " + gradleVersionsUrl);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }
-
-        };
+            throw new IOException("Could not get Gradle versions at: " + gradleVersionsUrl);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     public String getDistributionUrl() {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/GradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/util/GradleWrapperTest.java
@@ -96,7 +96,7 @@ public class GradleWrapperTest {
     @Test
     void validateDistributionTypeBin() {
         mockGradleServices(mockWebServer -> {
-            Validated validated = GradleWrapper.validate(new InMemoryExecutionContext(), "7.x", "bin", null, "http://%s:%d/versions/all".formatted(mockWebServer.getHostName(), mockWebServer.getPort()));
+            Validated<GradleWrapper> validated = GradleWrapper.validate(new InMemoryExecutionContext(), "7.x", "bin", "http://%s:%d/versions/all".formatted(mockWebServer.getHostName(), mockWebServer.getPort()));
             GradleWrapper gw = validated.getValue();
             assertThat(validated.isValid()).isTrue();
             assertThat(gw).isNotNull();
@@ -107,7 +107,7 @@ public class GradleWrapperTest {
     @Test
     void validateWithDistributionNull() {
         mockGradleServices(mockWebServer -> {
-            Validated validated = GradleWrapper.validate(new InMemoryExecutionContext(), "latest.release", null, null, "http://%s:%d/versions/all".formatted(mockWebServer.getHostName(), mockWebServer.getPort()));
+            Validated<GradleWrapper> validated = GradleWrapper.validate(new InMemoryExecutionContext(), "latest.release", null, "http://%s:%d/versions/all".formatted(mockWebServer.getHostName(), mockWebServer.getPort()));
             GradleWrapper gw = validated.getValue();
             assertThat(validated.isValid()).isTrue();
             assertThat(gw).isNotNull();

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevel.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevel.java
@@ -57,7 +57,7 @@ public class ChangeMethodAccessLevel extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("newAccessLevel", "Must be one of 'private', 'protected', 'package', 'public'",
                 newAccessLevel, level -> "private".equals(level) || "protected".equals(level) || "package".equals(level) || "public".equals(level)));
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
@@ -61,7 +61,7 @@ public class SimplifyMethodChain extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("methodPatternChain",
                 "Requires more than one pattern",
                 methodPatternChain, c -> c.size() > 1));

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/DeclarationSiteTypeVariance.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/DeclarationSiteTypeVariance.java
@@ -67,8 +67,8 @@ public class DeclarationSiteTypeVariance extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated v = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> v = super.validate();
         for (String variantType : variantTypes) {
             v = v.and(Validated.test("variantTypes", "Must be a valid variant type", variantType, vt -> {
                 try {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindLiterals.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindLiterals.java
@@ -49,7 +49,7 @@ public class FindLiterals extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(
                 Validated.test("pattern", "Must be a valid regular expression", pattern,
                         p -> {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindText.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindText.java
@@ -53,7 +53,7 @@ public class FindText extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test(
                 "patterns",
                 "Patterns must be compilable regular expressions",

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/HasJavaVersion.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/HasJavaVersion.java
@@ -57,8 +57,8 @@ public class HasJavaVersion extends Recipe {
 
     @SuppressWarnings("ConstantConditions")
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (version != null) {
             validated = validated.and(Semver.validate(version, null));
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.maven;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.*;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
@@ -133,8 +132,8 @@ public class AddDependency extends Recipe {
     Boolean acceptTransitive;
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         //noinspection ConstantConditions
         if (version != null) {
             validated = validated.or(Semver.validate(version, versionPattern));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -113,7 +113,7 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
             }
         }
 
-        Validated versionValidation = Semver.validate(version, versionPattern);
+        Validated<VersionComparator> versionValidation = Semver.validate(version, versionPattern);
         if (versionValidation.isValid()) {
             versionComparator = versionValidation.getValue();
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -108,8 +108,8 @@ public class AddManagedDependency extends Recipe {
     Boolean addToRootPom;
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         //noinspection ConstantConditions
         if (version != null) {
             validated = validated.or(Semver.validate(version, versionPattern));
@@ -180,7 +180,7 @@ public class AddManagedDependency extends Recipe {
                         Xml maven = super.visitDocument(document, executionContext);
 
                         if (!Boolean.TRUE.equals(addToRootPom) || rootPoms.contains(document)) {
-                            Validated versionValidation = Semver.validate(version, versionPattern);
+                            Validated<VersionComparator> versionValidation = Semver.validate(version, versionPattern);
                             if (versionValidation.isValid()) {
                                 VersionComparator versionComparator = requireNonNull(versionValidation.getValue());
                                 try {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -107,8 +107,8 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -96,8 +96,8 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -126,8 +126,8 @@ public class ChangeParentPom extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         //noinspection ConstantConditions
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ExcludeDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ExcludeDependency.java
@@ -53,7 +53,7 @@ public class ExcludeDependency extends Recipe {
     String scope;
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("scope", "scope is a valid Maven scope", scope, s -> {
             try {
                 if (s != null) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
@@ -63,7 +63,7 @@ public class RemoveDependency extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("scope", "Scope must be one of compile, runtime, test, or provided",
                 scope, s -> !Scope.Invalid.equals(Scope.fromName(s))));
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
@@ -68,7 +68,7 @@ public class RemoveManagedDependency extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("scope", "Scope must be one of compile, runtime, test, or provided",
                 scope, s -> !Scope.Invalid.equals(Scope.fromName(s))));
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -77,8 +77,8 @@ public class RemoveRedundantDependencyVersions extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = Validated.none();
+    public Validated<Object> validate() {
+        Validated<Object> validated = Validated.none();
         if (except != null) {
             for (int i = 0; i < except.size(); i++) {
                 final String retainVersion = except.get(i);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -98,8 +98,8 @@ public class UpgradeDependencyVersion extends Recipe {
 
     @SuppressWarnings("ConstantConditions")
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -79,8 +79,8 @@ public class UpgradeParentVersion extends Recipe {
     }
 
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         //noinspection ConstantConditions
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -78,8 +78,8 @@ public class UpgradePluginVersion extends Recipe {
 
     @SuppressWarnings("ConstantConditions")
     @Override
-    public Validated validate() {
-        Validated validated = super.validate();
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.maven.search;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -71,7 +70,7 @@ public class DependencyInsight extends Recipe {
     UUID searchId = randomId();
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("scope", "scope is a valid Maven scope", scope,
                 s -> Scope.fromName(s) != Scope.Invalid));
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DoesNotIncludeDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DoesNotIncludeDependency.java
@@ -69,7 +69,7 @@ public class DoesNotIncludeDependency extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate()
                 .and(notBlank("groupId", groupId).and(notBlank("artifactId", artifactId)))
                 .and(Validated.test("scope", "scope is a valid Maven scope", scope,

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
@@ -29,7 +29,7 @@ class AddManagedDependencyTest implements RewriteTest {
     void validation()  {
         AddManagedDependency recipe = new AddManagedDependency("org.apache.logging.log4j", "log4j-bom", "latest.release", "import",
           "pom", null, null, null, "org.apache.logging:*", true);
-        Validated validated = recipe.validate();
+        Validated<Object> validated = recipe.validate();
         assertThat(validated).allMatch(Validated::isValid);
     }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/AddOwaspDateBoundSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/AddOwaspDateBoundSuppressions.java
@@ -63,7 +63,7 @@ public class AddOwaspDateBoundSuppressions extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("untilDate", "Must be empty or a valid date of format yyyy-MM-dd", untilDate, date -> {
             if (date != null && !date.isEmpty()) {
                 try {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/UpdateOwaspSuppressionDate.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/UpdateOwaspSuppressionDate.java
@@ -68,7 +68,7 @@ public class UpdateOwaspSuppressionDate extends Recipe {
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("untilDate", "Must be empty or a valid date of format yyyy-MM-dd", untilDate, date -> {
             if (date != null && !date.isEmpty()) {
                 try {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -62,7 +62,7 @@ public class MergeYaml extends Recipe {
     String objectIdentifyingProperty;
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate()
                 .and(Validated.test("yaml", "Must be valid YAML",
                         yaml, y -> {


### PR DESCRIPTION
Funnily enough, this is NOT an API breaking change.

Any downstream users not using validated with generics will, mostly continue to have their code compile and run fine. But if you want to use generics, you can get added type protection from the compiler! 🎉 

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
