### PR TITLE
Support version ranges in parent reference

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -258,6 +258,34 @@ class MavenParserTest implements RewriteTest {
     }
 
     @Test
+    void parentVersionRange() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.managed.test</groupId>
+                  <artifactId>a</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>com.fasterxml.jackson</groupId>
+                      <artifactId>jackson-parent</artifactId>
+                      <version>[2.9.1,2.10.0)</version>
+                  </parent>
+                  <dependencies>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.11</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void guava25() {
         rewriteRun(
           pomXml(


### PR DESCRIPTION
As of Maven 3.5.0 version ranges are also supported in the parent reference (see https://issues.apache.org/jira/browse/MNG-2199 for details).

Fixes: openrewrite/rewrite-maven-plugin#530
