### PR TITLE
Recipe instances now store their `RecipeDescriptor` to avoid cost of …

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -32,7 +32,6 @@ import java.util.*;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.internal.RecipeIntrospectionUtils.constructRecipe;
-import static org.openrewrite.internal.RecipeIntrospectionUtils.recipeDescriptorFromRecipe;
 
 public class ClasspathScanningLoader implements ResourceLoader {
     private static final Logger logger = LoggerFactory.getLogger(ClasspathScanningLoader.class);
@@ -137,7 +136,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
                 }
                 try {
                     Recipe recipe = constructRecipe(recipeClass);
-                    recipeDescriptors.add(recipeDescriptorFromRecipe(recipe));
+                    recipeDescriptors.add(recipe.getDescriptor());
                     recipes.add(recipe);
                 } catch (Exception e) {
                     logger.warn("Unable to configure {}", recipeClass.getName(), e);

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.*;
 
+import static java.util.Collections.emptyList;
 import static org.openrewrite.Validated.invalid;
 
 @RequiredArgsConstructor
@@ -157,6 +158,17 @@ public class DeclarativeRecipe extends CompositeRecipe {
         }
     }
 
+    @Override
+    protected RecipeDescriptor createRecipeDescriptor() {
+        List<RecipeDescriptor> recipeList = new ArrayList<>();
+        for (Recipe childRecipe : getRecipeList()) {
+            recipeList.add(childRecipe.getDescriptor());
+        }
+        //noinspection deprecation
+        return new RecipeDescriptor(getName(), getDisplayName(), getDescription(),
+                getTags(), getEstimatedEffortPerOccurrence(),
+                emptyList(), getLanguages(), recipeList, getDataTableDescriptors(), getMaintainers(), getContributors(), source);
+    }
 
     public enum RecipeUse {
         /**

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.intellij.lang.annotations.Language;
 import org.openrewrite.*;
 import org.openrewrite.internal.PropertyPlaceholderHelper;
-import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
@@ -330,7 +329,7 @@ public class YamlResourceLoader implements ResourceLoader {
             DeclarativeRecipe declarativeRecipe = (DeclarativeRecipe) recipe;
             declarativeRecipe.initialize(allRecipes);
             declarativeRecipe.setContributors(recipeNamesToContributors.get(recipe.getName()));
-            recipeDescriptors.add(RecipeIntrospectionUtils.recipeDescriptorFromDeclarativeRecipe(declarativeRecipe, source));
+            recipeDescriptors.add(declarativeRecipe.getDescriptor());
         }
         return recipeDescriptors;
     }

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -524,7 +524,7 @@ class RecipeLifecycleTest implements RewriteTest {
 
                 var aDescriptor = recipeDescriptors.get(0);
                 var bDescriptor = aDescriptor.getRecipeList().get(0);
-                // B (2 test recipes, 2 ChangeText with different options and 1 noChangeRecipe) resulting in 4 changes
+                // B recipeList = D, E, ChangeText(E1), ChangeText(E2)
                 assertThat(bDescriptor.getName()).isEqualTo("B");
                 assertThat(bDescriptor.getRecipeList()).hasSize(4);
             })

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Contributor;
 import org.openrewrite.Maintainer;
 import org.openrewrite.Recipe;
-import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.test.RewriteTest;
 
 import java.io.ByteArrayInputStream;
@@ -239,7 +238,7 @@ class YamlResourceLoaderTest implements RewriteTest {
         List<Contributor> descriptorContributors = descriptor.getContributors();
         assertThat(descriptorContributors).containsExactlyElementsOf(contributors);
 
-        RecipeDescriptor introspectedDescriptor = RecipeIntrospectionUtils.recipeDescriptorFromRecipe(recipe);
-        assertThat(introspectedDescriptor.getContributors()).containsExactlyElementsOf(contributors);
+        RecipeDescriptor recipeDescriptor = recipe.getDescriptor();
+        assertThat(recipeDescriptor.getContributors()).containsExactlyElementsOf(contributors);
     }
 }


### PR DESCRIPTION
…repeated instantiation (especially during OSS plugin recipe stack printout)

https://github.com/openrewrite/rewrite-maven-plugin/issues/486

Significant time savings with this change, running a large recipe (based on the Spring Boot upgrade recipes) via Maven plugin on a (small!) private project:
- 1.17 recipe bom + plugin: 8m50s
- 1.18 snapshot recipe bom + plugin (with these changes): 4m48s

And those times *include* time spent on parsing+visits; all of the time savings were outside of that "critical path".

Execution time from generating RecipeDescriptors seems nearly eliminated.
The recipe "stack trace" view at the end of OSS plugin output now seems to move at basically the speed of IO.