### PR TITLE
Execute lookup for declaring scope instead of parent scope

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizeLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/FinalizeLocalVariablesTest.java
@@ -281,6 +281,38 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     }
 
     @Test
+    void shouldNotFinalizeForCounterWhichIsReassignedWithinForHeader() {
+        rewriteRun(
+                java("""
+                class A {             
+                    static {
+                        for (int i = 0; i < 10; i++) {
+                            // no-op
+                        }
+                    }
+                }
+                """
+                )
+        );
+    }
+
+    @Test
+    void shouldNotFinalizeForCounterWhichIsReassignedWithinForBody() {
+        rewriteRun(
+                java("""
+                class A {             
+                    static {
+                        for (int i = 0; i < 10;) {
+                            i = 11;
+                        }
+                    }
+                }
+                """
+                )
+        );
+    }
+
+    @Test
     void nonModifyingUnaryOperatorAwareness() {
         rewriteRun(
           java(
@@ -365,6 +397,26 @@ class FinalizeLocalVariablesTest implements RewriteTest {
             }
               """
           ), 17)
+        );
+    }
+
+    @Test
+    void shouldNotFinalizeVariableWhichIsReassigedInAnotherSwitchBranch() {
+        rewriteRun(
+                java("""
+                class A {             
+                    static int variable = 0;
+                    static {
+                        switch (variable) {
+                          case 0:
+                              int notFinalized = 0;
+                          default:
+                              notFinalized = 1;
+                        }
+                    }
+                }
+                """
+                )
         );
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/FinalizeLocalVariables.java
@@ -68,7 +68,10 @@ public class FinalizeLocalVariables extends Recipe {
                 }
 
                 if (mv.getVariables().stream()
-                        .noneMatch(v -> FindAssignmentReferencesToVariable.find(getCursor().getParentTreeCursor().getValue(), v).get())) {
+                        .noneMatch(v -> {
+                            Cursor declaringCursor = v.getDeclaringScope(getCursor());
+                            return FindAssignmentReferencesToVariable.find(declaringCursor.getValue(), v).get();
+                        })) {
                     mv = autoFormat(
                             mv.withModifiers(
                                     ListUtils.concat(mv.getModifiers(), new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, J.Modifier.Type.Final, Collections.emptyList()))

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5586,13 +5586,18 @@ public interface J extends Tree {
                 return v.visitVariable(this, p);
             }
 
+            public Cursor getDeclaringScope(Cursor cursor) {
+                return cursor.dropParentUntil(it ->
+                        it instanceof J.Block
+                        || it instanceof J.Lambda
+                        || it instanceof J.MethodDeclaration
+                        || it == Cursor.ROOT_VALUE);
+            }
+
             public boolean isField(Cursor cursor) {
-                Cursor declaringScope = cursor.dropParentUntil(it -> it instanceof J.Block || it instanceof J.Lambda
-                        || it instanceof J.MethodDeclaration || it == Cursor.ROOT_VALUE);
-                if(!(declaringScope.getValue() instanceof J.Block)) {
-                    return false;
-                }
-                return declaringScope.getParentTreeCursor().getValue() instanceof J.ClassDeclaration;
+                Cursor declaringScope = getDeclaringScope(cursor);
+                return declaringScope.getValue() instanceof J.Block
+                        && declaringScope.getParentTreeCursor().getValue() instanceof J.ClassDeclaration;
             }
 
             public Padding getPadding() {


### PR DESCRIPTION
For example in context switch-cases the scope is the whole switch statement even when a variable is declared in separate case branch. Before, we only took the parent scope into account which is solely the individual case branch.

Fixes #2953