### PR TITLE
Invalidate cached recipe descriptor

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -297,6 +297,7 @@ public abstract class Recipe implements Cloneable {
             throw new IllegalArgumentException("Cannot add a recipe to itself.");
         }
         recipeList.add(recipe);
+        descriptor = null;
         return this;
     }
 


### PR DESCRIPTION
If a recipe is added to the list invalidate cached recipe descriptor. Test is here: https://github.com/openrewrite/rewrite-spring/pull/322