### PR TITLE
Allow `JavaTemplate` to use shared `JavaTypeCache`

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
@@ -27,10 +27,10 @@ import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
 
-public class Java17Parser implements JavaParser {
-    private final JavaParser delegate;
+public class Java17Parser implements JavaParser, JavaParser.Internal {
+    private final JavaParser.Internal delegate;
 
-    Java17Parser(JavaParser delegate) {
+    Java17Parser(JavaParser.Internal delegate) {
         this.delegate = delegate;
     }
 
@@ -70,6 +70,16 @@ public class Java17Parser implements JavaParser {
         return new Builder();
     }
 
+    @Override
+    public Collection<Path> getClasspath() {
+        return delegate.getClasspath();
+    }
+
+    @Override
+    public void setTypeCache(JavaTypeCache typeCache) {
+        delegate.setTypeCache(typeCache);
+    }
+
     public static class Builder extends JavaParser.Builder<Java17Parser, Builder> {
 
         @Nullable
@@ -98,7 +108,7 @@ public class Java17Parser implements JavaParser {
 
                 parserConstructor.setAccessible(true);
 
-                JavaParser delegate = (JavaParser) parserConstructor
+                JavaParser.Internal delegate = (JavaParser.Internal) parserConstructor
                         .newInstance(logCompilationWarningsAndErrors, classpath, classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
 
                 return new Java17Parser(delegate);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -20,7 +20,6 @@ import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.DiagnosticSource;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Options;
 import io.micrometer.core.instrument.Metrics;
@@ -60,16 +59,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 
 /**
  * This parser is NOT thread-safe, as the OpenJDK parser maintains in-memory caches in static state.
  */
 @NonNullApi
-public class ReloadableJava17Parser implements JavaParser {
+public class ReloadableJava17Parser implements JavaParser, JavaParser.Internal {
     private String sourceSet = "main";
-    private final JavaTypeCache typeCache;
+    private JavaTypeCache typeCache;
 
     @Nullable
     private transient JavaSourceSet sourceSetProvenance;
@@ -350,6 +349,16 @@ public class ReloadableJava17Parser implements JavaParser {
         com.sun.tools.javac.util.List<JCTree.JCCompilationUnit> compilationUnits = com.sun.tools.javac.util.List.from(
                 cus.toArray(JCTree.JCCompilationUnit[]::new));
         enter.main(compilationUnits);
+    }
+
+    @Override
+    public Collection<Path> getClasspath() {
+        return classpath == null ? emptyList() : unmodifiableCollection(classpath);
+    }
+
+    @Override
+    public void setTypeCache(JavaTypeCache typeCache) {
+        this.typeCache = typeCache;
     }
 
     private static class ResettableLog extends Log {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
@@ -38,10 +38,10 @@ class RemoveObjectsIsNullTest implements RewriteTest {
             """
               import static java.util.Objects.isNull;
               public class A {
-                  public void test() {
+                  public void test(Object o) {
                       boolean a = true;
                       if (java.util.Objects.isNull(a)) {
-                          System.out.println("a is null");
+                          System.out.println(java.util.Objects.isNull(o));
                       }
                   }
               }
@@ -49,10 +49,10 @@ class RemoveObjectsIsNullTest implements RewriteTest {
             """
               import static java.util.Objects.isNull;
               public class A {
-                  public void test() {
+                  public void test(Object o) {
                       boolean a = true;
                       if (a == null) {
-                          System.out.println("a is null");
+                          System.out.println(o == null);
                       }
                   }
               }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -22,6 +22,7 @@ import io.github.classgraph.ScanResult;
 import org.intellij.lang.annotations.Language;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Incubating;
 import org.openrewrite.Parser;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.JavaTypeCache;
@@ -37,9 +38,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -178,6 +177,7 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
                             );
                             missingArtifactNames.remove(artifactName);
                             artifacts.add(artifact);
+                        } catch (FileAlreadyExistsException ignore) {
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }
@@ -401,5 +401,16 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
                                    .orElse(Long.toString(System.nanoTime())) + ".java";
 
         return prefix.resolve(Paths.get(pkg + className));
+    }
+
+    /**
+     * Extension interface which can optionally be implemented by `JavaParser` implementation classes,
+     * providing internal accessors.
+     */
+    @Incubating(since = "7.38.0")
+    interface Internal extends JavaParser {
+        Collection<Path> getClasspath();
+
+        void setTypeCache(JavaTypeCache typeCache);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaTypeSource.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaTypeSource.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal;
+
+public enum JavaTypeSource {
+    SOURCE, CLASS;
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -159,7 +159,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     getCursor().getParentOrThrow());
                         }
                         case EXTENDS: {
-                            TypeTree anExtends = substitutions.unsubstitute(templateParser.parseExtends(substitutedTemplate));
+                            TypeTree anExtends = substitutions.unsubstitute(templateParser.parseExtends(substitutedTemplate, getCursor()));
                             J.ClassDeclaration c = classDecl.withExtends(anExtends);
 
                             //noinspection ConstantConditions
@@ -167,7 +167,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return c;
                         }
                         case IMPLEMENTS: {
-                            List<TypeTree> implementings = substitutions.unsubstitute(templateParser.parseImplements(substitutedTemplate));
+                            List<TypeTree> implementings = substitutions.unsubstitute(templateParser.parseImplements(substitutedTemplate, getCursor()));
                             List<JavaType.FullyQualified> implementsTypes = implementings.stream()
                                     .map(TypedTree::getType)
                                     .map(TypeUtils::asFullyQualified)
@@ -213,7 +213,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     getCursor().getParentOrThrow());
                         }
                         case TYPE_PARAMETERS: {
-                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(substitutedTemplate));
+                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(substitutedTemplate, getCursor()));
                             return classDecl.withTypeParameters(typeParameters);
                         }
                     }
@@ -268,7 +268,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitLambda(J.Lambda lambda, Integer p) {
                 if (loc.equals(LAMBDA_PARAMETERS_PREFIX) && lambda.getParameters().isScope(insertionPoint)) {
-                    return lambda.withParameters(substitutions.unsubstitute(templateParser.parseLambdaParameters(substitutedTemplate)));
+                    return lambda.withParameters(substitutions.unsubstitute(templateParser.parseLambdaParameters(substitutedTemplate, getCursor())));
                 }
                 return maybeReplaceStatement(lambda, J.class, 0);
             }
@@ -310,7 +310,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return method.withBody(autoFormat(body, p, getCursor()));
                         }
                         case METHOD_DECLARATION_PARAMETERS: {
-                            List<Statement> parameters = substitutions.unsubstitute(templateParser.parseParameters(substitutedTemplate));
+                            List<Statement> parameters = substitutions.unsubstitute(templateParser.parseParameters(substitutedTemplate, getCursor()));
 
                             // Update the J.MethodDeclaration's type information to reflect its new parameter list
                             JavaType.Method type = method.getMethodType();
@@ -368,7 +368,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return method.withParameters(parameters).withMethodType(type);
                         }
                         case THROWS: {
-                            J.MethodDeclaration m = method.withThrows(substitutions.unsubstitute(templateParser.parseThrows(substitutedTemplate)));
+                            J.MethodDeclaration m = method.withThrows(substitutions.unsubstitute(templateParser.parseThrows(substitutedTemplate, getCursor())));
 
                             // Update method type information to reflect the new checked exceptions
                             JavaType.Method type = m.getMethodType();
@@ -388,7 +388,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return m;
                         }
                         case TYPE_PARAMETERS: {
-                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(substitutedTemplate));
+                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(substitutedTemplate, getCursor()));
                             J.MethodDeclaration m = method.withTypeParameters(typeParameters);
                             return autoFormat(m, typeParameters.get(typeParameters.size() - 1), p,
                                     getCursor().getParentOrThrow());
@@ -438,7 +438,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitPackage(J.Package pkg, Integer integer) {
                 if (loc.equals(PACKAGE_PREFIX) && pkg.isScope(insertionPoint)) {
-                    return pkg.withExpression(substitutions.unsubstitute(templateParser.parsePackage(substitutedTemplate)));
+                    return pkg.withExpression(substitutions.unsubstitute(templateParser.parsePackage(substitutedTemplate, getCursor())));
                 }
                 return super.visitPackage(pkg, integer);
             }


### PR DESCRIPTION
As currently every application of `JavaTemplate` leads to a new `JavaParser` getting created with its own `JavaTypeCache` the result is that every time a `JavaTemplate` get applied, the LST will end up containing type attribution linked to identical yet distinct copies of `JavaType` objects, even if the LST elements refer to the same Java elements on the classpath. This in turn can cause a lot of memory overhead.

This commit aims at mitigating this issue by allowing `JavaTemplate` (specifically `JavaTemplateParser`) to use a shared `JavaTypeCache`. The life cycle of the `JavaTypeCache` is the same as that of the `ExecutionContext` and it will get used by every `JavaTemplate` with the same classpath. At the end of each compilation performed by the `JavaTemplateParser` the `JavaType` objects which were created for the parsed Java sources get purged again.

Since the `JavaTypeCache` structure itself isn't thread-safe, each `JavaTemplateParser` will create a clone of the shared `JavaTypeCache` and work with that.

The feature can be disabled by setting the `org.openrewrite.java.typecache.sharing` system property to `false`.