### PR TITLE
Add code examples to recipe descriptor

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CodeExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CodeExample.java
@@ -1,0 +1,21 @@
+package org.openrewrite;
+
+import lombok.Value;
+
+@Value
+public class CodeExample {
+    /**
+     * Description of the example.
+     */
+    String description;
+
+    /**
+     * The example code before change.
+     */
+    String before;
+
+    /**
+     * The example code after change.
+     */
+    String after;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -195,9 +195,9 @@ public abstract class Recipe implements Cloneable {
 
     protected RecipeDescriptor createRecipeDescriptor() {
         List<OptionDescriptor> options = getOptionDescriptors(this.getClass());
-        List<RecipeDescriptor> recipeList1 = new ArrayList<>();
+        List<RecipeDescriptor> recipeList = new ArrayList<>();
         for (Recipe next : getRecipeList()) {
-            recipeList1.add(next.getDescriptor());
+            recipeList.add(next.getDescriptor());
         }
         URI recipeSource;
         try {
@@ -207,8 +207,8 @@ public abstract class Recipe implements Cloneable {
         }
 
         return new RecipeDescriptor(getName(), getDisplayName(), getDescription(), getTags(),
-                getEstimatedEffortPerOccurrence(), options, getLanguages(), recipeList1, getDataTableDescriptors(),
-                getMaintainers(), getContributors(), recipeSource);
+                getEstimatedEffortPerOccurrence(), options, getLanguages(), recipeList, getDataTableDescriptors(),
+                getMaintainers(), getContributors(), getExamples(), recipeSource);
     }
 
     private List<OptionDescriptor> getOptionDescriptors(Class<?> recipeClass) {
@@ -260,6 +260,13 @@ public abstract class Recipe implements Cloneable {
      * @return a list of the organization(s) responsible for maintaining this recipe.
      */
     public List<Maintainer> getMaintainers() {
+        return emptyList();
+    }
+
+    /**
+     * @return a list of the code example(s) demonstrating the changes made by the recipe.
+     */
+    public List<CodeExample> getExamples() {
         return emptyList();
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -64,6 +64,9 @@ public class DeclarativeRecipe extends CompositeRecipe {
     @Getter
     private final List<Maintainer> maintainers;
 
+    @Getter
+    private final List<CodeExample> examples;
+
     @JsonIgnore
     private Validated validation = Validated.test("initialization",
             "initialize(..) must be called on DeclarativeRecipe prior to use.",
@@ -166,8 +169,9 @@ public class DeclarativeRecipe extends CompositeRecipe {
         }
         //noinspection deprecation
         return new RecipeDescriptor(getName(), getDisplayName(), getDescription(),
-                getTags(), getEstimatedEffortPerOccurrence(),
-                emptyList(), getLanguages(), recipeList, getDataTableDescriptors(), getMaintainers(), getContributors(), source);
+            getTags(), getEstimatedEffortPerOccurrence(),
+            emptyList(), getLanguages(), recipeList, getDataTableDescriptors(),
+            getMaintainers(), getContributors(), getExamples(), source);
     }
 
     public enum RecipeUse {

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
@@ -18,6 +18,7 @@ package org.openrewrite.config;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.CodeExample;
 import org.openrewrite.Contributor;
 import org.openrewrite.Maintainer;
 import org.openrewrite.internal.lang.Nullable;
@@ -57,6 +58,8 @@ public class RecipeDescriptor {
     List<Maintainer> maintainers;
 
     List<Contributor> contributors;
+
+    List<CodeExample> examples;
 
     URI source;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -230,7 +230,8 @@ public class YamlResourceLoader implements ResourceLoader {
                 }
             }
             DeclarativeRecipe recipe = new DeclarativeRecipe(name, displayName, description, tags,
-                    estimatedEffortPerOccurrence, source, (boolean) r.getOrDefault("causesAnotherCycle", false), maintainers);
+                estimatedEffortPerOccurrence, source, (boolean) r.getOrDefault("causesAnotherCycle", false),
+                maintainers, Collections.emptyList());
 
             List<Object> recipeList = (List<Object>) r.get("recipeList");
             if (recipeList == null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCalls.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.cleanup;
 
+import org.openrewrite.CodeExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -27,6 +28,7 @@ import org.openrewrite.java.PartProvider;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -49,6 +51,28 @@ public class ChainStringBuilderAppendCalls extends Recipe {
     @Override
     public @Nullable Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(2);
+    }
+
+    @Override
+    public List<CodeExample> getExamples() {
+        CodeExample example = new CodeExample("Chain `StringBuilder.append()` calls instead of the '+' operator to efficiently concatenate strings and numbers",
+            "class A {\n" +
+            "  void method() {\n" +
+            "      StringBuilder sb = new StringBuilder();\n" +
+            "      String op = \"+\";\n" +
+            "      sb.append(\"A\" + op + \"B\");\n" +
+            "      sb.append(1 + op + 2);\n" +
+            "  }\n" +
+            "}",
+            "class A {\n" +
+            "  void method() {\n" +
+            "      StringBuilder sb = new StringBuilder();\n" +
+            "      String op = \"+\";\n" +
+            "      sb.append(\"A\").append(op).append(\"B\");\n" +
+            "      sb.append(1).append(op).append(2);\n" +
+            "  }\n" +
+            "}");
+        return Collections.singletonList(example);
     }
 
     @Override


### PR DESCRIPTION
Currently, we don't have code example(s) on the recipe doc page. 
Code speaks more than words, so adding this helps people visually understand what changes the recipe will going to make.
This is the corresponding UI of this change.

![Screen Shot 2023-03-29 at 8 54 58 AM](https://user-images.githubusercontent.com/122563761/228598543-36872426-c981-4747-881b-23c859212056.png)




