### PR TITLE
Fix `tabsize` inaccurate issue

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -219,7 +219,7 @@ class AutodetectTest implements RewriteTest {
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
     }
 
-    // TabSize 3 is unnormal, but if it exists, we can detect it.
+    // TabSize 3 is atypical but not unheard of
     @Test
     void mixedTabAndWhiteSpacesIndentsWithTabSize3() {
         var cus = jp().parse(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -54,6 +54,8 @@ class AutodetectTest implements RewriteTest {
         var styles = Autodetect.detect(cus);
         var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
@@ -88,9 +90,9 @@ class AutodetectTest implements RewriteTest {
         var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
-        assertThat(tabsAndIndents.getTabSize()).isEqualTo(1);
-        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(1);
-        assertThat(tabsAndIndents.getContinuationIndent()).isEqualTo(2);
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getContinuationIndent()).isEqualTo(8);
     }
 
     @SuppressWarnings("InfiniteRecursion")
@@ -184,8 +186,126 @@ class AutodetectTest implements RewriteTest {
         var styles = Autodetect.detect(cus);
         var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
-        assertThat(tabsAndIndents.getTabSize()).isEqualTo(1);
-        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(1);
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
+    }
+
+    @Test
+    void mixedTabAndWhiteSpacesIndentsWithTabSize4() {
+        var cus = jp().parse(
+          """
+            /**
+             *
+             */
+            public class Test {
+            	private final ApplicationEventPublisher publisher;
+            	public void method() {
+            		int value = 0;
+                	int value1 = 1;
+            	    int value2 = 2;
+            		{
+            	        int value3 = 2;
+                	    int value4 = 4;
+            		}
+            	}
+            }
+            """
+        );
+
+        var styles = Autodetect.detect(cus);
+        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
+    }
+
+    // TabSize 3 is unnormal, but if it exists, we can detect it.
+    @Test
+    void mixedTabAndWhiteSpacesIndentsWithTabSize3() {
+        var cus = jp().parse(
+          """
+            /**
+             *
+             */
+            public class Test {
+            	private final ApplicationEventPublisher publisher;
+            	public void method() {
+            		int value = 0;
+            	   int value1 = 1;
+            	   int value2 = 2;
+            		{
+            	      int value3 = 2;
+            	      int value4 = 4;
+            		}
+            	}
+            }
+            """
+        );
+
+        var styles = Autodetect.detect(cus);
+        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(3);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(3);
+    }
+
+    @Test
+    void mixedTabAndWhiteSpacesIndentsWithTabSize4AndUseTabIsFalse() {
+        var cus = jp().parse(
+          """
+            /**
+             *
+             */
+            public class Test {
+            	private final ApplicationEventPublisher publisher;
+                public void method() {
+            	    int value = 0;
+            	    int value1 = 1;
+            	    int value2 = 2;
+            	    {
+                	    int value3 = 2;
+                    	int value4 = 4;
+            	    }
+            	}
+            }
+            """
+        );
+
+        var styles = Autodetect.detect(cus);
+        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
+    }
+
+
+    @Test
+    void mixedTabAndWhiteSpacesIndentsWithTabSize4WithSomeErrors() {
+        var cus = jp().parse(
+          """
+            /**
+             *
+             */
+            public class Test {
+                private final ApplicationEventPublisher publisher;
+                public void method() {
+            	     int value = 0;
+            	   int value1 = 1;
+            	    int value2 = 2;
+            	    {
+                	     int value3 = 2;
+                   	int value4 = 4;
+            	    }
+            	}
+            }
+            """
+        );
+
+        var styles = Autodetect.detect(cus);
+        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
     }
 
     @Test

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -230,29 +230,31 @@ public class Autodetect extends NamedStyles {
             /**
              * For each line, if the code follows an indentation style exactly,
              * Assume :
-             *      1. nw = white space count in prefix
-             *      2. nt = tabs count in prefix
-             *      3. d = block depth
-             *      4. X = tabSize, which means  white space count per tab, unknown to be solved here.
+             *      nw = white space count in prefix
+             *      nt = tabs count in prefix
+             *      d = block depth
+             *      X = tabSize, which means  white space count per tab, unknown to be solved here.
              * So theoretically the formula is:
-             *          d = nt + (nw / X)                                                                   (1)
-             *          X = nw / (d - nt)                                                                   (2)
+             *      d = nt + (nw / X)                                                                       (1)
+             *      X = nw / (d - nt)                                                                       (2)
              * Because this is a linear equation, it also applies to the sum of multiple values, that is:
              *          d1 + d2 + .. + dn = (nt1 + nt2 + .. + ntn) + (nw1 +nw2 + ... + nwn) / X             (3)
              * So let's define:
-             * D = d1 + d2 + .. + dn, which is the total count of depth.
-             * NT = nt1 + nt2 + .. + ntn, which is the total count of tabs.
-             * NW = nw1 +nw2 + ... + nwn, which is the total count of white spaces.
+             *      D = d1 + d2 + .. + dn, which is the total count of depth.
+             *      NT = nt1 + nt2 + .. + ntn, which is the total count of tabs.
+             *      NW = nw1 +nw2 + ... + nwn, which is the total count of white spaces.
              * So
-             *          D = NT + (NW / X)                                                                   (4)
-             *          X = NW / (D - NT)                                                                   (5)
+             *      D = NT + (NW / X)                                                                       (4)
+             *      X = NW / (D - NT)                                                                       (5)
              * the more data (more lines of code), the more accuracy.
              *
              * (1) How to determine the `useTabs` boolean value?
              * From formula #4, D is composed of two parts, the Tabs part (NT) and the white spaces part (NW / X).
              * so `useTabs` should be determined by which part is bigger (> 50%).
-             * define: PT = (NT / D), which means the percentage of tabs.
-             * So `useTabs = PT > 0.5`
+             * define:
+             *      PT = (NT / D), which means the percentage of tabs.
+             * So
+             *      useTabs = PT > 0.5
              *
              * (2) Details to solve X via formula (5)
              * There are three scenarios here
@@ -260,9 +262,10 @@ public class Autodetect extends NamedStyles {
              *      then we use the default value 4. Because small errors exist in reality, it is impossible to strictly
              *      satisfy the condition of (D - NT) being zero, so we use a threshold here to determine this case.
              *      let's say PT > 80%.
-             * #2. If the code contains white spaces only. NT ~= 0, X = NW / D.
+             * #2. If the code contains white spaces only. NT ~= 0, X ~= NW / D.
              * #3. Mixed tabs and white spaces
-             * Both #2 and #3, the tab size X can use solve by formula #5.
+             *
+             * So #1 returns default, and both #2 and #3, the tab size X can use solve by formula #5.
              */
 
             if (this.accumulateDepthCount == 0) {
@@ -318,13 +321,11 @@ public class Autodetect extends NamedStyles {
 
             for (int i = 0; i < chars.length; i++) {
                 char c = chars[i];
-                if (c == '\n' || c == '\r') {
-                    if (c == '\n') {
-                        if (i == 0 || chars[i - 1] != '\r') {
-                            stats.linesWithLFNewLines++;
-                        } else {
-                            stats.linesWithCRLFNewLines++;
-                        }
+                if (c == '\n') {
+                    if (i == 0 || chars[i - 1] != '\r') {
+                        stats.linesWithLFNewLines++;
+                    } else {
+                        stats.linesWithCRLFNewLines++;
                     }
                 }
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -265,36 +265,15 @@ public class Autodetect extends NamedStyles {
              * Both #2 and #3, the tab size X can use solve by formula #5.
              */
 
-            long d = this.accumulateDepthCount;         // D in above comments
-            long nw = 0;                                // NW in above comments
-            long nt = 0;                                // NT in above comments
-            double pt;                                  // PT in above comments
-            final double TAB_PORTION_THRESHOLD = 0.8;
-
-            //  spaceIndentFrequencies
-            for (Map.Entry<IndentStatistic.DepthCoordinate, Map<Integer, Long>> entry :  tabIndentFrequencies.depthToSpaceIndentFrequencies.entrySet()) {
-                Map<Integer, Long> tabCountToOccureenceCountMap = entry.getValue();
-                for (Map.Entry<Integer, Long> entry1 : tabCountToOccureenceCountMap.entrySet()) {
-                    int tabCount = entry1.getKey();
-                    long occurrenceCount = entry1.getValue();
-                    nt += (tabCount * occurrenceCount);
-                }
-            }
-
-            for (Map.Entry<IndentStatistic.DepthCoordinate, Map<Integer, Long>> entry :  spaceIndentFrequencies.depthToSpaceIndentFrequencies.entrySet()) {
-                Map<Integer, Long> spaceCountToOccureenceCountMap = entry.getValue();
-                for (Map.Entry<Integer, Long> entry1 : spaceCountToOccureenceCountMap.entrySet()) {
-                    int spaceCount = entry1.getKey();
-                    long occurrenceCount = entry1.getValue();
-                    nw += (spaceCount * occurrenceCount);
-                }
-            }
-
-            if (d == 0) {
+            if (this.accumulateDepthCount == 0) {
                 return IntelliJ.tabsAndIndents();
             }
 
-            pt = nt / (double) d;
+            long d = this.accumulateDepthCount;                                 // D in above comments
+            long nw = getTotalCharCount(spaceIndentFrequencies);    // NW in above comments
+            long nt = getTotalCharCount(tabIndentFrequencies);      // NT in above comments
+            double pt = nt / (double) d;                                        // PT in above comments
+            final double TAB_PORTION_THRESHOLD = 0.8;
 
             boolean useTabs = pt >= 0.5;
             int tabSize;
@@ -321,6 +300,14 @@ public class Autodetect extends NamedStyles {
                             multilineAlignedToFirstArgument >= multilineNotAlignedToFirstArgument)
             );
         }
+    }
+
+    private static long getTotalCharCount(IndentStatistic indentStatistic) {
+        return indentStatistic.depthToSpaceIndentFrequencies.entrySet()
+            .stream()
+            .flatMap(entry -> entry.getValue().entrySet().stream())
+            .mapToLong(entry -> entry.getKey() * entry.getValue())
+            .sum();
     }
 
     private static class FindLineFormatJavaVisitor extends JavaIsoVisitor<GeneralFormatStatistics> {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -119,7 +119,7 @@ public class Autodetect extends NamedStyles {
             int indentDepth;
             int continuationDepth;
         }
-        // depth -> count of whitespace/tab char (4 spaces, 2 tabs, etc) -> count of occurrences
+        // depth -> count of whitespace char (4 spaces, 2 tabs, etc) -> count of occurrences
         Map<DepthCoordinate, Map<Integer, Long>> depthToSpaceIndentFrequencies = new ConcurrentHashMap<>();
 
         public void record(int indentDepth, int continuationDepth, int charCount) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -269,10 +269,10 @@ public class Autodetect extends NamedStyles {
                 return IntelliJ.tabsAndIndents();
             }
 
-            long d = this.accumulateDepthCount;                                 // D in above comments
+            long d = this.accumulateDepthCount;                     // D in above comments
             long nw = getTotalCharCount(spaceIndentFrequencies);    // NW in above comments
             long nt = getTotalCharCount(tabIndentFrequencies);      // NT in above comments
-            double pt = nt / (double) d;                                        // PT in above comments
+            double pt = nt / (double) d;                            // PT in above comments
             final double TAB_PORTION_THRESHOLD = 0.8;
 
             boolean useTabs = pt >= 0.5;


### PR DESCRIPTION
Currently, If a file contains tab characters only (not any white space), the AutoDetect will detect tab size as 1.
which doesn't look correct, it should be the default 4.

This PR introduces a new way to calculate tab size and the `useTab` flag.

Here is the solution:
```
/**
 * For each line, if the code follows an indentation style exactly,
 * Assume :
 *      nw = white space count in prefix
 *      nt = tabs count in prefix
 *      d = block depth
 *      X = tabSize, which means  white space count per tab, unknown to be solved here.
 * So theoretically the formula is:
 *      d = nt + (nw / X)                                                                       (1)
 *      X = nw / (d - nt)                                                                       (2)
 * Because this is a linear equation, it also applies to the sum of multiple values, that is:
 *          d1 + d2 + .. + dn = (nt1 + nt2 + .. + ntn) + (nw1 +nw2 + ... + nwn) / X             (3)
 * So let's define:
 *      D = d1 + d2 + .. + dn, which is the total count of depth.
 *      NT = nt1 + nt2 + .. + ntn, which is the total count of tabs.
 *      NW = nw1 +nw2 + ... + nwn, which is the total count of white spaces.
 * So
 *      D = NT + (NW / X)                                                                       (4)
 *      X = NW / (D - NT)                                                                       (5)
 * the more data (more lines of code), the more accuracy.
 *
 * (1) How to determine the `useTabs` boolean value?
 * From formula #4, D is composed of two parts, the Tabs part (NT) and the white spaces part (NW / X).
 * so `useTabs` should be determined by which part is bigger (> 50%).
 * define:
 *      PT = (NT / D), which means the percentage of tabs.
 * So
 *      useTabs = PT > 0.5
 *
 * (2) Details to solve X via formula (5)
 * There are three scenarios here
 * #1. If the code contains tabs only, D ~= NT, PT ~= 100%, and NW ~= 0, so X = 0/0, it's an unknown value,
 *      then we use the default value 4. Because small errors exist in reality, it is impossible to strictly
 *      satisfy the condition of (D - NT) being zero, so we use a threshold here to determine this case.
 *      let's say PT > 80%.
 * #2. If the code contains white spaces only. NT ~= 0, X ~= NW / D.
 * #3. Mixed tabs and white spaces
 *
 * So #1 returns default, and both #2 and #3, the tab size X can use solve by formula #5.
 */
```
