### PR TITLE
Support continuation lines in properties files

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ActivateStyle.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ActivateStyle.java
@@ -122,7 +122,7 @@ public class ActivateStyle extends Recipe {
                     keyExists.set(true);
                     if(overwriteExistingStyles) {
                         if(!fullyQualifiedStyleName.equals(entry.getValue().getText())) {
-                            entry = entry.withValue(entry.getValue().withText(fullyQualifiedStyleName));
+                            entry = entry.withValue(entry.getValue().withText(fullyQualifiedStyleName).withSource(fullyQualifiedStyleName));
                         }
                     } else {
                         List<String> activeStyles = Arrays.stream(entry.getValue().getText().split(",")).collect(Collectors.toList());
@@ -130,7 +130,8 @@ public class ActivateStyle extends Recipe {
                             return entry;
                         }
                         activeStyles.add(fullyQualifiedStyleName);
-                        entry = entry.withValue(entry.getValue().withText(String.join(",", activeStyles)));
+                        String stylesValue = String.join(",", activeStyles);
+                        entry = entry.withValue(entry.getValue().withText(stylesValue).withSource(stylesValue));
                     }
                 }
                 return entry;
@@ -138,8 +139,8 @@ public class ActivateStyle extends Recipe {
             if(!keyExists.get()) {
                 // Existing key not found, need to add one
                 p = p.withContent(ListUtils.concat(p.getContent(),
-                        new Properties.Entry(randomId(), "\n", Markers.EMPTY, STYLE_KEY, "", Properties.Entry.Delimiter.EQUALS,
-                                new Properties.Value(randomId(), "", Markers.EMPTY, fullyQualifiedStyleName))));
+                        new Properties.Entry(randomId(), "\n", Markers.EMPTY, STYLE_KEY, STYLE_KEY, "", Properties.Entry.Delimiter.EQUALS,
+                                new Properties.Value(randomId(), "", Markers.EMPTY, fullyQualifiedStyleName, fullyQualifiedStyleName))));
             }
             return p;
         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -180,8 +180,9 @@ public class UpdateGradleWrapper extends Recipe {
             Properties p = super.visitFile(file, executionContext);
             Set<Properties.Entry> properties = FindProperties.find(p, DISTRIBUTION_SHA_256_SUM_KEY, false);
             if (properties.isEmpty()) {
-                Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, gradleWrapper.getDistributionChecksum().getHexValue());
-                Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, "", Properties.Entry.Delimiter.EQUALS, propertyValue);
+                String hexValue = gradleWrapper.getDistributionChecksum().getHexValue();
+                Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, hexValue, hexValue);
+                Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, DISTRIBUTION_SHA_256_SUM_KEY, DISTRIBUTION_SHA_256_SUM_KEY, "", Properties.Entry.Delimiter.EQUALS, propertyValue);
                 List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
                 p = ((Properties.File) p).withContent(contentList);
             }
@@ -191,10 +192,12 @@ public class UpdateGradleWrapper extends Recipe {
         @Override
         public Properties visitEntry(Properties.Entry entry, ExecutionContext context) {
             if ("distributionUrl".equals(entry.getKey())) {
-                return entry.withValue(entry.getValue().withText(gradleWrapper.getPropertiesFormattedUrl()));
+                String value = gradleWrapper.getPropertiesFormattedUrl();
+                return entry.withValue(entry.getValue().withText(value).withSource(value));
             }
             if (DISTRIBUTION_SHA_256_SUM_KEY.equals(entry.getKey())) {
-                return entry.withValue(entry.getValue().withText(gradleWrapper.getDistributionChecksum().getHexValue()));
+                String value = gradleWrapper.getDistributionChecksum().getHexValue();
+                return entry.withValue(entry.getValue().withText(value).withSource(value));
             }
             return entry;
         }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -98,10 +98,10 @@ public class AddProperty extends Recipe {
                 if (!StringUtils.isBlank(property) && !StringUtils.isBlank(value)) {
                     Set<Properties.Entry> properties = FindProperties.find(p, property, false);
                     if (properties.isEmpty()) {
-                        Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, value);
+                        Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, value, value);
                         Properties.Entry.Delimiter delimitedBy = delimiter != null && !delimiter.isEmpty() ? Properties.Entry.Delimiter.getDelimiter(delimiter) : Properties.Entry.Delimiter.EQUALS;
                         String beforeEquals = delimitedBy == Properties.Entry.Delimiter.NONE ? delimiter : "";
-                        Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, property, beforeEquals, delimitedBy, propertyValue);
+                        Properties.Entry entry = new Properties.Entry(Tree.randomId(), "\n", Markers.EMPTY, property, property, beforeEquals, delimitedBy, propertyValue);
                         List<Properties.Content> contentList = ListUtils.concat(((Properties.File) p).getContent(), entry);
                         p = ((Properties.File) p).withContent(contentList);
                     }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyKey.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyKey.java
@@ -109,14 +109,18 @@ public class ChangePropertyKey extends Recipe {
                 if (!Boolean.FALSE.equals(relaxedBinding)
                         ? NameCaseConvention.matchesRegexRelaxedBinding(entry.getKey(), oldPropertyKey)
                         : entry.getKey().matches(oldPropertyKey)) {
-                    entry = entry.withKey(entry.getKey().replaceFirst(oldPropertyKey, newPropertyKey))
+                    entry = entry
+                            .withKey(entry.getKey().replaceFirst(oldPropertyKey, newPropertyKey))
+                            .withKeySource(entry.getKeySource().replaceFirst(oldPropertyKey, newPropertyKey))
                             .withPrefix(entry.getPrefix());
                 }
             } else {
                 if (!Boolean.FALSE.equals(relaxedBinding)
                         ? NameCaseConvention.equalsRelaxedBinding(entry.getKey(), oldPropertyKey)
                         : entry.getKey().equals(oldPropertyKey)) {
-                    entry = entry.withKey(newPropertyKey)
+                    entry = entry
+                            .withKey(newPropertyKey)
+                            .withKeySource(newPropertyKey)
                             .withPrefix(entry.getPrefix());
                 }
             }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyValue.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyValue.java
@@ -107,9 +107,12 @@ public class ChangePropertyValue extends Recipe {
 
         @Nullable // returns null if value should not change
         private Properties.Value updateValue(Properties.Value value) {
-            Properties.Value updatedValue = value.withText(Boolean.TRUE.equals(regex)
-                    ? value.getText().replaceAll(Objects.requireNonNull(oldValue), newValue) : newValue);
-            return updatedValue.getText().equals(value.getText()) ? null : updatedValue;
+            String text = Boolean.TRUE.equals(regex)
+                    ? value.getText().replaceAll(Objects.requireNonNull(oldValue), newValue) : newValue;
+            if (text.equals(value.getText())) {
+                return null;
+            }
+            return value.withText(text).withSource(text);
         }
 
         private boolean matchesOldValue(Properties.Value value) {

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
@@ -38,13 +38,13 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
     @Override
     public Properties visitEntry(Properties.Entry entry, PrintOutputCapture<P> p) {
         beforeSyntax(entry, p);
-        p.append(entry.getKey())
+        p.append(entry.getKeySource())
                 .append(entry.getBeforeEquals());
         if (entry.getDelimiter() != Properties.Entry.Delimiter.NONE) {
             p.append(entry.getDelimiter().getCharacter());
         }
         beforeSyntax(entry.getValue().getPrefix(), entry.getValue().getMarkers(), p);
-        p.append(entry.getValue().getText());
+        p.append(entry.getValue().getSource());
         afterSyntax(entry.getValue().getMarkers(), p);
         afterSyntax(entry, p);
         return entry;

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
@@ -142,6 +142,7 @@ public interface Properties extends Tree {
         String prefix;
         Markers markers;
         String key;
+        String keySource;
         String beforeEquals;
 
         @Nullable
@@ -165,6 +166,12 @@ public interface Properties extends Tree {
 
             Delimiter(Character character) {
                 this.character = character;
+            }
+
+            public static Delimiter getDelimiter(char value) {
+                return '=' == value ? Delimiter.EQUALS :
+                            ':' == value ? Delimiter.COLON :
+                            Delimiter.NONE;
             }
 
             public static Delimiter getDelimiter(String value) {
@@ -195,6 +202,7 @@ public interface Properties extends Tree {
         String prefix;
         Markers markers;
         String text;
+        String source;
     }
 
     @lombok.Value

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/ChangePropertyTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/ChangePropertyTest.java
@@ -18,8 +18,10 @@ package org.openrewrite.properties;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.properties.Assertions.properties;
 
 @SuppressWarnings("UnusedProperty")
@@ -94,6 +96,36 @@ class ChangePropertyTest implements RewriteTest {
               management=true
               management.metrics.enable.process.files=true
               """
+          )
+        );
+    }
+
+    @Test
+    void keepPropertyValueWithLineContinuations() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty(
+            "management.metrics.enable.process.files",
+            "true",
+            null,
+            null
+          )),
+          properties(
+            """
+              management=tr\\
+                ue
+              """,
+            """
+              management=tr\\
+                ue
+              management.metrics.enable.process.files=true
+              """,
+            spec -> {
+                spec.afterRecipe(after -> {
+                    Properties.Entry entry = (Properties.Entry) after.getContent().get(0);
+                    assertThat(entry.getValue().getText()).isEqualTo("true");
+                    assertThat(entry.getValue().getSource()).isEqualTo("tr\\\n  ue");
+                });
+            }
           )
         );
     }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/search/FindPropertiesTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/search/FindPropertiesTest.java
@@ -39,6 +39,23 @@ class FindPropertiesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void valueWithLineContinuation() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperties("foo", null)),
+          properties(
+            """
+              foo=tr\\
+                ue
+              """,
+            """
+              foo=~~>tr\\
+                ue
+              """
+          )
+        );
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
       "acme.my-project.person.first-name",
@@ -99,6 +116,25 @@ class FindPropertiesTest implements RewriteTest {
               acme.my-project.person.first-name=~~>example
               acme.myProject.person.firstName=example
               acme.my_project.person.first_name=example
+              """
+          )
+        );
+    }
+
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1168")
+    void propertyKeyWithContinuations() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperties("enabled", null)),
+          properties(
+            """
+              ena\\
+                  bled = true
+              """,
+            """
+              ena\\
+                  bled = ~~>true
               """
           )
         );


### PR DESCRIPTION
Java `.properties` files can have continuation lines. The parser already supported this but the continuation lines were lost after parsing, meaning that after applying a recipe and serializing the LST again, the continuation lines got lost.

Adds a new `Properties.Entry#keySource` property and a new `Properties.Value#source` property to keep the original parsed source text, so that it can be serialized again.

Fixes: #2473