### PR TITLE
Optimize `StringUtils#matchesGlob()`

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
     compileOnly("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
 
     implementation("org.openrewrite.tools:java-object-diff:latest.release")
-    implementation("org.apache.ant:ant:latest.release")
 
     implementation("io.quarkus.gizmo:gizmo:1.0.+")
 


### PR DESCRIPTION
This Glob matching utility was using Ant's `SelectorUtils#match()` method, which uses `String#toCharArray()`. Often it is however faster to work with `String#charAt()`. Performance measurements indicate that the implementation is now more than twice as fast and since it is used very intensively in `rewrite-maven` (to match GAVs), the boost will be visible in some recipes.
