### PR TITLE
Use `JavaParser.Builder` when constructing `JavaTemplate`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDelegatesToGradleApi.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDelegatesToGradleApi.java
@@ -110,9 +110,7 @@ public class AddDelegatesToGradleApi extends Recipe {
                     param = param.withTemplate(
                             JavaTemplate.builder(this::getCursor, "@DelegatesTo(#{}.class)")
                                     .imports(delegateType.getFullyQualifiedName(), DELEGATES_TO_TYPE.getFullyQualifiedName())
-                                    .javaParser(() -> JavaParser.fromJavaVersion()
-                                            .classpath("groovy")
-                                            .build())
+                                    .javaParser(JavaParser.fromJavaVersion().classpath("groovy"))
                                     .build(),
                             param.getCoordinates().addAnnotation(comparing(a -> 0)),
                             simpleName);

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
@@ -218,7 +218,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               @Override
               public J visitArrayAccess(J.ArrayAccess arrayAccess, ExecutionContext executionContext) {
                   var t = JavaTemplate.builder(this::getCursor, "Some.method()")
-                    .javaParser(() -> JavaParser.fromJavaVersion()
+                    .javaParser(JavaParser.fromJavaVersion()
                       .dependsOn(
                         """
                           public class Some {
@@ -227,7 +227,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                               }
                           }
                           """
-                      ).build()
+                      )
                     ).build();
 
                   return arrayAccess.withTemplate(t, arrayAccess.getCoordinates().replace());
@@ -259,7 +259,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               public J visitBinary(J.Binary binary, ExecutionContext executionContext) {
                   if (binary.getOperator() == J.Binary.Type.Equal) {
                       var t = JavaTemplate.builder(this::getCursor, "Some.method()")
-                        .javaParser(() -> JavaParser.fromJavaVersion()
+                        .javaParser(JavaParser.fromJavaVersion()
                           .dependsOn(
                             """
                               public class Some {
@@ -268,7 +268,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                                   }
                               }
                               """
-                          ).build()
+                          )
                         ).build();
 
                       return binary.withTemplate(t, binary.getCoordinates().replace());
@@ -299,7 +299,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               public J visitLiteral(J.Literal literal, ExecutionContext executionContext) {
                   if (literal.getValue().equals("literal")) {
                       var t = JavaTemplate.builder(this::getCursor, "Some.method()")
-                        .javaParser(() -> JavaParser.fromJavaVersion()
+                        .javaParser(JavaParser.fromJavaVersion()
                           .dependsOn(
                             """
                               public class Some {
@@ -308,7 +308,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                                   }
                               }
                               """
-                          ).build()
+                          )
                         ).build();
 
                       return literal.withTemplate(t, literal.getCoordinates().replace());
@@ -340,7 +340,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               public J visitNewArray(J.NewArray newArray, ExecutionContext executionContext) {
                   if (((J.Literal) newArray.getDimensions().get(0).getIndex()).getValue().equals(1)) {
                       var t = JavaTemplate.builder(this::getCursor, "Some.method()")
-                        .javaParser(() -> JavaParser.fromJavaVersion()
+                        .javaParser(JavaParser.fromJavaVersion()
                           .logCompilationWarningsAndErrors(true)
                           .dependsOn("""
                                 public class Some {
@@ -348,7 +348,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                                         return new int[0];
                                     }
                                 }
-                            """).build()
+                            """)
                         ).build();
                       return newArray.withTemplate(t, newArray.getCoordinates().replace());
                   }
@@ -379,10 +379,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               public J visitTernary(J.Ternary ternary, ExecutionContext executionContext) {
                   var t = JavaTemplate.builder(this::getCursor, "Arrays.asList(#{any()})")
                     .imports("java.util.Arrays")
-                    .javaParser(() -> JavaParser.fromJavaVersion()
-                      .logCompilationWarningsAndErrors(true)
-                      .build()
-                    ).build();
+                    .build();
                   maybeAddImport("java.util.Arrays");
                   return ternary.withTemplate(t, ternary.getCoordinates().replace(), ternary);
               }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest3Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest3Test.java
@@ -367,7 +367,7 @@ class JavaTemplateTest3Test implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
               final JavaTemplate t = JavaTemplate.builder(() -> getCursor().getParentOrThrow(), "acceptString(#{any()}.toString())")
-                .javaParser(() -> JavaParser.fromJavaVersion()
+                .javaParser(JavaParser.fromJavaVersion()
                   .dependsOn(
                     """
                           package org.openrewrite;
@@ -377,8 +377,7 @@ class JavaTemplateTest3Test implements RewriteTest {
                               public A someOtherMethod() { return this; }
                           }
                       """
-                  )
-                  .build()).build();
+                  )).build();
 
               @Override
               public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext p) {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/UseJavaParserBuilderInJavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/UseJavaParserBuilderInJavaTemplateTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UseJavaParserBuilderInJavaTemplateTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UseJavaParserBuilderInJavaTemplate())
+          .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+    @Test
+    void useBuilder() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.java.*;
+              class MyTest {
+                  Object o = JavaTemplate.builder(() -> null, "")
+                    .javaParser(() -> JavaParser.fromJavaVersion().build());
+              }
+              """,
+            """
+              import org.openrewrite.java.*;
+              class MyTest {
+                  Object o = JavaTemplate.builder(() -> null, "")
+                    .javaParser(JavaParser.fromJavaVersion());
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
@@ -150,9 +150,7 @@ public class ChangeStaticFieldToMethod extends Recipe {
                 }
                 return JavaTemplate
                         .builder(() -> statementCursor, methodInvocationTemplate)
-                        .javaParser(() -> JavaParser.fromJavaVersion()
-                                .dependsOn(methodStub)
-                                .build())
+                        .javaParser(JavaParser.fromJavaVersion().dependsOn(methodStub))
                         .imports(newClass)
                         .build();
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceLambdaWithMethodReference.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/ReplaceLambdaWithMethodReference.java
@@ -109,7 +109,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                             "package " + fullyQualified.getPackageName() + "; public class " +
                                     fullyQualified.getClassName();
                     JavaTemplate template = JavaTemplate.builder(this::getCursor, code)
-                            .javaParser(() -> JavaParser.fromJavaVersion().dependsOn(stub).build())
+                            .javaParser(JavaParser.fromJavaVersion().dependsOn(stub))
                             .imports(fullyQualified == null ? "" : fullyQualified.getFullyQualifiedName()).build();
                     return l.withTemplate(template, l.getCoordinates().replace(), identifier.getSimpleName());
                 } else if (body instanceof J.Binary) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -57,14 +57,14 @@ public class JavaTemplateParser {
     @Language("java")
     private static final String SUBSTITUTED_ANNOTATION = "@java.lang.annotation.Documented public @interface SubAnnotation { int value(); }";
 
-    private final Supplier<JavaParser> parser;
+    private final JavaParser.Builder<?, ?> parser;
     private final Consumer<String> onAfterVariableSubstitution;
     private final Consumer<String> onBeforeParseTemplate;
     private final Set<String> imports;
     private final BlockStatementTemplateGenerator statementTemplateGenerator;
     private final AnnotationTemplateGenerator annotationTemplateGenerator;
 
-    public JavaTemplateParser(Supplier<JavaParser> parser, Consumer<String> onAfterVariableSubstitution,
+    public JavaTemplateParser(JavaParser.Builder<?, ?> parser, Consumer<String> onAfterVariableSubstitution,
                               Consumer<String> onBeforeParseTemplate, Set<String> imports) {
         this.parser = parser;
         this.onAfterVariableSubstitution = onAfterVariableSubstitution;
@@ -240,8 +240,8 @@ public class JavaTemplateParser {
         ExecutionContext ctx = new InMemoryExecutionContext();
         ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true);
         return stub.contains("@SubAnnotation") ?
-                parser.get().reset().parse(ctx, stub, SUBSTITUTED_ANNOTATION).get(0) :
-                parser.get().reset().parse(ctx, stub).get(0);
+                parser.build().reset().parse(ctx, stub, SUBSTITUTED_ANNOTATION).get(0) :
+                parser.build().reset().parse(ctx, stub).get(0);
     }
 
     @SuppressWarnings("unchecked")

--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/UseJavaParserBuilderInJavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/UseJavaParserBuilderInJavaTemplate.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+public class UseJavaParserBuilderInJavaTemplate extends Recipe {
+    private static final MethodMatcher SUPPLIER_BASED_JAVA_PARSER = new MethodMatcher(
+            "org.openrewrite.java.JavaTemplate$Builder javaParser(java.util.function.Supplier)");
+    private static final MethodMatcher JAVA_PARSER_BUILD = new MethodMatcher(
+            "org.openrewrite.java.JavaParser$Builder build()");
+
+    @Override
+    public String getDisplayName() {
+        return "Use `JavaParser.Builder` when constructing `JavaTemplate`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Because we can now clone `JavaParser.Builder`, there is no need to fully build the parser inside a `Supplier<JavaParser>`. " +
+               "This also makes room for `JavaTemplate` to add shared `JavaTypeCache` implementations to parsers used to compile templates.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(SUPPLIER_BASED_JAVA_PARSER);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                if (SUPPLIER_BASED_JAVA_PARSER.matches(m)) {
+                    AtomicReference<J.MethodInvocation> builder = new AtomicReference<>();
+                    new JavaIsoVisitor<Integer>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                            if (JAVA_PARSER_BUILD.matches(method)) {
+                                builder.set(requireNonNull(method.getSelect()).withPrefix(Space.EMPTY));
+                            }
+                            return super.visitMethodInvocation(method, p);
+                        }
+                    }.visit(m.getArguments().get(0), 0);
+                    if (builder.get() != null) {
+                        m = m.withArguments(Collections.singletonList(builder.get()));
+                    }
+                }
+                return m;
+            }
+        };
+    }
+}


### PR DESCRIPTION
@knutwannheden this makes way for you to place your `JavaTypeCache` instance on the template's parser without having to add a setter to `JavaParser`.

The reason that this was initially `Supplier<JavaParser>` rather than `JavaParser.Builder` is we didn't have a `clone()` method on `JavaParser`.