### PR TITLE
Shared cursor root on all `TreeVisitor` returned by `Recipe#getVisitor`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -151,6 +151,11 @@ public interface RecipeScheduler {
         Recipe recipe = recipeStack.peek();
         assert recipe == runStats.getRecipe() : "Recipe stack should always contain the recipe being run";
 
+        // this root cursor is shared by all `TreeVisitor` instances used created from `getVisitor` and
+        // single source applicable tests so that data can be shared at the root (especially for caching
+        // use cases like sharing a `JavaTypeCache` between `JavaTemplate` parsers).
+        Cursor rootCursor = new Cursor(null, Cursor.ROOT_VALUE);
+
         ctx.putCurrentRecipe(recipe);
         if (ctx instanceof WatchableExecutionContext) {
             ((WatchableExecutionContext) ctx).resetHasNewMessages();
@@ -243,6 +248,7 @@ public interface RecipeScheduler {
                     }
 
                     TreeVisitor<?, ExecutionContext> visitor = recipe.getVisitor();
+                    visitor.cursor = rootCursor;
 
                     //noinspection unchecked
                     afterFile = (S) visitor.visitSourceFile(s, ctx);

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -54,7 +54,7 @@ import java.util.function.Function;
  * @param <P> An input object that is passed to every visit method.
  */
 public abstract class TreeVisitor<T extends Tree, P> {
-    private Cursor cursor = new Cursor(null, Cursor.ROOT_VALUE);
+    Cursor cursor = new Cursor(null, Cursor.ROOT_VALUE);
 
     public static <T extends Tree, P> TreeVisitor<T, P> noop() {
         return new TreeVisitor<T, P>() {


### PR DESCRIPTION
This is just a start. More changes would be required to ensure that `singleSourceApplicableTest` visitors also shared that same cursor root, but not sure these changes are worthwhile at this point.

cc / @knutwannheden 