### PR TITLE
Allow `JavaTemplate` to use shared `JavaTypeCache`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Cursor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Cursor.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -41,6 +42,11 @@ public class Cursor {
     public Cursor(@Nullable Cursor parent, Object value) {
         this.parent = parent;
         this.value = value;
+
+        // the root cursor will potentially be used concurrently
+        if (parent == null && value == ROOT_VALUE) {
+            messages = new ConcurrentHashMap<>();
+        }
     }
 
     public Cursor getRoot() {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -20,7 +20,6 @@ import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.DiagnosticSource;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Options;
 import io.micrometer.core.instrument.Metrics;

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -344,6 +344,10 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
             return (B) this;
         }
 
+        public Collection<Path> classpath() {
+            return Collections.unmodifiableCollection(this.classpath);
+        }
+
         public B classpath(Collection<Path> classpath) {
             this.classpath = classpath;
             return (B) this;

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/ForwardingJavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/ForwardingJavaParser.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.marker.JavaSourceSet;
+import org.openrewrite.java.tree.J;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+public abstract class ForwardingJavaParser implements JavaParser {
+
+    protected ForwardingJavaParser() {
+    }
+
+    protected abstract JavaParser delegate();
+
+    @Override
+    public List<J.CompilationUnit> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        return delegate().parseInputs(sources, relativeTo, ctx);
+    }
+
+    @Override
+    public JavaParser reset() {
+        delegate().reset();
+        return this;
+    }
+
+    @Override
+    public JavaParser reset(Collection<URI> uris) {
+        delegate().reset(uris);
+        return this;
+    }
+
+    @Override
+    public void setClasspath(Collection<Path> classpath) {
+        delegate().setClasspath(classpath);
+    }
+
+    @Override
+    public void setSourceSet(String sourceSet) {
+        delegate().setSourceSet(sourceSet);
+    }
+
+    @Override
+    public JavaSourceSet getSourceSet(ExecutionContext ctx) {
+        return delegate().getSourceSet(ctx);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaTypeSource.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaTypeSource.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal;
+
+/**
+ * Represents the source a Java type was loaded from by the compiler: `SOURCE` for types that were parsed
+ * from source files from the sourcepath and `CLASS` for types that were loaded from class files on the
+ * classpath.
+ */
+public enum JavaTypeSource {
+    SOURCE, CLASS;
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -159,7 +159,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     getCursor().getParentOrThrow());
                         }
                         case EXTENDS: {
-                            TypeTree anExtends = substitutions.unsubstitute(templateParser.parseExtends(substitutedTemplate));
+                            TypeTree anExtends = substitutions.unsubstitute(templateParser.parseExtends(getCursor(), substitutedTemplate));
                             J.ClassDeclaration c = classDecl.withExtends(anExtends);
 
                             //noinspection ConstantConditions
@@ -167,7 +167,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return c;
                         }
                         case IMPLEMENTS: {
-                            List<TypeTree> implementings = substitutions.unsubstitute(templateParser.parseImplements(substitutedTemplate));
+                            List<TypeTree> implementings = substitutions.unsubstitute(templateParser.parseImplements(getCursor(), substitutedTemplate));
                             List<JavaType.FullyQualified> implementsTypes = implementings.stream()
                                     .map(TypedTree::getType)
                                     .map(TypeUtils::asFullyQualified)
@@ -213,7 +213,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     getCursor().getParentOrThrow());
                         }
                         case TYPE_PARAMETERS: {
-                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(substitutedTemplate));
+                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
                             return classDecl.withTypeParameters(typeParameters);
                         }
                     }
@@ -268,7 +268,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitLambda(J.Lambda lambda, Integer p) {
                 if (loc.equals(LAMBDA_PARAMETERS_PREFIX) && lambda.getParameters().isScope(insertionPoint)) {
-                    return lambda.withParameters(substitutions.unsubstitute(templateParser.parseLambdaParameters(substitutedTemplate)));
+                    return lambda.withParameters(substitutions.unsubstitute(templateParser.parseLambdaParameters(getCursor(), substitutedTemplate)));
                 }
                 return maybeReplaceStatement(lambda, J.class, 0);
             }
@@ -310,7 +310,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return method.withBody(autoFormat(body, p, getCursor()));
                         }
                         case METHOD_DECLARATION_PARAMETERS: {
-                            List<Statement> parameters = substitutions.unsubstitute(templateParser.parseParameters(substitutedTemplate));
+                            List<Statement> parameters = substitutions.unsubstitute(templateParser.parseParameters(getCursor(), substitutedTemplate));
 
                             // Update the J.MethodDeclaration's type information to reflect its new parameter list
                             JavaType.Method type = method.getMethodType();
@@ -368,7 +368,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return method.withParameters(parameters).withMethodType(type);
                         }
                         case THROWS: {
-                            J.MethodDeclaration m = method.withThrows(substitutions.unsubstitute(templateParser.parseThrows(substitutedTemplate)));
+                            J.MethodDeclaration m = method.withThrows(substitutions.unsubstitute(templateParser.parseThrows(getCursor(), substitutedTemplate)));
 
                             // Update method type information to reflect the new checked exceptions
                             JavaType.Method type = m.getMethodType();
@@ -388,7 +388,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return m;
                         }
                         case TYPE_PARAMETERS: {
-                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(substitutedTemplate));
+                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
                             J.MethodDeclaration m = method.withTypeParameters(typeParameters);
                             return autoFormat(m, typeParameters.get(typeParameters.size() - 1), p,
                                     getCursor().getParentOrThrow());
@@ -438,7 +438,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitPackage(J.Package pkg, Integer integer) {
                 if (loc.equals(PACKAGE_PREFIX) && pkg.isScope(insertionPoint)) {
-                    return pkg.withExpression(substitutions.unsubstitute(templateParser.parsePackage(substitutedTemplate)));
+                    return pkg.withExpression(substitutions.unsubstitute(templateParser.parsePackage(getCursor(), substitutedTemplate)));
                 }
                 return super.visitPackage(pkg, integer);
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTypeCacheSharingJavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTypeCacheSharingJavaParser.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.template;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.internal.ForwardingJavaParser;
+import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.tree.J;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.StringJoiner;
+
+class JavaTypeCacheSharingJavaParser extends ForwardingJavaParser {
+    private final JavaParser delegate;
+    private final Cursor cursor;
+    private final JavaTypeCache typeCache;
+    private final String typeCacheKey;
+
+    public JavaTypeCacheSharingJavaParser(Builder<?, ?> parserBuilder, Cursor cursor) {
+        StringJoiner joiner = new StringJoiner(":", "type-cache-key(classpath=", ")");
+        parserBuilder.classpath().forEach(p -> joiner.add(p.toString()));
+        String typeCacheKey = joiner.toString();
+        JavaTypeCache typeCache = cursor.getRoot().getMessage(typeCacheKey);
+        JavaTypeCache finalTypeCache = typeCache == null ? new JavaTypeCache() : typeCache.clone();
+        parserBuilder.typeCache(finalTypeCache);
+
+        this.delegate = parserBuilder.build();
+        this.cursor = cursor;
+        this.typeCache = finalTypeCache;
+        this.typeCacheKey = typeCacheKey;
+    }
+
+    @Override
+    protected JavaParser delegate() {
+        return delegate;
+    }
+
+    @Override
+    public List<J.CompilationUnit> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
+        try {
+            return delegate.parseInputs(sources, relativeTo, ctx);
+        } finally {
+            typeCache.clear();
+            // TODO This is not perfect. Ideally the part from JavaTypeCache which gets loaded from classpath would itself be thread-safe and not need copying.
+            cursor.putMessage(typeCacheKey, typeCache);
+        }
+    }
+}


### PR DESCRIPTION
As currently every application of `JavaTemplate` leads to a new `JavaParser` getting created with its own `JavaTypeCache` the result is that every time a `JavaTemplate` get applied, the LST will end up containing type attribution linked to identical yet distinct copies of `JavaType` objects, even if the LST elements refer to the same Java elements on the classpath. This in turn can cause a lot of memory overhead.

This commit aims at mitigating this issue by allowing `JavaTemplate` (specifically `JavaTemplateParser`) to use a shared `JavaTypeCache`. The life cycle of the `JavaTypeCache` is the same as that of the root `Cursor`, which typically gets instantiated by the `RecipeScheduler`, and it will get used by every `JavaTemplate` with the exact same classpath. At the end of each compilation performed by the `JavaTemplateParser` the `JavaType` objects which were created for the parsed Java sources get purged again.

Since the `JavaTypeCache` structure itself isn't thread-safe, each `JavaTemplateParser` will create a clone of the shared `JavaTypeCache` and work with that.