### PR TITLE
Add recipe examples to recipe and recipe descriptors

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -25,6 +25,7 @@ import org.intellij.lang.annotations.Language;
 import org.openrewrite.config.DataTableDescriptor;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.config.RecipeExample;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.NullUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -208,7 +209,7 @@ public abstract class Recipe implements Cloneable {
 
         return new RecipeDescriptor(getName(), getDisplayName(), getDescription(), getTags(),
                 getEstimatedEffortPerOccurrence(), options, getLanguages(), recipeList1, getDataTableDescriptors(),
-                getMaintainers(), getContributors(), recipeSource);
+                getMaintainers(), getContributors(), getExamples(), recipeSource);
     }
 
     private List<OptionDescriptor> getOptionDescriptors(Class<?> recipeClass) {
@@ -271,6 +272,16 @@ public abstract class Recipe implements Cloneable {
             return emptyList();
         }
         return contributors;
+    }
+
+    @Setter
+    protected transient List<RecipeExample> examples;
+
+    public List<RecipeExample> getExamples() {
+        if(examples == null) {
+            return emptyList();
+        }
+        return examples;
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -41,9 +41,9 @@ public class ClasspathScanningLoader implements ResourceLoader {
 
     private final List<RecipeDescriptor> recipeDescriptors = new ArrayList<>();
     private final List<CategoryDescriptor> categoryDescriptors = new ArrayList<>();
-    private final List<RecipeExample> recipeExamples = new ArrayList<>();
 
     private final Map<String, List<Contributor>> recipeAttributions = new HashMap<>();
+    private final Map<String, List<RecipeExample>> recipeExamples = new HashMap<>();
 
     /**
      * Construct a ClasspathScanningLoader scans the runtime classpath of the current java process for recipes
@@ -114,11 +114,11 @@ public class ClasspathScanningLoader implements ResourceLoader {
                 recipes.addAll(resourceLoader.listRecipes());
                 categoryDescriptors.addAll(resourceLoader.listCategoryDescriptors());
                 styles.addAll(resourceLoader.listStyles());
-                recipeExamples.addAll(resourceLoader.listRecipeExamples());
                 recipeAttributions.putAll(resourceLoader.listContributors());
+                recipeExamples.putAll(resourceLoader.listRecipeExamples());
             }
             for(YamlResourceLoader resourceLoader : yamlResourceLoaders) {
-                recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes, recipeAttributions));
+                recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes, recipeAttributions, recipeExamples));
             }
         }
     }
@@ -178,7 +178,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
     }
 
     @Override
-    public Collection<RecipeExample> listRecipeExamples() {
+    public Map<String, List<RecipeExample>> listRecipeExamples() {
         return recipeExamples;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -168,7 +168,8 @@ public class DeclarativeRecipe extends CompositeRecipe {
         //noinspection deprecation
         return new RecipeDescriptor(getName(), getDisplayName(), getDescription(),
                 getTags(), getEstimatedEffortPerOccurrence(),
-                emptyList(), getLanguages(), recipeList, getDataTableDescriptors(), getMaintainers(), getContributors(), source);
+                emptyList(), getLanguages(), recipeList, getDataTableDescriptors(), getMaintainers(), getContributors(),
+                getExamples(), source);
     }
 
     @Value

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
@@ -58,5 +58,7 @@ public class RecipeDescriptor {
 
     List<Contributor> contributors;
 
+    List<RecipeExample> examples;
+
     URI source;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeExample.java
@@ -18,6 +18,7 @@ package org.openrewrite.config;
 import lombok.Value;
 import org.openrewrite.internal.lang.Nullable;
 
+
 @Value
 public class RecipeExample {
     @Nullable
@@ -26,7 +27,7 @@ public class RecipeExample {
     @Nullable
     String description;
 
-    String recipe;
     String before;
     String after;
+    String language;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
@@ -19,6 +19,8 @@ import org.openrewrite.Recipe;
 import org.openrewrite.style.NamedStyles;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 public interface ResourceLoader {
     Collection<Recipe> listRecipes();
@@ -29,5 +31,5 @@ public interface ResourceLoader {
 
     Collection<CategoryDescriptor> listCategoryDescriptors();
 
-    Collection<RecipeExample> listRecipeExamples();
+    Map<String, List<RecipeExample>> listRecipeExamples();
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -68,6 +68,9 @@ public class YamlResourceLoader implements ResourceLoader {
     @Nullable
     private Map<String, List<Contributor>> contributors;
 
+    @Nullable
+    private Map<String, List<RecipeExample>> recipeNameToExamples;
+
     private enum ResourceType {
         Recipe("specs.openrewrite.org/v1beta/recipe"),
         Style("specs.openrewrite.org/v1beta/style"),
@@ -311,10 +314,12 @@ public class YamlResourceLoader implements ResourceLoader {
 
     @Override
     public Collection<RecipeDescriptor> listRecipeDescriptors() {
-        return listRecipeDescriptors(emptyList(), listContributors());
+        return listRecipeDescriptors(emptyList(), listContributors(), listRecipeExamples());
     }
 
-    public Collection<RecipeDescriptor> listRecipeDescriptors(Collection<Recipe> externalRecipes, Map<String, List<Contributor>> recipeNamesToContributors) {
+    public Collection<RecipeDescriptor> listRecipeDescriptors(Collection<Recipe> externalRecipes,
+                                                              Map<String, List<Contributor>> recipeNamesToContributors,
+                                                              Map<String, List<RecipeExample>> recipeNamesToExamples) {
         Collection<Recipe> internalRecipes = listRecipes();
         Collection<Recipe> allRecipes = Stream.concat(
                 Stream.concat(
@@ -329,6 +334,7 @@ public class YamlResourceLoader implements ResourceLoader {
             DeclarativeRecipe declarativeRecipe = (DeclarativeRecipe) recipe;
             declarativeRecipe.initialize(allRecipes, recipeNamesToContributors);
             declarativeRecipe.setContributors(recipeNamesToContributors.get(recipe.getName()));
+            declarativeRecipe.setExamples(recipeNamesToExamples.get(recipe.getName()));
             recipeDescriptors.add(declarativeRecipe.getDescriptor());
         }
         return recipeDescriptors;
@@ -431,15 +437,32 @@ public class YamlResourceLoader implements ResourceLoader {
     }
 
     @Override
-    public Collection<RecipeExample> listRecipeExamples() {
-        return loadResources(ResourceType.Example).stream()
-                .map(c -> new RecipeExample(
-                        (String) c.get("name"),
-                        (String) c.get("description"),
-                        (String) c.get("recipe"),
-                        (String) c.get("before"),
-                        (String) c.get("after"))
-                ).collect(toList());
+    public Map<String, List<RecipeExample>> listRecipeExamples() {
+        if (recipeNameToExamples == null) {
+            recipeNameToExamples = new HashMap<>();
+        }
+
+        Collection<Map<String, Object>> rawExamples = loadResources(ResourceType.Example);
+
+        for (Map<String, Object> examplesMap : rawExamples) {
+            String recipeName = (String) examplesMap.get("recipeName");
+            recipeNameToExamples.computeIfAbsent(recipeName, key -> new ArrayList<>());
+
+
+            List<Map<String, Object>> examples = (List<Map<String, Object>>) examplesMap.get("examples");
+
+            List<RecipeExample> newExamples = examples.stream().map(exam -> new RecipeExample(
+                (String) exam.get("name"),
+                (String) exam.get("description"),
+                (String) exam.get("before"),
+                (String) exam.get("after"),
+                (String) exam.get("language")
+            )).collect(toList());
+
+            recipeNameToExamples.get(recipeName).addAll(newExamples);
+        }
+
+        return recipeNameToExamples;
     }
 
     public Map<String, List<Contributor>> listContributors() {

--- a/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
@@ -114,7 +114,7 @@ class CategoryTreeTest {
     private static RecipeDescriptor recipeDescriptor(String packageName) {
         return new RecipeDescriptor(packageName + ".MyRecipe",
           "My recipe", "", emptySet(), null, emptyList(),
-          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"));
+          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"));
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -275,4 +275,81 @@ class YamlResourceLoaderTest implements RewriteTest {
         Optional<Contributor> maybeJon = recipe.getContributors().stream().filter(c -> c.getName().equals("Jonathan Schneider")).findFirst();
         assertThat(maybeJon).isPresent();
     }
+
+    @Test
+    void recipeExamples() {
+        Environment env = Environment.builder()
+          .load(new YamlResourceLoader(new ByteArrayInputStream(
+            //language=yml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.ChangeTextToHello
+              displayName: Change text to hello
+              recipeList:
+                  - org.openrewrite.text.ChangeText:
+                      toText: Hello!
+              """.getBytes()
+          ), URI.create("rewrite.yml"), new Properties()))
+          .load(new YamlResourceLoader(new ByteArrayInputStream(
+            //language=yml
+            """
+              type: specs.openrewrite.org/v1beta/example
+              recipeName: test.ChangeTextToHello
+              examples:
+                - description: "Change World to Hello in a text file"
+                  before: "World"
+                  after: "Hello!"
+                  language: "text"
+                - description: "Change World to Hello in a java file"
+                  before: |
+                    public class A {
+                        void method() {
+                            System.out.println("world");
+                        }
+                    }
+                  after: |
+                    public class A {
+                        void method() {
+                            System.out.println("Hello!");
+                        }
+                    }
+                  language: "java"
+              """.getBytes()
+          ), URI.create("attribution/test.ChangeTextToHello.yml"), new Properties()))
+          .build();
+
+        Collection<Recipe> recipes = env.listRecipes();
+        assertThat(recipes).hasSize(1);
+        Recipe recipe = recipes.iterator().next();
+        List<RecipeExample> examples = recipe.getExamples();
+        assertThat(examples).hasSize(2);
+        RecipeExample example0 = examples.get(0);
+        assertThat(example0.getDescription()).isEqualTo("Change World to Hello in a text file");
+        assertThat(example0.getBefore()).isEqualTo("World");
+        assertThat(example0.getAfter()).isEqualTo("Hello!");
+        assertThat(example0.getLanguage()).isEqualTo("text");
+        RecipeExample example1 = examples.get(1);
+        assertThat(example1.getDescription()).isEqualTo("Change World to Hello in a java file");
+        assertThat(example1.getBefore()).isEqualTo("""
+          public class A {
+              void method() {
+                  System.out.println("world");
+              }
+          }
+          """);
+        assertThat(example1.getAfter()).isEqualTo("""
+          public class A {
+              void method() {
+                  System.out.println("Hello!");
+              }
+          }
+          """);
+        assertThat(example1.getLanguage()).isEqualTo("java");
+
+        Collection<RecipeDescriptor> recipeDescriptors = env.listRecipeDescriptors();
+        assertThat(recipeDescriptors).hasSize(1);
+        RecipeDescriptor descriptor = recipeDescriptors.iterator().next();
+        List<RecipeExample> descriptorExamples = descriptor.getExamples();
+        assertThat(descriptorExamples).containsExactlyElementsOf(examples);
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -304,7 +304,7 @@ class YamlResourceLoaderTest implements RewriteTest {
                   before: |
                     public class A {
                         void method() {
-                            System.out.println("world");
+                            System.out.println("World");
                         }
                     }
                   after: |

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -333,7 +333,7 @@ class YamlResourceLoaderTest implements RewriteTest {
         assertThat(example1.getBefore()).isEqualTo("""
           public class A {
               void method() {
-                  System.out.println("world");
+                  System.out.println("World");
               }
           }
           """);

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -319,37 +319,38 @@ class YamlResourceLoaderTest implements RewriteTest {
           .build();
 
         Collection<Recipe> recipes = env.listRecipes();
-        assertThat(recipes).hasSize(1);
-        Recipe recipe = recipes.iterator().next();
-        List<RecipeExample> examples = recipe.getExamples();
-        assertThat(examples).hasSize(2);
-        RecipeExample example0 = examples.get(0);
-        assertThat(example0.getDescription()).isEqualTo("Change World to Hello in a text file");
-        assertThat(example0.getBefore()).isEqualTo("World");
-        assertThat(example0.getAfter()).isEqualTo("Hello!");
-        assertThat(example0.getLanguage()).isEqualTo("text");
-        RecipeExample example1 = examples.get(1);
-        assertThat(example1.getDescription()).isEqualTo("Change World to Hello in a java file");
-        assertThat(example1.getBefore()).isEqualTo("""
-          public class A {
-              void method() {
-                  System.out.println("World");
-              }
-          }
-          """);
-        assertThat(example1.getAfter()).isEqualTo("""
-          public class A {
-              void method() {
-                  System.out.println("Hello!");
-              }
-          }
-          """);
-        assertThat(example1.getLanguage()).isEqualTo("java");
+        assertThat(recipes).singleElement().satisfies(r -> {
+            assertThat(r.getExamples()).hasSize(2);
+            assertThat(r.getExamples()).first().satisfies(e -> {
+                assertThat(e.getDescription()).isEqualTo("Change World to Hello in a text file");
+                assertThat(e.getBefore()).isEqualTo("World");
+                assertThat(e.getAfter()).isEqualTo("Hello!");
+                assertThat(e.getLanguage()).isEqualTo("text");
+            });
+            assertThat(r.getExamples().get(1)).satisfies(e -> {
+                assertThat(e.getDescription()).isEqualTo("Change World to Hello in a java file");
+                assertThat(e.getBefore()).isEqualTo("""
+                  public class A {
+                      void method() {
+                          System.out.println("World");
+                      }
+                  }
+                  """);
+                assertThat(e.getAfter()).isEqualTo("""
+                  public class A {
+                      void method() {
+                          System.out.println("Hello!");
+                      }
+                  }
+                  """);
+                assertThat(e.getLanguage()).isEqualTo("java");
+            });
+        });
 
         Collection<RecipeDescriptor> recipeDescriptors = env.listRecipeDescriptors();
-        assertThat(recipeDescriptors).hasSize(1);
-        RecipeDescriptor descriptor = recipeDescriptors.iterator().next();
-        List<RecipeExample> descriptorExamples = descriptor.getExamples();
-        assertThat(descriptorExamples).containsExactlyElementsOf(examples);
+        assertThat(recipeDescriptors).singleElement().satisfies(descriptor -> {
+            List<RecipeExample> descriptorExamples = descriptor.getExamples();
+            assertThat(descriptorExamples).containsExactlyElementsOf(recipes.iterator().next().getExamples());
+        });
     }
 }


### PR DESCRIPTION
Add recipe examples to recipe and recipe descriptors the same way as recipe contributors.
These recipe examples will be used to display on documents and saas.

This is the rewrite part change, and further work is needed to generate example yaml files in the building phase.