### PR TITLE
Add considering largest frequency group to calculate tabSize

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -245,8 +245,8 @@ class AutodetectTest implements RewriteTest {
         var styles = Autodetect.detect(cus);
         var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
-        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
-        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(3);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(3);
     }
 
     @Test

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -257,45 +257,20 @@ public class Autodetect extends NamedStyles {
              *      PT = (NT / D), which means the percentage of tabs.
              * So
              *      useTabs = PT > 0.5
-             *
-             * (2) Details to solve X via formula (5)
-             * There are three scenarios here
-             * #1. If the code contains tabs only, D ~= NT, PT ~= 100%, and NW ~= 0, so X = 0/0, it's an unknown value,
-             *      then we use the default value 4. Because small errors exist in reality, it is impossible to strictly
-             *      satisfy the condition of (D - NT) being zero, so we use a threshold here to determine this case.
-             *      let's say PT > 80%.
-             * #2. If the code contains spaces only. NT ~= 0, X ~= NW / D.
-             * #3. Mixed tabs and spaces
-             *
-             * So #1 returns default, and both #2 and #3, the tab size X can use solve by formula #5.
              */
             if (this.accumulateDepthCount == 0) {
                 return IntelliJ.tabsAndIndents();
             }
 
             long d = this.accumulateDepthCount;                     // D in above comments
-            long nw = getTotalCharCount(spaceIndentFrequencies);    // NW in above comments
             long nt = getTotalCharCount(tabIndentFrequencies);      // NT in above comments
             double pt = nt / (double) d;                            // PT in above comments
-            final double TAB_PORTION_THRESHOLD = 0.8;
-
             boolean useTabs = pt >= 0.5;
-            int tabSize;
-            if (pt > TAB_PORTION_THRESHOLD || d == nt) {
-                tabSize = 4;
-            } else {
-                double x =  nw / (double)(d - nt);
-                tabSize = getClosestEven(x);
-            }
 
             // Calculate tabSize based on the frequency, pick up the biggest frequency group.
             // Using frequency are less susceptible to outliers than means.
             int moreFrequentTabSize = getBiggestGroupOfTabSize(deltaSpaceIndentFrequencies);
-
-            // If two statistic results fight with each other, it means there are mess indentations in the code, then we use the default.
-            if (moreFrequentTabSize > 0 && tabSize != moreFrequentTabSize) {
-                tabSize = 4;
-            }
+            int tabSize = (moreFrequentTabSize == 0) ? 4 : moreFrequentTabSize;
 
             IndentStatistic continuationFrequencies = useTabs ? tabContinuationIndentFrequencies : spaceContinuationIndentFrequencies;
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -230,7 +230,6 @@ public class Autodetect extends NamedStyles {
 
         public TabsAndIndentsStyle getTabsAndIndentsStyle() {
             /**
-             * Calculate tabSize based on the means
              * For each line, if the code follows an indentation style exactly,
              * Assume :
              *      nw = space count in prefix


### PR DESCRIPTION
Add considering the largest frequency group to calculate tabSize to improve the confidence of tabSize calculation.

Before this PR, we use a way based on statistical means to calculate tab size.
This PR introduced a way to calculate the `tabSize` based on the biggest group, which has the benefit of being less susceptible to outliers.