### PR TITLE
Allow upgrading non-semver Maven dependencies

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -29,6 +29,10 @@ public class Semver {
     private Semver() {
     }
 
+    public static boolean isVersion(String version) {
+        return LatestRelease.RELEASE_PATTERN.matcher(version).matches();
+    }
+
     public static Validated validate(String toVersion, @Nullable String metadataPattern) {
         return test(
                 "metadataPattern",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -214,14 +214,16 @@ public class ChangeParentPom extends Recipe {
 
             private Optional<String> findNewerDependencyVersion(String groupId, String artifactId, String currentVersion,
                                                                 ExecutionContext ctx) throws MavenDownloadingException {
+                String finalCurrentVersion = !Semver.isVersion(currentVersion) ? "0.0.0" : currentVersion;
+
                 if (availableVersions == null) {
                     MavenMetadata mavenMetadata = metadataFailures.insertRows(ctx, () -> downloadMetadata(groupId, artifactId, ctx));
                     availableVersions = mavenMetadata.getVersioning().getVersions().stream()
-                            .filter(v -> versionComparator.isValid(currentVersion, v))
-                            .filter(v -> Boolean.TRUE.equals(allowVersionDowngrades) || versionComparator.compare(currentVersion, currentVersion, v) < 0)
+                            .filter(v -> versionComparator.isValid(finalCurrentVersion, v))
+                            .filter(v -> Boolean.TRUE.equals(allowVersionDowngrades) || versionComparator.compare(finalCurrentVersion, finalCurrentVersion, v) < 0)
                             .collect(Collectors.toList());
                 }
-                return Boolean.TRUE.equals(allowVersionDowngrades) ? availableVersions.stream().max((v1, v2) -> versionComparator.compare(currentVersion, v1, v2)) : versionComparator.upgrade(currentVersion, availableVersions);
+                return Boolean.TRUE.equals(allowVersionDowngrades) ? availableVersions.stream().max((v1, v2) -> versionComparator.compare(finalCurrentVersion, v1, v2)) : versionComparator.upgrade(finalCurrentVersion, availableVersions);
             }
         };
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -506,6 +506,40 @@ class ChangeParentPomTest implements RewriteTest {
         );
     }
 
+    @Test
+    void upgradeNonSemverVersion() {
+        rewriteRun(spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-starter-parent", null, "2021.0.5", null, false, null)),
+          pomXml("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>sample</artifactId>
+              <version>1.0.0</version>
+              
+              <parent>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-parent</artifactId>
+                <version>Hoxton.SR12</version>
+              </parent>
+            </project>
+            """, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>sample</artifactId>
+              <version>1.0.0</version>
+              
+              <parent>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-parent</artifactId>
+                <version>2021.0.5</version>
+              </parent>
+            </project>
+            """));
+    }
+
     @Nested
     @Issue("https://github.com/openrewrite/rewrite/issues/2418")
     class RetainVersions {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -124,6 +124,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void updateManagedDependencyVersion() {
         rewriteRun(
@@ -159,6 +160,52 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                               <artifactId>junit-jupiter-api</artifactId>
                               <version>5.7.2</version>
                               <scope>test</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void forceUpgradeNonSemverVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.springframework.cloud", "spring-cloud-dependencies", "2022.0.2", null,
+            false, null)),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.cloud</groupId>
+                              <artifactId>spring-cloud-dependencies</artifactId>
+                              <version>Camden.SR5</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.cloud</groupId>
+                              <artifactId>spring-cloud-dependencies</artifactId>
+                              <version>2022.0.2</version>
+                              <type>pom</type>
+                              <scope>import</scope>
                           </dependency>
                       </dependencies>
                   </dependencyManagement>


### PR DESCRIPTION
When an existing Maven dependency has a version which is non-semver-friendly (like `org.springframework.cloud:spring-cloud-dependencies:Camden.SR5`), the `UpgradeDependencyVersion` and `ChangeParentPom` recipes should be able to do the upgrade anyway.

Introduces a new `Semver#isVersion(String)` utility to check if a given version string is a valid semver version.