### PR TITLE
Correctly format annotated enum constants

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -447,9 +447,9 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             enumSet = padRight(
                     new J.EnumValueSet(
                             randomId(),
-                            enumValues.get(0).getElement().getPrefix(),
+                            EMPTY,
                             Markers.EMPTY,
-                            ListUtils.map(enumValues, (i, ev) -> i == 0 ? ev.withElement(ev.getElement().withPrefix(EMPTY)) : ev),
+                            enumValues,
                             semicolonPresent.get()
                     ),
                     EMPTY

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -499,9 +499,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             enumSet = padRight(
                     new J.EnumValueSet(
                             randomId(),
-                            enumValues.get(0).getElement().getPrefix(),
+                            EMPTY,
                             Markers.EMPTY,
-                            ListUtils.map(enumValues, (i, ev) -> i == 0 ? ev.withElement(ev.getElement().withPrefix(EMPTY)) : ev),
+                            enumValues,
                             semicolonPresent.get()
                     ),
                     EMPTY

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -444,9 +444,9 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
             enumSet = padRight(
                     new J.EnumValueSet(
                             randomId(),
-                            enumValues.get(0).getElement().getPrefix(),
+                            EMPTY,
                             Markers.EMPTY,
-                            ListUtils.map(enumValues, (i, ev) -> i == 0 ? ev.withElement(ev.getElement().withPrefix(EMPTY)) : ev),
+                            enumValues,
                             semicolonPresent.get()
                     ),
                     EMPTY

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/BlankLinesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/BlankLinesTest.java
@@ -34,7 +34,6 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.mavenProject;
 
 class BlankLinesTest implements RewriteTest {
 
@@ -902,6 +901,24 @@ class BlankLinesTest implements RewriteTest {
               package com.intellij.samples;
               
               public class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3089")
+    void enumAnnotations() {
+        rewriteRun(
+          blankLines(),
+          java(
+            """
+              public enum Test {
+                  @Deprecated
+                  A,
+                  @Deprecated
+                  B
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -2302,4 +2302,25 @@ class TabsAndIndentsTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3089")
+    @Test
+    void enumConstants() {
+        rewriteRun(
+          java(
+            """
+              public enum WorkflowStatus {
+                  @SuppressWarnings("value1")
+                  VALUE1,
+                  @SuppressWarnings("value2")
+                  VALUE2,
+                  @SuppressWarnings("value3")
+                  VALUE3,
+                  @SuppressWarnings("value4")
+                  VALUE4
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -542,9 +542,9 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         J.EnumValue e = enoom;
         e = e.withPrefix(visitSpace(e.getPrefix(), Space.Location.ENUM_VALUE_PREFIX, p));
         e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        e = e.withAnnotations(ListUtils.map(e.getAnnotations(), a -> visitAndCast(a, p)));
         e = e.withName(visitAndCast(e.getName(), p));
         e = e.withInitializer(visitAndCast(e.getInitializer(), p));
-        e = e.withAnnotations(ListUtils.map(e.getAnnotations(), a -> visitAndCast(a, p)));
         return e;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
@@ -133,6 +133,12 @@ public class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     @Override
+    public J.EnumValue visitEnumValue(J.EnumValue _enum, P p) {
+        J.EnumValue e = super.visitEnumValue(_enum, p);
+        return keepMaximumLines(e, style.getKeepMaximum().getInDeclarations());
+    }
+
+    @Override
     public J.Import visitImport(J.Import impoort, P p) {
         J.Import i = super.visitImport(impoort, p);
         JavaSourceFile cu = getCursor().firstEnclosingOrThrow(JavaSourceFile.class);
@@ -257,6 +263,9 @@ public class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private Space minimumLines(Space prefix, int min) {
+        if (min == 0) {
+            return prefix;
+        }
         if (prefix.getComments().isEmpty() ||
             prefix.getWhitespace().contains("\n") ||
             prefix.getComments().get(0) instanceof Javadoc ||


### PR DESCRIPTION
The problem here was basically that the `JavaVisitor` visited the annotations after the constant name.

Fixes: #3089
