### PR TITLE
Remove automatic source set addition to compilation units

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -26,6 +26,8 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.groovy.Assertions.srcMainGroovy;
 import static org.openrewrite.java.Assertions.*;
 
 class AddDependencyTest implements RewriteTest {
@@ -499,6 +501,37 @@ class AddDependencyTest implements RewriteTest {
           mavenProject("project2",
             buildGradle(
               ""
+            )
+          )
+        );
+    }
+
+    @Test
+    void addDependency() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("org.openrewrite:rewrite-core:1.0.0", "java.util.Date", "implementation")),
+          mavenProject("project",
+            srcMainGroovy(
+              groovy(
+                """
+                  import java.util.*;
+
+                  class MyClass {
+                      static void main(String[] args) {
+                          Date date = new Date();
+                          System.out.println("Hello world");
+                      }
+                  }
+                  """
+              )
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    implementation "org.openrewrite:rewrite-core:1.0.0"
+                }
+                """
             )
           )
         );

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/Assertions.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/Assertions.java
@@ -17,12 +17,16 @@ package org.openrewrite.groovy;
 
 
 import org.intellij.lang.annotations.Language;
+import org.openrewrite.SourceFile;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
 
 import java.util.function.Consumer;
+
+import static org.openrewrite.java.Assertions.sourceSet;
+import static org.openrewrite.test.SourceSpecs.dir;
 
 public class Assertions {
 
@@ -51,5 +55,21 @@ public class Assertions {
         SourceSpec<G.CompilationUnit> groovy = new SourceSpec<>(G.CompilationUnit.class, null, GroovyParser.builder(), before, s -> after);
         spec.accept(groovy);
         return groovy;
+    }
+
+    public static SourceSpecs srcMainGroovy(Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... javaSources) {
+        return dir("src/main/groovy", spec, javaSources);
+    }
+
+    public static SourceSpecs srcMainGroovy(SourceSpecs... javaSources) {
+        return srcMainGroovy(spec -> sourceSet(spec, "main"), javaSources);
+    }
+
+    public static SourceSpecs srcTestGroovy(Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... javaSources) {
+        return dir("src/test/groovy", spec, javaSources);
+    }
+
+    public static SourceSpecs srcTestGroovy(SourceSpecs... javaSources) {
+        return srcTestGroovy(spec -> sourceSet(spec, "test"), javaSources);
     }
 }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -199,21 +199,7 @@ public class ReloadableJava11Parser implements JavaParser {
                 .filter(Objects::nonNull)
                 .collect(toList());
 
-        JavaSourceSet sourceSet = getSourceSet(ctx);
-        if (!ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
-            List<JavaType.FullyQualified> classpath = sourceSet.getClasspath();
-            for (J.CompilationUnit cu : mappedCus) {
-                for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
-                    if (type instanceof JavaType.FullyQualified) {
-                        classpath.add((JavaType.FullyQualified) type);
-                    }
-                }
-            }
-            sourceSetProvenance = sourceSet.withClasspath(classpath);
-        }
-
-        assert sourceSetProvenance != null;
-        return ListUtils.map(mappedCus, cu -> cu.withMarkers(cu.getMarkers().add(sourceSetProvenance)));
+        return mappedCus;
     }
 
     LinkedHashMap<Input, JCTree.JCCompilationUnit> parseInputsToCompilerAst(Iterable<Input> sourceFiles, ExecutionContext ctx) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -200,21 +200,7 @@ public class ReloadableJava17Parser implements JavaParser {
                 .filter(Objects::nonNull)
                 .collect(toList());
 
-        JavaSourceSet sourceSet = getSourceSet(ctx);
-        if (!ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
-            List<JavaType.FullyQualified> classpath = sourceSet.getClasspath();
-            for (J.CompilationUnit cu : mappedCus) {
-                for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
-                    if (type instanceof JavaType.FullyQualified) {
-                        classpath.add((JavaType.FullyQualified) type);
-                    }
-                }
-            }
-            sourceSetProvenance = sourceSet.withClasspath(classpath);
-        }
-
-        assert sourceSetProvenance != null;
-        return ListUtils.map(mappedCus, cu -> cu.withMarkers(cu.getMarkers().add(sourceSetProvenance)));
+        return mappedCus;
     }
 
     LinkedHashMap<Input, JCTree.JCCompilationUnit> parseInputsToCompilerAst(Iterable<Input> sourceFiles, ExecutionContext ctx) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -228,21 +228,7 @@ class ReloadableJava8Parser implements JavaParser {
                 .filter(Objects::nonNull)
                 .collect(toList());
 
-        JavaSourceSet sourceSet = getSourceSet(ctx);
-        if (!ctx.getMessage(SKIP_SOURCE_SET_TYPE_GENERATION, false)) {
-            List<JavaType.FullyQualified> classpath = sourceSet.getClasspath();
-            for (J.CompilationUnit cu : mappedCus) {
-                for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
-                    if (type instanceof JavaType.FullyQualified) {
-                        classpath.add((JavaType.FullyQualified) type);
-                    }
-                }
-            }
-            sourceSetProvenance = sourceSet.withClasspath(classpath);
-        }
-
-        assert sourceSetProvenance != null;
-        return ListUtils.map(mappedCus, cu -> cu.withMarkers(cu.getMarkers().add(sourceSetProvenance)));
+        return mappedCus;
     }
 
     @Override

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @SuppressWarnings("rawtypes")
@@ -963,37 +963,37 @@ class AddImportTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/880")
     @Test
     void doNotFoldNormalImportWithNamespaceConflict() {
-        ExecutionContext ctx = new InMemoryExecutionContext();
-        ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false);
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false)))
-            .executionContext(ctx),
-          java(
-            """
-              import java.awt.*; // contains a List class
-              import java.util.Collection;
-              import java.util.Collections;
-              import java.util.Map;
-              import java.util.Set;
-                            
-              @SuppressWarnings("ALL")
-              class Test {
-                  List list;
-              }
-              """,
-            """
-              import java.awt.*; // contains a List class
-              import java.util.Collection;
-              import java.util.Collections;
-              import java.util.List;
-              import java.util.Map;
-              import java.util.Set;
-                            
-              @SuppressWarnings("ALL")
-              class Test {
-                  List list;
-              }
+            .beforeRecipe(addTypesToSourceSet("main")),
+          srcMainJava(
+            java(
               """
+                import java.awt.*; // contains a List class
+                import java.util.Collection;
+                import java.util.Collections;
+                import java.util.Map;
+                import java.util.Set;
+
+                @SuppressWarnings("ALL")
+                class Test {
+                    List list;
+                }
+                """,
+              """
+                import java.awt.*; // contains a List class
+                import java.util.Collection;
+                import java.util.Collections;
+                import java.util.List;
+                import java.util.Map;
+                import java.util.Set;
+
+                @SuppressWarnings("ALL")
+                class Test {
+                    List list;
+                }
+                """
+            )
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
@@ -16,8 +16,6 @@
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.style.NamedStyles;
@@ -27,8 +25,7 @@ import org.openrewrite.test.RewriteTest;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.java.Assertions.*;
 
 class OrderImportsTest implements RewriteTest {
 
@@ -643,18 +640,18 @@ class OrderImportsTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/859")
     @Test
     void doNotFoldPackageWithJavaLangClassNames() {
-        ExecutionContext ctx = new InMemoryExecutionContext();
-        ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, false);
         rewriteRun(
-          spec -> spec.executionContext(ctx),
-          java(
-            """
-              import kotlin.DeepRecursiveFunction;
-              import kotlin.Function;
-              import kotlin.Lazy;
-              import kotlin.Pair;
-              import kotlin.String;
+          spec -> spec.beforeRecipe(addTypesToSourceSet("main")),
+          srcMainJava(
+            java(
               """
+                import kotlin.DeepRecursiveFunction;
+                import kotlin.Function;
+                import kotlin.Lazy;
+                import kotlin.Pair;
+                import kotlin.String;
+                """
+            )
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/MethodNameCasingTest.java
@@ -24,8 +24,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.srcTestJava;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @Issue("https://github.com/openrewrite/rewrite/issues/466")
@@ -83,21 +82,23 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void correctMethodNameCasing() {
         rewriteRun(
-          java(
-            """
-              class Test {
-                  private String getFoo_bar() {
-                      return "foobar";
-                  }
-              }
-              """,
-            """
-              class Test {
-                  private String getFooBar() {
-                      return "foobar";
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class Test {
+                    private String getFoo_bar() {
+                        return "foobar";
+                    }
+                }
+                """,
+              """
+                class Test {
+                    private String getFooBar() {
+                        return "foobar";
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -136,17 +137,19 @@ class MethodNameCasingTest implements RewriteTest {
     void okToRenamePublicMethods() {
         rewriteRun(
           spec -> spec.recipe(new MethodNameCasing(true, true)),
-          java(
-            """
-              class Test {
-                  public void getFoo_bar(){}
-              }
-              """,
-            """
-              class Test {
-                  public void getFooBar(){}
-              }
+          srcTestJava(
+            java(
               """
+                class Test {
+                    public void getFoo_bar(){}
+                }
+                """,
+              """
+                class Test {
+                    public void getFooBar(){}
+                }
+                """
+            )
           )
         );
     }
@@ -195,19 +198,21 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void changeMethodDeclaration() {
         rewriteRun(
-          java(
-            """
-              class Test {
-                  void MyMethod_with_über() {
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void myMethodWithUber() {
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class Test {
+                    void MyMethod_with_über() {
+                    }
+                }
+                """,
+              """
+                class Test {
+                    void myMethodWithUber() {
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -215,19 +220,21 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void changeCamelCaseMethodWithFirstLetterUpperCase() {
         rewriteRun(
-          java(
-            """
-              class Test {
-                  void MyMethod() {
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void myMethod() {
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class Test {
+                    void MyMethod() {
+                    }
+                }
+                """,
+              """
+                class Test {
+                    void myMethod() {
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -235,34 +242,36 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void changeMethodInvocations() {
         rewriteRun(
-          java(
-            """
-              class Test {
-                  void MyMethod_with_über() {
-                  }
-              }
-              """, """
-              class Test {
-                  void myMethodWithUber() {
-                  }
-              }
+          srcMainJava(
+            java(
               """
-          ),
-          java(
-            """
-              class A {
-                  void test() {
-                      new Test().MyMethod_with_über();
-                  }
-              }
-              """,
-            """
-              class A {
-                  void test() {
-                      new Test().myMethodWithUber();
-                  }
-              }
+                class Test {
+                    void MyMethod_with_über() {
+                    }
+                }
+                """, """
+                class Test {
+                    void myMethodWithUber() {
+                    }
+                }
+                """
+            ),
+            java(
               """
+                class A {
+                    void test() {
+                        new Test().MyMethod_with_über();
+                    }
+                }
+                """,
+              """
+                class A {
+                    void test() {
+                        new Test().myMethodWithUber();
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -284,35 +293,37 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void changeMethodNameWhenOverride() {
         rewriteRun(
-          java(
-            """
-              class ParentClass {
-                  void Method() {
-                  }
-              }
-              """,
-            """
-              class ParentClass {
-                  void method() {
-                  }
-              }
+          srcMainJava(
+            java(
               """
-          ),
-          java(
-            """
-              class Test extends ParentClass {
-                  @Override
-                  void Method() {
-                  }
-              }
-              """,
-            """
-              class Test extends ParentClass {
-                  @Override
-                  void method() {
-                  }
-              }
+                class ParentClass {
+                    void Method() {
+                    }
+                }
+                """,
               """
+                class ParentClass {
+                    void method() {
+                    }
+                }
+                """
+            ),
+            java(
+              """
+                class Test extends ParentClass {
+                    @Override
+                    void Method() {
+                    }
+                }
+                """,
+              """
+                class Test extends ParentClass {
+                    @Override
+                    void method() {
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -336,25 +347,27 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void nameExistsInInnerClass() {
         rewriteRun(
-          java(
-            """
-              class T {
-                  void Method(){}
-                  
-                  private static class M {
-                      void Method(){}
-                  }
-              }
-              """,
-            """
-              class T {
-                  void method(){}
-                  
-                  private static class M {
-                      void method(){}
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class T {
+                    void Method(){}
+
+                    private static class M {
+                        void Method(){}
+                    }
+                }
+                """,
+              """
+                class T {
+                    void method(){}
+
+                    private static class M {
+                        void method(){}
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -364,43 +377,45 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void snakeCaseToCamelCase() {
         rewriteRun(
-          java(
-            """
-              class T {
-                  private static int SOME_METHOD() {
-                    return 1;
-                  }
-                  private static int some_method_2() {
-                    return 1;
-                  }
-                  private static int some_über_method() {
-                    return 1;
-                  }
-                  public static void anotherMethod() {
-                    int i = SOME_METHOD();
-                    i = some_method_2();
-                    i = some_über_method();
-                  }
-              }
-              """,
-            """
-              class T {
-                  private static int someMethod() {
-                    return 1;
-                  }
-                  private static int someMethod2() {
-                    return 1;
-                  }
-                  private static int someUberMethod() {
-                    return 1;
-                  }
-                  public static void anotherMethod() {
-                    int i = someMethod();
-                    i = someMethod2();
-                    i = someUberMethod();
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class T {
+                    private static int SOME_METHOD() {
+                      return 1;
+                    }
+                    private static int some_method_2() {
+                      return 1;
+                    }
+                    private static int some_über_method() {
+                      return 1;
+                    }
+                    public static void anotherMethod() {
+                      int i = SOME_METHOD();
+                      i = some_method_2();
+                      i = some_über_method();
+                    }
+                }
+                """,
+              """
+                class T {
+                    private static int someMethod() {
+                      return 1;
+                    }
+                    private static int someMethod2() {
+                      return 1;
+                    }
+                    private static int someUberMethod() {
+                      return 1;
+                    }
+                    public static void anotherMethod() {
+                      int i = someMethod();
+                      i = someMethod2();
+                      i = someUberMethod();
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -443,21 +458,23 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void keepCamelCase() {
         rewriteRun(
-          java(
-            """
-              class Test {
-                  private void Method() {
-                  
-                  }
-              }
-              """,
-            """
-              class Test {
-                  private void method() {
-                  
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class Test {
+                    private void Method() {
+
+                    }
+                }
+                """,
+              """
+                class Test {
+                    private void method() {
+
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -465,45 +482,47 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void keepCamelCase2() {
         rewriteRun(
-          java(
-            """
-              import java.util.*;
-                            
-              class Test {
-                  private List<String> GetNames() {
-                      List<String> result = new ArrayList<>();
-                      result.add("Alice");
-                      result.add("Bob");
-                      result.add("Carol");
-                      return result;
-                  }
-                  
-                  public void run() {
-                      for (String n: GetNames()) {
-                          System.out.println(n);
-                      }
-                  }
-              }
-              """,
-            """
-              import java.util.*;
-                            
-              class Test {
-                  private List<String> getNames() {
-                      List<String> result = new ArrayList<>();
-                      result.add("Alice");
-                      result.add("Bob");
-                      result.add("Carol");
-                      return result;
-                  }
-                  
-                  public void run() {
-                      for (String n: getNames()) {
-                          System.out.println(n);
-                      }
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                import java.util.*;
+
+                class Test {
+                    private List<String> GetNames() {
+                        List<String> result = new ArrayList<>();
+                        result.add("Alice");
+                        result.add("Bob");
+                        result.add("Carol");
+                        return result;
+                    }
+
+                    public void run() {
+                        for (String n: GetNames()) {
+                            System.out.println(n);
+                        }
+                    }
+                }
+                """,
+              """
+                import java.util.*;
+
+                class Test {
+                    private List<String> getNames() {
+                        List<String> result = new ArrayList<>();
+                        result.add("Alice");
+                        result.add("Bob");
+                        result.add("Carol");
+                        return result;
+                    }
+
+                    public void run() {
+                        for (String n: getNames()) {
+                            System.out.println(n);
+                        }
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -512,27 +531,29 @@ class MethodNameCasingTest implements RewriteTest {
     @Test
     void changeNameOfMethodWithArrayArgument() {
         rewriteRun(
-          java(
-            """
-              import java.util.*;
-                            
-              class Test {
-                  private List<String> GetNames(String[] names) {
-                      List<String> result = new ArrayList<>(Arrays.asList(names));
-                      return result;
-                  }
-              }
-              """,
-            """
-              import java.util.*;
-                            
-              class Test {
-                  private List<String> getNames(String[] names) {
-                      List<String> result = new ArrayList<>(Arrays.asList(names));
-                      return result;
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                import java.util.*;
+
+                class Test {
+                    private List<String> GetNames(String[] names) {
+                        List<String> result = new ArrayList<>(Arrays.asList(names));
+                        return result;
+                    }
+                }
+                """,
+              """
+                import java.util.*;
+
+                class Test {
+                    private List<String> getNames(String[] names) {
+                        List<String> result = new ArrayList<>(Arrays.asList(names));
+                        return result;
+                    }
+                }
+                """
+            )
           )
         );
     }
@@ -542,19 +563,21 @@ class MethodNameCasingTest implements RewriteTest {
     void unknownParameterTypes() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.none()),
-          java(
-            """
-              class Test {
-                  private void Foo(Unknown u) {
-                  }
-              }
-              """,
-            """
-              class Test {
-                  private void foo(Unknown u) {
-                  }
-              }
+          srcMainJava(
+            java(
               """
+                class Test {
+                    private void Foo(Unknown u) {
+                    }
+                }
+                """,
+              """
+                class Test {
+                    private void foo(Unknown u) {
+                    }
+                }
+                """
+            )
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -293,11 +293,14 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
      * Changes the source set on the parser. Intended for use in multiple pass parsing, where we want to keep the
      * compiler symbol table intact for type attribution on later parses, i.e. for maven multi-module projects.
      *
+     * @deprecated
      * @param sourceSet source set used to set {@link org.openrewrite.java.marker.JavaSourceSet} markers on
      *                  subsequently parsed {@link J.CompilationUnit}
      */
+    @Deprecated//(since = "7.40.0", forRemoval = true)
     void setSourceSet(String sourceSet);
 
+    @Deprecated//(since = "7.40.0", forRemoval = true)
     JavaSourceSet getSourceSet(ExecutionContext ctx);
 
     @SuppressWarnings("unchecked")

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -20,13 +20,11 @@ import org.openrewrite.*;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.OptionDescriptor;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
-import org.openrewrite.marker.SourceSet;
 import org.openrewrite.quark.Quark;
 import org.openrewrite.remote.Remote;
 import org.openrewrite.scheduling.DirectScheduler;
@@ -271,16 +269,6 @@ public interface RewriteTest extends SourceSpecs {
                     markers = markers.setByType(marker);
                 }
                 sourceFile = sourceFile.withMarkers(markers);
-
-                // Update the default 'main' SourceSet Marker added by the JavaParser with the specs sourceSetName
-                if (nextSpec.sourceSetName != null) {
-                    sourceFile = sourceFile.withMarkers((markers.withMarkers(ListUtils.map(markers.getMarkers(), m -> {
-                        if (m instanceof SourceSet) {
-                            m = ((SourceSet) m).withName(nextSpec.sourceSetName);
-                        }
-                        return m;
-                    }))));
-                }
 
                 // Validate that printing a parsed AST yields the same source text
                 int j = 0;

--- a/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
@@ -81,6 +81,7 @@ public class SourceSpec<T extends SourceFile> implements SourceSpecs {
 
     @Setter
     @Nullable
+    @Deprecated//(since = "7.40.0", forRemoval = true)
     protected String sourceSetName;
 
     protected Path dir = Paths.get("");


### PR DESCRIPTION
The purpose of this chunk of work is to fully align the way that `SourceSet` handling is performed. Presently, there are many ways that `SourceSet` instances are being handled. Below is a list of the places where this is occurring:

* `Java*Parser` implementations
* `KotlinParser` implementation
* Gradle build plugin
* Maven build plugin

Additionally, in the `GroovyParser` there is no `SourceSet` handling.

This change is important, so that we can properly add `SourceSet` markers when they are truly necessary and leave them missing when they should not be present. The _only_ place where this determination can be performed presently is by the build plugins themselves. A few examples of places where a `SourceSet` marker should *NOT* be present are:

* Gradle Groovy DSL (`*.gradle`)
* Gradle Kotlin DSL (`*.gradle.kts`; NOTE: not yet parsing these types)
* Maven Java Wrapper file (`.mvn/wrapper/MavenWrapperDownloader.java`)

While the above is not meant to by any means be an exhaustive list, it does illustrate that for the parsers that presently *ARE* doing `SourceSet` manipulation within their various `parseInputs(..)` implementations, there are cases with which we would desire for there to be no `SourceSet` marker added in that language parser implementation.