### PR TITLE
Try to fix a template issue on `cucumber-jvm-migration`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlow.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/controlflow/ControlFlow.java
@@ -775,8 +775,8 @@ public final class ControlFlow {
             String type = iteratorType instanceof JavaType.Primitive ? ((JavaType.Primitive) iteratorType).getClassName() : iteratorType.toString();
             Supplier<Cursor> cursorSupplier = () -> getCursor().dropParentUntil(J.Block.class::isInstance);
             JavaTemplate fakeIterableVariableTemplate = iterable.getType() instanceof JavaType.Array ?
-                    JavaTemplate.builder(cursorSupplier, "final Iterator<" + type + "> " + variableName + " = Arrays.stream(#{anyArray()}).iterator()").imports("java.util.Arrays").build() :
-                    JavaTemplate.builder(cursorSupplier, "final Iterator<" + type + "> " + variableName + " = #{any(java.lang.Iterable)}.iterator()").build();
+                    JavaTemplate.builder(cursorSupplier, "final Iterator<" + type + "> " + variableName + " = Arrays.stream(#{anyArray()}).iterator();").imports("java.util.Arrays").build() :
+                    JavaTemplate.builder(cursorSupplier, "final Iterator<" + type + "> " + variableName + " = #{any(java.lang.Iterable)}.iterator();").build();
             // Unfortunately, because J.NewArray isn't a statement, we have to find a place in the AST where a statement could be placed. This way a statement will always be generated.
             // Find the closes outer block to place our statement.
             J.Block block = getCursor().firstEnclosing(J.Block.class);

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -264,7 +264,8 @@ public class BlockStatementTemplateGenerator {
                 before.insert(0, "{\n");
             }
 
-            if (prior instanceof Statement) {
+            if (prior == insertionPoint && prior instanceof Expression) {
+                // the template represents an expression, so we need to wrap it in a statement
                 after.append(';');
             }
             after.append('}');


### PR DESCRIPTION
This PR attempts to fix the issue https://github.com/openrewrite/rewrite/issues/3102
I think the issue was introduced by [this commit](https://github.com/openrewrite/rewrite/commit/626d8c645bb7b6b9d81e69a7985759701eb9b133#r108541429), 
This PR just patched against that specified problem, it can fix the template problem, but it's a patch fix. I don't know whether it's a correct change.  I think the issue needs @knutwannheden 's help to also take a look.
