### PR TITLE
New recipe to utilise ChangeTagValueVisitor capabilities for general XML files

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
@@ -30,16 +30,16 @@ import org.openrewrite.xml.tree.Xml;
 public class ChangeTagValue extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Change XML Tag Name";
+        return "Change XML Tag Value";
     }
 
     @Override
     public String getDescription() {
-        return "Alters the name of XML tags matching the provided expression.";
+        return "Alters the value of XML tags matching the provided expression.";
     }
 
     @Option(displayName = "Element name",
-            description = "The name of the element whose attribute's value is to be changed. Interpreted as an XPath Expression.",
+            description = "The name of the element whose value is to be changed. Interpreted as an XPath Expression.",
             example = "/settings/servers/server/username")
     String elementName;
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
@@ -30,7 +30,7 @@ import org.openrewrite.xml.tree.Xml;
 public class ChangeTagValue extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Change XML Tag Value";
+        return "Change XML tag value";
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.HasSourcePath;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.xml.tree.Xml;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangeTagValue extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Change XML Tag Name";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Alters the name of XML tags matching the provided expression.";
+    }
+
+    @Option(displayName = "Element name",
+            description = "The name of the element whose attribute's value is to be changed. Interpreted as an XPath Expression.",
+            example = "/settings/servers/server/username")
+    String elementName;
+
+    @Option(displayName = "Old value",
+            description = "The old value of the tag.",
+            required = false,
+            example = "user")
+    @Nullable
+    String oldValue;
+
+    @Option(displayName = "New value",
+            description = "The new value for the tag.",
+            example = "user")
+    String newValue;
+
+    @Option(displayName = "File matcher",
+            description = "If provided only matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "'**/application-*.xml'")
+    @Nullable
+    String fileMatcher;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        if (fileMatcher != null) {
+            return new HasSourcePath<>(fileMatcher);
+        }
+        return null;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlVisitor<ExecutionContext>() {
+            private final XPathMatcher xPathMatcher = new XPathMatcher(elementName);
+
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                if (xPathMatcher.matches(getCursor())) {
+                    // if either no oldValue is supplied OR oldValue equals the value of this tag
+                    // then change the value to the newValue supplied
+                    if (oldValue == null || oldValue.equals(tag.getValue().orElse(null))) {
+                        doAfterVisit(new ChangeTagValueVisitor<>(tag, newValue));
+                    }
+                }
+                return super.visitTag(tag, ctx);
+            }
+        };
+    }
+}


### PR DESCRIPTION
The desired endpoint is to be able to change the value of a specific XML tag, defined by an XPath elementName parameter, and optional oldValue and fileMatcher parameters