### PR TITLE
Introduce a visitor to extract examples from a rewrite recipe unit test.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeExample.java
@@ -15,14 +15,15 @@
  */
 package org.openrewrite.config;
 
-import lombok.Value;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.openrewrite.internal.lang.Nullable;
 
-
-@Value
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class RecipeExample {
     @Nullable
-    String name;
+    public String name;
 
     @Nullable
     String description;

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeExample.java
@@ -23,7 +23,7 @@ import org.openrewrite.internal.lang.Nullable;
 @Data
 public class RecipeExample {
     @Nullable
-    public String name;
+    String name;
 
     @Nullable
     String description;

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -76,7 +76,6 @@ public class YamlResourceLoader implements ResourceLoader {
         Style("specs.openrewrite.org/v1beta/style"),
         Category("specs.openrewrite.org/v1beta/category"),
         Example("specs.openrewrite.org/v1beta/example"),
-
         Attribution("specs.openrewrite.org/v1beta/attribution");
 
         private final String spec;
@@ -451,13 +450,16 @@ public class YamlResourceLoader implements ResourceLoader {
 
             List<Map<String, Object>> examples = (List<Map<String, Object>>) examplesMap.get("examples");
 
-            List<RecipeExample> newExamples = examples.stream().map(exam -> new RecipeExample(
-                (String) exam.get("name"),
-                (String) exam.get("description"),
-                (String) exam.get("before"),
-                (String) exam.get("after"),
-                (String) exam.get("language")
-            )).collect(toList());
+            List<RecipeExample> newExamples = examples.stream().map(exam -> {
+                    RecipeExample recipeExample = new RecipeExample();
+                    recipeExample.setName((String) exam.get("name"));
+                    recipeExample.setDescription((String) exam.get("description"));
+                    recipeExample.setBefore((String) exam.get("before"));
+                    recipeExample.setAfter((String) exam.get("after"));
+                    recipeExample.setLanguage((String) exam.get("language"));
+                    return recipeExample;
+                }
+            ).collect(toList());
 
             recipeNameToExamples.get(recipeName).addAll(newExamples);
         }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/DocumentExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/DocumentExample.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.internal;
 
 import java.lang.annotation.Retention;

--- a/rewrite-core/src/main/java/org/openrewrite/internal/DocumentExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/DocumentExample.java
@@ -1,7 +1,16 @@
 package org.openrewrite.internal;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Mark a test as a good recipe example to present on document/web pages.
  */
+@Retention(
+    /* you're not going to be able to deny your contribution */
+    RetentionPolicy.RUNTIME
+)
 public @interface DocumentExample {
+    String name();
 }
+

--- a/rewrite-core/src/main/java/org/openrewrite/internal/DocumentExample.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/DocumentExample.java
@@ -1,0 +1,7 @@
+package org.openrewrite.internal;
+
+/**
+ * Mark a test as a good recipe example to present on document/web pages.
+ */
+public @interface DocumentExample {
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ExamplesExtractorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ExamplesExtractorTest.java
@@ -1,10 +1,6 @@
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Recipe;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.test.AdHocRecipe;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,16 +9,97 @@ import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class ExamplesExtractorTest implements RewriteTest {
 
-//    @Override
-//    public void defaults(RecipeSpec spec) {
-//        Recipe recipe = toRecipe(() -> new ExamplesExtractor());
-//        spec.recipe(recipe)
-//          .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
-//    }
+    @Test
+    void extractJavaExampleWithDefault() {
+        ExamplesExtractor examplesExtractor = new ExamplesExtractor();
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> examplesExtractor))
+            .parser(JavaParser.fromJavaVersion()
+              .classpath(JavaParser.runtimeClasspath())),
+          java(
+            """
+            package org.openrewrite.java.cleanup;
+            
+            import org.junit.jupiter.api.Test;
+            import org.openrewrite.Recipe;
+            import org.openrewrite.internal.DocumentExample;
+            import org.openrewrite.test.RecipeSpec;
+            import org.openrewrite.test.RewriteTest;
+            
+            import static org.openrewrite.java.Assertions.java;
+            
+            class ChainStringBuilderAppendCallsTest implements RewriteTest {
+                @Override
+                public void defaults(RecipeSpec spec) {
+                    Recipe recipe = new ChainStringBuilderAppendCalls();
+                    spec.recipe(recipe);
+                }
 
+                @DocumentExample(name = "Objects concatenation.")
+                @Test
+                void objectsConcatenation() {
+                    rewriteRun(
+                      java(
+                        \"""
+                                                      class A {
+                                                          void method1() {
+                                                              StringBuilder sb = new StringBuilder();
+                                                              String op = "+";
+                                                              sb.append("A" + op + "B");
+                                                              sb.append(1 + op + 2);
+                                                          }
+                                                      }
+                                                      \""",
+                        \"""
+                                                      class A {
+                                                          void method1() {
+                                                              StringBuilder sb = new StringBuilder();
+                                                              String op = "+";
+                                                              sb.append("A").append(op).append("B");
+                                                              sb.append(1).append(op).append(2);
+                                                          }
+                                                      }
+                                                      \"""
+                      )
+                    );
+                }
+            }
+            """
+          )
+        );
+
+        String yaml = examplesExtractor.printRecipeExampleYaml();
+        assertThat(yaml).isEqualTo(
+          """
+            type: specs.openrewrite.org/v1beta/example
+            recipeName: org.openrewrite.java.cleanup.ChainStringBuilderAppendCalls
+            examples:
+            - description: "Objects concatenation."
+              before: |
+                class A {
+                    void method1() {
+                        StringBuilder sb = new StringBuilder();
+                        String op = "+";
+                        sb.append("A" + op + "B");
+                        sb.append(1 + op + 2);
+                    }
+                }
+              after: |
+                class A {
+                    void method1() {
+                        StringBuilder sb = new StringBuilder();
+                        String op = "+";
+                        sb.append("A").append(op).append("B");
+                        sb.append(1).append(op).append(2);
+                    }
+                }
+              language: "java"
+            """
+        );
+    }
 
     @Test
-    void extractJavaExample() {
+    void extractJavaExampleRecipeInSpec() {
         ExamplesExtractor examplesExtractor = new ExamplesExtractor();
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> examplesExtractor))
@@ -40,15 +117,12 @@ class ExamplesExtractorTest implements RewriteTest {
             import static org.openrewrite.java.Assertions.java;
             
             class ChainStringBuilderAppendCallsTest implements RewriteTest {
-                @Override
-                public void defaults(RecipeSpec spec) {
-                    spec.recipe(new ChainStringBuilderAppendCalls());
-                }
-            
+
                 @DocumentExample(name = "Objects concatenation.")
                 @Test
                 void objectsConcatenation() {
                     rewriteRun(
+                      spec -> spec.recipe(new ChainStringBuilderAppendCalls()),
                       java(
                         \"""
                                                       class A {
@@ -105,8 +179,5 @@ class ExamplesExtractorTest implements RewriteTest {
               language: "java"
             """
         );
-
     }
-
-
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ExamplesExtractorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ExamplesExtractorTest.java
@@ -1,0 +1,76 @@
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.test.AdHocRecipe;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class ExamplesExtractorTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        Recipe recipe = toRecipe(() -> new ExamplesExtractor());
+        spec.recipe(recipe)
+          .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+
+    @Test
+    void extractJavaExample() {
+        rewriteRun(
+          java(
+            """
+            import org.junit.jupiter.api.Test;
+            import org.openrewrite.internal.DocumentExample;
+            import org.openrewrite.test.RecipeSpec;
+            import org.openrewrite.test.RewriteTest;
+            
+            import static org.openrewrite.java.Assertions.java;
+            
+            class ChainStringBuilderAppendCallsTest implements RewriteTest {
+                @Override
+                public void defaults(RecipeSpec spec) {
+                    spec.recipe(new ChainStringBuilderAppendCalls());
+                }
+            
+                @DocumentExample
+                @Test
+                void objectsConcatenation() {
+                    rewriteRun(
+                      java(
+                        \"""
+                                                      class A {
+                                                          void method1() {
+                                                              StringBuilder sb = new StringBuilder();
+                                                              String op = "+";
+                                                              sb.append("A" + op + "B");
+                                                              sb.append(1 + op + 2);
+                                                          }
+                                                      }
+                                                      \""",
+                        \"""
+                                                      class A {
+                                                          void method1() {
+                                                              StringBuilder sb = new StringBuilder();
+                                                              String op = "+";
+                                                              sb.append("A").append(op).append("B");
+                                                              sb.append(1).append(op).append(2);
+                                                          }
+                                                      }
+                                                      \"""
+                      )
+                    );
+                }
+            }
+            """
+          )
+        );
+    }
+
+
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ExamplesExtractorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ExamplesExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.cleanup;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -27,6 +28,7 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
         spec.recipe(new ChainStringBuilderAppendCalls());
     }
 
+    @DocumentExample
     @Test
     void objectsConcatenation() {
         rewriteRun(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.cleanup;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
 import org.openrewrite.internal.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/ChainStringBuilderAppendCallsTest.java
@@ -28,7 +28,7 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
         spec.recipe(new ChainStringBuilderAppendCalls());
     }
 
-    @DocumentExample
+    @DocumentExample(name = "Objects concatenation.")
     @Test
     void objectsConcatenation() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
@@ -1,0 +1,19 @@
+package org.openrewrite.java;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.tree.J;
+
+public class ExamplesExtractor extends JavaIsoVisitor<ExecutionContext> {
+
+    @Override
+    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+        return super.visitCompilationUnit(cu, executionContext);
+    }
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+
+
+        return super.visitMethodInvocation(method, executionContext);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
@@ -1,10 +1,80 @@
 package org.openrewrite.java;
 
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.tree.J;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Extract recipe examples from a test file which are annotated with @DocumentExample
+ * Output is the content of the yaml file to present examples
+ * Format is like:
+ * <pre>
+ *               type: specs.openrewrite.org/v1beta/example
+ *               recipeName: test.ChangeTextToHello
+ *               examples:
+ *                 - description: "Change World to Hello in a text file"
+ *                   before: "World"
+ *                   after: "Hello!"
+ *                   language: "text"
+ *                 - description: "Change World to Hello in a java file"
+ *                   before: |
+ *                     public class A {
+ *                         void method() {
+ *                             System.out.println("World");
+ *                         }
+ *                     }
+ *                   after: |
+ *                     public class A {
+ *                         void method() {
+ *                             System.out.println("Hello!");
+ *                         }
+ *                     }
+ *                   language: "java"
+ * </pre>
+ */
 public class ExamplesExtractor extends JavaIsoVisitor<ExecutionContext> {
 
+    private final StringBuilder outputSb;
+
+
+    protected ExamplesExtractor() {
+        outputSb = new StringBuilder();
+    }
+
+    /**
+     * print the recipe example yaml.
+     */
+    public String printRecipeExampleYaml() {
+        return outputSb.toString();
+    }
+
+    /*
+    Yaml format:
+              type: specs.openrewrite.org/v1beta/example
+              recipeName: test.ChangeTextToHello
+              examples:
+                - description: "Change World to Hello in a text file"
+                  before: "World"
+                  after: "Hello!"
+                  language: "text"
+                - description: "Change World to Hello in a java file"
+                  before: |
+                    public class A {
+                        void method() {
+                            System.out.println("World");
+                        }
+                    }
+                  after: |
+                    public class A {
+                        void method() {
+                            System.out.println("Hello!");
+                        }
+                    }
+                  language: "java"
+     */
     @Override
     public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
         return super.visitCompilationUnit(cu, executionContext);
@@ -14,6 +84,12 @@ public class ExamplesExtractor extends JavaIsoVisitor<ExecutionContext> {
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
 
 
+
         return super.visitMethodInvocation(method, executionContext);
+    }
+
+    @Override
+    public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
+        return super.visitNewClass(newClass, executionContext);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
@@ -1,8 +1,12 @@
 package org.openrewrite.java;
 
-import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.config.RecipeExample;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,59 +41,225 @@ import java.util.List;
  */
 public class ExamplesExtractor extends JavaIsoVisitor<ExecutionContext> {
 
-    private final StringBuilder outputSb;
+    private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
+    private static final AnnotationMatcher DOCUMENT_EXAMPLE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.openrewrite.internal.DocumentExample");
 
+    private static final MethodMatcher REWRITE_RUN_METHOD_MATCHER_WITH_SPEC =
+        new MethodMatcher("org.openrewrite.test.RewriteTest rewriteRun(java.util.function.Consumer, org.openrewrite.test.SourceSpecs[])");
+    private static final MethodMatcher REWRITE_RUN_METHOD_MATCHER =
+        new MethodMatcher("org.openrewrite.test.RewriteTest rewriteRun(org.openrewrite.test.SourceSpecs[])");
+    private static final MethodMatcher RECIPE_METHOD_MATCHER = new MethodMatcher("org.openrewrite.test.RecipeSpec recipe(org.openrewrite.Recipe)");
+
+    private static final MethodMatcher JAVA_METHOD_MATCHER = new MethodMatcher("org.openrewrite.java.Assertions java(..)");
+    private static final MethodMatcher BUILD_GRADLE_METHOD_MATCHER = new MethodMatcher("org.openrewrite.gradle.Assertions buildGradle(..)");
+    private static final MethodMatcher POM_XML_METHOD_MATCHER = new MethodMatcher("org.openrewrite.maven.Assertions pomXml(..)");
+
+    private static final MethodMatcher DEFAULT_METHOD_MATCHER = new MethodMatcher("org.openrewrite.test.RewriteTest defaults(org.openrewrite.test.RecipeSpec)");
+    private static final MethodMatcher SPEC_RECIPE_METHOD_MATCHER = new MethodMatcher("org.openrewrite.test.RecipeSpec recipe(org.openrewrite.Recipe)");
+
+    private String recipeType;
+    private String defaultRecipeName;
+    private String recipeName;
+    private List<RecipeExample> recipeExamples;
+    private String exampleDescription;
 
     protected ExamplesExtractor() {
-        outputSb = new StringBuilder();
+        recipeType = "specs.openrewrite.org/v1beta/example";
+        recipeExamples = new ArrayList<>();
     }
 
     /**
      * print the recipe example yaml.
      */
     public String printRecipeExampleYaml() {
-        return outputSb.toString();
+        String name = (recipeName != null && !recipeName.isEmpty()) ? recipeName : defaultRecipeName;
+        return new YamlPrinter().print(recipeType, name, recipeExamples);
     }
 
-    /*
-    Yaml format:
-              type: specs.openrewrite.org/v1beta/example
-              recipeName: test.ChangeTextToHello
-              examples:
-                - description: "Change World to Hello in a text file"
-                  before: "World"
-                  after: "Hello!"
-                  language: "text"
-                - description: "Change World to Hello in a java file"
-                  before: |
-                    public class A {
-                        void method() {
-                            System.out.println("World");
+    @Override
+    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+        if ( method.getMethodType().getDeclaringType().getInterfaces().get(0).getFullyQualifiedName().equals("org.openrewrite.test.RewriteTest") &&
+             method.getName().getSimpleName().equals("defaults")) {
+            defaultRecipeName = findDefaultRecipeName(method);
+            return method;
+        }
+
+        List<J.Annotation> annotations = method.getLeadingAnnotations();
+        if (!hasAnnotation(annotations, TEST_ANNOTATION_MATCHER) &&
+            !hasAnnotation(annotations, DOCUMENT_EXAMPLE_ANNOTATION_MATCHER)) {
+            return method;
+        }
+
+        new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                if (DOCUMENT_EXAMPLE_ANNOTATION_MATCHER.matches(annotation)) {
+                    List<Expression> args = annotation.getArguments();
+                    if (args.size() == 1 && args.get(0) instanceof J.Assignment) {
+                        J.Assignment assignment = (J.Assignment) args.get(0);
+                        if (assignment.getAssignment() instanceof J.Literal) {
+                            exampleDescription = (String) ((J.Literal) assignment.getAssignment()).getValue();
                         }
                     }
-                  after: |
-                    public class A {
-                        void method() {
-                            System.out.println("Hello!");
+                }
+                return annotation;
+            }
+        }.visit(method, ctx);
+
+        return super.visitMethodDeclaration(method, ctx);
+    }
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        List<Expression> args = method.getArguments();
+        RecipeExample example = null;
+        if (REWRITE_RUN_METHOD_MATCHER_WITH_SPEC.matches(method)) {
+            String maybeName = findRecipeNameFromSpecParam(args.get(0));
+            if (maybeName != null) {
+                recipeName = maybeName;
+            }
+            example = extractRecipeExample(args.get(1));
+
+        } else if (REWRITE_RUN_METHOD_MATCHER.matches(method)) {
+            example = extractRecipeExample(args.get(0));
+        }
+
+        if (example != null) {
+            example.setDescription(exampleDescription);
+            this.recipeExamples.add(example);
+        }
+        return method;
+    }
+
+    private static boolean hasAnnotation( List<J.Annotation> annotations, AnnotationMatcher matcher) {
+        return annotations.stream().anyMatch(matcher::matches);
+    }
+
+    public static class YamlPrinter {
+        String print(String recipeType,
+                     String recipeName,
+                     List<RecipeExample> examples) {
+            if (recipeName == null ||
+                recipeName.isEmpty() ||
+                examples.isEmpty()
+                ) {
+                return "";
+            }
+
+            StringBuilder output = new StringBuilder();
+            output.append("type: ").append(recipeType).append("\n");
+            output.append("recipeName: ").append(recipeName).append("\n");
+            output.append("examples:\n");
+            for (RecipeExample example : examples) {
+                output.append("- description: \"").append(example.getDescription()).append("\"\n");
+                output.append("  before: |\n");
+                output.append(indentTextBlock(example.getBefore()));
+                output.append("  after: |\n");
+                output.append(indentTextBlock(example.getAfter()));
+                output.append("  language: \"").append(example.getLanguage()).append("\"\n");
+            }
+            return output.toString();
+        }
+
+        private String indentTextBlock(String text) {
+            String str = "    " + text.replace("\n", "\n    ").trim();
+            if (!str.endsWith("\n")) {
+                str = str + "\n";
+            }
+            return str;
+        }
+    }
+
+    @Nullable
+    private String findRecipeNameFromSpecParam(Expression arg) {
+        return new JavaIsoVisitor<List<String>>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            List<String> recipeNames) {
+                if (RECIPE_METHOD_MATCHER.matches(method)) {
+                    new JavaIsoVisitor<List<String>>() {
+                        @Override
+                        public J.NewClass visitNewClass(J.NewClass newClass, List<String> recipeNames) {
+                            if (TypeUtils.isAssignableTo("org.openrewrite.Recipe", newClass.getType())) {
+                                JavaType type = newClass.getType();
+                                if (type instanceof JavaType.Class) {
+                                    JavaType.Class tc = (JavaType.Class) type;
+                                    recipeNames.add(tc.getFullyQualifiedName());
+                                }
+                            }
+                            return newClass;
                         }
-                    }
-                  language: "java"
-     */
-    @Override
-    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
-        return super.visitCompilationUnit(cu, executionContext);
+                    }.visit(method, recipeNames);
+                    return method;
+                }
+                return method;
+            }
+        }.reduce(arg, new ArrayList<>()).stream().findFirst().orElse(null);
     }
 
-    @Override
-    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
-
-
-
-        return super.visitMethodInvocation(method, executionContext);
+    @Nullable
+    private String findDefaultRecipeName(J.MethodDeclaration defaultsMethod) {
+        return new JavaIsoVisitor<List<String>>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, List<String> strings) {
+                if (SPEC_RECIPE_METHOD_MATCHER.matches(method)) {
+                    new JavaIsoVisitor<List<String>>() {
+                        @Override
+                        public J.NewClass visitNewClass(J.NewClass newClass, List<String> recipeNames) {
+                            if (TypeUtils.isAssignableTo("org.openrewrite.Recipe", newClass.getType())) {
+                                JavaType type = newClass.getType();
+                                if (type instanceof JavaType.Class) {
+                                    JavaType.Class tc = (JavaType.Class) type;
+                                    recipeNames.add(tc.getFullyQualifiedName());
+                                }
+                            }
+                            return newClass;
+                        }
+                    }.visit(defaultsMethod, strings);
+                }
+                return method;
+            }
+        }.reduce(defaultsMethod, new ArrayList<>()).stream().findFirst().orElse(null);
     }
 
-    @Override
-    public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
-        return super.visitNewClass(newClass, executionContext);
+    @Nullable
+    private RecipeExample extractRecipeExample(Expression sourceSpecArg) {
+        RecipeExample recipeExample = new RecipeExample();
+
+        new JavaIsoVisitor<RecipeExample>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method,
+                                                            RecipeExample recipeExample) {
+                if (JAVA_METHOD_MATCHER.matches(method)) {
+                    recipeExample.setLanguage("java");
+                } else if (BUILD_GRADLE_METHOD_MATCHER.matches(method)) {
+                    recipeExample.setLanguage("groovy");
+                } else if (POM_XML_METHOD_MATCHER.matches(method)) {
+                    recipeExample.setLanguage("xml");
+                } else {
+                    return method;
+                }
+
+                List<Expression> args = method.getArguments();
+
+                // arg0 is always `before`. arg1 is optional to be `after`, to adjust if code changed
+                J.Literal before = !args.isEmpty() ? (args.get(0) instanceof J.Literal ? (J.Literal) args.get(0) : null) : null;
+                J.Literal after = args.size() > 1? (args.get(1) instanceof J.Literal ? (J.Literal) args.get(1) : null) : null;
+
+                if (before != null) {
+                    recipeExample.setBefore((String) before.getValue());
+                }
+
+                if (after != null) {
+                    recipeExample.setAfter((String) after.getValue());
+                }
+                return method;
+            }
+        }.visit(sourceSpecArg, recipeExample);
+
+        if (recipeExample.getLanguage() != null && !recipeExample.getLanguage().isEmpty()) {
+            return recipeExample;
+        }
+        return null;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ExamplesExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java;
 
 import org.openrewrite.ExecutionContext;


### PR DESCRIPTION
This PR creates a visitor to extract examples from a rewrite recipe unit test.
This will be used to support the recipe example feature.
The yaml files will be generated by `build-gradle-plugin`, got merged, and output recipe descriptor finally with recipe examples included.
