### PR TITLE
Implement prerelease versions according to Maven rules

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -48,10 +48,12 @@ public class LatestRelease implements VersionComparator {
     }
 
     static String normalizeVersion(String version) {
-        if (version.endsWith(".RELEASE")) {
-            return version.substring(0, version.length() - ".RELEASE".length());
-        } else if (version.endsWith(".FINAL") || version.endsWith(".Final")) {
-            return version.substring(0, version.length() - ".FINAL".length());
+        int lastDotIdx = version.lastIndexOf('.');
+        for (String suffix : RELEASE_SUFFIXES) {
+            if (version.regionMatches(true, lastDotIdx, suffix, 0, suffix.length())) {
+                version = version.substring(0, lastDotIdx);
+                break;
+            }
         }
 
         long versionParts = countVersionParts(version);

--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -24,7 +24,8 @@ import java.util.regex.Pattern;
 
 public interface VersionComparator extends Comparator<String> {
     Pattern RELEASE_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?([-+].*)?.*");
-    Pattern PRE_RELEASE_ENDING = Pattern.compile("[.-](SNAPSHOT|RC|rc|M|m|milestone|beta|alpha)[.-]?\\d*$");
+    String[] RELEASE_SUFFIXES = new String[]{".final", ".ga", ".release"};
+    Pattern PRE_RELEASE_ENDING = Pattern.compile("[.-](alpha|a|beta|b|milestone|m|rc|cr|snapshot)[.-]?\\d*$", Pattern.CASE_INSENSITIVE);
 
     @Deprecated
     default boolean isValid(String version) {

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
@@ -32,16 +32,21 @@ class LatestReleaseTest {
     @Test
     void nonNumericPartsValid() {
         assertThat(latestRelease.isValid("1.0", "1.1.1.1")).isTrue();
+        assertThat(latestRelease.isValid("1.0", "1.0.RELEASE")).isTrue();
+        assertThat(latestRelease.isValid("1.0", "1.0.0.Final")).isTrue();
         assertThat(latestRelease.isValid("1.0", "1.1.1")).isTrue();
         assertThat(latestRelease.isValid("1.0", "1.1")).isTrue();
         assertThat(latestRelease.isValid("1.0", "1")).isTrue();
-        assertThat(latestRelease.isValid("1.0", "1.1.a")).isTrue();
-        assertThat(latestRelease.compare(null, "1.0", "1.1.a")).isLessThan(0);
-        assertThat(latestRelease.isValid("1.0", "1.1.1.1.a")).isTrue();
-        assertThat(latestRelease.compare(null, "1.0", "1.1.1.1.a")).isLessThan(0);
         assertThat(latestRelease.isValid("1.0", "1.1.1.1.1")).isTrue();
+
         assertThat(latestRelease.isValid("1.0", "1.1.1.1.1-SNAPSHOT")).isFalse();
         assertThat(latestRelease.isValid("1.0", "1.1.0-SNAPSHOT")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "1.1.a")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "1.1.1.1.a")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "2.0.0.Alpha2")).isFalse();
+
+        assertThat(latestRelease.compare(null, "1.0", "1.1.a")).isLessThan(0);
+        assertThat(latestRelease.compare(null, "1.0", "1.1.1.1.a")).isLessThan(0);
     }
 
     @Test
@@ -82,6 +87,15 @@ class LatestReleaseTest {
         assertThat(latestRelease.compare("1.0", "1.1.1", "1.1.1.1")).isLessThan(0);
         assertThat(latestRelease.compare("1.0", "1.1", "1.1.1")).isLessThan(0);
         assertThat(latestRelease.compare("1.0", "1", "1.1")).isLessThan(0);
+    }
+
+    @Test
+    void preReleases() {
+        assertThat(latestRelease.isValid("1.0", "1.1.0-Alpha")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "1.1.0-Alpha1")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "1.1.0-Alpha.1")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "1.1.0-Alpha-1")).isFalse();
+        assertThat(latestRelease.isValid("1.0", "1.1.0-Alpha=1")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
The version qualifiers in Maven versions are case-insensitive. Adjusting the code accordingly and also matching `CR` as an alias for `RC` (this is for example used by the Quarkus project).

Fixes: #3143