### PR TITLE
Skip relativePaths containing colon as that fails on Windows

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -455,7 +455,7 @@ public class MavenPomDownloader {
         }
 
         if (containingPom != null && containingPom.getRequested().getSourcePath() != null &&
-            !StringUtils.isBlank(relativePath)) {
+            !StringUtils.isBlank(relativePath) && !relativePath.contains(":")) {
             Path folderContainingPom = containingPom.getRequested().getSourcePath().getParent();
             if (folderContainingPom != null) {
                 Pom maybeLocalPom = projectPoms.get(folderContainingPom.resolve(Paths.get(relativePath, "pom.xml"))


### PR DESCRIPTION
Fixes #3167

artemis-pom-2.28.0.pom contains a weird relative path: https://repo1.maven.org/maven2/org/apache/activemq/artemis-pom/2.28.0/artemis-pom-2.28.0.pom

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.apache.activemq</groupId>
    <artifactId>artemis-pom</artifactId>
    <packaging>pom</packaging>
    <version>2.28.0</version>
    <parent>
        <groupId>org.apache</groupId>
        <artifactId>apache</artifactId>
        <version>27</version>
        <relativePath>org.apache:apache</relativePath>
    </parent>
```

This worked okay-ish on Linux/Mac, as passing the relativePath into `Paths.get(relativePath, "pom.xml")` will just result in a null `maybeLocalPom`. On Windows however, a colon is not valid to pass into Paths.get(..), and it fails with the reported exception.

Since we were effectively ignoring the relative path on Mac/Linux before, we might as well skip it entirely for Windows as well.