### PR TITLE
Add tests to cover additional cases: fully qualified names

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveAnnotationTest.java
@@ -72,6 +72,7 @@ class RemoveAnnotationTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/105")
     void removeFullyQualifiedJavaLangAnnotation() {
         rewriteRun(
           spec -> spec.recipe(new RemoveAnnotation("@java.lang.Deprecated")),
@@ -101,6 +102,7 @@ class RemoveAnnotationTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/105")
     void removeFullyQualifiedCustomAnnotation() {
         rewriteRun(
           spec -> spec.recipe(new RemoveAnnotation("@org.b.ThirdAnnotation")),

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveAnnotationTest.java
@@ -71,6 +71,76 @@ class RemoveAnnotationTest implements RewriteTest {
         );
     }
 
+    @Test
+    void removeFullyQualifiedJavaLangAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotation("@java.lang.Deprecated")),
+          java(
+            """
+              import java.util.List;
+
+              @java.lang.Deprecated
+              public class Test {
+                  @java.lang.Deprecated
+                  void test() {
+                      @java.lang.Deprecated int n;
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              public class Test {
+                  void test() {
+                      int n;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeFullyQualifiedCustomAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotation("@org.b.ThirdAnnotation")),
+          java(
+            """
+              package org.b;
+                          
+              import java.lang.annotation.Target;
+              import static java.lang.annotation.ElementType.*;
+                          
+              @Target({TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, LOCAL_VARIABLE})
+              public @interface ThirdAnnotation {
+              }
+              """
+          ),
+          java(
+            """
+              import java.util.List;
+
+              @org.b.ThirdAnnotation
+              public class Test {
+                  @org.b.ThirdAnnotation
+                  void test() {
+                      @org.b.ThirdAnnotation int n;
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              public class Test {
+                  void test() {
+                      int n;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/697")
     @Test
     void preserveWhitespaceOnModifiers() {


### PR DESCRIPTION
Added some tests to cover case where annotations are used with fully qualified names (as opposed to import+simple name), both for "default" java.lang annotation and custom one.
