### PR TITLE
Fixes circular references serializing markers

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ExceptionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ExceptionUtils.java
@@ -15,10 +15,7 @@
  */
 package org.openrewrite.internal;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
+import java.util.*;
 
 public class ExceptionUtils {
     /**
@@ -48,18 +45,17 @@ public class ExceptionUtils {
     }
 
     public static boolean containsCircularReferences(Throwable exception) {
-        List<Throwable> causes = new LinkedList<Throwable>();
+        Set<Throwable> causes = Collections.newSetFromMap(new IdentityHashMap<>());
         causes.add(exception);
         boolean containsACircularReference = false;
         while (exception != null && exception.getCause() != null) {
             Throwable exceptionToFind = exception.getCause();
             if (exceptionToFind != null) {
-                Optional<Throwable> duplicate = causes.stream().filter(e -> e == exceptionToFind).findFirst();
-                if (duplicate.isPresent()) {
+
+                if (!causes.add(exceptionToFind)) {
                     containsACircularReference = true;
-                    exception = null;
+                    break;
                 } else {
-                    causes.add(exceptionToFind);
                     exception = exceptionToFind;
                 }
             } else {

--- a/rewrite-core/src/main/java/org/openrewrite/marker/Markup.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/Markup.java
@@ -50,10 +50,18 @@ public interface Markup extends Marker {
     }
 
     static <T extends Tree> T error(T t, Throwable throwable) {
+        if (ExceptionUtils.containsCircularReferences(throwable)) {
+            throwable = new Exception(throwable.getMessage());
+            throwable.setStackTrace(throwable.getStackTrace());
+        }
         return markup(t, new Markup.Error(randomId(), throwable));
     }
 
     static <T extends Tree> T warn(T t, Throwable throwable) {
+        if (ExceptionUtils.containsCircularReferences(throwable)) {
+            throwable = new Exception(throwable.getMessage());
+            throwable.setStackTrace(throwable.getStackTrace());
+        }
         return markup(t, new Markup.Warn(randomId(), throwable));
     }
 
@@ -76,6 +84,7 @@ public interface Markup extends Marker {
     static <T extends Tree> T markup(T t, Markup markup) {
         return t.withMarkers(t.getMarkers().compute(markup, (s1, s2) -> s1 == null ? s2 : s1));
     }
+
 
     @Value
     @With

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RecipeMarkupDemonstrationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RecipeMarkupDemonstrationTest.java
@@ -15,21 +15,16 @@
  */
 package org.openrewrite.java;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.List;
-
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class RecipeMarkupDemonstrationTest implements RewriteTest {
 
@@ -52,10 +47,22 @@ class RecipeMarkupDemonstrationTest implements RewriteTest {
     }
 
     @Test
-    void exceptionsWithoutCicularReferences() {
-        Recipe testRecipe = new TestRecipe();
+    void exceptionsWithoutCircularReferences() {
         rewriteRun(
-          spec -> spec.recipe(testRecipe),
+          spec -> spec
+            .recipe(toRecipe(r -> new JavaIsoVisitor<>() {
+                @Override
+                public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext p) {
+                    Exception exception = new RuntimeException("this the parent of a circular exception");
+                    Exception exception2 = new RuntimeException("this the child of a circular exception", exception);
+                    exception.initCause(exception2);
+                    JavaSourceFile sf = Markup.error(cu, exception);
+                    Markup.Error marker = sf.getMarkers().findFirst(Markup.Error.class).get();
+                    assert marker.getException().getCause() == null;
+                    //Otherwise, there is an error if the exception is serialized.
+                    return sf;
+                }
+            })),
           java(
             """
               class Test {
@@ -67,29 +74,4 @@ class RecipeMarkupDemonstrationTest implements RewriteTest {
               """)
         );
     }
-    @EqualsAndHashCode(callSuper = false)
-    static class TestRecipe extends Recipe {
-        @Override
-        public String getDisplayName() {
-            return "test recipe that produces an error";
-        }
-        @Override
-        public String getDescription() {
-            return "test recipe that produces an error using a circular exception cause.";
-        }
-        @Override
-        protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
-            return ListUtils.mapFirst(before, sourceFile -> {
-                Exception exception = new RuntimeException("this the parent of a circular exception");
-                Exception exception2 = new RuntimeException("this the child of a circular exception", exception);
-                exception.initCause(exception2);
-                SourceFile sf = Markup.error(sourceFile, exception);
-                Markup.Error marker = sf.getMarkers().findFirst(Markup.Error.class).get();
-                assert marker.getException().getCause() == null;
-                //Otherwise, there is an error if the exception is serialized.
-                return sf;
-            });
-        }
-    };
-
 }


### PR DESCRIPTION
This error appears when we build the rewrite repository with the Moderne CLI

```
Caused by: java.lang.RuntimeException: java.io.UncheckedIOException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Direct self-reference leading to cycle (through reference chain: java.util.ArrayList[272]->org.openrewrite.text.PlainText["markers"]->org.openrewrite.marker.Markers["markers"]->java.util.ArrayList[5]->org.openrewrite.marker.Markup$Warn["exception"]->java.lang.RuntimeException["cause"]->org.gradle.api.artifacts.ResolveException["cause"])
	at io.moderne.gradle.DelegatingSerializingProjectParser.unwrapInvocationException(DelegatingSerializingProjectParser.java:172)
	at io.moderne.gradle.DelegatingSerializingProjectParser.writeAstFile(DelegatingSerializingProjectParser.java:64)
	at io.moderne.gradle.ModerneAstTask.run(ModerneAstTask.java:91)
```