### PR TITLE
Show diff on RewriteTest comparison failures

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -423,7 +423,11 @@ public interface RewriteTest extends SourceSpecs {
                             String expected = sourceSpec.noTrim ?
                                     expectedAfter :
                                     trimIndentPreserveCRLF(expectedAfter);
-                            assertThat(actual).as("Unexpected result in \"" + result.getAfter().getSourcePath() + "\"").isEqualTo(expected);
+                            assertThat(actual)
+                                    .as(() -> String.format("Unexpected result in \"%s\"%s",
+                                            result.getAfter().getSourcePath(),
+                                            result.diff().isEmpty() ? "" : "\n" + result.diff()))
+                                    .isEqualTo(expected);
                             sourceSpec.eachResult.accept(result.getAfter(), testMethodSpec, testClassSpec);
                         } else {
                             if (result.diff().isEmpty() && !(result.getAfter() instanceof Remote)) {


### PR DESCRIPTION
I've spent a bit too much time looking for whitespace changes on long before/after blocks. This ought to help, even if it's crude. Figured get feedback on if we want something like this first, and see from there how best to phrase this in the message.