### PR TITLE
Reproducer for #3227 Gradle change dependency ignores platform

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
@@ -94,6 +94,19 @@ public class ChangeDependencyArtifactId extends Recipe {
                 }
 
                 List<Expression> depArgs = m.getArguments();
+                if (depArgs.get(0) instanceof J.Literal || depArgs.get(0) instanceof G.GString || depArgs.get(0) instanceof G.MapEntry) {
+                    m = updateDependency(m);
+                } else if (depArgs.get(0) instanceof J.MethodInvocation &&
+                        (((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("platform") ||
+                                ((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("enforcedPlatform"))) {
+                    m = m.withArguments(ListUtils.map(depArgs, platform -> updateDependency((J.MethodInvocation) platform)));
+                }
+
+                return m;
+            }
+
+            private J.MethodInvocation updateDependency(J.MethodInvocation m) {
+                List<Expression> depArgs = m.getArguments();
                 if (depArgs.get(0) instanceof J.Literal) {
                     String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
                     if (gav != null) {
@@ -108,10 +121,10 @@ public class ChangeDependencyArtifactId extends Recipe {
                 } else if (depArgs.get(0) instanceof G.GString) {
                     List<J> strings = ((G.GString) depArgs.get(0)).getStrings();
                     if (strings.size() >= 2 &&
-                      strings.get(0) instanceof J.Literal) {
+                            strings.get(0) instanceof J.Literal) {
                         Dependency dependency = DependencyStringNotationConverter.parse((String) ((J.Literal) strings.get(0)).getValue());
                         if (!newArtifactId.equals(dependency.getArtifactId())
-                          && depMatcher.matches(dependency.getGroupId(), dependency.getArtifactId())) {
+                                && depMatcher.matches(dependency.getGroupId(), dependency.getArtifactId())) {
                             dependency = dependency.withArtifactId(newArtifactId);
                             String replacement = dependency.toStringNotation();
                             m = m.withArguments(ListUtils.mapFirst(depArgs, arg -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
@@ -94,6 +94,19 @@ public class ChangeDependencyGroupId extends Recipe {
                 }
 
                 List<Expression> depArgs = m.getArguments();
+                if (depArgs.get(0) instanceof J.Literal || depArgs.get(0) instanceof G.GString || depArgs.get(0) instanceof G.MapEntry) {
+                    m = updateDependency(m);
+                } else if (depArgs.get(0) instanceof J.MethodInvocation &&
+                        (((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("platform") ||
+                                ((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("enforcedPlatform"))) {
+                    m = m.withArguments(ListUtils.mapFirst(depArgs, platform -> updateDependency((J.MethodInvocation) platform)));
+                }
+
+                return m;
+            }
+
+            private J.MethodInvocation updateDependency(J.MethodInvocation m) {
+                List<Expression> depArgs = m.getArguments();
                 if (depArgs.get(0) instanceof J.Literal) {
                     String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
                     if (gav != null) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -93,8 +93,8 @@ public class UpgradeDependencyVersion extends Recipe {
         //language=markdown
         return "Upgrade the version of a dependency in a build.gradle file. " +
                 "Supports updating dependency declarations of various forms:\n" +
-                "* `String` notation:  `implementation \"group:artifact:version\"` \n" +
-                "* `Map` notation: `implementation group: 'group', name: 'artifact', version: 'version'`\n" +
+                "* `String` notation:  `\"group:artifact:version\"` \n" +
+                "* `Map` notation: `group: 'group', name: 'artifact', version: 'version'`\n" +
                 "Can update version numbers which are defined earlier in the same file in variable declarations.";
     }
 
@@ -151,112 +151,125 @@ public class UpgradeDependencyVersion extends Recipe {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (dependencyDsl.matches(m)) {
                     List<Expression> depArgs = m.getArguments();
-                    if(depArgs.get(0) instanceof G.GString) {
-                        G.GString gString = (G.GString) depArgs.get(0);
-                        List<J> strings = gString.getStrings();
-                        if(strings.size() != 2 || !(strings.get(0) instanceof J.Literal) || !(strings.get(1) instanceof G.GString.Value)) {
-                            return m;
-                        }
-                        J.Literal groupArtifact = (J.Literal) strings.get(0);
-                        G.GString.Value versionValue = (G.GString.Value) strings.get(1);
-                        if(!(versionValue.getTree() instanceof J.Identifier) || !(groupArtifact.getValue() instanceof String)) {
-                            return m;
-                        }
-                        Dependency dep = DependencyStringNotationConverter.parse((String) groupArtifact.getValue());
-                        if(StringUtils.matchesGlob(dep.getGroupId(), groupId)
-                           && StringUtils.matchesGlob(dep.getArtifactId(), artifactId)) {
-                            String versionVariableName = ((J.Identifier) versionValue.getTree()).getSimpleName();
-                            getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, VERSION_VARIABLE_KEY, versionVariableName);
-                        }
-                    } else if (depArgs.get(0) instanceof J.Literal) {
-                        String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
-                        if(gav == null) {
-                            return Markup.warn(m, new IllegalStateException("Unable to update version"));
-                        }
-                        Dependency dep = DependencyStringNotationConverter.parse(gav);
-                        if(StringUtils.matchesGlob(dep.getGroupId(), groupId)
-                           && StringUtils.matchesGlob(dep.getArtifactId(), artifactId)
-                           && dep.getVersion() != null
-                           && !dep.getVersion().startsWith("$")) {
-                            GradleProject gradleProject = getCursor().firstEnclosingOrThrow(JavaSourceFile.class)
-                                    .getMarkers()
-                                    .findFirst(GradleProject.class)
-                                    .orElseThrow(() -> new IllegalArgumentException("Gradle files are expected to have a GradleProject marker."));
-                            String version = dep.getVersion();
-                            try {
-                                String newVersion = findNewerVersion(groupId, artifactId, version, versionComparator,
-                                        gradleProject, ctx);
-                                if (newVersion == null || version.equals(newVersion)) {
-                                    return m;
-                                }
-                                getCursor().dropParentUntil(p -> p instanceof SourceFile)
-                                        .computeMessageIfAbsent(NEW_VERSION_KEY, it -> new LinkedHashSet<GroupArtifactVersion>())
-                                        .add(new GroupArtifactVersion(groupId, artifactId, newVersion));
+                    if (depArgs.get(0) instanceof J.Literal || depArgs.get(0) instanceof G.GString || depArgs.get(0) instanceof G.MapEntry) {
+                        m = updateDependency(m, ctx);
+                    } else if (depArgs.get(0) instanceof J.MethodInvocation &&
+                            (((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("platform") ||
+                                    ((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("enforcedPlatform"))) {
+                        m = m.withArguments(ListUtils.mapFirst(depArgs, platform -> updateDependency((J.MethodInvocation) platform, ctx)));
+                    }
+                }
+                return m;
+            }
 
-                                return m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> {
-                                    J.Literal literal = (J.Literal) arg;
-                                    String newGav = dep
-                                            .withVersion(newVersion)
-                                            .toStringNotation();
-                                    return literal
-                                            .withValue(newGav)
-                                            .withValueSource(requireNonNull(literal.getValueSource()).replace(gav, newGav));
-                                }));
-                            } catch (MavenDownloadingException e) {
-                                return e.warn(m);
-                            }
-                        }
-                    } else if (depArgs.size() >= 3 && depArgs.get(0) instanceof G.MapEntry
-                            && depArgs.get(1) instanceof G.MapEntry
-                            && depArgs.get(2) instanceof G.MapEntry) {
-                        Expression groupValue = ((G.MapEntry) depArgs.get(0)).getValue();
-                        Expression artifactValue = ((G.MapEntry) depArgs.get(1)).getValue();
-                        if(!(groupValue instanceof J.Literal) || !(artifactValue instanceof J.Literal)) {
-                            return m;
-                        }
-                        J.Literal groupLiteral = (J.Literal) groupValue;
-                        J.Literal artifactLiteral = (J.Literal) artifactValue;
-                        if(!groupId.equals(groupLiteral.getValue()) || !artifactId.equals(artifactLiteral.getValue())) {
-                            return m;
-                        }
-                        G.MapEntry versionEntry = (G.MapEntry) depArgs.get(2);
-                        Expression versionExp = versionEntry.getValue();
-                        if(versionExp instanceof J.Literal && ((J.Literal) versionExp).getValue() instanceof String) {
-                            GradleProject gradleProject = getCursor().firstEnclosingOrThrow(JavaSourceFile.class)
-                                    .getMarkers()
-                                    .findFirst(GradleProject.class)
-                                    .orElseThrow(() -> new IllegalArgumentException("Gradle files are expected to have a GradleProject marker."));
-                            J.Literal versionLiteral = (J.Literal) versionExp;
-                            String version = (String) versionLiteral.getValue();
-                            if(version.startsWith("$")) {
-                                return m;
-                            }
-                            String newVersion;
-                            try {
-                                newVersion = findNewerVersion(groupId, artifactId, version, versionComparator,
-                                        gradleProject, ctx);
-                            } catch (MavenDownloadingException e) {
-                                return e.warn(m);
-                            }
+            private J.MethodInvocation updateDependency(J.MethodInvocation m, ExecutionContext ctx) {
+                List<Expression> depArgs = m.getArguments();
+                if (depArgs.get(0) instanceof G.GString) {
+                    G.GString gString = (G.GString) depArgs.get(0);
+                    List<J> strings = gString.getStrings();
+                    if (strings.size() != 2 || !(strings.get(0) instanceof J.Literal) || !(strings.get(1) instanceof G.GString.Value)) {
+                        return m;
+                    }
+                    J.Literal groupArtifact = (J.Literal) strings.get(0);
+                    G.GString.Value versionValue = (G.GString.Value) strings.get(1);
+                    if (!(versionValue.getTree() instanceof J.Identifier) || !(groupArtifact.getValue() instanceof String)) {
+                        return m;
+                    }
+                    Dependency dep = DependencyStringNotationConverter.parse((String) groupArtifact.getValue());
+                    if (StringUtils.matchesGlob(dep.getGroupId(), groupId)
+                            && StringUtils.matchesGlob(dep.getArtifactId(), artifactId)) {
+                        String versionVariableName = ((J.Identifier) versionValue.getTree()).getSimpleName();
+                        getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, VERSION_VARIABLE_KEY, versionVariableName);
+                    }
+                } else if (depArgs.get(0) instanceof J.Literal) {
+                    String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
+                    if (gav == null) {
+                        return Markup.warn(m, new IllegalStateException("Unable to update version"));
+                    }
+                    Dependency dep = DependencyStringNotationConverter.parse(gav);
+                    if(StringUtils.matchesGlob(dep.getGroupId(), groupId)
+                            && StringUtils.matchesGlob(dep.getArtifactId(), artifactId)
+                            && dep.getVersion() != null
+                            && !dep.getVersion().startsWith("$")) {
+                        GradleProject gradleProject = getCursor().firstEnclosingOrThrow(JavaSourceFile.class)
+                                .getMarkers()
+                                .findFirst(GradleProject.class)
+                                .orElseThrow(() -> new IllegalArgumentException("Gradle files are expected to have a GradleProject marker."));
+                        String version = dep.getVersion();
+                        try {
+                            String newVersion = findNewerVersion(groupId, artifactId, version, versionComparator,
+                                    gradleProject, ctx);
                             if (newVersion == null || version.equals(newVersion)) {
                                 return m;
                             }
-                            List<Expression> newArgs = new ArrayList<>(3);
-                            newArgs.add(depArgs.get(0));
-                            newArgs.add(depArgs.get(1));
-                            newArgs.add(versionEntry.withValue(
-                                    versionLiteral
-                                            .withValueSource(requireNonNull(versionLiteral.getValueSource()).replace(version, newVersion))
-                                            .withValue(newVersion)));
-                            newArgs.addAll(depArgs.subList(3, depArgs.size()));
+                            getCursor().dropParentUntil(p -> p instanceof SourceFile)
+                                    .computeMessageIfAbsent(NEW_VERSION_KEY, it -> new LinkedHashSet<GroupArtifactVersion>())
+                                    .add(new GroupArtifactVersion(groupId, artifactId, newVersion));
 
-                            return m.withArguments(newArgs);
-                        } else if(versionExp instanceof J.Identifier) {
-                            String versionVariableName = ((J.Identifier) versionExp).getSimpleName();
-                            getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, VERSION_VARIABLE_KEY, versionVariableName);
+                            return m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> {
+                                J.Literal literal = (J.Literal) arg;
+                                String newGav = dep
+                                        .withVersion(newVersion)
+                                        .toStringNotation();
+                                return literal
+                                        .withValue(newGav)
+                                        .withValueSource(requireNonNull(literal.getValueSource()).replace(gav, newGav));
+                            }));
+                        } catch (MavenDownloadingException e) {
+                            return e.warn(m);
                         }
                     }
+                } else if (depArgs.size() >= 3 && depArgs.get(0) instanceof G.MapEntry
+                        && depArgs.get(1) instanceof G.MapEntry
+                        && depArgs.get(2) instanceof G.MapEntry) {
+                    Expression groupValue = ((G.MapEntry) depArgs.get(0)).getValue();
+                    Expression artifactValue = ((G.MapEntry) depArgs.get(1)).getValue();
+                    if (!(groupValue instanceof J.Literal) || !(artifactValue instanceof J.Literal)) {
+                        return m;
+                    }
+                    J.Literal groupLiteral = (J.Literal) groupValue;
+                    J.Literal artifactLiteral = (J.Literal) artifactValue;
+                    if (!groupId.equals(groupLiteral.getValue()) || !artifactId.equals(artifactLiteral.getValue())) {
+                        return m;
+                    }
+                    G.MapEntry versionEntry = (G.MapEntry) depArgs.get(2);
+                    Expression versionExp = versionEntry.getValue();
+                    if (versionExp instanceof J.Literal && ((J.Literal) versionExp).getValue() instanceof String) {
+                        GradleProject gradleProject = getCursor().firstEnclosingOrThrow(JavaSourceFile.class)
+                                .getMarkers()
+                                .findFirst(GradleProject.class)
+                                .orElseThrow(() -> new IllegalArgumentException("Gradle files are expected to have a GradleProject marker."));
+                        J.Literal versionLiteral = (J.Literal) versionExp;
+                        String version = (String) versionLiteral.getValue();
+                        if (version.startsWith("$")) {
+                            return m;
+                        }
+                        String newVersion;
+                        try {
+                            newVersion = findNewerVersion(groupId, artifactId, version, versionComparator,
+                                    gradleProject, ctx);
+                        } catch (MavenDownloadingException e) {
+                            return e.warn(m);
+                        }
+                        if (newVersion == null || version.equals(newVersion)) {
+                            return m;
+                        }
+                        List<Expression> newArgs = new ArrayList<>(3);
+                        newArgs.add(depArgs.get(0));
+                        newArgs.add(depArgs.get(1));
+                        newArgs.add(versionEntry.withValue(
+                                versionLiteral
+                                        .withValueSource(requireNonNull(versionLiteral.getValueSource()).replace(version, newVersion))
+                                        .withValue(newVersion)));
+                        newArgs.addAll(depArgs.subList(3, depArgs.size()));
+
+                        return m.withArguments(newArgs);
+                    } else if (versionExp instanceof J.Identifier) {
+                        String versionVariableName = ((J.Identifier) versionExp).getSimpleName();
+                        getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, VERSION_VARIABLE_KEY, versionVariableName);
+                    }
                 }
+
                 return m;
             }
         };

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyArtifactIdTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyArtifactIdTest.java
@@ -306,7 +306,7 @@ class ChangeDependencyArtifactIdTest implements RewriteTest {
     @Test
     void worksWithPlatform() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependencyArtifactId("org.optaplanner", "optaplanner-bom", "timefold-bom", null)),
+          spec -> spec.recipe(new ChangeDependencyArtifactId("org.optaplanner", "optaplanner-bom", "timefold-solver-bom", null)),
           buildGradle(
             """
               plugins {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyArtifactIdTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyArtifactIdTest.java
@@ -301,4 +301,42 @@ class ChangeDependencyArtifactIdTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3227")
+    @Test
+    void worksWithPlatform() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyArtifactId("org.optaplanner", "optaplanner-bom", "timefold-bom", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation platform("org.optaplanner:optaplanner-bom:9.37.0.Final")
+                  implementation "org.optaplanner:optaplanner-core"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation platform("org.optaplanner:timefold-solver-bom:9.37.0.Final")
+                  implementation "org.optaplanner:optaplanner-core"
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyGroupIdTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyGroupIdTest.java
@@ -301,4 +301,42 @@ class ChangeDependencyGroupIdTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3227")
+    @Test
+    void worksWithPlatform() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupId("org.optaplanner", "*", "ai.timefold.solver", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+                
+              repositories {
+                  mavenCentral()
+              }
+                            
+              dependencies {
+                  implementation platform("org.optaplanner:optaplanner-bom:9.37.0.Final")
+                  implementation "org.optaplanner:optaplanner-core"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+                
+              repositories {
+                  mavenCentral()
+              }
+                            
+              dependencies {
+                  implementation platform("ai.timefold.solver:optaplanner-bom:9.37.0.Final")
+                  implementation "ai.timefold.solver:optaplanner-core"
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -16,9 +16,10 @@
 package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -208,6 +209,41 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                 implementation (group: "com.google.guava", name: "guava", version: '30.1.1-jre') {
                   force = true
                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3227")
+    @Test
+    void worksWithPlatform() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              repositories {
+                mavenCentral()
+              }
+              
+              dependencies {
+                implementation platform("com.google.guava:guava:29.0-jre")
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              repositories {
+                mavenCentral()
+              }
+              
+              dependencies {
+                implementation platform("com.google.guava:guava:30.1.1-jre")
               }
               """
           )


### PR DESCRIPTION
This is a reproducer for #3227 Gradle change dependency groupId/artifactId ignores platform dependencies

It does not fix the issue.

@sambsnyd Tim said I should tag you as you might be working in this corner and might want to be aware of it.