### PR TITLE
Support 21-ea as value for java.version in JavaParser

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -206,7 +206,7 @@ public interface JavaParser extends Parser<J.CompilationUnit> {
      */
     static JavaParser.Builder<? extends JavaParser, ?> fromJavaVersion() {
         JavaParser.Builder<? extends JavaParser, ?> javaParser;
-        String[] versionParts = System.getProperty("java.version").split("\\.");
+        String[] versionParts = System.getProperty("java.version").split("[.-]");
         int version = Integer.parseInt(versionParts[0]);
         if (version == 1) {
             version = 8;


### PR DESCRIPTION
For https://github.com/openrewrite/rewrite/issues/3170