### PR TITLE
Invalid Javadoc should remain unchanged

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddLicenseHeaderTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddLicenseHeaderTest.java
@@ -101,4 +101,25 @@ class AddLicenseHeaderTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite/issues/3198")
+    void dontChangeInvalidJavadoc() {
+        rewriteRun(
+          java(
+            """
+              /*
+               * My license header
+               */
+              package com.sample;
+              /**
+               * {@link Stream<? extends Foo>}
+               */              
+              class Test {
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Related to https://github.com/openrewrite/rewrite/issues/3198

In this case invalid Javadoc gets changed in an unexpected way. I would expect OpenRewrite to either leave such JavaDoc unmodified or to bail out with a failure (like it would on regular Java code I suppose). 