### PR TITLE
Support case-insensitive enum deserialization  In `YamlResourceLoader`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -140,6 +140,7 @@ public class YamlResourceLoader implements ResourceLoader {
 
         mapper = JsonMapper.builder()
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
                 .registerModule(new ParameterNamesModule())

--- a/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
@@ -60,7 +60,7 @@ public class AppendToTextFile extends Recipe {
                     + "Subsequent instances of this recipe in the same Rewrite execution will always append.",
             valid = {"continue", "replace", "leave"},
             required = false)
-    @Nullable String existingFileStrategy;
+    @Nullable Strategy existingFileStrategy;
     public enum Strategy { CONTINUE, REPLACE, LEAVE }
 
     private final static String CREATED_THIS_EXECUTION_MESSAGE_KEY = "AppendToTextFile.CreatedThisExecution";
@@ -81,7 +81,7 @@ public class AppendToTextFile extends Recipe {
                 relativeFileName,
                 content + maybeNewline,
                 preamble != null ? preamble + maybeNewline : "",
-                existingFileStrategy != null ? Strategy.valueOf(existingFileStrategy.toUpperCase()) : Strategy.LEAVE);
+                existingFileStrategy != null ? existingFileStrategy : Strategy.LEAVE);
     }
 
     private List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx,

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -387,4 +387,29 @@ class YamlResourceLoaderTest implements RewriteTest {
             assertThat(descriptorExamples).containsExactlyElementsOf(recipes.iterator().next().getExamples());
         });
     }
+
+    @Test
+    void caseInsensitiveEnums() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml(
+            //language=yml
+            """
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.gradle.testCaseInsensitiveEnumInYaml
+              displayName: test Enum in yaml
+              description: test Enum in yaml.
+              recipeList:
+                - org.openrewrite.text.AppendToTextFile:
+                    relativeFileName: "file.txt"
+                    content: " World!"
+                    preamble: "preamble"
+                    appendNewline : false
+                    existingFileStrategy: "Continue"
+              """,
+            "org.openrewrite.gradle.testCaseInsensitiveEnumInYaml"
+          ),
+          text("Hello", "Hello World!")
+        );
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/AppendToTextFileTest.java
@@ -32,7 +32,7 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void createsFileIfNeeded() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, "leave")),
+          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.LEAVE)),
           text(
             null,
             """
@@ -45,7 +45,7 @@ class AppendToTextFileTest implements RewriteTest {
 
     @Test
     void createsFileIfNeededWithMultipleInstances() {
-        Supplier<Recipe> r = () -> new AppendToTextFile("file.txt", "content", "preamble", true, "leave");
+        Supplier<Recipe> r = () -> new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.LEAVE);
         rewriteRun(
           spec -> spec.recipe(r.get().doNext(r.get())),
           text(
@@ -64,7 +64,7 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void replacesFileIfRequested() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, "replace")),
+          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.REPLACE)),
           text(
             """
               existing
@@ -81,7 +81,7 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void continuesFileIfRequested() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, "continue")),
+          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.CONTINUE)),
           text(
             """
               existing
@@ -98,7 +98,7 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void leavesFileIfRequested() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, "leave")),
+          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.LEAVE)),
           text("existing", spec -> spec.path("file.txt"))
         );
     }
@@ -107,8 +107,8 @@ class AppendToTextFileTest implements RewriteTest {
     void multipleInstancesCanAppend() {
         rewriteRun(
           spec -> spec.recipe(
-            new AppendToTextFile("file.txt", "content", "preamble", true, "replace")
-              .doNext(new AppendToTextFile("file.txt", "content", "preamble", true, "replace"))),
+            new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.REPLACE)
+              .doNext(new AppendToTextFile("file.txt", "content", "preamble", true, AppendToTextFile.Strategy.REPLACE))),
           text(
             "existing",
             """
@@ -124,7 +124,7 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void noLeadingNewlineIfNoPreamble() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", null, true, "replace")),
+          spec -> spec.recipe(new AppendToTextFile("file.txt", "content", null, true, AppendToTextFile.Strategy.REPLACE)),
           text(
             """
               existing
@@ -140,8 +140,8 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void multipleFiles() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
-            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, AppendToTextFile.Strategy.REPLACE)
+            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, AppendToTextFile.Strategy.REPLACE))),
           text(
             "existing1",
             """
@@ -166,8 +166,8 @@ class AppendToTextFileTest implements RewriteTest {
     void missingExpectedGeneratedFiles() {
         assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
           rewriteRun(
-            spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
-              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+            spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, AppendToTextFile.Strategy.REPLACE)
+              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, AppendToTextFile.Strategy.REPLACE))),
             text(
               "existing2",
               """
@@ -183,8 +183,8 @@ class AppendToTextFileTest implements RewriteTest {
     @Test
     void changeAndCreatedFilesIfNeeded() {
         rewriteRun(
-          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
-            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+          spec -> spec.recipe(new AppendToTextFile("file1.txt", "content1", "preamble1", true, AppendToTextFile.Strategy.REPLACE)
+            .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, AppendToTextFile.Strategy.REPLACE))),
           text(
             "existing2",
             """
@@ -207,10 +207,10 @@ class AppendToTextFileTest implements RewriteTest {
     void multipleInstancesOnMultipleFiles() {
         rewriteRun(
           spec -> spec.recipe(
-            new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace")
-              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))
-              .doNext(new AppendToTextFile("file1.txt", "content1", "preamble1", true, "replace"))
-              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, "replace"))),
+            new AppendToTextFile("file1.txt", "content1", "preamble1", true, AppendToTextFile.Strategy.REPLACE)
+              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, AppendToTextFile.Strategy.REPLACE))
+              .doNext(new AppendToTextFile("file1.txt", "content1", "preamble1", true, AppendToTextFile.Strategy.REPLACE))
+              .doNext(new AppendToTextFile("file2.txt", "content2", "preamble2", true, AppendToTextFile.Strategy.REPLACE))),
           text(
             "existing1",
             """

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterprise.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterprise.java
@@ -87,7 +87,7 @@ public class AddGradleEnterprise extends Recipe {
                     "When omitted scans will be published only when the `--scan` option is passed to the build.",
             required = false,
             valid = {"always", "failure"},
-            example = "true")
+            example = "always")
     @Nullable
     PublishCriteria publishCriteria;
 


### PR DESCRIPTION
To support case-insensitive enum deserialization  In `YamlResourceLoader`
Just 1 line of code change by config the JsonMapper

Slack discussion [here](https://moderneinc.slack.com/archives/C02JYCSNM4G/p1684507999745499) 