### PR TITLE
Support using different configurations for different test source sets when adding gradle dependency

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -20,19 +20,13 @@ import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
-import org.openrewrite.gradle.util.Dependency;
-import org.openrewrite.gradle.util.DependencyStringNotationConverter;
-import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.MavenDownloadingExceptions;
 import org.openrewrite.maven.internal.MavenPomDownloader;
@@ -50,7 +44,6 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -119,13 +112,12 @@ public class AddDependency extends Recipe {
     @Nullable
     String familyPattern;
 
-    @Option(displayName = "Test Source Set",
-            description = "The test source set which will be used to determine the test configuration with which to add the dependency. " +
-                    "If not specified, all source sets other than 'test' will be added to 'implementation' configuration.",
-            example = "test",
+    @Option(displayName = "Accept transitive",
+            description = "Default false. If enabled, the dependency will not be added if it is already on the classpath as a transitive dependency.",
+            example = "true",
             required = false)
     @Nullable
-    String testSourceSet;
+    Boolean acceptTransitive;
 
     static final String DEPENDENCY_PRESENT = "org.openrewrite.gradle.AddDependency.DEPENDENCY_PRESENT";
 
@@ -159,152 +151,105 @@ public class AddDependency extends Recipe {
 
     @Override
     protected List<SourceFile> visit(List<SourceFile> before, ExecutionContext ctx) {
-        Map<JavaProject, String> configurationByProject = new HashMap<>();
+        Map<JavaProject, Set<String>> configurationsByProject = new HashMap<>();
         for (SourceFile source : before) {
             source.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject ->
                     source.getMarkers().findFirst(JavaSourceSet.class).ifPresent(sourceSet -> {
                         if (source != new UsesType<>(onlyIfUsing, true).visit(source, ctx)) {
-                            if (configurationByProject.containsKey(javaProject) && "implementation".equals(configurationByProject.get(javaProject))) {
-                                return;
-                            }
-                            if (StringUtils.isNullOrEmpty(testSourceSet)) {
-                                configurationByProject.compute(javaProject, (jp, configuration) ->
-                                        "test".equals(sourceSet.getName()) ? "testImplementation" : "implementation"
-                                );
-                            } else if ("main".equals(sourceSet.getName()) || testSourceSet.equals(sourceSet.getName())) {
-                                configurationByProject.compute(javaProject, (jp, configuration) ->
-                                        "main".equals(sourceSet.getName()) ? "implementation" : sourceSet.getName() + "Implementation"
-                                );
-                            }
+                            Set<String> configurations = configurationsByProject.computeIfAbsent(javaProject, ignored -> new HashSet<>());
+                            configurations.add("main".equals(sourceSet.getName()) ? "implementation" : sourceSet.getName() + "Implementation");
                         }
                     }));
         }
 
-        if (configurationByProject.isEmpty()) {
+        if (configurationsByProject.isEmpty()) {
             return before;
         }
 
-        MethodMatcher dependencyDslMatcher = new MethodMatcher("DependencyHandlerSpec *(..)");
         Pattern familyPatternCompiled = StringUtils.isBlank(familyPattern) ? null : Pattern.compile(familyPattern.replace("*", ".*"));
 
-        return ListUtils.map(before, s -> s.getMarkers().findFirst(JavaProject.class)
-                .map(javaProject -> (Tree) new GroovyIsoVisitor<ExecutionContext>() {
-                    @Override
-                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
-                        J.MethodInvocation m = super.visitMethodInvocation(method, executionContext);
-                        String resolvedConfiguration = StringUtils.isBlank(configuration) ? configurationByProject.get(javaProject) : configuration;
-                        if ((dependencyDslMatcher.matches(m) && (StringUtils.isBlank(configuration) || configuration.equals(m.getSimpleName()))) ||
-                                (StringUtils.isNotEmpty(resolvedConfiguration) && resolvedConfiguration.equals(m.getSimpleName()))) {
-                            if (m.getArguments().get(0) instanceof J.Literal) {
-                                //noinspection ConstantConditions
-                                Dependency dependency = DependencyStringNotationConverter.parse((String) ((J.Literal) m.getArguments().get(0)).getValue());
-                                if (groupId.equals(dependency.getGroupId()) && artifactId.equals(dependency.getArtifactId())) {
-                                    getCursor().putMessageOnFirstEnclosing(G.CompilationUnit.class, DEPENDENCY_PRESENT, true);
-                                }
-                            } else if (m.getArguments().get(0) instanceof G.GString) {
-                                List<J> strings = ((G.GString) m.getArguments().get(0)).getStrings();
-                                if (strings.size() >= 2 &&
-                                        strings.get(0) instanceof J.Literal) {
-                                    //noinspection DataFlowIssue
-                                    Dependency dependency = DependencyStringNotationConverter.parse((String) ((J.Literal) strings.get(0)).getValue());
-                                    if (groupId.equals(dependency.getGroupId()) && artifactId.equals(dependency.getArtifactId())) {
-                                        getCursor().putMessageOnFirstEnclosing(G.CompilationUnit.class, DEPENDENCY_PRESENT, true);
-                                    }
-                                }
-                            } else if (m.getArguments().get(0) instanceof G.MapEntry) {
-                                G.MapEntry groupEntry = null;
-                                G.MapEntry artifactEntry = null;
+        return ListUtils.map(before, s -> {
+            if (!s.getSourcePath().toString().endsWith(".gradle") || s.getSourcePath().getFileName().toString().equals("settings.gradle")) {
+                return s;
+            }
 
-                                for (Expression e : m.getArguments()) {
-                                    if (!(e instanceof G.MapEntry)) {
-                                        continue;
-                                    }
-                                    G.MapEntry arg = (G.MapEntry) e;
-                                    if (!(arg.getKey() instanceof J.Literal) || !(arg.getValue() instanceof J.Literal)) {
-                                        continue;
-                                    }
-                                    J.Literal key = (J.Literal) arg.getKey();
-                                    J.Literal value = (J.Literal) arg.getValue();
-                                    if (!(key.getValue() instanceof String) || !(value.getValue() instanceof String)) {
-                                        continue;
-                                    }
-                                    if ("group".equals(key.getValue())) {
-                                        groupEntry = arg;
-                                    } else if ("name".equals(key.getValue())) {
-                                        artifactEntry = arg;
-                                    }
-                                }
+            Optional<JavaProject> maybeJp = s.getMarkers().findFirst(JavaProject.class);
+            if (!maybeJp.isPresent()) {
+                return s;
+            }
 
-                                if (groupEntry == null || artifactEntry == null) {
-                                    return m;
-                                }
+            JavaProject jp = maybeJp.get();
+            if (!configurationsByProject.containsKey(jp)) {
+                return s;
+            }
 
-                                if (groupId.equals(((J.Literal) groupEntry.getValue()).getValue())
-                                        && artifactId.equals(((J.Literal) artifactEntry.getValue()).getValue())) {
-                                    getCursor().putMessageOnFirstEnclosing(G.CompilationUnit.class, DEPENDENCY_PRESENT, true);
-                                }
-                            }
-                        }
+            Optional<GradleProject> maybeGp = s.getMarkers().findFirst(GradleProject.class);
+            if (!maybeGp.isPresent()) {
+                return s;
+            }
 
-                        return m;
+            GradleProject gp = maybeGp.get();
+
+            Set<String> resolvedConfigurations = StringUtils.isBlank(configuration) ? configurationsByProject.get(jp) : new HashSet<>(Collections.singletonList(configuration));
+            Set<String> tmpConfigurations = new HashSet<>(resolvedConfigurations);
+            for (String tmpConfiguration : tmpConfigurations) {
+                GradleDependencyConfiguration gdc = gp.getConfiguration(tmpConfiguration);
+                if (gdc == null || gdc.findRequestedDependency(groupId, artifactId) != null) {
+                    resolvedConfigurations.remove(tmpConfiguration);
+                }
+            }
+
+            tmpConfigurations = new HashSet<>(resolvedConfigurations);
+            for (String tmpConfiguration : tmpConfigurations) {
+                GradleDependencyConfiguration gdc = gp.getConfiguration(tmpConfiguration);
+                for (GradleDependencyConfiguration transitive : gp.configurationsExtendingFrom(gdc, true)) {
+                    if (resolvedConfigurations.contains(transitive.getName()) ||
+                            (Boolean.TRUE.equals(acceptTransitive) && transitive.findResolvedDependency(groupId, artifactId) != null)) {
+                        resolvedConfigurations.remove(transitive.getName());
                     }
+                }
+            }
 
-                    @Override
-                    public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext executionContext) {
-                        if (!cu.getSourcePath().toString().endsWith(".gradle") || cu.getSourcePath().getFileName().toString().equals("settings.gradle")) {
-                            return cu;
+            if (resolvedConfigurations.isEmpty()) {
+                return s;
+            }
+
+            String resolvedVersion = version;
+            if (version != null) {
+                Validated versionValidation = Semver.validate(version, versionPattern);
+                if (versionValidation.isValid() && versionValidation.getValue() != null) {
+                    VersionComparator versionComparator = versionValidation.getValue();
+                    if(!(versionComparator instanceof ExactVersion)) {
+                        try {
+                            resolvedVersion = findNewerVersion(groupId, artifactId, version, versionComparator, gp, ctx);
+                        } catch (MavenDownloadingException e) {
+                            throw new RuntimeException(e);
                         }
-
-                        String maybeConfiguration = configurationByProject.get(javaProject);
-                        if (maybeConfiguration == null) {
-                            return cu;
-                        }
-
-                        G.CompilationUnit g = super.visitCompilationUnit(cu, executionContext);
-
-                        if (getCursor().getMessage(DEPENDENCY_PRESENT, false)) {
-                            return g;
-                        }
-
-                        String resolvedConfiguration = StringUtils.isBlank(configuration) ? maybeConfiguration : configuration;
-                        String resolvedVersion = version;
-                        Optional<GradleProject> maybeGp = g.getMarkers().findFirst(GradleProject.class);
-                        if (version != null && maybeGp.isPresent()) {
-                            Validated versionValidation = Semver.validate(version, versionPattern);
-                            if (versionValidation.isValid() && versionValidation.getValue() != null) {
-                                VersionComparator versionComparator = versionValidation.getValue();
-                                if(!(versionComparator instanceof ExactVersion)) {
-                                    try {
-                                        resolvedVersion = findNewerVersion(groupId, artifactId, version, versionComparator, maybeGp.get(), ctx);
-                                    } catch (MavenDownloadingException e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                }
-                            }
-                        }
-
-                        g = (G.CompilationUnit) new AddDependencyVisitor(groupId, artifactId, resolvedVersion,
-                                StringUtils.isBlank(versionPattern) ? null : versionPattern,
-                                resolvedConfiguration,
-                                StringUtils.isBlank(classifier) ? null : classifier,
-                                StringUtils.isBlank(extension) ? null : extension,
-                                familyPatternCompiled).visitNonNull(g, ctx, requireNonNull(getCursor().getParent()));
-                        if(g != cu && maybeGp.isPresent()) {
-                            String versionWithPattern = resolvedVersion + (StringUtils.isBlank(versionPattern) ? "" : versionPattern);
-                            GradleProject gp = maybeGp.get();
-                            GradleProject newGp = addDependency(gp,
-                                    gp.getConfiguration(resolvedConfiguration),
-                                    new GroupArtifactVersion(groupId, artifactId, versionWithPattern),
-                                    classifier,
-                                    ctx);
-                            g = g.withMarkers(g.getMarkers().setByType(newGp));
-                        }
-                        return g;
                     }
-                }.visit(s, ctx))
-                .map(SourceFile.class::cast)
-                .orElse(s)
-        );
+                }
+            }
+
+            G.CompilationUnit g = (G.CompilationUnit) s;
+            for (String resolvedConfiguration : resolvedConfigurations) {
+                g = (G.CompilationUnit) new AddDependencyVisitor(groupId, artifactId, resolvedVersion, StringUtils.isBlank(versionPattern) ? null : versionPattern, resolvedConfiguration,
+                        StringUtils.isBlank(classifier) ? null : classifier, StringUtils.isBlank(extension) ? null : extension, familyPatternCompiled).visitNonNull(g, ctx);
+            }
+
+            if (g != s) {
+                String versionWithPattern = StringUtils.isBlank(resolvedVersion) || resolvedVersion.startsWith("$") ? null : resolvedVersion;
+                GradleProject newGp = gp;
+                for (String resolvedConfiguration : resolvedConfigurations) {
+                    newGp = addDependency(newGp,
+                            newGp.getConfiguration(resolvedConfiguration),
+                            new GroupArtifactVersion(groupId, artifactId, versionWithPattern),
+                            classifier,
+                            ctx);
+                }
+                g = g.withMarkers(g.getMarkers().setByType(newGp));
+            }
+
+            return g;
+        });
     }
 
     /**
@@ -328,11 +273,18 @@ public class AddDependency extends Recipe {
             if(gav.getGroupId() == null || gav.getArtifactId() == null || configuration == null) {
                 return gp;
             }
-            MavenPomDownloader mpd = new MavenPomDownloader(emptyMap(), ctx, null,  null);
-            Pom pom = mpd.download(gav, null, null, gp.getMavenRepositories());
-            ResolvedPom resolvedPom = pom.resolve(emptyList(), mpd, gp.getMavenRepositories(), ctx);
-            ResolvedGroupArtifactVersion resolvedGav = resolvedPom.getGav();
-            List<ResolvedDependency> transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ctx);
+            ResolvedGroupArtifactVersion resolvedGav;
+            List<ResolvedDependency> transitiveDependencies;
+            if (gav.getVersion() == null) {
+                resolvedGav = null;
+                transitiveDependencies = Collections.emptyList();
+            } else {
+                MavenPomDownloader mpd = new MavenPomDownloader(emptyMap(), ctx, null, null);
+                Pom pom = mpd.download(gav, null, null, gp.getMavenRepositories());
+                ResolvedPom resolvedPom = pom.resolve(emptyList(), mpd, gp.getMavenRepositories(), ctx);
+                resolvedGav = resolvedPom.getGav();
+                transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ctx);
+            }
             Map<String, GradleDependencyConfiguration> nameToConfiguration = gp.getNameToConfiguration();
             Map<String, GradleDependencyConfiguration> newNameToConfiguration = new HashMap<>(nameToConfiguration.size());
 
@@ -341,8 +293,8 @@ public class AddDependency extends Recipe {
                             gp.configurationsExtendingFrom(configuration, true).stream())
                     .collect(Collectors.toSet());
 
-            for(GradleDependencyConfiguration gdc : nameToConfiguration.values()) {
-                if(!configurationsToAdd.contains(gdc)) {
+            for (GradleDependencyConfiguration gdc : nameToConfiguration.values()) {
+                if (!configurationsToAdd.contains(gdc)) {
                     newNameToConfiguration.put(gdc.getName(), gdc);
                     continue;
                 }
@@ -359,7 +311,7 @@ public class AddDependency extends Recipe {
                             return requested;
                         }),
                         newRequested));
-                if(newGdc.isCanBeResolved()) {
+                if (newGdc.isCanBeResolved() && resolvedGav != null) {
                     newGdc = newGdc.withResolved(ListUtils.concat(
                             ListUtils.map(gdc.getResolved(), resolved -> {
                                 // Remove any existing dependency with the same group and artifact id

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -164,6 +164,9 @@ public class AddDependency extends Recipe {
             source.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject ->
                     source.getMarkers().findFirst(JavaSourceSet.class).ifPresent(sourceSet -> {
                         if (source != new UsesType<>(onlyIfUsing, true).visit(source, ctx)) {
+                            if (configurationByProject.containsKey(javaProject) && "implementation".equals(configurationByProject.get(javaProject))) {
+                                return;
+                            }
                             if (StringUtils.isNullOrEmpty(testSourceSet)) {
                                 configurationByProject.compute(javaProject, (jp, configuration) ->
                                         "test".equals(sourceSet.getName()) ? "testImplementation" : "implementation"

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.toolingapi.OpenRewriteModelBuilder;
 import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.groovy.GroovyParser;
 import org.openrewrite.groovy.tree.G;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.OperatingSystemProvenance;
 import org.openrewrite.properties.tree.Properties;
@@ -47,8 +46,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
-import static org.openrewrite.properties.Assertions.properties;
-import static org.openrewrite.test.SourceSpecs.*;
 
 public class Assertions {
 
@@ -70,7 +67,9 @@ public class Assertions {
                             G.CompilationUnit g = (G.CompilationUnit) sourceFile;
                             if (g.getSourcePath().toString().endsWith(".gradle")) {
                                 Path groovyGradle = tempDirectory.resolve(g.getSourcePath());
-                                projectDir = groovyGradle.getParent();
+                                if (!tempDirectory.equals(groovyGradle.getParent()) && tempDirectory.equals(groovyGradle.getParent().getParent())) {
+                                    projectDir = groovyGradle.getParent();
+                                }
                                 Files.createDirectories(groovyGradle.getParent());
                                 Files.write(groovyGradle, g.printAllAsBytes());
                             }
@@ -78,7 +77,9 @@ public class Assertions {
                             Properties.File f = (Properties.File) sourceFile;
                             if (f.getSourcePath().endsWith("gradle.properties")) {
                                 Path gradleProperties = tempDirectory.resolve(f.getSourcePath());
-                                projectDir = gradleProperties.getParent();
+                                if (!tempDirectory.equals(gradleProperties.getParent()) && tempDirectory.equals(gradleProperties.getParent().getParent())) {
+                                    projectDir = gradleProperties.getParent();
+                                }
                                 Files.createDirectories(gradleProperties.getParent());
                                 Files.write(gradleProperties, f.printAllAsBytes());
                             }
@@ -106,13 +107,12 @@ public class Assertions {
                         Files.copy(requireNonNull(AddGradleWrapper.class.getResourceAsStream("/gradlew.bat")), projectDir.resolve(GradleWrapper.WRAPPER_BATCH_LOCATION));
                     }
 
-                    OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile());
-                    GradleProject gradleProject = GradleProject.fromToolingModel(model.gradleProject());
                     for (int i = 0; i < sourceFiles.size(); i++) {
                         SourceFile sourceFile = sourceFiles.get(i);
-                        if (sourceFile.getSourcePath().toString().endsWith(".gradle")) {
+                        if (sourceFile.getSourcePath().toString().endsWith(".gradle") && !sourceFile.getSourcePath().endsWith("settings.gradle")) {
+                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile());
+                            GradleProject gradleProject = GradleProject.fromToolingModel(model.gradleProject());
                             sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleProject)));
-                            break;
                         }
                     }
                 } finally {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -77,6 +77,28 @@ class AddDependencyTest implements RewriteTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
+    void onlyIfUsingSmokeTestScope(String onlyIfUsing) {
+        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, onlyIfUsing, null, null, null, "smokeTest");
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          mavenProject("project",
+            srcSmokeTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    smokeTestImplementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
     void onlyIfUsingCompileScope(String onlyIfUsing) {
         rewriteRun(
           spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", onlyIfUsing)),
@@ -119,7 +141,7 @@ class AddDependencyTest implements RewriteTest {
 
     @Test
     void addDependencyWithClassifier() {
-        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", "2.0.54.Final", null, "implementation", "com.google.common.math.IntMath", "linux-x86_64", null, null);
+        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", "2.0.54.Final", null, "implementation", "com.google.common.math.IntMath", "linux-x86_64", null, null, null);
         rewriteRun(
           spec -> spec.recipe(addDep),
           mavenProject("project",
@@ -140,7 +162,7 @@ class AddDependencyTest implements RewriteTest {
 
     @Test
     void addDependencyWithoutVersion() {
-        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", null, null, "implementation", "com.google.common.math.IntMath", null, null, null);
+        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", null, null, "implementation", "com.google.common.math.IntMath", null, null, null, null);
         rewriteRun(
           spec -> spec.recipe(addDep),
           mavenProject("project",
@@ -162,7 +184,7 @@ class AddDependencyTest implements RewriteTest {
     @Test
     void addDependencyWithoutVersionWithClassifier() {
         // Without a version, classifier must not be present in the result
-        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", null, null, "implementation", "com.google.common.math.IntMath", "linux-x86_64", null, null);
+        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", null, null, "implementation", "com.google.common.math.IntMath", "linux-x86_64", null, null, null);
         rewriteRun(
           spec -> spec.recipe(addDep),
           mavenProject("project",
@@ -520,7 +542,7 @@ class AddDependencyTest implements RewriteTest {
 
     @Test
     void addDependenciesWithoutVersionWithClassifierToExistingGrouping() {
-        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", null, null, "testImplementation", "com.google.common.math.IntMath", "linux-x86_64", null, null);
+        AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", null, null, "testImplementation", "com.google.common.math.IntMath", "linux-x86_64", null, null, null);
         rewriteRun(
           spec -> spec.recipe(addDep),
           mavenProject("project",
@@ -791,7 +813,7 @@ class AddDependencyTest implements RewriteTest {
         String[] gavParts = gav.split(":");
         return new AddDependency(
           gavParts[0], gavParts[1], (gavParts.length < 3) ? null : gavParts[2], null, configuration, onlyIfUsing,
-          (gavParts.length < 4) ? null : gavParts[3], null, null
+          (gavParts.length < 4) ? null : gavParts[3], null, null, null
         );
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -19,7 +19,6 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
@@ -39,8 +38,8 @@ import static org.openrewrite.java.Assertions.*;
 class AddDependencyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion()
-          .classpath("junit-jupiter-api", "guava", "jackson-databind", "jackson-core", "lombok"));
+        spec.beforeRecipe(withToolingApi())
+          .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api", "guava", "jackson-databind", "jackson-core", "lombok"));
     }
 
     @Language("java")
@@ -50,7 +49,6 @@ class AddDependencyTest implements RewriteTest {
                 boolean getMap() {
                     return IntMath.isPrime(5);
                 }
-         
             }
       """;
 
@@ -64,8 +62,24 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 dependencies {
                     testImplementation "com.google.guava:guava:29.0-jre"
                 }
@@ -78,7 +92,7 @@ class AddDependencyTest implements RewriteTest {
     @ParameterizedTest
     @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
     void onlyIfUsingSmokeTestScope(String onlyIfUsing) {
-        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, onlyIfUsing, null, null, null, "smokeTest");
+        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, onlyIfUsing, null, null, null, null);
         rewriteRun(
           spec -> spec.recipe(addDep),
           mavenProject("project",
@@ -86,8 +100,38 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "test"
+                    }
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "test"
+                    }
+                }
+                
                 dependencies {
                     smokeTestImplementation "com.google.guava:guava:29.0-jre"
                 }
@@ -152,8 +196,24 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 dependencies {
                     implementation "com.google.guava:guava:29.0-jre"
                 }
@@ -166,7 +226,7 @@ class AddDependencyTest implements RewriteTest {
     @ParameterizedTest
     @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
     void usedInMultipleSourceSetsUsingExplicitSourceSet(String onlyIfUsing) {
-        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, onlyIfUsing, null, null, null, "smokeTest");
+        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, onlyIfUsing, null, null, null, Boolean.TRUE);
         rewriteRun(
           spec -> spec.recipe(addDep),
           mavenProject("project",
@@ -180,10 +240,150 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "test"
+                    }
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "test"
+                    }
+                }
+                
                 dependencies {
                     implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void usedInTransitiveSourceSet() {
+        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, "com.google.common.math.IntMath", null, null, null, Boolean.TRUE);
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          mavenProject("project",
+            srcSmokeTestJava(
+              java(usingGuavaIntMath)
+            ),
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "test"
+                    }
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "test"
+                    }
+                }
+                
+                dependencies {
+                    testImplementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addDependencyIfNotUsedInATransitive() {
+        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, "com.google.common.math.IntMath", null, null, null, Boolean.TRUE);
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          mavenProject("project",
+            srcSmokeTestJava(
+              java(usingGuavaIntMath)
+            ),
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "main"
+                    }
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                    id "com.netflix.nebula.facet" version "10.1.3"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                facets {
+                    smokeTest {
+                        parentSourceSet = "main"
+                    }
+                }
+                
+                dependencies {
+                    smokeTestImplementation "com.google.guava:guava:29.0-jre"
+                
+                    testImplementation "com.google.guava:guava:29.0-jre"
                 }
                 """
             )
@@ -201,8 +401,24 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 dependencies {
                     implementation "io.netty:netty-tcnative-boringssl-static:2.0.54.Final:linux-x86_64"
                 }
@@ -222,8 +438,24 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 dependencies {
                     implementation "io.netty:netty-tcnative-boringssl-static"
                 }
@@ -244,8 +476,24 @@ class AddDependencyTest implements RewriteTest {
               java(usingGuavaIntMath)
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 dependencies {
                     implementation "io.netty:netty-tcnative-boringssl-static"
                 }
@@ -357,7 +605,7 @@ class AddDependencyTest implements RewriteTest {
     @Test
     void addDependenciesKeepFormatting() {
         rewriteRun(
-          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath")),
+          spec -> spec.recipe(addDependency("org.slf4j:slf4j-api:2.0.7", "com.google.common.math.IntMath")),
           mavenProject("project",
             srcMainJava(
               java(usingGuavaIntMath)
@@ -373,7 +621,7 @@ class AddDependencyTest implements RewriteTest {
                 }
                 
                 dependencies {
-                    implementation "com.example:example:1.0"
+                    implementation "org.openrewrite:rewrite-core:7.40.8"
                     testImplementation "junit:junit:4.12"
                 }
                 """,
@@ -387,8 +635,8 @@ class AddDependencyTest implements RewriteTest {
                 }
                 
                 dependencies {
-                    implementation "com.example:example:1.0"
-                    implementation "com.google.guava:guava:29.0-jre"
+                    implementation "org.openrewrite:rewrite-core:7.40.8"
+                    implementation "org.slf4j:slf4j-api:2.0.7"
                     testImplementation "junit:junit:4.12"
                 }
                 """
@@ -400,7 +648,7 @@ class AddDependencyTest implements RewriteTest {
     @Test
     void addDependencyToNewGrouping() {
         rewriteRun(
-          spec -> spec.recipe(addDependency("org.projectlombok:lombok:1.0", "lombok.Value", "annotationProcessor")),
+          spec -> spec.recipe(addDependency("org.projectlombok:lombok:1.18.26", "lombok.Value", "annotationProcessor")),
           mavenProject("project",
             srcMainJava(
               java("""
@@ -424,7 +672,7 @@ class AddDependencyTest implements RewriteTest {
                 }
                 
                 dependencies {
-                    implementation "commons-lang:commons-lang:1.0"
+                    implementation "commons-lang:commons-lang:2.6"
 
                     testImplementation "junit:junit:4.13"
                 }
@@ -439,10 +687,10 @@ class AddDependencyTest implements RewriteTest {
                 }
                 
                 dependencies {
-                    annotationProcessor "org.projectlombok:lombok:1.0"
-                    
-                    implementation "commons-lang:commons-lang:1.0"
-                    
+                    annotationProcessor "org.projectlombok:lombok:1.18.26"
+                
+                    implementation "commons-lang:commons-lang:2.6"
+                
                     testImplementation "junit:junit:4.13"
                 }
                 """
@@ -464,11 +712,11 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
 
@@ -480,14 +728,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     testImplementation group: "com.google.guava", name: "guava", version: "29.0-jre"
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
@@ -511,14 +759,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
                 }
@@ -527,14 +775,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     testImplementation group: "com.google.guava", name: "guava"
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
@@ -558,14 +806,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
                 }
@@ -574,14 +822,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     testImplementation group: "com.google.guava", name: "guava", version: "29.0-jre", classifier: "test"
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
@@ -606,14 +854,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
                 }
@@ -622,14 +870,14 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-                                
+                
                 repositories {
                     mavenCentral()
                 }
-                                
+                
                 dependencies {
                     implementation group: "commons-lang", name: "commons-lang", version: "1.0"
-
+                
                     testImplementation group: "io.netty", name: "netty-tcnative-boringssl-static", classifier: "linux-x86_64"
                     def junitVersion = "4.12"
                     testImplementation group: "junit", name: "junit", version: junitVersion
@@ -725,8 +973,24 @@ class AddDependencyTest implements RewriteTest {
               )
             ),
             buildGradle(
-              "",
               """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 dependencies {
                     %s "com.fasterxml.jackson.core:jackson-core:2.12.0"
                 }
@@ -749,24 +1013,40 @@ class AddDependencyTest implements RewriteTest {
                 include "project1"
                 include "project2"
                 """
-            )
-          ),
-          mavenProject("project1",
-            srcMainJava(
-              java(usingGuavaIntMath)
             ),
-            buildGradle(
-              "",
-              """
-                dependencies {
-                    implementation "com.google.guava:guava:29.0-jre"
-                }
+            mavenProject("project1",
+              srcMainJava(
+                java(usingGuavaIntMath)
+              ),
+              buildGradle(
                 """
-            )
-          ),
-          mavenProject("project2",
-            buildGradle(
-              ""
+                  plugins {
+                      id 'java-library'
+                  }
+                  
+                  repositories {
+                      mavenCentral()
+                  }
+                  """,
+                """
+                  plugins {
+                      id 'java-library'
+                  }
+                  
+                  repositories {
+                      mavenCentral()
+                  }
+                  
+                  dependencies {
+                      implementation "com.google.guava:guava:29.0-jre"
+                  }
+                  """
+              )
+            ),
+            mavenProject("project2",
+              buildGradle(
+                ""
+              )
             )
           )
         );
@@ -798,6 +1078,7 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java'
                 }
+                
                 repositories {
                     mavenCentral()
                 }
@@ -806,6 +1087,7 @@ class AddDependencyTest implements RewriteTest {
                 plugins {
                     id 'java'
                 }
+                
                 repositories {
                     mavenCentral()
                 }
@@ -843,9 +1125,25 @@ class AddDependencyTest implements RewriteTest {
             ),
             buildGradle(
               """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 def gauvaVersion = "29.0-jre"
                 """,
               """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
                 def gauvaVersion = "29.0-jre"
                 
                 dependencies {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -139,6 +139,58 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
+    void onlyIfUsingMultipleScopes(String onlyIfUsing) {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", onlyIfUsing)),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
+    void usedInMultipleSourceSetsUsingExplicitSourceSet(String onlyIfUsing) {
+        AddDependency addDep = new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, onlyIfUsing, null, null, null, "smokeTest");
+        rewriteRun(
+          spec -> spec.recipe(addDep),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            srcSmokeTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              "",
+              """
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
     @Test
     void addDependencyWithClassifier() {
         AddDependency addDep = new AddDependency("io.netty", "netty-tcnative-boringssl-static", "2.0.54.Final", null, "implementation", "com.google.common.math.IntMath", "linux-x86_64", null, null, null);

--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -170,6 +170,14 @@ public class Assertions {
         return srcTestResources(spec -> sourceSet(spec, "test"), resources);
     }
 
+    public static SourceSpecs srcSmokeTestJava(Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... javaSources) {
+        return dir("src/smokeTest/java", spec, javaSources);
+    }
+
+    public static SourceSpecs srcSmokeTestJava(SourceSpecs... javaSources) {
+        return srcSmokeTestJava(spec -> sourceSet(spec, "smokeTest"), javaSources);
+    }
+
     public static SourceSpec<?> version(SourceSpec<?> sourceSpec, int version) {
         return sourceSpec.markers(javaVersion(version));
     }


### PR DESCRIPTION
We are using the Nebula test facets plugin (https://github.com/nebula-plugins/nebula-project-plugin#test-facets) to create `smokeTest` source set, if a class is only used in `smokeTest`, we'd like to add that as `smokeTestImplementation` dependency instead of `implementation` or `testImplementation` dependency. 

Currently, the openrewrite logic only handles `implementation` and `testImplementation` dependencies. If `onlyIfUsing` matches code in `smokeTest` source set, it would add that as `implementation`. 

With this change, it adds an additional optional config `testSourceSet`. If that's not specified, it will keep the existing behavior (any source sets other than `test` will add as `implementation` dependency). If that's specified, `main` source set will be `implementation`, and other matching source sets will add `<source set name>Implementation` (e.g. `smokeTest` source set will add `smokeTestImplementation`)

Slack thread: https://rewriteoss.slack.com/archives/C01A843MWG5/p1684359544460089