### PR TITLE
Fix unexpected varargs parsing

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1472,10 +1472,14 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
         Space varargs = null;
         if (typeExpr != null && typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
-            int varargStart = indexOfNextNonWhitespace(vartype.getStartPosition(), source);
+            int varargStart = indexOfNextNonWhitespace(vartype.pos, source);
             if (source.startsWith("...", varargStart)) {
-                varargs = format(source.substring(cursor, varargStart));
                 cursor = varargStart + 3;
+                if (vartype instanceof JCArrayTypeTree) {
+                    JCExpression elementType = ((JCArrayTypeTree) vartype).elemtype;
+                    varargStart = vartype.getStartPosition() + elementType.toString().length();
+                }
+                varargs = format(source.substring(varargStart, cursor));
             }
         }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodDeclarationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodDeclarationTest.java
@@ -64,6 +64,20 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void typeVarargs() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void foo(String  ...  args) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void interfaceMethodDecl() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -794,7 +794,6 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
         }
         if (multiVariable.getVarargs() != null) {
             visitSpace(multiVariable.getVarargs(), Space.Location.VARARGS, p);
-            p.append("...");
         }
         visitRightPadded(multiVariable.getPadding().getVariables(), JRightPadded.Location.NAMED_VARIABLE, ",", p);
         afterSyntax(multiVariable, p);


### PR DESCRIPTION
To fix unexpected varargs parsing in the Java17 parser (The parsing implementation of Java7 and Java11 parsers for varargs are different, so not included in this PR)

Found by @traceyyoshima in this Slack [thread](https://moderneinc.slack.com/archives/C01VADFPJQZ/p1685155406306999)

To parse the code 
```java
class Test {
    void foo(String  ...  args) {
    }
}
```

Before this change, the `...` is stored in the variable's whitespace prefix.
<img width="1190" alt="Screen Shot 2023-05-29 at 11 43 54 AM" src="https://github.com/openrewrite/rewrite/assets/122563761/3ffe3a96-259d-4b97-84ea-e26fa73efa86">

After this change, the `...` is stored in the `varargs` field of the `J.VariableDeclarations`.
![Screen Shot 2023-05-29 at 11 42 33 AM](https://github.com/openrewrite/rewrite/assets/122563761/cc40ddb2-2099-4f4e-93af-5a37fdd300fb)
