### PR TITLE
a new recipe to add a profile into a maven pom.xml file

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.*;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.Optional;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class AddProfile extends Recipe {
+
+    private static final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
+
+    @Override
+    public String getDisplayName() {
+        return "Add Maven profile";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add a maven profile to a `pom.xml` file.";
+    }
+
+    @Option(displayName = "id",
+            description = "The profile id.",
+            example = "default")
+    String id;
+
+    @Option(displayName = "Activation",
+            description = "activation details of a maven profile, provided as raw XML.",
+            example     = "<activation><foo>foo</foo></activation>",
+            required = false)
+    String activation;
+
+    @Option(displayName = "Properties",
+            description = "properties of a maven profile, provided as raw XML.",
+            example     = "<properties><foo>foo</foo><bar>bar</bar></properties>",
+            required = false)
+    String properties;
+
+    @Option(displayName = "build",
+            description = "build details of a maven profile, provided as raw XML.",
+            example     = "<build><foo>foo</foo></build>",
+            required = false)
+    String build;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AddProfile.AddProfileVisitor();
+    }
+
+    private class AddProfileVisitor extends MavenIsoVisitor<ExecutionContext> {
+
+
+
+        @Override
+        public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            Xml.Tag t = super.visitTag(tag, ctx);
+
+            if (PROJECT_MATCHER.matches(getCursor())) {
+                Optional<Xml.Tag> maybeProfiles = t.getChild("profiles");
+                Xml.Tag profiles;
+                if(maybeProfiles.isPresent()) {
+                    profiles = maybeProfiles.get();
+                } else {
+                    t = (Xml.Tag) new AddToTagVisitor<>(t, Xml.Tag.build("<profiles/>")).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+                    //noinspection OptionalGetWithoutIsPresent
+                    profiles = t.getChild("profiles").get();
+                }
+
+                Optional<Xml.Tag> maybeProfile = profiles.getChildren().stream()
+                        .filter(profile ->
+                                "profile".equals(profile.getId())
+                        )
+                        .findAny();
+
+                if (maybeProfile.isPresent()) {
+                    Xml.Tag profile = maybeProfile.get();
+
+                        t = (Xml.Tag) new RemoveContentVisitor(profile, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+
+                } else {
+                    Xml.Tag profileTag = Xml.Tag.build("<profile>\n" +
+                            "<id>" + id + "</id>\n" +
+                            (activation != null ? activation.trim() + "\n" : "") +
+                            (properties != null ? properties.trim() + "\n" : "") +
+                            (build != null ? build.trim() + "\n" : "") +
+                            "</profile>");
+                    t = (Xml.Tag) new AddToTagVisitor<>(profiles, profileTag).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+                }
+            }
+
+            return t;
+        }
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
@@ -21,6 +21,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.*;
 import org.openrewrite.xml.tree.Xml;
 
@@ -49,20 +50,23 @@ public class AddProfile extends Recipe {
 
     @Option(displayName = "Activation",
             description = "activation details of a maven profile, provided as raw XML.",
-            example     = "<activation><foo>foo</foo></activation>",
+            example = "<activation><foo>foo</foo></activation>",
             required = false)
+    @Nullable
     String activation;
 
     @Option(displayName = "Properties",
             description = "properties of a maven profile, provided as raw XML.",
-            example     = "<properties><foo>foo</foo><bar>bar</bar></properties>",
+            example = "<properties><foo>foo</foo><bar>bar</bar></properties>",
             required = false)
+    @Nullable
     String properties;
 
     @Option(displayName = "build",
             description = "build details of a maven profile, provided as raw XML.",
-            example     = "<build><foo>foo</foo></build>",
+            example = "<build><foo>foo</foo></build>",
             required = false)
+    @Nullable
     String build;
 
     @Override
@@ -73,7 +77,6 @@ public class AddProfile extends Recipe {
     private class AddProfileVisitor extends MavenIsoVisitor<ExecutionContext> {
 
 
-
         @Override
         public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
             Xml.Tag t = super.visitTag(tag, ctx);
@@ -81,7 +84,7 @@ public class AddProfile extends Recipe {
             if (PROJECT_MATCHER.matches(getCursor())) {
                 Optional<Xml.Tag> maybeProfiles = t.getChild("profiles");
                 Xml.Tag profiles;
-                if(maybeProfiles.isPresent()) {
+                if (maybeProfiles.isPresent()) {
                     profiles = maybeProfiles.get();
                 } else {
                     t = (Xml.Tag) new AddToTagVisitor<>(t, Xml.Tag.build("<profiles/>")).visitNonNull(t, ctx, getCursor().getParentOrThrow());
@@ -98,7 +101,7 @@ public class AddProfile extends Recipe {
                 if (maybeProfile.isPresent()) {
                     Xml.Tag profile = maybeProfile.get();
 
-                        t = (Xml.Tag) new RemoveContentVisitor(profile, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+                    t = (Xml.Tag) new RemoveContentVisitor(profile, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
 
                 } else {
                     Xml.Tag profileTag = Xml.Tag.build("<profile>\n" +

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.xml.Assertions.xml;
+
+public class AddProfileTest implements RewriteTest {
+
+
+    @DocumentExample
+    @Test
+    void addProfileToPom() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+            "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>"))
+          .cycles(1)
+          .expectedCyclesThatMakeChanges(1),
+          pomXml(
+            """
+              <project>
+                <groupId>group</groupId>
+                <artifactId>artifact</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>group</groupId>
+                <artifactId>artifact</artifactId>
+                <version>1</version>
+                <profiles>
+                  <profile>
+                    <id>myprofile</id>
+                    <activation>
+                      <foo>foo</foo>
+                    </activation>
+                    <properties>
+                      <bar>bar</bar>
+                    </properties>
+                    <build>
+                      <param>value</param>
+                    </build>
+                  </profile>
+                </profiles>
+              </project>
+              """
+
+          )
+        );
+    }
+
+
+    @DocumentExample
+    @Test
+    void notAPom() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProfile("myprofile", "<activation></activation>",
+            "<properties></properties>", "<build></build>")),
+          xml(
+            """
+              <project>
+              </project>
+              """,
+            documentSourceSpec -> documentSourceSpec.path("my/project/beans.xml")
+
+          )
+        );
+    }
+
+}
+


### PR DESCRIPTION


## What's changed?
a new recipe to add a profile into a maven pom.xml file



### Checklist
- [ y] I've added unit tests to cover both positive and negative cases
- [y] I've added the license header to any new files through `./gradlew licenseFormat`
- [ y] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
