### PR TITLE
Fix for type cast error in Gradle AddDependency recipe.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -160,14 +160,16 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 SourceFile sourceFile = (SourceFile) requireNonNull(tree);
-                sourceFile.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject ->
-                        sourceFile.getMarkers().findFirst(JavaSourceSet.class).ifPresent(sourceSet -> {
-                            if (sourceFile != new UsesType<>(onlyIfUsing, true).visit(sourceFile, ctx)) {
-                                acc.usingType = true;
-                                Set<String> configurations = acc.configurationsByProject.computeIfAbsent(javaProject, ignored -> new HashSet<>());
-                                configurations.add("main".equals(sourceSet.getName()) ? "implementation" : sourceSet.getName() + "Implementation");
-                            }
-                        }));
+                if (sourceFile instanceof JavaSourceFile) {
+                    sourceFile.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject ->
+                            sourceFile.getMarkers().findFirst(JavaSourceSet.class).ifPresent(sourceSet -> {
+                                if (sourceFile != new UsesType<>(onlyIfUsing, true).visit(sourceFile, ctx)) {
+                                    acc.usingType = true;
+                                    Set<String> configurations = acc.configurationsByProject.computeIfAbsent(javaProject, ignored -> new HashSet<>());
+                                    configurations.add("main".equals(sourceSet.getName()) ? "implementation" : sourceSet.getName() + "Implementation");
+                                }
+                            }));
+                }
                 return tree;
             }
         };


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
An instanceof check for JavaSourceFile is added to AddDependency.java.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Without this type check, the invocation of `UsesType` in `AddDependency`'s scanning visitor fails when encountering non-Java files such as a properties file.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
