### PR TITLE
Support `Recipe.getRecipeList()` for `doAfterVisit` method

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -158,6 +158,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
         List<Recipe> subRecipes = recipe.getRecipeList();
         if (!subRecipes.isEmpty()) {
             for (Recipe r : subRecipes) {
+                //noinspection unchecked
                 afterVisit.add((TreeVisitor<T, P>) r.getVisitor());
             }
         }


### PR DESCRIPTION
just found a failing test that `TreeVisitor#doAfterVisit()` doesn’t work if the parameter is a recipe which overridden  `Recipe#getRecipeList()`, [here](https://github.com/openrewrite/rewrite-spring/blob/main/src/testWithSpringBoot_2_4/java/org/openrewrite/maven/spring/UpgradeExplicitSpringBootDependenciesTest.java#L812) is the failing test.

Root cause: Method  `doAfterVisit` ([Code](https://github.com/openrewrite/rewrite/blob/main/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java#L158)) takes recipe.getVisitor() but ignored `getRecipeList`.




