### PR TITLE
Reduce GroovyParser memory retention

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeSignatureBuilderTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeSignatureBuilderTest.java
@@ -42,7 +42,7 @@ public class GroovyTypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
         singletonList(new Parser.Input(Paths.get("GroovyTypeGoat.groovy"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))),
         null,
         new ParsingExecutionContextView(new InMemoryExecutionContext(Throwable::printStackTrace)))
-      .map(GroovyParser.Pair::getKey)
+      .map(GroovyParser.Intermediate::getCompiledGroovySource)
       .iterator()
       .next();
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeSignatureBuilderTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeSignatureBuilderTest.java
@@ -42,7 +42,7 @@ public class GroovyTypeSignatureBuilderTest implements JavaTypeSignatureBuilderT
         singletonList(new Parser.Input(Paths.get("GroovyTypeGoat.groovy"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))),
         null,
         new ParsingExecutionContextView(new InMemoryExecutionContext(Throwable::printStackTrace)))
-      .keySet()
+      .map(GroovyParser.Pair::getKey)
       .iterator()
       .next();
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
