### PR TITLE
Update MigrateToRewrite8 referenced recipes

### DIFF
--- a/rewrite-java/src/main/resources/META-INF/rewrite/migrate-rewrite.yml
+++ b/rewrite-java/src/main/resources/META-INF/rewrite/migrate-rewrite.yml
@@ -23,6 +23,6 @@ description: |
   In those cases, this recipe will add a comment to the code and request a human to review and handle it manually.
   Reference : Migration guide (URL to be written).
 recipeList:
-  - org.openrewrite.java.upgrade.MigrateRecipeToRewrite8
-  - org.openrewrite.java.upgrade.MigrateTestToRewrite8
-  - org.openrewrite.java.upgrade.MigrateMarkersSearchResult
+  - org.openrewrite.java.recipes.MigrateRecipeToRewrite8
+  - org.openrewrite.java.recipes.MigrateTestToRewrite8
+  - org.openrewrite.java.recipes.MigrateMarkersSearchResult


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The package of referenced recipes in `MigrateToRewrite8`.

## What's your motivation?
I tried to run the `MigrateToRewrite8` recipe introduced in #3241, but saw these messages:

```
> Task :rewriteDryRun
Validating active recipes
Recipe validation error in org.openrewrite.java.upgrade.MigrateToRewrite8.recipeList[0] (in jar:file:/home/sghill/.gradle/caches/modules-2/files-2.1/org.openrewrite/rewrite-java/8.0.0/5846c136ff8dc89b163dbff7445633bd6bb4c9c2/rewrite-java-8.0.0.jar!/META-INF/rewrite/migrate-rewrite.yml): 
recipe 'org.openrewrite.java.upgrade.MigrateRecipeToRewrite8' does not exist.
Recipe validation error in org.openrewrite.java.upgrade.MigrateToRewrite8.recipeList[1] (in jar:file:/home/sghill/.gradle/caches/modules-2/files-2.1/org.openrewrite/rewrite-java/8.0.0/5846c136ff8dc89b163dbff7445633bd6bb4c9c2/rewrite-java-8.0.0.jar!/META-INF/rewrite/migrate-rewrite.yml): 
recipe 'org.openrewrite.java.upgrade.MigrateTestToRewrite8' does not exist.
Recipe validation error in org.openrewrite.java.upgrade.MigrateToRewrite8.recipeList[2] (in jar:file:/home/sghill/.gradle/caches/modules-2/files-2.1/org.openrewrite/rewrite-java/8.0.0/5846c136ff8dc89b163dbff7445633bd6bb4c9c2/rewrite-java-8.0.0.jar!/META-INF/rewrite/migrate-rewrite.yml): 
recipe 'org.openrewrite.java.upgrade.MigrateMarkersSearchResult' does not exist.
```

The classes were relocated in #3118.

## Have you considered any alternatives or workarounds?
I'm using the gradle plugin, so I copied this version with the package change into my local `rewrite.yml` and saw it succeed :tada: