### PR TITLE
fix: fetch correct maven packaging for purl qualifier

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/PrintMavenAsCycloneDxBom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/PrintMavenAsCycloneDxBom.java
@@ -80,13 +80,13 @@ public final class PrintMavenAsCycloneDxBom {
 
         //(Scope scope, String groupId, String artifactId, String version, String packaging, List<String> licenses, String bomReference, StringBuilder bom) {
         String packaging = ("war".equals(pom.getPackaging()) || "ear".equals(pom.getPackaging())) ? "application" : "library";
-
         writeComponent(
                 Scope.Compile,
                 pom.getValue(pom.getGroupId()),
                 pom.getArtifactId(),
                 pom.getValue(pom.getVersion()),
                 packaging,
+                pom.getPackaging(),
                 pom.getRequested().getLicenses(),
                 bom);
 
@@ -106,6 +106,7 @@ public final class PrintMavenAsCycloneDxBom {
                     dependency.getArtifactId(),
                     dependency.getVersion(),
                     "library",
+                    "jar",
                     dependency.getLicenses(),
                     bom);
         }
@@ -116,6 +117,7 @@ public final class PrintMavenAsCycloneDxBom {
                     dependency.getArtifactId(),
                     dependency.getVersion(),
                     "library",
+                    "jar",
                     dependency.getLicenses(),
                     bom);
         }
@@ -133,7 +135,7 @@ public final class PrintMavenAsCycloneDxBom {
     }
 
     private static void writeDependency(ResolvedDependency dependency, StringBuilder bom) {
-        String bomReference = getBomReference(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+        String bomReference = getBomReference(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(), "jar");
         bom.append("        <dependency ref=\"").append(bomReference).append("\">\n");
         if (dependency.getDependencies() != null) {
             for (ResolvedDependency nested : dependency.getDependencies()) {
@@ -141,7 +143,8 @@ public final class PrintMavenAsCycloneDxBom {
                         .append(getBomReference(
                                 nested.getGroupId(),
                                 nested.getArtifactId(),
-                                nested.getVersion())
+                                nested.getVersion(),
+                                "jar")
                         ).append("\"/>\n");
             }
         }
@@ -149,10 +152,10 @@ public final class PrintMavenAsCycloneDxBom {
     }
 
     private static void writeComponent(Scope scope, String groupId, String artifactId, String version,
-                                       String packaging, List<License> licenses, StringBuilder bom) {
+                                       String packaging, String mavenPackaging, List<License> licenses, StringBuilder bom) {
 
         String indent = "        ";
-        String bomReference = getBomReference(groupId, artifactId, version);
+        String bomReference = getBomReference(groupId, artifactId, version, mavenPackaging);
         bom.append(indent).append("<component bom-ref=\"").append(bomReference).append("\" type=\"").append(packaging).append("\">\n");
         bom.append(indent).append("    <group>").append(groupId).append("</group>\n");
         bom.append(indent).append("    <name>").append(artifactId).append("</name>\n");
@@ -217,7 +220,7 @@ public final class PrintMavenAsCycloneDxBom {
         }
     }
 
-    private static String getBomReference(String group, String artifactId, String version) {
-        return "pkg:maven/" + group + "/" + artifactId + "@" + version + "?type=jar";
+    private static String getBomReference(String group, String artifactId, String version, String mavenPackaging) {
+        return "pkg:maven/" + group + "/" + artifactId + "@" + version + "?type=" + mavenPackaging;
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsCycloneDxBomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsCycloneDxBomTest.java
@@ -141,6 +141,7 @@ class PrintMavenAsCycloneDxBomTest implements RewriteTest {
         String bom = PrintMavenAsCycloneDxBom.print(pom)
           .replaceAll("<timestamp>.*</timestamp>", "<timestamp>TODAY</timestamp>");
 
+        String expectedQualifier = "type=pom";
         assertThat(bom).isEqualTo(String.format(
             """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -159,11 +160,11 @@ class PrintMavenAsCycloneDxBomTest implements RewriteTest {
                         <name>pom_packaging</name>
                         <version>1.0</version>
                         <scope>required</scope>
-                        <purl>pkg:maven/org.example/pom_packaging@1.0?type=pom</purl>
+                        <purl>pkg:maven/org.example/pom_packaging@1.0?%s</purl>
                     </component>
                 </metadata>
             </bom>
-            """, pom.getId().toString())
+            """, pom.getId().toString(), expectedQualifier)
         );
 
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsCycloneDxBomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsCycloneDxBomTest.java
@@ -141,7 +141,6 @@ class PrintMavenAsCycloneDxBomTest implements RewriteTest {
         String bom = PrintMavenAsCycloneDxBom.print(pom)
           .replaceAll("<timestamp>.*</timestamp>", "<timestamp>TODAY</timestamp>");
 
-        String expectedQualifier = "type=pom";
         assertThat(bom).isEqualTo(String.format(
             """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -160,11 +159,11 @@ class PrintMavenAsCycloneDxBomTest implements RewriteTest {
                         <name>pom_packaging</name>
                         <version>1.0</version>
                         <scope>required</scope>
-                        <purl>pkg:maven/org.example/pom_packaging@1.0?%s</purl>
+                        <purl>pkg:maven/org.example/pom_packaging@1.0?type=pom</purl>
                     </component>
                 </metadata>
             </bom>
-            """, pom.getId().toString(), expectedQualifier)
+            """, pom.getId().toString())
         );
 
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The packaging mentioned in the pURL qualifier was assumed to be a `jar`. The changes fix that. I produce a test that takes a pom for a maven project whose packaging is `pom`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes https://github.com/openrewrite/rewrite-maven-plugin/issues/579

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
