### PR TITLE
More data in FindParseFailures

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/maven/MavenParserBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/maven/MavenParserBenchmark.java
@@ -23,18 +23,16 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
 import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenParser;
 import org.openrewrite.maven.cache.CompositeMavenPomCache;
 import org.openrewrite.maven.cache.InMemoryMavenPomCache;
 import org.openrewrite.maven.cache.RocksdbMavenPomCache;
-import org.openrewrite.maven.tree.MavenResolutionResult;
-import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 @Fork(1)
 @Measurement(iterations = 2)
@@ -61,7 +59,7 @@ public class MavenParserBenchmark {
         MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
         ctx.setPomCache(pomCache);
 
-        Optional<Xml.Document> maven = MavenParser.builder().build().parse(ctx,
+        Optional<SourceFile> maven = MavenParser.builder().build().parse(ctx,
                 "" +
                 "<project>" +
                 "  <parent>" +

--- a/rewrite-core/src/main/java/org/openrewrite/ParseExceptionResult.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ParseExceptionResult.java
@@ -18,6 +18,8 @@ package org.openrewrite;
 import lombok.Value;
 import lombok.With;
 import org.openrewrite.internal.ExceptionUtils;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
@@ -28,9 +30,28 @@ import static org.openrewrite.Tree.randomId;
 @With
 public class ParseExceptionResult implements Marker {
     UUID id;
+    String parserType;
+    String exceptionType;
     String message;
 
+    /**
+     * The type of tree element that was being parsed when the failure occurred.
+     */
+    @Nullable
+    String treeType;
+
+    public static ParseExceptionResult build(Class<? extends Parser> parserClass, Throwable t) {
+        String simpleName = t.getClass().getSimpleName();
+        return new ParseExceptionResult(
+                randomId(),
+                parserClass.getSimpleName(),
+                !StringUtils.isBlank(simpleName) ? simpleName : t.getClass().getName(),
+                ExceptionUtils.sanitizeStackTrace(t, parserClass),
+                null
+        );
+    }
+
     public static ParseExceptionResult build(Parser parser, Throwable t) {
-        return new ParseExceptionResult(randomId(), ExceptionUtils.sanitizeStackTrace(t, parser.getClass()));
+        return build(parser.getClass(), t);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -380,7 +380,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
     }
 
     @SuppressWarnings("rawtypes")
-    private Class<? extends Tree> visitorTreeType(Class<? extends TreeVisitor> v) {
+    protected Class<? extends Tree> visitorTreeType(Class<? extends TreeVisitor> v) {
         for (TypeVariable<? extends Class<? extends TreeVisitor>> tp : v.getTypeParameters()) {
             for (Type bound : tp.getBounds()) {
                 if (bound instanceof Class && Tree.class.isAssignableFrom((Class<?>) bound)) {

--- a/rewrite-core/src/main/java/org/openrewrite/table/ParseFailures.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/ParseFailures.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.Recipe;
+import org.openrewrite.internal.lang.Nullable;
 
 @JsonIgnoreType
 public class ParseFailures extends DataTable<ParseFailures.Row> {
@@ -31,8 +32,27 @@ public class ParseFailures extends DataTable<ParseFailures.Row> {
 
     @Value
     public static class Row {
+        @Column(displayName = "Parser", description = "The parser implementation that failed.")
+        String parser;
+
         @Column(displayName = "Source path", description = "The file that failed to parse.")
         String sourcePath;
+
+        @Column(displayName = "Exception type", description = "The class name of the exception that produce the parse failure.")
+        @Nullable
+        String exceptionType;
+
+        @Column(displayName = "Tree type", description = "The type of the tree element that was being parsed " +
+                                                         "when the failure occurred. This can refer either to the intended " +
+                                                         "target OpenRewrite Tree type or a parser or compiler internal tree " +
+                                                         "type that we couldn't determine how to map.")
+        @Nullable
+        String treeType;
+
+        @Column(displayName = "Snippet",
+                description = "The code snippet that the failure occurred on. Omitted when the parser fails on the whole file.")
+        @Nullable
+        String snippet;
 
         @Column(displayName = "Stack trace", description = "The stack trace of the failure.")
         String stackTrace;

--- a/rewrite-core/src/main/java/org/openrewrite/text/ChangeText.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/ChangeText.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.text;
 
-import lombok.*;
-import lombok.experimental.FieldDefaults;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
@@ -24,6 +24,8 @@ import org.openrewrite.TreeVisitor;
 
 import java.util.Collections;
 import java.util.Set;
+
+import static java.util.Collections.emptyList;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -53,8 +55,10 @@ public class ChangeText extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new PlainTextVisitor<ExecutionContext>() {
             @Override
-            public PlainText preVisit(PlainText tree, ExecutionContext ctx) {
-                return tree.withText(toText);
+            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+                return text
+                        .withSnippets(emptyList())
+                        .withText(toText);
             }
         };
     }

--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -93,18 +93,9 @@ public class CreateTextFile extends ScanningRecipe<AtomicBoolean> {
     public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean created) {
         Path path = Paths.get(relativeFileName);
         return new PlainTextVisitor<ExecutionContext>() {
-
-            @Override
-            public @Nullable PlainText visit(@Nullable Tree tree, ExecutionContext executionContext) {
-                if(created.get()) {
-                    return (PlainText) tree;
-                }
-                return super.visit(tree, executionContext);
-            }
-
             @Override
             public PlainText visitText(PlainText text, ExecutionContext ctx) {
-                if (path.toString().equals(text.getSourcePath().toString()) && Boolean.TRUE.equals(overwriteExisting)) {
+                if ((created.get() || Boolean.TRUE.equals(overwriteExisting)) && path.toString().equals(text.getSourcePath().toString())) {
                     return text.withText(fileContents);
                 }
                 return text;

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
@@ -137,7 +137,7 @@ public class PlainText implements SourceFile, Tree {
 
         @Override
         public <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) {
-            return false;
+            return v.isAdaptableTo(PlainTextVisitor.class);
         }
 
         @SuppressWarnings("unchecked")

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
@@ -15,12 +15,12 @@
  */
 package org.openrewrite.text;
 
-import org.openrewrite.Cursor;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 
-public class PlainTextVisitor<P> extends TreeVisitor<PlainText, P> {
+public class PlainTextVisitor<P> extends TreeVisitor<Tree, P> {
 
     @Override
     public boolean isAcceptable(SourceFile sourceFile, P p) {
@@ -28,13 +28,9 @@ public class PlainTextVisitor<P> extends TreeVisitor<PlainText, P> {
     }
 
     public PlainText visitText(PlainText text, P p) {
-        PlainText t = text.withMarkers(visitMarkers(text.getMarkers(), p));
-        t = t.withSnippets(ListUtils.map(t.getSnippets(), snippet -> {
-            setCursor(new Cursor(getCursor(), snippet));
-            PlainText.Snippet s = visitSnippet(snippet, p);
-            setCursor(getCursor().getParent());
-            return s;
-        }));
+        PlainText t = text;
+        t = t.withMarkers(visitMarkers(t.getMarkers(), p));
+        t = t.withSnippets(ListUtils.map(t.getSnippets(), s -> visitAndCast(s, p)));
         return t;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainTextVisitor.java
@@ -27,6 +27,14 @@ public class PlainTextVisitor<P> extends TreeVisitor<Tree, P> {
         return sourceFile instanceof PlainText;
     }
 
+    public boolean isAdaptableTo(@SuppressWarnings("rawtypes") Class<? extends TreeVisitor> adaptTo) {
+        if (adaptTo.isAssignableFrom(getClass())) {
+            return true;
+        }
+        Class<? extends Tree> theirs = visitorTreeType(adaptTo);
+        return theirs.equals(PlainText.class) || theirs.equals(PlainText.Snippet.class);
+    }
+
     public PlainText visitText(PlainText text, P p) {
         PlainText t = text;
         t = t.withMarkers(visitMarkers(t.getMarkers(), p));

--- a/rewrite-core/src/test/java/org/openrewrite/FindParseFailuresTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/FindParseFailuresTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.table.ParseFailures;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextParser;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.openrewrite.test.SourceSpecs.text;
+
+public class FindParseFailuresTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new FindParseFailures(5));
+    }
+
+    @Test
+    void findParseFailures() {
+        ParseExceptionResult per = ParseExceptionResult.build(PlainTextParser.class, new RuntimeException("boom"));
+        rewriteRun(
+          spec -> spec.dataTable(ParseFailures.Row.class, rows -> {
+              assertThat(rows).hasSize(1);
+              ParseFailures.Row row = rows.get(0);
+              assertThat(row.getParser()).isEqualTo("PlainTextParser");
+              assertThat(row.getSourcePath()).isEqualTo("file.txt");
+              assertThat(row.getExceptionType()).isEqualTo("RuntimeException");
+              assertThat(row.getSnippet()).isEqualTo("hello");
+          }),
+          text(
+            "hello world!",
+            "~~(%s)~~>hello world!".formatted(per.getMessage()),
+            spec -> spec
+              .mapBeforeRecipe(pt -> pt
+                .withSnippets(List.of(new PlainText.Snippet(
+                  Tree.randomId(),
+                  new Markers(Tree.randomId(), List.of(per)),
+                  pt.getText())))
+                .withText("")
+              )
+          )
+        );
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/PreconditionsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/PreconditionsTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -88,12 +87,7 @@ class PreconditionsTest implements RewriteTest {
     void checkApplicabilityAgainstOtherSourceTypes() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> Preconditions.check(
-            new PlainTextVisitor<>() {
-                @Override
-                public @Nullable PlainText visit(@Nullable Tree tree, ExecutionContext ctx) {
-                    return super.visit(tree, ctx);
-                }
-            },
+            new PlainTextVisitor<>(),
             new PlainTextVisitor<>()
           ))),
           other("hello")
@@ -112,7 +106,7 @@ class PreconditionsTest implements RewriteTest {
     PlainTextVisitor<ExecutionContext> contains(String s) {
         return new PlainTextVisitor<>() {
             @Override
-            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+            public PlainText visitText(PlainText text, ExecutionContext ctx) {
                 if (text.getText().contains(s)) {
                     return SearchResult.found(text);
                 }

--- a/rewrite-core/src/test/java/org/openrewrite/table/RecipeRunStatsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/table/RecipeRunStatsTest.java
@@ -53,7 +53,7 @@ public class RecipeRunStatsTest implements RewriteTest {
               },
               new PlainTextVisitor<>() {
                   @Override
-                  public PlainText preVisit(PlainText tree, ExecutionContext ctx) {
+                  public PlainText visitText(PlainText tree, ExecutionContext ctx) {
                       return tree.withText("sam");
                   }
               });

--- a/rewrite-java/src/test/java/org/openrewrite/java/TreeAdaptabilityTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/TreeAdaptabilityTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
@@ -31,14 +32,7 @@ class TreeAdaptabilityTest implements RewriteTest {
     void adaptParameterizedPlainTextTreeVisitor() {
         //noinspection rawtypes
         assertThat(new PlainTextVisitor() {}.isAdaptableTo(JavaVisitor.class)).isFalse();
-        assertThat(new TreeVisitor<PlainText, Integer>() {}.isAdaptableTo(JavaVisitor.class)).isFalse();
-        assertThat(new TreeVisitor<PlainText, Integer>() {}.isAdaptableTo(PlainTextVisitor.class)).isTrue();
-    }
-
-    public static class VisitLiteral<P> extends JavaIsoVisitor<P> {
-        @Override
-        public J.Literal visitLiteral(J.Literal literal, P p) {
-            return super.visitLiteral(literal, p);
-        }
+        assertThat(new TreeVisitor<PlainText,Integer > () {}.isAdaptableTo(JavaVisitor.class)).isFalse();
+        assertThat(new TreeVisitor<Tree, Integer>() {}.isAdaptableTo(PlainTextVisitor.class)).isTrue();
     }
 }


### PR DESCRIPTION
Allows us to remove the duplicate effort in `rewrite-all` that was also causing a cyclic dependency between language modules and rewrite-all