### PR TITLE
Fix/yaml encoding

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -37,8 +37,7 @@ public class XmlParser implements Parser {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
         return acceptedInputs(sourceFiles).map(sourceFile -> {
             Path path = sourceFile.getRelativePath(relativeTo);
-            try {
-                EncodingDetectingInputStream is = sourceFile.getSource(ctx);
+            try (EncodingDetectingInputStream is = sourceFile.getSource(ctx)) {
                 String sourceStr = is.readFully();
 
                 XMLParser parser = new XMLParser(new CommonTokenStream(new XMLLexer(

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -34,11 +34,9 @@ import org.yaml.snakeyaml.reader.StreamReader;
 import org.yaml.snakeyaml.scanner.Scanner;
 import org.yaml.snakeyaml.scanner.ScannerImpl;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -106,9 +104,8 @@ public class YamlParser implements org.openrewrite.Parser {
             yamlSourceWithVariablePlaceholders.append(yamlSource, pos, yamlSource.length());
         }
 
-        try (FormatPreservingReader reader = new FormatPreservingReader(
-                new InputStreamReader(new ByteArrayInputStream(yamlSourceWithVariablePlaceholders.toString()
-                        .getBytes(StandardCharsets.UTF_8))))) {
+        try (StringReader stringReader = new StringReader(yamlSourceWithVariablePlaceholders.toString());
+             FormatPreservingReader reader = new FormatPreservingReader(stringReader)) {
             StreamReader streamReader = new StreamReader(reader);
             Scanner scanner = new ScannerImpl(streamReader, new LoaderOptions());
             Parser parser = new ParserImpl(scanner);


### PR DESCRIPTION
## What's changed?
- The InputStreamReader use UTF-8 instead of the default encoding (ISO-8859-1 for windows)
- Close all readers and streams with try-resource

## What's your motivation?
Issue #3312

## Anything in particular you'd like reviewers to focus on?
I added the streams and readers to the try-resource.
This bug is only testable under Windows, so no test is added. Tested it locally and it works.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
