### PR TITLE
[Draft to be discussed] [Prototype] Proposal of alternative single-source-applicable test for yaml recipes

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/RecipeChainExecutorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/RecipeChainExecutorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.recipes;
 
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/RecipeChainExecutorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/RecipeChainExecutorTest.java
@@ -1,0 +1,47 @@
+package org.openrewrite.java.recipes;
+
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+class RecipeChainExecutorTest implements RewriteTest {
+
+    @Test
+    void yamlApplicabilityWithSingleSource() {
+        @Language("yaml")
+        String yamlRecipe = """
+          ---
+          type: specs.openrewrite.org/v1beta/recipe
+          name: org.openrewrite.ApplicabilityExactlyOnce
+          displayName: Applicability test runs once for the whole recipe list
+          description: >
+            An applicability test should be run once and if a match is found, all recipes in the list should be run.
+            So if one of the recipes in the list makes a change which would cause the applicability test to no longer match,
+            subsequent recipes in the list should still execute.
+            
+            Given a text file containing the number "1", running this recipe should result in a file which contains "3".
+            If the applicability test is incorrectly applied to individual recipes in the list, the (incorrect) result would be "2".
+          recipeList:
+            - org.openrewrite.java.recipes.RecipeChainExecutor:
+                preCondition:
+                  - org.openrewrite.text.FindAndReplace:
+                      find: "1"
+                      replace: "A"
+                recipes:
+                  - org.openrewrite.text.ChangeText:
+                      toText: "2"
+                  - org.openrewrite.text.ChangeText:
+                      toText: "3"
+          """;
+        rewriteRun(
+          spec -> spec.recipeFromYaml(yamlRecipe, "org.openrewrite.ApplicabilityExactlyOnce"),
+          text("1", "3"),
+          text("2")
+        );
+    }
+
+}
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/RecipeChainExecutor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/RecipeChainExecutor.java
@@ -1,0 +1,92 @@
+package org.openrewrite.java.recipes;
+
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RecipeChainExecutor extends Recipe {
+    @Option(displayName = "preCondition recipe",
+        description = "preCondition recipe FQN and parameters. Used for yaml recipe usage only",
+        example = "org.openrewrite.text.FindAndReplace")
+    Object preCondition;
+
+    @Option(displayName = "Recipe list to run",
+        description = "Recipe list to run.",
+        example = "org.openrewrite.text.ChangeText")
+    Object recipes;
+
+    @Override
+    public String getDisplayName() {
+        return "Single source preconditioned recipe chain executor";
+    }
+
+    @Override
+    public String getDescription() {
+        return "For yaml recipe usage only, alternative solution of single applicable test in yaml recipe.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        ObjectMapper mapper = JsonMapper.builder()
+            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+            .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
+            .build()
+            .registerModule(new ParameterNamesModule())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        // load precondition recipe
+        Object preconditionRecipeData = ((ArrayList<Object>) preCondition).get(0);
+        Map.Entry<String, Object> preconditionRecipeNameAndConfig = ((Map<String, Object>) preconditionRecipeData).entrySet().iterator().next();
+        Map<Object, Object> preconditionRecipeWithJsonType = new HashMap<>((Map<String, Object>) preconditionRecipeNameAndConfig.getValue());
+        preconditionRecipeWithJsonType.put("@c", preconditionRecipeNameAndConfig.getKey());
+        Recipe preConditionRecipe = mapper.convertValue(preconditionRecipeWithJsonType, Recipe.class);
+
+        // Load recipes
+        ArrayList<Object> recipeListDataList = (ArrayList<Object>) recipes;
+        List<Recipe> recipesToRun = new ArrayList<>();
+        for (Object recipeData : recipeListDataList) {
+            Map.Entry<String, Object> recipeNameAndConfig = ((Map<String, Object>) recipeData).entrySet().iterator().next();
+            Map<Object, Object> recipeWithJsonType = new HashMap<>((Map<String, Object>) recipeNameAndConfig.getValue());
+            recipeWithJsonType.put("@c", recipeNameAndConfig.getKey());
+            Recipe r = mapper.convertValue(recipeWithJsonType, Recipe.class);
+            if (r != null) {
+                recipesToRun.add(r);
+            }
+        }
+
+        if (preConditionRecipe == null) {
+            // todo, not sure whether returning null is OK here
+            return null;
+        }
+
+        return Preconditions.check(
+            preConditionRecipe.getVisitor(),
+            new TreeVisitor<Tree, ExecutionContext>() {
+                @Override
+                public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                    if (tree instanceof SourceFile) {
+                        for (Recipe r : recipesToRun) {
+                            tree = r.getVisitor().visit(tree, ctx);
+                        }
+                    }
+                    return tree;
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
As we know, rewrite 8 doesn't support single-source / any-source applicable tests for yaml recipes.
This is a proposal of an alternative single-source-applicable test for yaml recipes, (any-source applicable tests supports are not included in this PR. but we can support it in a similar way)

This approach is to manage sub-recipes execution and lifecycle in a separate recipe, it should not impact the outer recipe execution, but just like a regular recipe running,  I think this will provide more flexibility to support customized conditioned recipe executions.

Here is an example of yaml recipe

Before rewrite8, with `singleSource` applicability test
```yaml
type: specs.openrewrite.org/v1beta/recipe
name: org.openrewrite.ApplicabilityExactlyOnce
displayName: Applicability test runs once for the whole recipe list
description: >
  An applicability test should be run once and if a match is found, all recipes in the list should be run.
  So if one of the recipes in the list makes a change which would cause the applicability test to no longer match,
  subsequent recipes in the list should still execute.
  
  Given a text file containing the number "1", running this recipe should result in a file which contains "3".
  If the applicability test is incorrectly applied to individual recipes in the list, the (incorrect) result would be "2".
applicability:
  singleSource:
    - org.openrewrite.text.FindAndReplace:
        find: "1"
        replace: "A"
recipeList:
  - org.openrewrite.text.ChangeText:
        toText: "2"
  - org.openrewrite.text.ChangeText:
        toText: "3"
```
Now, equivalent to before
```yaml
type: specs.openrewrite.org/v1beta/recipe
name: org.openrewrite.ApplicabilityExactlyOnce
displayName: Applicability test runs once for the whole recipe list
description: >
  An applicability test should be run once and if a match is found, all recipes in the list should be run.
  So if one of the recipes in the list makes a change which would cause the applicability test to no longer match,
  subsequent recipes in the list should still execute.
  
  Given a text file containing the number "1", running this recipe should result in a file which contains "3".
  If the applicability test is incorrectly applied to individual recipes in the list, the (incorrect) result would be "2".
recipeList:
  - org.openrewrite.java.recipes.RecipeChainExecutor:
      preCondition:
        - org.openrewrite.text.FindAndReplace:
            find: "1"
            replace: "A"
      recipes:
        - org.openrewrite.text.ChangeText:
            toText: "2"
        - org.openrewrite.text.ChangeText:
            toText: "3"
```