### PR TITLE
The `ProtoParser` must not return `null` values

### DIFF
--- a/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/ProtoParserTest.java
+++ b/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/ProtoParserTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.protobuf;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.SourceFile;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProtoParserTest implements RewriteTest {
+
+    @Test
+    void noNullsForProto3Files() {
+        List<SourceFile> sources = ProtoParser.builder().build().parse("syntax = \"proto3\";")
+          .collect(Collectors.toList());
+        assertThat(sources).isEmpty();
+    }
+}


### PR DESCRIPTION
The `Parser` API contract requires the implementation to return a stream of non-`null` `SourceFile` objects.

Since `proto3` sources are not really erroneous, just currently not supported by the parser, it doesn't really make sense to return a `ParseError` object, so instead the parser simply skips these sources.
