### PR TITLE
Refactor `MethodMatcher` and extract Interface

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/SimpleMethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/SimpleMethodMatcher.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.List;
+
+/**
+ * A simpler version of {@link MethodMatcher} that allows for custom matching logic.
+ */
+public interface SimpleMethodMatcher {
+
+    default boolean matches(@Nullable Expression maybeMethod) {
+        return (maybeMethod instanceof J.MethodInvocation && matches((J.MethodInvocation) maybeMethod)) ||
+               (maybeMethod instanceof J.NewClass && matches((J.NewClass) maybeMethod)) ||
+               (maybeMethod instanceof J.MemberReference && matches((J.MemberReference) maybeMethod));
+    }
+
+    default boolean matches(@Nullable J.MethodInvocation method) {
+        if (method == null) {
+            return false;
+        }
+        if (method.getMethodType() == null) {
+            return false;
+        }
+        if (!matchesTargetType(method.getMethodType().getDeclaringType())) {
+            return false;
+        }
+
+        if (!matchesMethodName(method.getSimpleName())) {
+            return false;
+        }
+
+        return matchesParameterTypes(method.getMethodType().getParameterTypes());
+    }
+
+    default boolean matches(@Nullable J.NewClass constructor) {
+        if (constructor == null) {
+            return false;
+        }
+        JavaType.FullyQualified type = TypeUtils.asFullyQualified(constructor.getType());
+        if (type == null || constructor.getConstructorType() == null) {
+            return false;
+        }
+
+        if (!matchesTargetType(type)) {
+            return false;
+        }
+
+        if (!matchesMethodName("<constructor>")) {
+            return false;
+        }
+
+        return matchesParameterTypes(constructor.getConstructorType().getParameterTypes());
+    }
+
+    default boolean matches(@Nullable J.MemberReference memberReference) {
+        if (memberReference == null) {
+            return false;
+        }
+        return matches(memberReference.getMethodType());
+    }
+
+    default boolean matches(@Nullable JavaType.Method type) {
+        if (type == null || !matchesTargetType(type.getDeclaringType())) {
+            return false;
+        }
+
+        if (!matchesMethodName(type.getName())) {
+            return false;
+        }
+
+        return matchesParameterTypes(type.getParameterTypes());
+    }
+
+
+    boolean matchesTargetType(@Nullable JavaType.FullyQualified type);
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    boolean matchesMethodName(String methodName);
+
+    boolean matchesParameterTypes(List<JavaType> parameterTypes);
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/DeclaresMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/DeclaresMethod.java
@@ -19,6 +19,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.SimpleMethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -27,7 +28,7 @@ import org.openrewrite.marker.SearchResult;
 import static java.util.Objects.requireNonNull;
 
 public class DeclaresMethod<P> extends JavaIsoVisitor<P> {
-    private final MethodMatcher methodMatcher;
+    private final SimpleMethodMatcher methodMatcher;
 
     public DeclaresMethod(String methodPattern) {
         this(methodPattern, false);
@@ -41,7 +42,7 @@ public class DeclaresMethod<P> extends JavaIsoVisitor<P> {
         this(new MethodMatcher(methodPattern, matchesOverrides));
     }
 
-    public DeclaresMethod(MethodMatcher methodMatcher) {
+    public DeclaresMethod(SimpleMethodMatcher methodMatcher) {
         this.methodMatcher = methodMatcher;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
@@ -20,6 +20,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.SimpleMethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -36,9 +37,9 @@ import static java.util.Objects.requireNonNull;
  */
 @RequiredArgsConstructor
 public class UsesAllMethods<P> extends JavaIsoVisitor<P> {
-    private final List<MethodMatcher> methodMatchers;
+    private final List<SimpleMethodMatcher> methodMatchers;
 
-    public UsesAllMethods(MethodMatcher... methodMatchers) {
+    public UsesAllMethods(SimpleMethodMatcher... methodMatchers) {
         this(Arrays.asList(methodMatchers));
     }
 
@@ -46,7 +47,7 @@ public class UsesAllMethods<P> extends JavaIsoVisitor<P> {
     public J visit(@Nullable Tree tree, P p) {
         if (tree instanceof JavaSourceFile) {
             JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-            List<MethodMatcher> unmatched = new ArrayList<>(methodMatchers);
+            List<SimpleMethodMatcher> unmatched = new ArrayList<>(methodMatchers);
             for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
                 if (unmatched.removeIf(matcher -> matcher.matches(type)) && unmatched.isEmpty()) {
                     return SearchResult.found(cu);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -19,6 +19,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.SimpleMethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -27,7 +28,7 @@ import org.openrewrite.marker.SearchResult;
 import static java.util.Objects.requireNonNull;
 
 public class UsesMethod<P> extends JavaIsoVisitor<P> {
-    private final MethodMatcher methodMatcher;
+    private final SimpleMethodMatcher methodMatcher;
 
     public UsesMethod(String methodPattern) {
         this(new MethodMatcher(methodPattern));
@@ -41,7 +42,7 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
         this(new MethodMatcher(methodPattern, Boolean.TRUE.equals(matchOverrides)));
     }
 
-    public UsesMethod(MethodMatcher methodMatcher) {
+    public UsesMethod(SimpleMethodMatcher methodMatcher) {
         this.methodMatcher = methodMatcher;
     }
 


### PR DESCRIPTION
Extracts a majority of the logic of `MethodMatcher` into an interface `SimpleMethodMatcher`.

Simplifies the `SimpleMethodMatcher` into 3 basic predicates:
 - `matchesTargetType`
 - `matchesMethodName`
 - `matchesParameterTypes`

A custom implementation of `SimpleMethodMatcher` can implement those predicates however they choose.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
