### PR TITLE
Add `FindMethodsVisitor` and refactor `FindMethods`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTypeMethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTypeMethodMatcher.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.MethodCall;
+
+/**
+ * The most basic version of a {@link MethodMatcher} that allows implementers to craft custom matching logic.
+ */
+@Incubating(since = "8.1.3")
+@FunctionalInterface
+public interface JavaTypeMethodMatcher {
+
+    /**
+     * Whether the method invocation or constructor matches the criteria of this matcher.
+     *
+     * @param type The type of the method invocation or constructor.
+     * @return True if the invocation or constructor matches the criteria of this matcher.
+     */
+    boolean matches(@Nullable JavaType.Method type);
+
+    default boolean matches(@Nullable MethodCall methodCall) {
+        if (methodCall == null) {
+            return false;
+        }
+        return matches(methodCall.getMethodType());
+    }
+
+    /**
+     * Whether the method invocation or constructor matches the criteria of this matcher.
+     *
+     * @param maybeMethod Any {@link Expression} that might be a method invocation or constructor.
+     * @return True if the invocation or constructor matches the criteria of this matcher.
+     */
+    default boolean matches(@Nullable Expression maybeMethod) {
+        return maybeMethod instanceof MethodCall && matches(((MethodCall) maybeMethod).getMethodType());
+    }
+
+    static JavaTypeMethodMatcher fromMethodMatcher(MethodMatcher methodMatcher) {
+        return methodMatcher::matches;
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/DeclaresMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/DeclaresMethod.java
@@ -15,9 +15,11 @@
  */
 package org.openrewrite.java.search;
 
+import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTypeMethodMatcher;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
@@ -27,7 +29,7 @@ import org.openrewrite.marker.SearchResult;
 import static java.util.Objects.requireNonNull;
 
 public class DeclaresMethod<P> extends JavaIsoVisitor<P> {
-    private final MethodMatcher methodMatcher;
+    private final JavaTypeMethodMatcher methodMatcher;
 
     public DeclaresMethod(String methodPattern) {
         this(methodPattern, false);
@@ -42,6 +44,11 @@ public class DeclaresMethod<P> extends JavaIsoVisitor<P> {
     }
 
     public DeclaresMethod(MethodMatcher methodMatcher) {
+        this(methodMatcher::matches);
+    }
+
+    @Incubating(since = "8.1.3")
+    public DeclaresMethod(JavaTypeMethodMatcher methodMatcher) {
         this.methodMatcher = methodMatcher;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethodsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethodsVisitor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTypeMethodMatcher;
+import org.openrewrite.java.table.MethodCalls;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * This visitor is used to find method invocations that match a given method pattern as defined by {@link JavaTypeMethodMatcher}.
+ * <p/>
+ * This visitor is most often useful for testing custom implementations of {@link JavaTypeMethodMatcher}.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FindMethodsVisitor extends JavaIsoVisitor<ExecutionContext> {
+    private final JavaTypeMethodMatcher methodMatcher;
+    @Nullable
+    private final MethodCalls methodCalls;
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+        if (methodMatcher.matches(method)) {
+            addToMethodCalls(method, ctx);
+            m = SearchResult.found(m);
+        }
+        return m;
+    }
+
+    @Override
+    public J.MemberReference visitMemberReference(J.MemberReference memberRef, ExecutionContext ctx) {
+        J.MemberReference m = super.visitMemberReference(memberRef, ctx);
+        if (methodMatcher.matches(m.getMethodType())) {
+            addToMethodCalls(memberRef, ctx);
+            m = m.withReference(SearchResult.found(m.getReference()));
+        }
+        return m;
+    }
+
+    @Override
+    public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+        J.NewClass n = super.visitNewClass(newClass, ctx);
+        if (methodMatcher.matches(newClass)) {
+            addToMethodCalls(newClass, ctx);
+            n = SearchResult.found(n);
+        }
+        return n;
+    }
+
+    private void addToMethodCalls(Tree tree, ExecutionContext ctx) {
+        if (methodCalls != null) {
+            JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
+            if (javaSourceFile != null) {
+                methodCalls.insertRow(ctx, new MethodCalls.Row(
+                        javaSourceFile.getSourcePath().toString(),
+                        tree.printTrimmed(getCursor())
+                ));
+            }
+        }
+    }
+
+    @Incubating(since = "8.1.3")
+    public static TreeVisitor<?, ExecutionContext> createVisitor(JavaTypeMethodMatcher methodMatcher, @Nullable MethodCalls methodCalls) {
+        return Preconditions.check(new UsesMethod<>(methodMatcher), new FindMethodsVisitor(methodMatcher, methodCalls));
+    }
+
+    @Incubating(since = "8.1.3")
+    public static TreeVisitor<?, ExecutionContext> createVisitor(JavaTypeMethodMatcher methodMatcher) {
+        return createVisitor(methodMatcher, null);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
@@ -15,10 +15,11 @@
  */
 package org.openrewrite.java.search;
 
-import lombok.RequiredArgsConstructor;
+import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTypeMethodMatcher;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
@@ -28,25 +29,40 @@ import org.openrewrite.marker.SearchResult;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Marks a {@link JavaSourceFile} as matching if all the passed methods are found.
  */
-@RequiredArgsConstructor
 public class UsesAllMethods<P> extends JavaIsoVisitor<P> {
-    private final List<MethodMatcher> methodMatchers;
+    private final List<JavaTypeMethodMatcher> methodMatchers;
 
     public UsesAllMethods(MethodMatcher... methodMatchers) {
+        this(
+                Arrays.stream(methodMatchers)
+                        .map(JavaTypeMethodMatcher::fromMethodMatcher)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Incubating(since = "8.1.3")
+    public UsesAllMethods(JavaTypeMethodMatcher... methodMatchers) {
         this(Arrays.asList(methodMatchers));
     }
+
+    @Incubating(since = "8.1.3")
+    public UsesAllMethods(List<JavaTypeMethodMatcher> methodMatchers) {
+        this.methodMatchers = methodMatchers;
+    }
+
 
     @Override
     public J visit(@Nullable Tree tree, P p) {
         if (tree instanceof JavaSourceFile) {
             JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-            List<MethodMatcher> unmatched = new ArrayList<>(methodMatchers);
+            List<JavaTypeMethodMatcher> unmatched = new ArrayList<>(methodMatchers);
             for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
                 if (unmatched.removeIf(matcher -> matcher.matches(type)) && unmatched.isEmpty()) {
                     return SearchResult.found(cu);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -15,9 +15,11 @@
  */
 package org.openrewrite.java.search;
 
+import org.openrewrite.Incubating;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTypeMethodMatcher;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
@@ -27,7 +29,7 @@ import org.openrewrite.marker.SearchResult;
 import static java.util.Objects.requireNonNull;
 
 public class UsesMethod<P> extends JavaIsoVisitor<P> {
-    private final MethodMatcher methodMatcher;
+    private final JavaTypeMethodMatcher methodMatcher;
 
     public UsesMethod(String methodPattern) {
         this(new MethodMatcher(methodPattern));
@@ -42,6 +44,11 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
     }
 
     public UsesMethod(MethodMatcher methodMatcher) {
+        this(JavaTypeMethodMatcher.fromMethodMatcher(methodMatcher));
+    }
+
+    @Incubating(since = "8.1.3")
+    public UsesMethod(JavaTypeMethodMatcher methodMatcher) {
         this.methodMatcher = methodMatcher;
     }
 


### PR DESCRIPTION
Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>


Also adds a new incubating `JavaTypeMethodMatcher` interface that can be seen as `MethodMatcher` "light". A significantly smaller interface that consumers can rely upon over depending upon the entire `MethodMatcher` API. Thus decoupling the visitors away from the implementation details of how methods are actually matched against, and leaving them with the sole responsibility of performing the appropriate actions when matching occurs.