### PR TITLE
Further `MethodMatcher` cleanup & refactoring

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTypeMethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTypeMethodMatcher.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.MethodCall;
+
+/**
+ * The most basic version of a {@link MethodMatcher} that allows implementers to craft custom matching logic.
+ */
+@FunctionalInterface
+public interface JavaTypeMethodMatcher {
+
+    /**
+     * Whether the method invocation or constructor matches the criteria of this matcher.
+     *
+     * @param type The type of the method invocation or constructor.
+     * @return True if the invocation or constructor matches the criteria of this matcher.
+     */
+    boolean matches(@Nullable JavaType.Method type);
+
+    default boolean matches(@Nullable MethodCall methodCall) {
+        if (methodCall == null) {
+            return false;
+        }
+        return matches(methodCall.getMethodType());
+    }
+
+    /**
+     * Whether the method invocation or constructor matches the criteria of this matcher.
+     *
+     * @param maybeMethod Any {@link Expression} that might be a method invocation or constructor.
+     * @return True if the invocation or constructor matches the criteria of this matcher.
+     */
+    default boolean matches(@Nullable Expression maybeMethod) {
+        return maybeMethod instanceof MethodCall && matches(((MethodCall) maybeMethod).getMethodType());
+    }
+
+    static JavaTypeMethodMatcher fromMethodMatcher(MethodMatcher methodMatcher) {
+        return methodMatcher::matches;
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/SimpleMethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/SimpleMethodMatcher.java
@@ -15,72 +15,31 @@
  */
 package org.openrewrite.java;
 
+import lombok.NoArgsConstructor;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.List;
 
 /**
  * A simpler version of {@link MethodMatcher} that allows for custom matching logic.
+ * <p>
+ * Defines four predicates that, in the general sense, can be used to define if a method matches:
+ * <ul>
+ *     <li>{@link #isMatchOverrides()}</li>
+ *     <li>{@link #matchesTargetTypeName(String)}</li>
+ *     <li>{@link #matchesMethodName(String)}</li>
+ *     <li>{@link #matchesParameterTypes(List)}</li>
+ * </ul>
  */
-public interface SimpleMethodMatcher {
+public interface SimpleMethodMatcher extends JavaTypeMethodMatcher {
 
-    default boolean matches(@Nullable Expression maybeMethod) {
-        return (maybeMethod instanceof J.MethodInvocation && matches((J.MethodInvocation) maybeMethod)) ||
-               (maybeMethod instanceof J.NewClass && matches((J.NewClass) maybeMethod)) ||
-               (maybeMethod instanceof J.MemberReference && matches((J.MemberReference) maybeMethod));
-    }
-
-    default boolean matches(@Nullable J.MethodInvocation method) {
-        if (method == null) {
-            return false;
-        }
-        if (method.getMethodType() == null) {
-            return false;
-        }
-        if (!matchesTargetType(method.getMethodType().getDeclaringType())) {
-            return false;
-        }
-
-        if (!matchesMethodName(method.getSimpleName())) {
-            return false;
-        }
-
-        return matchesParameterTypes(method.getMethodType().getParameterTypes());
-    }
-
-    default boolean matches(@Nullable J.NewClass constructor) {
-        if (constructor == null) {
-            return false;
-        }
-        JavaType.FullyQualified type = TypeUtils.asFullyQualified(constructor.getType());
-        if (type == null || constructor.getConstructorType() == null) {
-            return false;
-        }
-
-        if (!matchesTargetType(type)) {
-            return false;
-        }
-
-        if (!matchesMethodName("<constructor>")) {
-            return false;
-        }
-
-        return matchesParameterTypes(constructor.getConstructorType().getParameterTypes());
-    }
-
-    default boolean matches(@Nullable J.MemberReference memberReference) {
-        if (memberReference == null) {
-            return false;
-        }
-        return matches(memberReference.getMethodType());
-    }
-
+    @Override
     default boolean matches(@Nullable JavaType.Method type) {
-        if (type == null || !matchesTargetType(type.getDeclaringType())) {
+        if (type == null) {
+            return false;
+        }
+        if (!matchesTargetType(type.getDeclaringType())) {
             return false;
         }
 
@@ -92,11 +51,59 @@ public interface SimpleMethodMatcher {
     }
 
 
-    boolean matchesTargetType(@Nullable JavaType.FullyQualified type);
+    /**
+     * @param type The declaring type of the method invocation or constructor.
+     * @return True if the declaring type matches the criteria of this matcher.
+     * @implNote {@link #isMatchOverrides()} will be used to determine if parent types should also be checked
+     */
+    default boolean matchesTargetType(@Nullable JavaType.FullyQualified type) {
+        if (type == null || type instanceof JavaType.Unknown) {
+            return false;
+        }
+
+        if (matchesTargetTypeName(type.getFullyQualifiedName())) {
+            return true;
+        }
+
+        if (isMatchOverrides()) {
+            if (!"java.lang.Object".equals(type.getFullyQualifiedName()) &&
+                matchesTargetType(SimpleMethodMatcherHolder.OBJECT_CLASS)) {
+                return true;
+            }
+
+            if (matchesTargetType(type.getSupertype())) {
+                return true;
+            }
+
+            for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+                if (matchesTargetType(anInterface)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return True if this method matcher should match on overrides of the target type.
+     * @implNote This will be used to determine if the target type should be checked against the supertypes
+     * passing super types to {@link #matchesTargetTypeName(String)}.
+     * @implSpec MUST return a constant value for all invocations.
+     */
+    boolean isMatchOverrides();
+
+    boolean matchesTargetTypeName(String fullyQualifiedTypeName);
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     boolean matchesMethodName(String methodName);
 
     boolean matchesParameterTypes(List<JavaType> parameterTypes);
 
+}
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+final class SimpleMethodMatcherHolder {
+    static final JavaType.ShallowClass OBJECT_CLASS =
+            JavaType.ShallowClass.build("java.lang.Object");
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/DeclaresMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/DeclaresMethod.java
@@ -17,9 +17,9 @@ package org.openrewrite.java.search;
 
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaTypeMethodMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.SimpleMethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -28,7 +28,7 @@ import org.openrewrite.marker.SearchResult;
 import static java.util.Objects.requireNonNull;
 
 public class DeclaresMethod<P> extends JavaIsoVisitor<P> {
-    private final SimpleMethodMatcher methodMatcher;
+    private final JavaTypeMethodMatcher methodMatcher;
 
     public DeclaresMethod(String methodPattern) {
         this(methodPattern, false);
@@ -42,7 +42,7 @@ public class DeclaresMethod<P> extends JavaIsoVisitor<P> {
         this(new MethodMatcher(methodPattern, matchesOverrides));
     }
 
-    public DeclaresMethod(SimpleMethodMatcher methodMatcher) {
+    public DeclaresMethod(JavaTypeMethodMatcher methodMatcher) {
         this.methodMatcher = methodMatcher;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesAllMethods.java
@@ -18,9 +18,8 @@ package org.openrewrite.java.search;
 import lombok.RequiredArgsConstructor;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaTypeMethodMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.SimpleMethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -37,9 +36,9 @@ import static java.util.Objects.requireNonNull;
  */
 @RequiredArgsConstructor
 public class UsesAllMethods<P> extends JavaIsoVisitor<P> {
-    private final List<SimpleMethodMatcher> methodMatchers;
+    private final List<JavaTypeMethodMatcher> methodMatchers;
 
-    public UsesAllMethods(SimpleMethodMatcher... methodMatchers) {
+    public UsesAllMethods(JavaTypeMethodMatcher... methodMatchers) {
         this(Arrays.asList(methodMatchers));
     }
 
@@ -47,7 +46,7 @@ public class UsesAllMethods<P> extends JavaIsoVisitor<P> {
     public J visit(@Nullable Tree tree, P p) {
         if (tree instanceof JavaSourceFile) {
             JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-            List<SimpleMethodMatcher> unmatched = new ArrayList<>(methodMatchers);
+            List<JavaTypeMethodMatcher> unmatched = new ArrayList<>(methodMatchers);
             for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
                 if (unmatched.removeIf(matcher -> matcher.matches(type)) && unmatched.isEmpty()) {
                     return SearchResult.found(cu);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -17,9 +17,9 @@ package org.openrewrite.java.search;
 
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaTypeMethodMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.SimpleMethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -28,7 +28,7 @@ import org.openrewrite.marker.SearchResult;
 import static java.util.Objects.requireNonNull;
 
 public class UsesMethod<P> extends JavaIsoVisitor<P> {
-    private final SimpleMethodMatcher methodMatcher;
+    private final JavaTypeMethodMatcher methodMatcher;
 
     public UsesMethod(String methodPattern) {
         this(new MethodMatcher(methodPattern));
@@ -42,7 +42,7 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
         this(new MethodMatcher(methodPattern, Boolean.TRUE.equals(matchOverrides)));
     }
 
-    public UsesMethod(SimpleMethodMatcher methodMatcher) {
+    public UsesMethod(JavaTypeMethodMatcher methodMatcher) {
         this.methodMatcher = methodMatcher;
     }
 


### PR DESCRIPTION
Creates another interface from `MethodMatcher` called `BasicMethodMatcher`
that further simplfies implementing a custom `MethodMatcher`

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
