### PR TITLE
Fixing runTimeout being ignored

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
@@ -22,12 +22,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public class InMemoryExecutionContext implements ExecutionContext {
     private final Map<String, Object> messages = new ConcurrentHashMap<>();
     private final Consumer<Throwable> onError;
-    private final Function<Integer, Duration> runTimeout;
     private final BiConsumer<Throwable, ExecutionContext> onTimeout;
 
     public InMemoryExecutionContext() {
@@ -38,19 +36,18 @@ public class InMemoryExecutionContext implements ExecutionContext {
     }
 
     public InMemoryExecutionContext(Consumer<Throwable> onError) {
-        this(onError, n -> Duration.ofHours(2));
+        this(onError, Duration.ofHours(2));
     }
 
-    public InMemoryExecutionContext(Consumer<Throwable> onError,
-                                    Function<Integer, Duration> runTimeout) {
+    public InMemoryExecutionContext(Consumer<Throwable> onError, Duration runTimeout) {
         this(onError, runTimeout, (throwable, ctx) -> {
         });
     }
 
-    public InMemoryExecutionContext(Consumer<Throwable> onError, Function<Integer, Duration> runTimeout, BiConsumer<Throwable, ExecutionContext> onTimeout) {
+    public InMemoryExecutionContext(Consumer<Throwable> onError, Duration runTimeout, BiConsumer<Throwable, ExecutionContext> onTimeout) {
         this.onError = onError;
-        this.runTimeout = runTimeout;
         this.onTimeout = onTimeout;
+        putMessage(ExecutionContext.RUN_TIMEOUT, runTimeout);
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
The optional parameter runTimeout was not being used at all after some changes on RecipeScheduler. It no longer makes sense for it to be a function that returns the timeout depending on the number of inputs, so I changed it to a fixed value and pushed the message into the context that later on is read by the RecipeScheduler to trigger a timeout.

## What's your motivation?
To fix the ignored parameter of runTimeout

## Have you considered any alternatives or workarounds?
We could also call the current function with a default value, to get the timeout, this way we wouldn't introduce any breaking change.
