### PR TITLE
Reduce memory overhead of `JavaType` implementations

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -162,8 +162,33 @@ public final class ListUtils {
         return newLs;
     }
 
+    // inlined version of `map(List, BiFunction)` for memory efficiency (no overhead for lambda)
     public static <T> List<T> map(@Nullable List<T> ls, UnaryOperator<T> map) {
-        return map(ls, (i, t) -> map.apply(t));
+        if (ls == null || ls.isEmpty()) {
+            //noinspection ConstantConditions
+            return ls;
+        }
+
+        List<T> newLs = ls;
+        boolean nullEncountered = false;
+        for (int i = 0; i < ls.size(); i++) {
+            T tree = ls.get(i);
+            T newTree = map.apply(tree);
+            if (newTree != tree) {
+                if (newLs == ls) {
+                    newLs = new ArrayList<>(ls);
+                }
+                newLs.set(i, newTree);
+            }
+            nullEncountered |= newTree == null;
+        }
+
+        if (newLs != ls && nullEncountered) {
+            //noinspection StatementWithEmptyBody
+            while (newLs.remove(null)) ;
+        }
+
+        return newLs;
     }
 
     public static <T> List<T> flatMap(@Nullable List<T> ls, BiFunction<Integer, T, Object> flatMap) {
@@ -298,4 +323,17 @@ public final class ListUtils {
     public static <T> List<T> nullIfEmpty(@Nullable List<T> ls) {
         return ls == null || ls.isEmpty() ? null : ls;
     }
+
+    public static <T> T[] arrayOrNullIfEmpty(@Nullable List<T> list, T[] array) {
+        if (list == null || list.isEmpty()) {
+            return null;
+        }
+        return list.toArray(array);
+    }
+
+    @Nullable
+    public static <T> T[] nullIfEmpty(@Nullable T[] list) {
+        return list == null || list.length == 0 ? null : list;
+    }
+
 }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -387,12 +387,14 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             return existing;
         }
 
-        List<String> paramNames = null;
+        String[] paramNames = null;
         if (!methodSymbol.params().isEmpty()) {
-            paramNames = new ArrayList<>(methodSymbol.params().size());
-            for (Symbol.VarSymbol p : methodSymbol.params()) {
+            paramNames = new String[methodSymbol.params().size()];
+            com.sun.tools.javac.util.List<Symbol.VarSymbol> params = methodSymbol.params();
+            for (int i = 0; i < params.size(); i++) {
+                Symbol.VarSymbol p = params.get(i);
                 String s = p.name.toString();
-                paramNames.add(s);
+                paramNames[i] = s;
             }
         }
 
@@ -481,12 +483,14 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                 return existing;
             }
 
-            List<String> paramNames = null;
+            String[] paramNames = null;
             if (!methodSymbol.params().isEmpty()) {
-                paramNames = new ArrayList<>(methodSymbol.params().size());
-                for (Symbol.VarSymbol p : methodSymbol.params()) {
+                paramNames = new String[methodSymbol.params().size()];
+                com.sun.tools.javac.util.List<Symbol.VarSymbol> params = methodSymbol.params();
+                for (int i = 0; i < params.size(); i++) {
+                    Symbol.VarSymbol p = params.get(i);
                     String s = p.name.toString();
-                    paramNames.add(s);
+                    paramNames[i] = s;
                 }
             }
             List<String> defaultValues = null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -325,12 +325,14 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
             return existing;
         }
 
-        List<String> paramNames = null;
+        String[] paramNames = null;
         if (method.getParameters().length > 0) {
-            paramNames = new ArrayList<>(method.getParameters().length);
-            for (Parameter p : method.getParameters()) {
+            paramNames = new String[method.getParameters().length];
+            Parameter[] parameters = method.getParameters();
+            for (int i = 0; i < parameters.length; i++) {
+                Parameter p = parameters[i];
                 if (!p.isSynthetic()) {
-                    paramNames.add(p.getName());
+                    paramNames[i] = p.getName();
                 }
             }
         }
@@ -387,11 +389,13 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
             return existing;
         }
 
-        List<String> paramNames = null;
+        String[] paramNames = null;
         if (method.getParameters().length > 0) {
-            paramNames = new ArrayList<>(method.getParameters().length);
-            for (Parameter p : method.getParameters()) {
-                paramNames.add(p.getName());
+            paramNames = new String[method.getParameters().length];
+            Parameter[] parameters = method.getParameters();
+            for (int i = 0; i < parameters.length; i++) {
+                Parameter p = parameters[i];
+                paramNames[i] = p.getName();
             }
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -30,13 +30,20 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.*;
-import static org.openrewrite.internal.ListUtils.nullIfEmpty;
+import static org.openrewrite.internal.ListUtils.*;
 import static org.openrewrite.java.tree.TypeUtils.unknownIfNull;
 
 @SuppressWarnings("unused")
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
 public interface JavaType {
+
+    FullyQualified[] EMPTY_FULLY_QUALIFIED_ARRAY = new FullyQualified[0];
+    Variable[] EMPTY_VARIABLE_ARRAY = new Variable[0];
+    Method[] EMPTY_METHOD_ARRAY = new Method[0];
+    String[] EMPTY_STRING_ARRAY = new String[0];
+    JavaType[] EMPTY_JAVA_TYPE_ARRAY = new JavaType[0];
+
     @JsonProperty("@c")
     default String getJacksonPolymorphicTypeTag() {
         return getClass().getName();
@@ -95,28 +102,33 @@ public interface JavaType {
 
     class MultiCatch implements JavaType {
         public MultiCatch(@Nullable List<JavaType> throwableTypes) {
+            this.throwableTypes = arrayOrNullIfEmpty(throwableTypes, EMPTY_JAVA_TYPE_ARRAY);
+        }
+
+        @JsonCreator
+        MultiCatch(@Nullable JavaType[] throwableTypes) {
             this.throwableTypes = nullIfEmpty(throwableTypes);
         }
 
-        private List<JavaType> throwableTypes;
+        private JavaType[] throwableTypes;
 
         public List<JavaType> getThrowableTypes() {
             if (throwableTypes == null) {
                 return Collections.emptyList();
             }
-            return throwableTypes;
+            return Arrays.asList(throwableTypes);
         }
 
         public MultiCatch withThrowableTypes(@Nullable List<JavaType> throwableTypes) {
-            throwableTypes = nullIfEmpty(throwableTypes);
-            if (this.throwableTypes == throwableTypes) {
+            JavaType[] throwableTypesArray = arrayOrNullIfEmpty(throwableTypes, EMPTY_JAVA_TYPE_ARRAY);
+            if (Arrays.equals(throwableTypesArray, this.throwableTypes)) {
                 return this;
             }
-            return new MultiCatch(throwableTypes);
+            return new MultiCatch(throwableTypesArray);
         }
 
         public MultiCatch unsafeSet(List<JavaType> throwableTypes) {
-            this.throwableTypes = nullIfEmpty(throwableTypes);
+            this.throwableTypes = arrayOrNullIfEmpty(throwableTypes, EMPTY_JAVA_TYPE_ARRAY);
             return this;
         }
     }
@@ -313,7 +325,7 @@ public interface JavaType {
 
         @NonFinal
         @Nullable
-        List<JavaType> typeParameters;
+        JavaType[] typeParameters;
 
         @With
         @Nullable
@@ -327,12 +339,32 @@ public interface JavaType {
 
         @Nullable
         @NonFinal
-        List<FullyQualified> annotations;
+        FullyQualified[] annotations;
 
         public Class(@Nullable Integer managedReference, long flagsBitMap, String fullyQualifiedName,
                      Kind kind, @Nullable List<JavaType> typeParameters, @Nullable FullyQualified supertype, @Nullable FullyQualified owningClass,
                      @Nullable List<FullyQualified> annotations, @Nullable List<FullyQualified> interfaces,
                      @Nullable List<Variable> members, @Nullable List<Method> methods) {
+            this(
+                    managedReference,
+                    flagsBitMap,
+                    fullyQualifiedName,
+                    kind,
+                    arrayOrNullIfEmpty(typeParameters, EMPTY_JAVA_TYPE_ARRAY),
+                    supertype,
+                    owningClass,
+                    arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY),
+                    arrayOrNullIfEmpty(interfaces, EMPTY_FULLY_QUALIFIED_ARRAY),
+                    arrayOrNullIfEmpty(members, EMPTY_VARIABLE_ARRAY),
+                    arrayOrNullIfEmpty(methods, EMPTY_METHOD_ARRAY)
+            );
+        }
+
+        @JsonCreator
+        Class(@Nullable Integer managedReference, long flagsBitMap, String fullyQualifiedName,
+              Kind kind, @Nullable JavaType[] typeParameters, @Nullable FullyQualified supertype, @Nullable FullyQualified owningClass,
+              @Nullable FullyQualified[] annotations, @Nullable FullyQualified[] interfaces,
+              @Nullable Variable[] members, @Nullable Method[] methods) {
             this.managedReference = managedReference;
             this.flagsBitMap = flagsBitMap & Flag.VALID_CLASS_FLAGS;
             this.fullyQualifiedName = fullyQualifiedName;
@@ -348,67 +380,67 @@ public interface JavaType {
         }
 
         public List<FullyQualified> getAnnotations() {
-            return annotations == null ? emptyList() : annotations;
+            return annotations == null ? emptyList() : Arrays.asList(annotations);
         }
 
         public Class withAnnotations(@Nullable List<FullyQualified> annotations) {
-            annotations = nullIfEmpty(annotations);
-            if (annotations == this.annotations) {
+            FullyQualified[] annotationsArray = arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY);
+            if (Arrays.equals(annotationsArray, this.annotations)) {
                 return this;
             }
             return new Class(this.managedReference, this.flagsBitMap, this.fullyQualifiedName, this.kind, this.typeParameters,
-                    this.supertype, this.owningClass, annotations, this.interfaces, this.members, this.methods);
+                    this.supertype, this.owningClass, annotationsArray, this.interfaces, this.members, this.methods);
         }
 
         @Nullable
         @NonFinal
-        List<FullyQualified> interfaces;
+        FullyQualified[] interfaces;
 
         public List<FullyQualified> getInterfaces() {
-            return interfaces == null ? emptyList() : interfaces;
+            return interfaces == null ? emptyList() : Arrays.asList(interfaces);
         }
 
         public Class withInterfaces(@Nullable List<FullyQualified> interfaces) {
-            interfaces = nullIfEmpty(interfaces);
-            if (interfaces == this.interfaces) {
+            FullyQualified[] interfacesArray = arrayOrNullIfEmpty(interfaces, EMPTY_FULLY_QUALIFIED_ARRAY);
+            if (Arrays.equals(interfacesArray, this.interfaces)) {
                 return this;
             }
             return new Class(this.managedReference, this.flagsBitMap, this.fullyQualifiedName, this.kind, this.typeParameters,
-                    this.supertype, this.owningClass, this.annotations, interfaces, this.members, this.methods);
+                    this.supertype, this.owningClass, this.annotations, interfacesArray, this.members, this.methods);
         }
 
         @Nullable
         @NonFinal
-        List<Variable> members;
+        Variable[] members;
 
         public List<Variable> getMembers() {
-            return members == null ? emptyList() : members;
+            return members == null ? emptyList() : Arrays.asList(members);
         }
 
         public Class withMembers(@Nullable List<Variable> members) {
-            members = nullIfEmpty(members);
-            if (members == this.members) {
+            Variable[] membersArray = arrayOrNullIfEmpty(members, EMPTY_VARIABLE_ARRAY);
+            if (Arrays.equals(membersArray, this.members)) {
                 return this;
             }
             return new Class(this.managedReference, this.flagsBitMap, this.fullyQualifiedName, this.kind, this.typeParameters,
-                    this.supertype, this.owningClass, this.annotations, this.interfaces, members, this.methods);
+                    this.supertype, this.owningClass, this.annotations, this.interfaces, membersArray, this.methods);
         }
 
         @Nullable
         @NonFinal
-        List<Method> methods;
+        Method[] methods;
 
         public List<Method> getMethods() {
-            return methods == null ? emptyList() : methods;
+            return methods == null ? emptyList() : Arrays.asList(methods);
         }
 
         public Class withMethods(@Nullable List<Method> methods) {
-            methods = nullIfEmpty(methods);
-            if (methods == this.methods) {
+            Method[] methodsArray = arrayOrNullIfEmpty(methods, EMPTY_METHOD_ARRAY);
+            if (Arrays.equals(methodsArray, this.methods)) {
                 return this;
             }
             return new Class(this.managedReference, this.flagsBitMap, this.fullyQualifiedName, this.kind, this.typeParameters,
-                    this.supertype, this.owningClass, this.annotations, this.interfaces, this.members, methods);
+                    this.supertype, this.owningClass, this.annotations, this.interfaces, this.members, methodsArray);
         }
 
         @Override
@@ -432,20 +464,20 @@ public interface JavaType {
 
         @Override
         public List<JavaType> getTypeParameters() {
-            return typeParameters == null ? emptyList() : typeParameters;
+            return typeParameters == null ? emptyList() : Arrays.asList(typeParameters);
         }
 
         public Class withTypeParameters(@Nullable List<JavaType> typeParameters) {
-            typeParameters = nullIfEmpty(typeParameters);
-            if (typeParameters == this.typeParameters) {
+            JavaType[] typeParametersArray = arrayOrNullIfEmpty(typeParameters, EMPTY_JAVA_TYPE_ARRAY);
+            if (Arrays.equals(typeParametersArray, this.typeParameters)) {
                 return this;
             }
-            return new Class(this.managedReference, this.flagsBitMap, this.fullyQualifiedName, this.kind, typeParameters,
+            return new Class(this.managedReference, this.flagsBitMap, this.fullyQualifiedName, this.kind, typeParametersArray,
                     this.supertype, this.owningClass, this.annotations, this.interfaces, this.members, methods);
         }
 
         public boolean isParameterized() {
-            return typeParameters != null && !typeParameters.isEmpty();
+            return typeParameters != null && typeParameters.length > 0;
         }
 
         @Override
@@ -458,13 +490,13 @@ public interface JavaType {
                                @Nullable List<FullyQualified> annotations, @Nullable List<FullyQualified> interfaces,
                                @Nullable List<Variable> members, @Nullable List<Method> methods) {
             //noinspection DuplicatedCode
-            this.typeParameters = nullIfEmpty(typeParameters);
+            this.typeParameters = arrayOrNullIfEmpty(typeParameters, EMPTY_JAVA_TYPE_ARRAY);
             this.supertype = supertype;
             this.owningClass = owningClass;
-            this.annotations = nullIfEmpty(annotations);
-            this.interfaces = nullIfEmpty(interfaces);
-            this.members = nullIfEmpty(members);
-            this.methods = nullIfEmpty(methods);
+            this.annotations = arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY);
+            this.interfaces = arrayOrNullIfEmpty(interfaces, EMPTY_FULLY_QUALIFIED_ARRAY);
+            this.members = arrayOrNullIfEmpty(members, EMPTY_VARIABLE_ARRAY);
+            this.methods = arrayOrNullIfEmpty(methods, EMPTY_METHOD_ARRAY);
             return this;
         }
 
@@ -474,7 +506,7 @@ public interface JavaType {
             if (o == null || getClass() != o.getClass()) return false;
             Class aClass = (Class) o;
             return TypeUtils.fullyQualifiedNamesAreEqual(fullyQualifiedName, aClass.fullyQualifiedName) &&
-                   (typeParameters == null && aClass.typeParameters == null || typeParameters != null && typeParameters.equals(aClass.typeParameters));
+                   (typeParameters == null && aClass.typeParameters == null || typeParameters != null && Arrays.equals(typeParameters, aClass.typeParameters));
         }
 
         @Override
@@ -487,7 +519,7 @@ public interface JavaType {
         public ShallowClass(@Nullable Integer managedReference, long flagsBitMap, String fullyQualifiedName, Kind kind,
                             @Nullable List<JavaType> typeParameters, @Nullable FullyQualified supertype, @Nullable FullyQualified owningClass,
                             @Nullable List<FullyQualified> annotations, @Nullable List<FullyQualified> interfaces, @Nullable List<Variable> members, @Nullable List<Method> methods) {
-            super(managedReference, flagsBitMap, fullyQualifiedName, kind, null, null, owningClass, null, null, null, null);
+            super(managedReference, flagsBitMap, fullyQualifiedName, kind, (List<JavaType>) null, null, owningClass, null, null, null, null);
         }
 
         /**
@@ -537,10 +569,20 @@ public interface JavaType {
 
         @NonFinal
         @Nullable
-        List<JavaType> typeParameters;
+        JavaType[] typeParameters;
 
         public Parameterized(@Nullable Integer managedReference, @Nullable FullyQualified type,
                              @Nullable List<JavaType> typeParameters) {
+            this(
+                    managedReference,
+                    type,
+                    arrayOrNullIfEmpty(typeParameters, EMPTY_JAVA_TYPE_ARRAY)
+            );
+        }
+
+        @JsonCreator
+        Parameterized(@Nullable Integer managedReference, @Nullable FullyQualified type,
+                             @Nullable JavaType[] typeParameters) {
             this.managedReference = managedReference;
             this.type = unknownIfNull(type);
             this.typeParameters = nullIfEmpty(typeParameters);
@@ -552,15 +594,15 @@ public interface JavaType {
 
         @Override
         public List<JavaType> getTypeParameters() {
-            return typeParameters == null ? emptyList() : typeParameters;
+            return typeParameters == null ? emptyList() : Arrays.asList(typeParameters);
         }
 
         public Parameterized withTypeParameters(@Nullable List<JavaType> typeParameters) {
-            typeParameters = nullIfEmpty(typeParameters);
-            if (typeParameters == this.typeParameters) {
+            JavaType[] typeParametersArray = arrayOrNullIfEmpty(typeParameters, EMPTY_JAVA_TYPE_ARRAY);
+            if (Arrays.equals(typeParametersArray, this.typeParameters)) {
                 return this;
             }
-            return new Parameterized(managedReference, type, typeParameters);
+            return new Parameterized(managedReference, type, typeParametersArray);
         }
 
         @Override
@@ -572,7 +614,7 @@ public interface JavaType {
         public Parameterized unsafeSet(@Nullable FullyQualified type, @Nullable List<JavaType> typeParameters) {
             assert type != this;
             this.type = unknownIfNull(type);
-            this.typeParameters = nullIfEmpty(typeParameters);
+            this.typeParameters = arrayOrNullIfEmpty(typeParameters, EMPTY_JAVA_TYPE_ARRAY);
             return this;
         }
 
@@ -635,7 +677,7 @@ public interface JavaType {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Parameterized that = (Parameterized) o;
-            return Objects.equals(type, that.type) && Objects.equals(typeParameters, that.typeParameters);
+            return Objects.equals(type, that.type) && Arrays.equals(typeParameters, that.typeParameters);
         }
 
         @Override
@@ -664,9 +706,19 @@ public interface JavaType {
 
         @NonFinal
         @Nullable
-        List<JavaType> bounds;
+        JavaType[] bounds;
 
         public GenericTypeVariable(@Nullable Integer managedReference, String name, Variance variance, @Nullable List<JavaType> bounds) {
+            this(
+                    managedReference,
+                    name,
+                    variance,
+                    arrayOrNullIfEmpty(bounds, EMPTY_JAVA_TYPE_ARRAY)
+            );
+        }
+
+        @JsonCreator
+        GenericTypeVariable(@Nullable Integer managedReference, String name, Variance variance, @Nullable JavaType[] bounds) {
             this.managedReference = managedReference;
             this.name = name;
             this.variance = variance;
@@ -674,15 +726,15 @@ public interface JavaType {
         }
 
         public List<JavaType> getBounds() {
-            return bounds == null ? emptyList() : bounds;
+            return bounds == null ? emptyList() : Arrays.asList(bounds);
         }
 
         public GenericTypeVariable withBounds(@Nullable List<JavaType> bounds) {
-            bounds = nullIfEmpty(bounds);
-            if (bounds == this.bounds) {
+            JavaType[] boundsArray = arrayOrNullIfEmpty(bounds, EMPTY_JAVA_TYPE_ARRAY);
+            if (Arrays.equals(boundsArray, this.bounds)) {
                 return this;
             }
-            return new GenericTypeVariable(managedReference, name, variance, bounds);
+            return new GenericTypeVariable(managedReference, name, variance, boundsArray);
         }
 
         @Override
@@ -694,7 +746,7 @@ public interface JavaType {
         public GenericTypeVariable unsafeSet(String name, Variance variance, @Nullable List<JavaType> bounds) {
             this.name = name;
             this.variance = variance;
-            this.bounds = nullIfEmpty(bounds);
+            this.bounds = arrayOrNullIfEmpty(bounds, EMPTY_JAVA_TYPE_ARRAY);
             return this;
         }
 
@@ -704,7 +756,7 @@ public interface JavaType {
             if (o == null || getClass() != o.getClass()) return false;
             GenericTypeVariable that = (GenericTypeVariable) o;
             return name.equals(that.name) && variance == that.variance &&
-                   (variance == Variance.INVARIANT && bounds == null && that.bounds == null || bounds != null && bounds.equals(that.bounds));
+                   (variance == Variance.INVARIANT && bounds == null && that.bounds == null || bounds != null && Arrays.equals(bounds, that.bounds));
         }
 
         @Override
@@ -902,19 +954,19 @@ public interface JavaType {
         JavaType returnType;
 
         @Nullable
-        List<String> parameterNames;
+        String[] parameterNames;
 
         @NonFinal
         @Nullable
-        List<JavaType> parameterTypes;
+        JavaType[] parameterTypes;
 
         @NonFinal
         @Nullable
-        List<FullyQualified> thrownExceptions;
+        FullyQualified[] thrownExceptions;
 
         @NonFinal
         @Nullable
-        List<FullyQualified> annotations;
+        FullyQualified[] annotations;
 
         @Incubating(since = "7.34.0")
         @Nullable
@@ -928,11 +980,29 @@ public interface JavaType {
                     thrownExceptions, annotations, null);
         }
 
-        @JsonCreator
         public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
                       @Nullable JavaType returnType, @Nullable List<String> parameterNames,
                       @Nullable List<JavaType> parameterTypes, @Nullable List<FullyQualified> thrownExceptions,
                       @Nullable List<FullyQualified> annotations, @Nullable List<String> defaultValue) {
+            this(
+                    managedReference,
+                    flagsBitMap,
+                    declaringType,
+                    name,
+                    returnType,
+                    arrayOrNullIfEmpty(parameterNames, EMPTY_STRING_ARRAY),
+                    arrayOrNullIfEmpty(parameterTypes, EMPTY_JAVA_TYPE_ARRAY),
+                    arrayOrNullIfEmpty(thrownExceptions, EMPTY_FULLY_QUALIFIED_ARRAY),
+                    arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY),
+                    defaultValue
+            );
+        }
+
+        @JsonCreator
+        public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
+               @Nullable JavaType returnType, @Nullable String[] parameterNames,
+               @Nullable JavaType[] parameterTypes, @Nullable FullyQualified[] thrownExceptions,
+               @Nullable FullyQualified[] annotations, @Nullable List<String> defaultValue) {
             this.managedReference = managedReference;
             this.flagsBitMap = flagsBitMap & Flag.VALID_FLAGS;
             this.declaringType = unknownIfNull(declaringType);
@@ -942,7 +1012,7 @@ public interface JavaType {
             this.parameterTypes = nullIfEmpty(parameterTypes);
             this.thrownExceptions = nullIfEmpty(thrownExceptions);
             this.annotations = nullIfEmpty(annotations);
-            this.defaultValue = defaultValue;
+            this.defaultValue = nullIfEmpty(defaultValue);
         }
 
         @Override
@@ -958,9 +1028,9 @@ public interface JavaType {
                                 @Nullable List<FullyQualified> annotations) {
             this.declaringType = unknownIfNull(declaringType);
             this.returnType = unknownIfNull(returnType);
-            this.parameterTypes = nullIfEmpty(parameterTypes);
-            this.thrownExceptions = nullIfEmpty(thrownExceptions);
-            this.annotations = nullIfEmpty(annotations);
+            this.parameterTypes = arrayOrNullIfEmpty(parameterTypes, EMPTY_JAVA_TYPE_ARRAY);
+            this.thrownExceptions = arrayOrNullIfEmpty(thrownExceptions, EMPTY_FULLY_QUALIFIED_ARRAY);
+            this.annotations = arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY);
             return this;
         }
 
@@ -1039,55 +1109,55 @@ public interface JavaType {
         }
 
         public List<String> getParameterNames() {
-            return parameterNames == null ? emptyList() : parameterNames;
+            return parameterNames == null ? emptyList() : Arrays.asList(parameterNames);
         }
 
         public Method withParameterNames(@Nullable List<String> parameterNames) {
-            parameterNames = nullIfEmpty(parameterNames);
-            if (parameterNames == this.parameterNames) {
+            String[] parameterNamesArray = arrayOrNullIfEmpty(parameterNames, EMPTY_STRING_ARRAY);
+            if (Arrays.equals(parameterNamesArray, this.parameterNames)) {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    parameterNames, this.parameterTypes, this.thrownExceptions, this.annotations, this.defaultValue);
+                    parameterNamesArray, this.parameterTypes, this.thrownExceptions, this.annotations, this.defaultValue);
         }
 
         public List<JavaType> getParameterTypes() {
-            return parameterTypes == null ? emptyList() : parameterTypes;
+            return parameterTypes == null ? emptyList() : Arrays.asList(parameterTypes);
         }
 
         public Method withParameterTypes(@Nullable List<JavaType> parameterTypes) {
-            parameterTypes = nullIfEmpty(parameterTypes);
-            if (parameterTypes == this.parameterTypes) {
+            JavaType[] parameterTypesArray = arrayOrNullIfEmpty(parameterTypes, EMPTY_JAVA_TYPE_ARRAY);
+            if (Arrays.equals(parameterTypesArray, this.parameterTypes)) {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    this.parameterNames, parameterTypes, this.thrownExceptions, this.annotations, this.defaultValue);
+                    this.parameterNames, parameterTypesArray, this.thrownExceptions, this.annotations, this.defaultValue);
         }
 
         public List<FullyQualified> getThrownExceptions() {
-            return thrownExceptions == null ? emptyList() : thrownExceptions;
+            return thrownExceptions == null ? emptyList() : Arrays.asList(thrownExceptions);
         }
 
         public Method withThrownExceptions(@Nullable List<FullyQualified> thrownExceptions) {
-            thrownExceptions = nullIfEmpty(thrownExceptions);
-            if (thrownExceptions == this.thrownExceptions) {
+            FullyQualified[] thrownExceptionsArray = arrayOrNullIfEmpty(thrownExceptions, EMPTY_FULLY_QUALIFIED_ARRAY);
+            if (Arrays.equals(thrownExceptionsArray, this.thrownExceptions)) {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    this.parameterNames, this.parameterTypes, thrownExceptions, this.annotations, this.defaultValue);
+                    this.parameterNames, this.parameterTypes, thrownExceptionsArray, this.annotations, this.defaultValue);
         }
 
         public List<FullyQualified> getAnnotations() {
-            return annotations == null ? emptyList() : annotations;
+            return annotations == null ? emptyList() : Arrays.asList(annotations);
         }
 
         public Method withAnnotations(@Nullable List<FullyQualified> annotations) {
-            annotations = nullIfEmpty(annotations);
-            if (annotations == this.annotations) {
+            FullyQualified[] annotationsArray = arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY);
+            if (Arrays.equals(annotationsArray, this.annotations)) {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    this.parameterNames, this.parameterTypes, this.thrownExceptions, annotations, this.defaultValue);
+                    this.parameterNames, this.parameterTypes, this.thrownExceptions, annotationsArray, this.defaultValue);
         }
 
         public boolean hasFlags(Flag... test) {
@@ -1110,7 +1180,7 @@ public interface JavaType {
             return Objects.equals(declaringType, method.declaringType) &&
                    name.equals(method.name) &&
                    Objects.equals(returnType, method.returnType) &&
-                   Objects.equals(parameterTypes, method.parameterTypes);
+                   Arrays.equals(parameterTypes, method.parameterTypes);
         }
 
         @Override
@@ -1145,10 +1215,23 @@ public interface JavaType {
 
         @NonFinal
         @Nullable
-        List<FullyQualified> annotations;
+        FullyQualified[] annotations;
 
         public Variable(@Nullable Integer managedReference, long flagsBitMap, String name, @Nullable JavaType owner,
                         @Nullable JavaType type, @Nullable List<FullyQualified> annotations) {
+            this(
+                    managedReference,
+                    flagsBitMap,
+                    name,
+                    owner,
+                    type,
+                    arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY)
+            );
+        }
+
+        @JsonCreator
+        Variable(@Nullable Integer managedReference, long flagsBitMap, String name, @Nullable JavaType owner,
+                        @Nullable JavaType type, @Nullable FullyQualified[] annotations) {
             this.managedReference = managedReference;
             this.flagsBitMap = flagsBitMap & Flag.VALID_FLAGS;
             this.name = name;
@@ -1163,15 +1246,15 @@ public interface JavaType {
         }
 
         public List<FullyQualified> getAnnotations() {
-            return annotations == null ? emptyList() : annotations;
+            return annotations == null ? emptyList() : Arrays.asList(annotations);
         }
 
         public Variable withAnnotations(@Nullable List<FullyQualified> annotations) {
-            annotations = nullIfEmpty(annotations);
-            if (this.annotations == annotations) {
+            FullyQualified[] annotationsArray = arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY);
+            if (Arrays.equals(annotationsArray, this.annotations)) {
                 return this;
             }
-            return new Variable(this.managedReference, this.flagsBitMap, this.name, this.owner, this.type, annotations);
+            return new Variable(this.managedReference, this.flagsBitMap, this.name, this.owner, this.type, annotationsArray);
         }
 
         public boolean hasFlags(Flag... test) {
@@ -1196,7 +1279,7 @@ public interface JavaType {
                                   @Nullable List<FullyQualified> annotations) {
             this.owner = owner;
             this.type = unknownIfNull(type);
-            this.annotations = nullIfEmpty(annotations);
+            this.annotations = arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY);
             return this;
         }
 
@@ -1307,4 +1390,5 @@ public interface JavaType {
             return false;
         }
     }
+
 }


### PR DESCRIPTION
When Jackson deserializes an array into a `List` it by default creates an `ArrayList` with the default capacity (10) and populates it with the values. For `JavaType.Method` that is typically quite wasteful, since it uses lists for parameter names, parameter types, thrown exceptions, and annotations and these lists are very often shorter.

One alternative is to register a custom `ValueInstantiator` for `ArrayList` which creates lists with a smaller capacity (e.g. 4 or even just 1).

Another alternative, as done in this commit, is to change the internal representation to use arrays and create a corresponding `@JsonCreator` annotated constructor.
