### PR TITLE
No JsonIdentityInfo on Tree

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -15,10 +15,8 @@
  */
 package org.openrewrite;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.openrewrite.internal.MetricsHelper;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -26,7 +24,6 @@ import org.openrewrite.marker.Markers;
 
 import java.util.UUID;
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
 public interface Tree {
     @SuppressWarnings("unused")


### PR DESCRIPTION
Since we no longer referentially deduplicate subtrees, this identity info only represents a cost.