### PR TITLE
Refactor `MethodMatcher#matchesTargetType`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -148,31 +148,11 @@ public class MethodMatcher {
     }
 
     boolean matchesTargetType(@Nullable JavaType.FullyQualified type) {
-        if (type == null || type instanceof JavaType.Unknown) {
-            return false;
-        }
-
-        if (matchesTargetTypeName(type.getFullyQualifiedName())) {
-            return true;
-        }
-
-        if (matchOverrides) {
-            if (!"java.lang.Object".equals(type.getFullyQualifiedName()) && matchesTargetType(OBJECT_CLASS)) {
-                return true;
-            }
-
-            if (matchesTargetType(type.getSupertype())) {
-                return true;
-            }
-
-            for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
-                if (matchesTargetType(anInterface)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return TypeUtils.isOfTypeWithName(
+                        type,
+                        matchOverrides,
+                        this::matchesTargetTypeName
+                );
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")


### PR DESCRIPTION
## What's changed?

Extracts `MethodMatcher#matchesTargetType` into `TypeUtils#isOfTypeWithName`.

## What's your motivation?

This makes is easier for external actors to implement custom `MethodMatcher`
implementations without copying and pasting logic out of `MethodMatcher`.

You can see that, currently, the entire contents of `MethodMatcher#matchesTargetType` is currently copy-pasted here:
https://github.com/openrewrite/rewrite-analysis/blob/5956c0868de11bff8d892b4203ea02b3d2c08905/src/main/java/org/openrewrite/analysis/BasicJavaTypeMethodMatcher.java#L43-L74

## Anything in particular you'd like reviewers to focus on?

 - Is the name of the method `isOfTypeWithName` fine?
 - Should `isOfTypeWithName` be a static method on `TypeUtils` or on `MethodMatcher`?
 - Is the `@Incubating` annotation on the new method `isOfTypeWithName` specifying the correct version?

## Have you considered any alternatives or workarounds?

Continuing to operate with copy-pasted code in both codebases.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
