### PR TITLE
Annotate `Tree` and `JavaType` with `@JsonIgnoreProperties`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -27,6 +28,7 @@ import java.util.UUID;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
 @JsonPropertyOrder({"@c"}) // serialize type info first
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Tree {
     @SuppressWarnings("unused")
     @JsonProperty("@c")

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -36,6 +36,7 @@ import static org.openrewrite.java.tree.TypeUtils.unknownIfNull;
 @SuppressWarnings("unused")
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface JavaType {
 
     FullyQualified[] EMPTY_FULLY_QUALIFIED_ARRAY = new FullyQualified[0];


### PR DESCRIPTION
During deserialization the `@c` property appears to be treated as an unknown property, which adds some extra overhead.
