### PR TITLE
Demonstrate Validated.lazy failures bug

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/ValidatedTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ValidatedTest.java
@@ -1,0 +1,18 @@
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidatedTest {
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3385")
+    void lazyFailures() {
+        Validated<String> validated = Validated.lazy("Hello", () -> null);
+        assertFalse(validated.isValid());
+        // throws ClassCastException: class org.openrewrite.Validated$LazyValidated cannot be cast to class org.openrewrite.Validated$Invalid
+        assertDoesNotThrow(validated::failures);
+    }
+
+}


### PR DESCRIPTION
## What's changed?
Added a test to replicate #3385

## What's your motivation?
We should be able to retrieve and present failures, even when they are lazily evaluated.

## Anything in particular you'd like reviewers to focus on?
Suggestions for how to fix welcome; it's getting late here.

## Any additional context
Fails on these lines
https://github.com/openrewrite/rewrite/blob/19d21322bf844051b945fdd68263751dd6677a2f/rewrite-core/src/main/java/org/openrewrite/Validated.java#L55-L63