### PR TITLE
My proposal for ensuring recipe validation happens exactly once per run

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -84,11 +84,6 @@ public abstract class Recipe implements Cloneable {
         public String getDescription() {
             return "Default no-op test, does nothing.";
         }
-
-        @Override
-        public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return TreeVisitor.noop();
-        }
     }
 
     /**
@@ -320,7 +315,7 @@ public abstract class Recipe implements Cloneable {
         return validateAll(new InMemoryExecutionContext(), new ArrayList<>());
     }
 
-    private Collection<Validated<Object>> validateAll(ExecutionContext ctx, Collection<Validated<Object>> acc) {
+    public Collection<Validated<Object>> validateAll(ExecutionContext ctx, Collection<Validated<Object>> acc) {
         acc.add(validate(ctx));
         for (Recipe recipe : getRecipeList()) {
             recipe.validateAll(ctx, acc);

--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -141,7 +141,7 @@ public class RecipeScheduler {
         public LargeSourceSet scanSources(LargeSourceSet sourceSet, int cycle) {
             return mapForRecipeRecursively(sourceSet, (recipeStack, sourceFile) -> {
                 Recipe recipe = recipeStack.peek();
-                if (recipe.maxCycles() < cycle || !recipe.validate(ctx).isValid()) {
+                if (recipe.maxCycles() < cycle) {
                     return sourceFile;
                 }
 
@@ -175,7 +175,7 @@ public class RecipeScheduler {
             while (!allRecipesStack.isEmpty()) {
                 Stack<Recipe> recipeStack = allRecipesStack.pop();
                 Recipe recipe = recipeStack.peek();
-                if (recipe.maxCycles() < cycle || !recipe.validate(ctx).isValid()) {
+                if (recipe.maxCycles() < cycle) {
                     continue;
                 }
 
@@ -200,7 +200,7 @@ public class RecipeScheduler {
         public LargeSourceSet editSources(LargeSourceSet sourceSet, int cycle) {
             return mapForRecipeRecursively(sourceSet, (recipeStack, sourceFile) -> {
                 Recipe recipe = recipeStack.peek();
-                if (recipe.maxCycles() < cycle || !recipe.validate(ctx).isValid()) {
+                if (recipe.maxCycles() < cycle) {
                     return sourceFile;
                 }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -132,12 +132,11 @@ class UpdateGradleWrapperTest implements RewriteTest {
               distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
               """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
-              .afterRecipe(gradleWrapperProperties -> {
-                  assertThat(gradleWrapperProperties.getMarkers().findFirst(BuildTool.class)).hasValueSatisfying(buildTool -> {
-                      assertThat(buildTool.getType()).isEqualTo(BuildTool.Type.Gradle);
-                      assertThat(buildTool.getVersion()).isEqualTo("7.4.2");
-                  });
-              })
+              .afterRecipe(gradleWrapperProperties ->
+                assertThat(gradleWrapperProperties.getMarkers().findFirst(BuildTool.class)).hasValueSatisfying(buildTool -> {
+                    assertThat(buildTool.getType()).isEqualTo(BuildTool.Type.Gradle);
+                    assertThat(buildTool.getVersion()).isEqualTo("7.4.2");
+                }))
           ),
           gradlew,
           gradlewBat,
@@ -222,9 +221,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("7.x", null, null, Boolean.FALSE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
-            .afterRecipe(run -> {
-                assertThat(run.getChangeset().getAllResults()).isEmpty();
-            })
+            .afterRecipe(run -> assertThat(run.getChangeset().getAllResults()).isEmpty())
         );
     }
 
@@ -403,6 +400,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
                 var gradleWrapperJar = result(run, Remote.class, "gradle-wrapper.jar");
                 assertThat(gradleWrapperJar.getSourcePath()).isEqualTo(WRAPPER_JAR_LOCATION);
+                //noinspection OptionalGetWithoutIsPresent
                 BuildTool buildTool = gradleWrapperJar.getMarkers().findFirst(BuildTool.class).get();
                 assertThat(buildTool.getVersion()).isNotEqualTo("7.4");
                 assertThat(gradleWrapperJar.getUri()).isEqualTo(URI.create("https://services.gradle.org/distributions/gradle-" + buildTool.getVersion() + "-bin.zip"));

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -156,10 +156,6 @@ public interface RewriteTest extends SourceSpecs {
                 .as("A recipe must be specified")
                 .isNotNull();
 
-        assertThat(recipe.validate().failures())
-                .as("Recipe validation must have no failures")
-                .isEmpty();
-
         if (!(recipe instanceof AdHocRecipe) && !(recipe instanceof CompositeRecipe) &&
             testClassSpec.serializationValidation &&
             testMethodSpec.serializationValidation) {
@@ -200,6 +196,11 @@ public interface RewriteTest extends SourceSpecs {
         for (SourceSpec<?> s : sourceSpecs) {
             s.customizeExecutionContext.accept(executionContext);
         }
+        List<Validated<Object>> validations = new ArrayList<>();
+        recipe.validateAll(executionContext, validations);
+        assertThat(validations)
+                .as("Recipe validation must have no failures")
+                .noneMatch(Validated::isInvalid);
 
         Map<Parser.Builder, List<SourceSpec<?>>> sourceSpecsByParser = new HashMap<>();
         List<Parser.Builder> methodSpecParsers = testMethodSpec.parsers;


### PR DESCRIPTION
Make it the responsibility of whatever is going to run the recipe, not RecipeScheduler
