### PR TITLE
putCurrentRecipe ExecutionContext message

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -221,6 +221,7 @@ public class RecipeScheduler {
                         return sourceFile;
                     }
 
+                    ctx.putCurrentRecipe(recipe);
                     TreeVisitor<?, ExecutionContext> visitor = recipe.getVisitor();
                     // set root cursor as it is required by the `ScanningRecipe#isAcceptable()`
                     visitor.setCursor(rootCursor);


### PR DESCRIPTION
## What's changed?
There is a default function `void putCurrentRecipe(Recipe recipe)` in ExecutionContext  that right now is not used anywhere. I do not know the original motivation around this method, but I think it could be useful to detect the progress of running a recipe through RecipeScheduler, intercepting those messages in the ExecutionContext
https://github.com/openrewrite/rewrite/blob/bdc9dc4c4c73a5254c1a8402a2bd7e933965df2a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java#L90-L92

## What's your motivation?
I would like to be able to detect the progress being done in the RecipeScheduler after calling `scheduleRun`, and if we also instrument ExecutionContext and capture the messages of this type (probably together with `currentCycle`), we could track some progress of the running recipe.
Since I found out this method being added long time ago, and not being used at all right now, I wonder if we could finish the implementation so it's useful for this use case.

## Anything in particular you'd like reviewers to focus on?
Maybe we should also add the push of this message in the scan and generate steps?

## Anyone you would like to review specifically?
@jkschneider @sambsnyd @knutwannheden @rpau 

## Have you considered any alternatives or workarounds?
Other alternatives to track progress could be to instrument the `Recipe::getVisitor` method, since it's called once per cycle just before the recipe being used, but can be a bit more tricky to do that from outside the lib.
Adding some explicit callback mechanism just to track progress may be cumbersome and tedious just for this very specific use case.
