### PR TITLE
Issue 3275/fix remove used param

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1072,6 +1072,68 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3275")
+    @Test
+    void doesNotRemoveReferencedClassesBeingUsedAsParameters() {
+        rewriteRun(
+          java(
+            """
+              package com.Source.$;
+
+              public class A {
+                  public static final short SHORT1 = (short)1;
+
+                  public short getShort1() {
+                    return SHORT1;
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              package com.test;
+
+              import com.Source.$.A;
+
+              class Test {
+                  void f(A classA) {
+                    classA.getShort1();
+                  }
+              }
+              """
+          )
+        );
+
+        rewriteRun(
+          java(
+            """
+              package com.Source.mine;
+
+              public class A {
+                  public static final short SHORT1 = (short)1;
+                  
+                  public short getShort1() {
+                    return SHORT1;
+                  } 
+              }
+              """
+          ),
+          java(
+            """
+              package com.test;
+
+              import com.Source.mine.A;
+              
+              class Test {
+                  void f(A classA) {
+                    classA.getShort1();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void removeImportUsedAsLambdaParameter() {
         rewriteRun(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1078,35 +1078,6 @@ class RemoveUnusedImportsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              package com.Source.$;
-
-              public class A {
-                  public static final short SHORT1 = (short)1;
-
-                  public short getShort1() {
-                    return SHORT1;
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              package com.test;
-
-              import com.Source.$.A;
-
-              class Test {
-                  void f(A classA) {
-                    classA.getShort1();
-                  }
-              }
-              """
-          )
-        );
-
-        rewriteRun(
-          java(
-            """
               package com.Source.mine;
 
               public class A {
@@ -1124,6 +1095,39 @@ class RemoveUnusedImportsTest implements RewriteTest {
 
               import com.Source.mine.A;
               
+              class Test {
+                  void f(A classA) {
+                    classA.getShort1();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3275")
+    @Test
+    void doesNotRemoveReferencedClassesBeingUsedAsParametersUnusualPackageName() {
+        rewriteRun(
+          java(
+            """
+              package com.Source.$;
+
+              public class A {
+                  public static final short SHORT1 = (short)1;
+
+                  public short getShort1() {
+                    return SHORT1;
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              package com.test;
+
+              import com.Source.$.A;
+
               class Test {
                   void f(A classA) {
                     classA.getShort1();

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 
 import static java.util.Collections.emptySet;
 import static org.openrewrite.java.style.ImportLayoutStyle.isPackageAlwaysFolded;
+import static org.openrewrite.java.tree.TypeUtils.fullyQualifiedNamesAreEqualAsPredicate;
 
 /**
  * This recipe will remove any imports for types that are not referenced within the compilation unit. This recipe
@@ -136,7 +137,7 @@ public class RemoveUnusedImports extends Recipe {
                     // see https://github.com/openrewrite/rewrite/issues/1698 for more detail
                     String target = qualid.getTarget().toString();
                     String modifiedTarget = methodsAndFieldsByTypeName.keySet().stream()
-                            .filter(classPathMatcher(target))
+                            .filter(fullyQualifiedNamesAreEqualAsPredicate(target))
                             .findFirst()
                             .orElse(target);
                     SortedSet<String> targetMethodsAndFields = methodsAndFieldsByTypeName.get(modifiedTarget);
@@ -229,7 +230,7 @@ public class RemoveUnusedImports extends Recipe {
                         if ("*".equals(elem.getQualid().getSimpleName())) {
                             return elem.getPackageName().equals(c.getPackageName());
                         }
-                        return classPathMatcher(c.getFullyQualifiedName()).test(elem.getTypeName());
+                        return fullyQualifiedNamesAreEqualAsPredicate(c.getFullyQualifiedName()).test(elem.getTypeName());
                     })) {
                         anImport.used = false;
                         changed = true;
@@ -284,10 +285,6 @@ public class RemoveUnusedImports extends Recipe {
 
             return cu;
         }
-    }
-
-    private static Predicate<String> classPathMatcher(final String target){
-        return (s) -> s.matches(target.replaceAll("[\\.\\$]", "(\\\\\\.|\\\\\\$)"));
     }
 
     private static String packageKey(String packageName, String className) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -46,6 +46,10 @@ public class TypeUtils {
         return fqn1 == null && fqn2 == null;
     }
 
+    public static Predicate<String> fullyQualifiedNamesAreEqualAsPredicate (@Nullable String fqn1) {
+        return (fqn2) -> fullyQualifiedNamesAreEqual(fqn1, fqn2);
+    }
+
     /**
      * Returns true if the JavaTypes are of the same type.
      * {@link JavaType.Parameterized} will be checked for both the FQN and each of the parameters.


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
https://github.com/openrewrite/rewrite/issues/3275 pointed out an issue with incorrectly removing an import that was being used as a function parameter. This change updates the class path matching logic to check for either a `.` or a `$` class path separator. 

## What's your motivation?
My motivation is to resolve https://github.com/openrewrite/rewrite/issues/3275 and make the RemoveUnusedImports recipe more reliable for wider adoption. 

## Anything in particular you'd like reviewers to focus on?
I co-opted the predicate used in https://github.com/openrewrite/rewrite/pull/3363 to more generally match against class paths that have a `$` as a separator. 

## Anyone you would like to review specifically?
Any maintainer 😄 

## Have you considered any alternatives or workarounds?
n/a<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
n/a<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
