### PR TITLE
Use default constructor as `@JsonCreator` for `JavaType` implementations

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -31,7 +31,8 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.*;
-import static org.openrewrite.internal.ListUtils.*;
+import static org.openrewrite.internal.ListUtils.arrayOrNullIfEmpty;
+import static org.openrewrite.internal.ListUtils.nullIfEmpty;
 import static org.openrewrite.java.tree.TypeUtils.unknownIfNull;
 
 @SuppressWarnings("unused")
@@ -51,6 +52,7 @@ public interface JavaType {
         return getClass().getName();
     }
 
+    // TODO: To be removed with OpenRewrite 9
     @Nullable
     default Integer getManagedReference() {
         return null;
@@ -107,9 +109,12 @@ public interface JavaType {
             this.throwableTypes = arrayOrNullIfEmpty(throwableTypes, EMPTY_JAVA_TYPE_ARRAY);
         }
 
-        @JsonCreator
         MultiCatch(@Nullable JavaType[] throwableTypes) {
             this.throwableTypes = nullIfEmpty(throwableTypes);
+        }
+
+        @JsonCreator
+        MultiCatch() {
         }
 
         private JavaType[] throwableTypes;
@@ -322,12 +327,15 @@ public interface JavaType {
         Integer managedReference;
 
         @With(AccessLevel.NONE)
+        @NonFinal
         long flagsBitMap;
 
         @With
+        @NonFinal
         String fullyQualifiedName;
 
         @With
+        @NonFinal
         Kind kind;
 
         @NonFinal
@@ -367,7 +375,6 @@ public interface JavaType {
             );
         }
 
-        @JsonCreator
         Class(@Nullable Integer managedReference, long flagsBitMap, String fullyQualifiedName,
               Kind kind, @Nullable JavaType[] typeParameters, @Nullable FullyQualified supertype, @Nullable FullyQualified owningClass,
               @Nullable FullyQualified[] annotations, @Nullable FullyQualified[] interfaces,
@@ -384,6 +391,10 @@ public interface JavaType {
             this.interfaces = nullIfEmpty(interfaces);
             this.members = nullIfEmpty(members);
             this.methods = nullIfEmpty(methods);
+        }
+
+        @JsonCreator
+        Class() {
         }
 
         public List<FullyQualified> getAnnotations() {
@@ -543,6 +554,10 @@ public interface JavaType {
             super(managedReference, flagsBitMap, fullyQualifiedName, kind, (List<JavaType>) null, null, owningClass, null, null, null, null);
         }
 
+        @JsonCreator
+        ShallowClass() {
+        }
+
         /**
          * Build a class type only from the class' fully qualified name.
          *
@@ -601,12 +616,15 @@ public interface JavaType {
             );
         }
 
-        @JsonCreator
         Parameterized(@Nullable Integer managedReference, @Nullable FullyQualified type,
                              @Nullable JavaType[] typeParameters) {
             this.managedReference = managedReference;
             this.type = unknownIfNull(type);
             this.typeParameters = nullIfEmpty(typeParameters);
+        }
+
+        @JsonCreator
+        Parameterized() {
         }
 
         public FullyQualified getType() {
@@ -745,12 +763,15 @@ public interface JavaType {
             );
         }
 
-        @JsonCreator
         GenericTypeVariable(@Nullable Integer managedReference, String name, Variance variance, @Nullable JavaType[] bounds) {
             this.managedReference = managedReference;
             this.name = name;
             this.variance = variance;
             this.bounds = nullIfEmpty(bounds);
+        }
+
+        @JsonCreator
+        GenericTypeVariable() {
         }
 
         public List<JavaType> getBounds() {
@@ -820,6 +841,10 @@ public interface JavaType {
         public Array(@Nullable Integer managedReference, @Nullable JavaType elemType) {
             this.managedReference = managedReference;
             this.elemType = unknownIfNull(elemType);
+        }
+
+        @JsonCreator
+        Array() {
         }
 
         public JavaType getElemType() {
@@ -975,6 +1000,7 @@ public interface JavaType {
         Integer managedReference;
 
         @With(AccessLevel.PRIVATE)
+        @NonFinal
         long flagsBitMap;
 
         @With
@@ -982,6 +1008,7 @@ public interface JavaType {
         FullyQualified declaringType;
 
         @With
+        @NonFinal
         String name;
 
         @With
@@ -989,6 +1016,7 @@ public interface JavaType {
         JavaType returnType;
 
         @Nullable
+        @NonFinal
         String[] parameterNames;
 
         @NonFinal
@@ -1005,6 +1033,7 @@ public interface JavaType {
 
         @Incubating(since = "7.34.0")
         @Nullable
+        @NonFinal
         List<String> defaultValue;
 
         public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
@@ -1033,7 +1062,6 @@ public interface JavaType {
             );
         }
 
-        @JsonCreator
         public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
                @Nullable JavaType returnType, @Nullable String[] parameterNames,
                @Nullable JavaType[] parameterTypes, @Nullable FullyQualified[] thrownExceptions,
@@ -1048,6 +1076,10 @@ public interface JavaType {
             this.thrownExceptions = nullIfEmpty(thrownExceptions);
             this.annotations = nullIfEmpty(annotations);
             this.defaultValue = nullIfEmpty(defaultValue);
+        }
+
+        @JsonCreator
+        Method() {
         }
 
         @Override
@@ -1247,9 +1279,11 @@ public interface JavaType {
         Integer managedReference;
 
         @With(AccessLevel.PRIVATE)
+        @NonFinal
         long flagsBitMap;
 
         @With
+        @NonFinal
         String name;
 
         @With
@@ -1277,7 +1311,6 @@ public interface JavaType {
             );
         }
 
-        @JsonCreator
         Variable(@Nullable Integer managedReference, long flagsBitMap, String name, @Nullable JavaType owner,
                         @Nullable JavaType type, @Nullable FullyQualified[] annotations) {
             this.managedReference = managedReference;
@@ -1286,6 +1319,10 @@ public interface JavaType {
             this.owner = owner;
             this.type = unknownIfNull(type);
             this.annotations = nullIfEmpty(annotations);
+        }
+
+        @JsonCreator
+        Variable() {
         }
 
         @Nullable


### PR DESCRIPTION
In order for Jackson to be able to correctly deserialize an object graph containing cycles, the `@JsonCreator` annotated method must not contain the properties, which correspond to the edges participating in the cycles.

This commit adds a new (package private) default constructor to all `JavaType` implementations and moves the `@JsonCreator` annotation to this new constructor. This then allows Jackson to properly serialize and deserialize the object cycles. Eventually this will then allow removing the `managedReference` fields from the implementation classes to save some more memory.
