### PR TITLE
JavaTemplate.Builder.imports - throw on blank import

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -153,22 +153,20 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
 
         public Builder staticImports(String... fullyQualifiedMemberTypeNames) {
             for (String typeName : fullyQualifiedMemberTypeNames) {
-                if (shouldAddImport(typeName)) {
-                    this.imports.add("import static " + typeName + ";\n");
-                }
+                validateImport(typeName);
+                this.imports.add("import static " + typeName + ";\n");
             }
             return this;
         }
 
-        private boolean shouldAddImport(String typeName) {
+        private void validateImport(String typeName) {
             if (StringUtils.isBlank(typeName)) {
-                return false;
+                throw new IllegalArgumentException("Imports must not be blank");
             } else if (typeName.startsWith("import ") || typeName.startsWith("static ")) {
                 throw new IllegalArgumentException("Imports are expressed as fully-qualified names and should not include an \"import \" or \"static \" prefix");
             } else if (typeName.endsWith(";") || typeName.endsWith("\n")) {
                 throw new IllegalArgumentException("Imports are expressed as fully-qualified names and should not include a suffixed terminator");
             }
-            return true;
         }
 
         public Builder javaParser(JavaParser.Builder<?, ?> javaParser) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -144,9 +144,8 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
 
         public Builder imports(String... fullyQualifiedTypeNames) {
             for (String typeName : fullyQualifiedTypeNames) {
-                if (shouldAddImport(typeName)) {
-                    this.imports.add("import " + typeName + ";\n");
-                }
+                validateImport(typeName);
+                this.imports.add("import " + typeName + ";\n");
             }
             return this;
         }


### PR DESCRIPTION
Small change; including a blank `String` in the `imports` when building a `JavaTemplate` now throws an exception, instead of silently ignoring the blank entry.

I think failing fast here is more helpful and matches the spirit of a non-null API