### PR TITLE
Only return the fully matched items from a sequence of binary expressions in JsonPathMatcher.

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonPathMatcher.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonPathMatcher.java
@@ -572,6 +572,17 @@ public class JsonPathMatcher {
                 rhs = getBinaryExpressionResult(rhs);
                 if ("&&".equals(operator) &&
                         ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) && (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {
+                    // Return the result of the evaluated expression.
+                    if (lhs instanceof Json) {
+                        return rhs;
+                    } else if (rhs instanceof Json) {
+                        return lhs;
+                    }
+
+                    // Return the result of the expression that has the fewest matches.
+                    if (lhs instanceof List && rhs instanceof List && ((List<?>) lhs).size() != ((List<?>) rhs).size()) {
+                        return ((List<?>) lhs).size() < ((List<?>) rhs).size() ? lhs : rhs;
+                    }
                     return scopeOfLogicalOp;
                 } else if ("||".equals(operator) &&
                         ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) || (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonPathMatcherTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonPathMatcherTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.json.tree.Json;
 import org.openrewrite.json.tree.Space;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -746,6 +747,71 @@ class JsonPathMatcherTest {
                   }
               """
           )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3401")
+    @Test
+    void multipleBinaryExpressions() {
+        assertMatched(
+          "$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'match' && @.type == 'type')].pattern",
+          List.of(
+            """
+              {
+                "foo": {
+                  "bar": [
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "other",
+                      "types": "something",
+                      "pattern": "p1"
+                    },
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "match",
+                      "types": "something",
+                      "pattern": "p2"
+                    }
+                  ]
+                }
+              }
+              """),
+          List.of("\"pattern\": \"p2\""
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3401")
+    @Test
+    void noMatchWithBinaryExpressions() {
+        assertMatched(
+          "$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'nomatch' && @.type == 'type')].pattern",
+          List.of(
+            """
+              {
+                "foo": {
+                  "bar": [
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "other",
+                      "types": "something",
+                      "pattern": "p1"
+                    },
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "match",
+                      "types": "something",
+                      "pattern": "p2"
+                    }
+                  ]
+                }
+              }
+              """),
+          Collections.emptyList()
         );
     }
 

--- a/rewrite-json/src/test/java/org/openrewrite/json/search/FindKeyTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/search/FindKeyTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.json.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.json.Assertions.json;
@@ -44,6 +45,59 @@ class FindKeyTest implements RewriteTest {
                 "metadata": {
                   /*~~>*/"name": "monitoring-tools",
                   "namespace": "monitoring-tools"
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3401")
+    @Test
+    void findKeyWithMultipleBinaryExpressions() {
+        rewriteRun(
+          spec -> spec.recipe(new FindKey("$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'match' && @.type == 'type')].pattern")),
+          json("""
+              {
+                "foo": {
+                  "bar": [
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "other",
+                      "types": "something",
+                      "pattern": "p1"
+                    },
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "match",
+                      "types": "something",
+                      "pattern": "p2"
+                    }
+                  ]
+                }
+              }
+              """,
+            """
+              {
+                "foo": {
+                  "bar": [
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "other",
+                      "types": "something",
+                      "pattern": "p1"
+                    },
+                    {
+                      "type": "type",
+                      "group": "group",
+                      "category": "match",
+                      "types": "something",
+                      /*~~>*/"pattern": "p2"
+                    }
+                  ]
                 }
               }
               """

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/JsonPathMatcher.java
@@ -587,6 +587,17 @@ public class JsonPathMatcher {
                 if ("&&".equals(operator) &&
                         ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) &&
                                 (rhs != null && (!(rhs instanceof List) || !((List<Object>) rhs).isEmpty())))) {
+                    // Return the result of the evaluated expression.
+                    if (lhs instanceof Yaml) {
+                        return rhs;
+                    } else if (rhs instanceof Yaml) {
+                        return lhs;
+                    }
+
+                    // Return the result of the expression that has the fewest matches.
+                    if (lhs instanceof List && rhs instanceof List && ((List<?>) lhs).size() != ((List<?>) rhs).size()) {
+                        return ((List<?>) lhs).size() < ((List<?>) rhs).size() ? lhs : rhs;
+                    }
                     return scopeOfLogicalOp;
                 } else if ("||".equals(operator) &&
                         ((lhs != null && (!(lhs instanceof List) || !((List<Object>) lhs).isEmpty())) ||

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/JsonPathMatcherTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/JsonPathMatcherTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -674,6 +675,59 @@ class JsonPathMatcherTest {
                  property: property
               """
           )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3401")
+    @Test
+    void multipleBinaryExpressions() {
+        assertMatched(
+          "$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'match' && @.type == 'type')].pattern",
+          List.of(
+            """
+              foo:
+                bar:
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "other"
+                    types: "something"
+                    pattern: "p1"
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "match"
+                    types: "something"
+                    pattern: "p2"
+              """),
+          List.of("pattern: \"p2\""
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3401")
+    @Test
+    void noMatchWithBinaryExpressions() {
+        assertMatched(
+          "$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'nomatch' && @.type == 'type')].pattern",
+          List.of(
+            """
+              foo:
+                bar:
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "other"
+                    types: "something"
+                    pattern: "p1"
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "match"
+                    types: "something"
+                    pattern: "p2"
+              """),
+          Collections.emptyList()
         );
     }
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindKeyTest.java
@@ -63,4 +63,45 @@ class FindKeyTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3401")
+    @Test
+    void findKeyWithMultipleBinaryExpressions() {
+        rewriteRun(
+          spec -> spec.recipe(new FindKey("$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'match' && @.type == 'type')].pattern")),
+          yaml("""
+              foo:
+                bar:
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "other"
+                    types: "something"
+                    pattern: "p1"
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "match"
+                    types: "something"
+                    pattern: "p2"
+              """,
+            """
+              foo:
+                bar:
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "other"
+                    types: "something"
+                    pattern: "p1"
+                  -
+                    type: "type"
+                    group: "group"
+                    category: "match"
+                    types: "something"
+                    ~~>pattern: "p2"
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
JsonPathMatcher will only return the items in a list that fully patch a sequence of binary expressions.

## What's your motivation?
Issue reported by design partner.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)

fixes #3401
