### PR TITLE
String fields are null by default.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
@@ -112,8 +112,6 @@ public class RecipeIntrospectionUtils {
             java.lang.reflect.Parameter param = primaryConstructor.getParameters()[i];
             if (param.getType().isPrimitive()) {
                 constructorArgs[i] = getPrimitiveDefault(param.getType());
-            } else if (param.getType().equals(String.class)) {
-                constructorArgs[i] = "";
             } else if (Enum.class.isAssignableFrom(param.getType())) {
                 try {
                     Object[] values = (Object[]) param.getType().getMethod("values").invoke(null);


### PR DESCRIPTION
## What's changed?
When creating a Recipe instance String constructor arguments will be null

## What's your motivation?
Recipes with required parameters with type String and that don't override validate method will be considered valid since those parameters would be initialized with an empty string. As a result, default implementation won't catch it.

## Anything in particular you'd like reviewers to focus on?
I'd like to know whether there is a negative implication of this change.

## Anyone you would like to review specifically?
@sambsnyd @jkschneider 

## Any additional context
This change is part of the scope of the issue that allows run recipe without required parameters been passed on
