### PR TITLE
Added optional filters on find parse failures.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/FindParseFailures.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindParseFailures.java
@@ -32,6 +32,18 @@ public class FindParseFailures extends Recipe {
     @Nullable
     Integer maxSnippetLength;
 
+    @Option(displayName = "Parser name",
+            description = "Only display specified parser failures.",
+            required = false)
+    @Nullable
+    String parserType;
+
+    @Option(displayName = "Stack trace",
+            description = "Only mark specified stack traces.",
+            required = false)
+    @Nullable
+    String stackTrace;
+
     transient ParseFailures failures = new ParseFailures(this);
 
     @Override
@@ -53,6 +65,14 @@ public class FindParseFailures extends Recipe {
             public Tree postVisit(Tree tree, ExecutionContext ctx) {
                 return tree.getMarkers().findFirst(ParseExceptionResult.class)
                         .map(exceptionResult -> {
+                            if (parserType != null && !exceptionResult.getParserType().equals(parserType)) {
+                                return tree;
+                            }
+
+                            if (stackTrace != null && !exceptionResult.getMessage().contains(stackTrace)) {
+                                return tree;
+                            }
+
                             String snippet = tree instanceof SourceFile ? null : tree.printTrimmed(getCursor());
                             if(snippet != null && maxSnippetLength != null && snippet.length() > maxSnippetLength) {
                                 snippet = snippet.substring(0, maxSnippetLength);

--- a/rewrite-core/src/test/java/org/openrewrite/FindParseFailuresTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/FindParseFailuresTest.java
@@ -32,7 +32,7 @@ public class FindParseFailuresTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new FindParseFailures(5));
+        spec.recipe(new FindParseFailures(5, null, null));
     }
 
     @Test


### PR DESCRIPTION
Changes:

- Added optional filters to `FindParseFailures`:
    - `parserType` only marks sources with the specified parserType.
    - `stackTrace` only marks sources with the specified stackTrace.

The changes will be used with data tables and notebooks to focus on fixing the most common parsing failures first.