### PR TITLE
`UsesMethod` should rely on `TypesInUse`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -54,6 +54,7 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
                     return SearchResult.found(cu);
                 }
             }
+            return (J) tree;
         }
         return super.visit(tree, p);
     }


### PR DESCRIPTION
If `UsesMethod` does not find any reference to the desired method in `TypesInUse` then it should return rather than traversing the entire LST in an attempt to find a match.

This change is being made for performance reasons, because this visitor is used very frequently as a precondition by recipes.
