### PR TITLE
Prevent NPE and surface the cause as a ParserErrorResult in YamlParser.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -306,6 +306,9 @@ public class YamlParser implements org.openrewrite.Parser {
 
                         AliasEvent alias = (AliasEvent) event;
                         Yaml.Anchor anchor = anchors.get(alias.getAnchor());
+                        if (anchor == null) {
+                            throw new UnsupportedOperationException("Unknown anchor: " + alias.getAnchor());
+                        }
                         BlockBuilder builder = blockStack.peek();
                         builder.push(new Yaml.Alias(randomId(), fmt, Markers.EMPTY, anchor));
                         lastEnd = event.getEndMark().getIndex();


### PR DESCRIPTION
Changes:

- Detect a null anchor to prevent an NPE in Yaml$Alias.
- Throws an exception to surface the parsing error as a ParserErrorResult.