### PR TITLE
Polish Gradle Enterprise recipes names and descriptions

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePlugin.java
@@ -49,7 +49,7 @@ import static org.openrewrite.gradle.plugins.AddPluginVisitor.resolvePluginVersi
 @Value
 @EqualsAndHashCode(callSuper = true)
 @Incubating(since = "7.33.0")
-public class AddGradleEnterprise extends Recipe {
+public class AddGradleEnterpriseGradlePlugin extends Recipe {
     @EqualsAndHashCode.Exclude
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 
@@ -106,12 +106,12 @@ public class AddGradleEnterprise extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Add the Gradle Enterprise plugin";
+        return "Add the Gradle Enterprise Gradle plugin";
     }
 
     @Override
     public String getDescription() {
-        return "Add the Gradle Enterprise plugin to settings.gradle files.";
+        return "Add the Gradle Enterprise Gradle plugin to settings.gradle files.";
     }
 
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePluginTest.java
@@ -33,12 +33,12 @@ import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.Assertions.*;
 import static org.openrewrite.test.SourceSpecs.dir;
 
-class AddGradleEnterpriseTest implements RewriteTest {
+class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.beforeRecipe(withToolingApi())
-                .recipe(new AddGradleEnterprise("3.x", null, null, null, null, null));
+                .recipe(new AddGradleEnterpriseGradlePlugin("3.x", null, null, null, null, null));
     }
 
     private static Consumer<SourceSpec<CompilationUnit>> interpolateResolvedVersion(@Language("groovy") String after) {
@@ -174,7 +174,7 @@ class AddGradleEnterpriseTest implements RewriteTest {
     void withConfigurationInSettings() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
-            .recipe(new AddGradleEnterprise("3.x", "https://ge.sam.com/", true, true, true, AddGradleEnterprise.PublishCriteria.Always)),
+            .recipe(new AddGradleEnterpriseGradlePlugin("3.x", "https://ge.sam.com/", true, true, true, AddGradleEnterpriseGradlePlugin.PublishCriteria.Always)),
           buildGradle(
             ""
           ),
@@ -206,7 +206,7 @@ class AddGradleEnterpriseTest implements RewriteTest {
     void withConfigurationOldInputCapture() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
-            .recipe(new AddGradleEnterprise("3.6", null, null, true, null, null)),
+            .recipe(new AddGradleEnterpriseGradlePlugin("3.6", null, null, true, null, null)),
           buildGradle(
             ""
           ),

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddGradleEnterpriseMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddGradleEnterpriseMavenExtension.java
@@ -67,9 +67,9 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
                                                                         "  <artifactId>gradle-enterprise-maven-extension</artifactId>\n" +
                                                                         "</extension>";
 
-    @Option(displayName = "Plugin version",
-            description = "An exact version number or node-style semver selector used to select the gradle-enterprise-maven-extension version.",
-            example = "1.x")
+    @Option(displayName = "Extension version",
+            description = "A maven-compatible version number to select the gradle-enterprise-maven-extension version.",
+            example = "1.17.4")
     @Nullable
     String version;
 
@@ -79,8 +79,8 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
     String server;
 
     @Option(displayName = "Allow untrusted server",
-            description = "When set to `true` the plugin will be configured to allow unencrypted http connections with the server. " +
-                          "If set to `false` or omitted, the plugin will refuse to communicate without transport layer security enabled.",
+            description = "When set to `true` the extension will be configured to allow unencrypted http connections with the server. " +
+                          "If set to `false` or omitted, the extension will refuse to communicate without transport layer security enabled.",
             required = false,
             example = "true")
     @Nullable
@@ -127,12 +127,12 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
 
     @Override
     public String getDisplayName() {
-        return "Add Gradle Enterprise Maven Extension to maven projects";
+        return "Add Gradle Enterprise Maven extension to maven projects";
     }
 
     @Override
     public String getDescription() {
-        return "To integrate gradle enterprise maven extension into maven projects, ensure that the " +
+        return "To integrate Gradle Enterprise Maven extension into maven projects, ensure that the " +
                "`gradle-enterprise-maven-extension` is added to the `.mvn/extensions.xml` file if not already present. " +
                "Additionally, configure the extension by adding the `.mvn/gradle-enterprise.xml` configuration file.";
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Main change is renaming `AddGradleEnterprise` to `AddGradleEnterpriseGradlePlugin`. Others are just fixing param descriptions.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Have consistent labeling between the Gradle Enterprise related recipes.

### Checklist
- [ ] I've updated the documentation (if applicable)
I assume the documentation will be re-generated from those changes ?
