### PR TITLE
Fix SearchResults.mergingFound duplicating description

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/SearchResult.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/SearchResult.java
@@ -55,17 +55,22 @@ public final class SearchResult implements Marker {
 
     /**
      * Merge the description of two search results into a single search result with a unified description.
+     * <p>
+     * If the there already exists a search result with the same description, the existing search result is returned.
      */
-    @Incubating(since ="8.0.0")
-    public static <T extends Tree> T mergingFound(@Nullable T t,String description) {
+    @Incubating(since = "8.0.0")
+    public static <T extends Tree> T mergingFound(@Nullable T t, String description) {
         return mergingFound(t, description, ", ");
     }
 
     /**
      * Merge the description of two search results into a single search result with a unified description.
+     * <p>
+     * If the there already exists a search result with the same description, the existing search result is returned.
+     *
      * @param delimiter The delimiter to use when merging descriptions.
      */
-    @Incubating(since ="8.0.0")
+    @Incubating(since = "8.0.0")
     public static <T extends Tree> T mergingFound(@Nullable T t, String description, String delimiter) {
         Objects.requireNonNull(delimiter, "delimiter must not be null");
         if (t == null) {
@@ -84,6 +89,12 @@ public final class SearchResult implements Marker {
                         return s2;
                     }
                     if (s2.getDescription() == null) {
+                        return s1;
+                    }
+                    if (s1.getDescription().equals(s2.getDescription()) ||
+                        s1.getDescription().startsWith(s2.getDescription() + delimiter) ||
+                        s1.getDescription().contains(delimiter + s2.getDescription() + delimiter) ||
+                        s1.getDescription().endsWith(s2.getDescription())) {
                         return s1;
                     }
                     return s1.withDescription(s1.getDescription() + delimiter + s2.getDescription());

--- a/rewrite-java-test/src/test/java/org/openrewrite/marker/SearchResultsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/marker/SearchResultsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.marker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class SearchResultsTest implements RewriteTest {
+
+    @Test
+    void searchResultIsOnlyAddedOnceEvenWhenRunMultipleTimesByScheduler() {
+        rewriteRun(spec -> {
+              spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                  @Override
+                  public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                      return SearchResult.mergingFound(super.visitMethodInvocation(method, executionContext), method.getSimpleName());
+                  }
+              }));
+          },
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello, world!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      /*~~(println)~~>*/System.out.println("Hello, world!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleSearchResultIsOnlyAddedOnceEvenWhenRunMultipleTimesByScheduler() {
+        rewriteRun(spec -> {
+              spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                  @Override
+                  public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                      return SearchResult.mergingFound(
+                        SearchResult.mergingFound(
+                          SearchResult.mergingFound(
+                            super.visitMethodInvocation(method, executionContext),
+                            "42"
+                          ),
+                          "Hello, world!"
+                        ),
+                        method.getSimpleName()
+                      );
+                  }
+              }));
+          },
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello, world!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      /*~~(42, Hello, world!, println)~~>*/System.out.println("Hello, world!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void foundSearchResultsShouldNotClobberResultsWithDescription() {
+        rewriteRun(spec -> {
+              spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                  @Override
+                  public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                      return SearchResult.found(
+                        SearchResult.found(
+                          super.visitMethodInvocation(method, executionContext),
+                          "Hello, world!"
+                        )
+                      );
+                  }
+              }));
+          },
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello, world!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      /*~~(Hello, world!)~~>*/System.out.println("Hello, world!");
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

## What's changed?

`SearchResult.mergingFound` has been fixed to only add the description if
the description isn't already present on a found `SearchResult`.

## What's your motivation?

Externally having to guard against a `SearchResult` marker before calling
`mergingFound` is annoying, and, given the use of this method, often the behaviour
you would want anyways.

This is particularily true given that, by default, the recipe scheduler runs any recipe
twice. As such, any `mergingFound` call by default will be invoked twice.

In recipe tests, you can fix this by calling `expectedCyclesThatMakeChanges(1)`.
But that's a bit of a hack, and should be avoided.

<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
