### PR TITLE
Account for Unicode characters in Yaml FormatPreservingReader

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/config/ChangeTextToSam.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/ChangeTextToSam.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.config;
 
 import org.openrewrite.ExecutionContext;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -37,7 +37,6 @@ class FormatPreservingReader extends Reader {
         this.delegate = delegate;
     }
 
-    // VisibleForTesting
     String prefix(int lastEnd, int startIndex) {
         assert lastEnd <= startIndex;
 
@@ -78,7 +77,11 @@ class FormatPreservingReader extends Reader {
         if (read > 0) {
             buffer.ensureCapacity(buffer.size() + read);
             for (int i = 0; i < read; i++) {
-                buffer.add(cbuf[i]);
+                char e = cbuf[i];
+                if (Character.UnicodeBlock.of(e) != Character.UnicodeBlock.BASIC_LATIN && i % 2 == 0) {
+                    bufferIndex--;
+                }
+                buffer.add(e);
             }
         }
         return read;

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.SourceFile;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.stream.Stream;
+
+class YamlParserTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "Breaking Changes",
+      "Breaking Changes 🛠"
+    })
+    void parseYamlWithUnicode(String input) {
+        Stream<SourceFile> yamlSources = YamlParser.builder().build().parse("title: %s\n".formatted(input));
+        SourceFile sourceFile = yamlSources.findFirst().get();
+        Yaml.Documents documents = (Yaml.Documents) sourceFile;
+        Yaml.Document document = documents.getDocuments().get(0);
+
+        // Assert that end is parsed correctly
+        Assertions.assertThat(document.getEnd().getPrefix()).isEqualTo("\n");
+
+        // Assert that the title is parsed correctly
+        Yaml.Mapping mapping = (Yaml.Mapping) document.getBlock();
+        Yaml.Mapping.Entry entry = mapping.getEntries().get(0);
+        Yaml.Scalar title = (Yaml.Scalar) entry.getValue();
+        Assertions.assertThat(title.getValue()).isEqualTo(input);
+    }
+
+}

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -15,35 +15,41 @@
  */
 package org.openrewrite.yaml;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.SourceFile;
+import org.openrewrite.tree.ParseError;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class YamlParserTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-      "Breaking Changes",
-      "Breaking Changes 🛠"
+      "b",
+      "🛠",
+      "🛠🛠",
+      "🛠 🛠"
     })
     void parseYamlWithUnicode(String input) {
-        Stream<SourceFile> yamlSources = YamlParser.builder().build().parse("title: %s\n".formatted(input));
+        Stream<SourceFile> yamlSources = YamlParser.builder().build().parse("a: %s\n".formatted(input));
         SourceFile sourceFile = yamlSources.findFirst().get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+
         Yaml.Documents documents = (Yaml.Documents) sourceFile;
         Yaml.Document document = documents.getDocuments().get(0);
 
         // Assert that end is parsed correctly
-        Assertions.assertThat(document.getEnd().getPrefix()).isEqualTo("\n");
+        assertThat(document.getEnd().getPrefix()).isEqualTo("\n");
 
         // Assert that the title is parsed correctly
         Yaml.Mapping mapping = (Yaml.Mapping) document.getBlock();
         Yaml.Mapping.Entry entry = mapping.getEntries().get(0);
         Yaml.Scalar title = (Yaml.Scalar) entry.getValue();
-        Assertions.assertThat(title.getValue()).isEqualTo(input);
+        assertThat(title.getValue()).isEqualTo(input);
     }
 
 }


### PR DESCRIPTION
## What's changed?
Add a test to verify how a Unicode suffix is parsed in Yaml.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/2062
