### PR TITLE
Checking RecipeIntrospectionUtils in rewrite-test

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.test.RewriteTest;
@@ -56,6 +58,7 @@ class RecipeSchedulerTest implements RewriteTest {
     }
 }
 
+@AllArgsConstructor
 class BoomRecipe extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-core/src/test/java/org/openrewrite/table/RecipeRunStatsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/table/RecipeRunStatsTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.table;
 
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
 import org.openrewrite.marker.SearchResult;
@@ -28,6 +29,7 @@ import static org.openrewrite.test.SourceSpecs.text;
 
 public class RecipeRunStatsTest implements RewriteTest {
 
+    @AllArgsConstructor
     static class RecipeWithApplicabilityTest extends Recipe {
         @Override
         public String getDisplayName() {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ExtractInterfaceTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ExtractInterfaceTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java;
 
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
 import org.openrewrite.java.tree.J;
@@ -29,6 +30,7 @@ import static org.openrewrite.java.Assertions.java;
 
 class ExtractInterfaceTest implements RewriteTest {
 
+    @AllArgsConstructor
     private static class ExtractTestInterface extends ScanningRecipe<AtomicReference<J.CompilationUnit>> {
         @Override
         public String getDisplayName() {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AssertionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AssertionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.maven;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,6 +95,7 @@ class AssertionsTest implements RewriteTest {
         assertThat(xmlCount.get()).isEqualTo(2);
     }
 
+    @AllArgsConstructor
     private static class MavenOnlyRecipe extends Recipe {
         @Override
         public String getDisplayName() {

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.*;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.OptionDescriptor;
+import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
@@ -41,8 +42,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.openrewrite.internal.StringUtils.trimIndentPreserveCRLF;
 
 @SuppressWarnings("unused")
@@ -163,6 +163,9 @@ public interface RewriteTest extends SourceSpecs {
             assertThat(recipeSerializer.read(recipeSerializer.write(recipe)))
                     .as("Recipe must be serializable/deserializable")
                     .isEqualTo(recipe);
+            assertThatCode(() -> RecipeIntrospectionUtils.constructRecipe(recipe.getClass()))
+                    .as("Recipe must be able to instantiate via RecipeIntrospectionUtils")
+                    .doesNotThrowAnyException();
             validateRecipeNameAndDescription(recipe);
             validateRecipeOptions(recipe);
         }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -171,8 +171,8 @@ public interface RewriteTest extends SourceSpecs {
                 // We add recipes to HashSet in some places, we need to validate that hashCode and equals does not fail.
                 //noinspection ResultOfMethodCallIgnored
                 r.hashCode();
-                //noinspection EqualsWithItself
-                assert r.equals(r);
+                //noinspection EqualsWithItself,ResultOfMethodCallIgnored
+                r.equals(r);
             })
                     .as("Recipe must be able to instantiate via RecipeIntrospectionUtils")
                     .doesNotThrowAnyException();


### PR DESCRIPTION
## What's changed?
Added checking if a recipe can be instantiated via RecipeIntrospectionUtils, because we are using it to get RecipeDescriptor, and if they fail because of null parameters it will make the recipe execution to fail in SaaS, CLI and build plugins.

## What's your motivation?
Recent changes in #3404
