### PR TITLE
Visit markers on RemoteVisitor

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/remote/RemoteVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/remote/RemoteVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,6 @@ public class RemoteVisitor<P> extends TreeVisitor<Remote, P> {
     }
 
     public Remote visitRemote(Remote remote, P p) {
-        return remote;
+        return remote.withMarkers(visitMarkers(remote.getMarkers(), p));
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteVisitorTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteVisitorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.remote;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.Markup;
+import org.openrewrite.marker.SearchResult;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RemoteVisitorTest {
+
+    @Test
+    void visitsMarkers() throws URISyntaxException {
+        AtomicBoolean markersVisited = new AtomicBoolean();
+        RemoteVisitor<Integer> remoteVisitor = new RemoteVisitor<>() {
+            @Override
+            public Markers visitMarkers(@Nullable Markers markers, Integer integer) {
+                Markers m = super.visitMarkers(markers, integer);
+                markersVisited.set(true);
+                return m;
+            }
+        };
+        remoteVisitor.visitRemote(new RemoteArchive(
+          Tree.randomId(),
+          Path.of("foo/bar/gradle-wrapper.jar"),
+          Markers.EMPTY,
+          new URI("https://gradle.gradle/gradle-wrapper.jar"),
+          null,
+          false,
+          null,
+          "Gradle wrapper jar",
+          Collections.emptyList(),
+          null
+        ), 0);
+
+        assertThat(markersVisited.get()).isTrue();
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Visit markers on `Remote` file types.

## What's your motivation?

Markers are visited in every other SourceFile type and I believe this should be standard. If not accepted, this could lead to a problem where a recipe author believes that `visitMarkers` should be called and isn't within a recipe.

## Anything in particular you'd like reviewers to focus on?

N/A

## Anyone you would like to review specifically?

@sambsnyd 

## Have you considered any alternatives or workarounds?

N/A

## Any additional context

N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
