### PR TITLE
fix: RemoteFile/RemoteArchive can now handle multiple threads trying to download the same file without error.

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/remote/BlackHoleOutputStream.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/BlackHoleOutputStream.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.remote;
+
+import java.io.OutputStream;
+
+public class BlackHoleOutputStream extends OutputStream {
+    @Override
+    public void write(int b) {
+        // Do nothing. This is used for testing length of input stream. See RemoteArchiveTest and RemoteFileTest
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteArchiveTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteArchiveTest.java
@@ -56,11 +56,11 @@ class RemoteArchiveTest {
     @ParameterizedTest
     @ValueSource(strings = {"7.4.2", "7.5-rc-1", "7.6"})
     void gradleWrapperConcurrent(String version) throws Exception {
-        int NUM_EXECUTIONS = 5;
-        ExecutorService executorService = Executors.newFixedThreadPool(NUM_EXECUTIONS);
+        int executionCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(executionCount);
         CompletionService<byte[]> completionService = new ExecutorCompletionService<>(executorService);
 
-        for (int i = 0; i < NUM_EXECUTIONS; i++) {
+        for (int i = 0; i < executionCount; i++) {
             completionService.submit(() -> {
                 URL distributionUrl = requireNonNull(RemoteArchiveTest.class.getClassLoader()
                   .getResource("gradle-" + version + "-bin.zip"));
@@ -80,11 +80,12 @@ class RemoteArchiveTest {
             });
         }
 
-        for (int i = 0; i < NUM_EXECUTIONS; i++) {
+        for (int i = 0; i < executionCount; i++) {
             Future<byte[]> result = completionService.take();
             byte[] actual = result.get();
-            assertThat(actual).hasSizeGreaterThan(50_000);
+            assertThat(actual).hasSizeGreaterThan(800);
         }
+        
         executorService.shutdown();
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteArchiveTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteArchiveTest.java
@@ -83,9 +83,9 @@ class RemoteArchiveTest {
         for (int i = 0; i < executionCount; i++) {
             Future<byte[]> result = completionService.take();
             byte[] actual = result.get();
-            assertThat(actual).hasSizeGreaterThan(800);
+            assertThat(actual).hasSizeGreaterThan(50_000);
         }
-        
+
         executorService.shutdown();
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
@@ -55,11 +55,11 @@ class RemoteFileTest {
 
     @Test
     void gradleWrapperPropertiesConcurrent() throws Exception {
-        int NUM_EXECUTIONS = 5;
-        ExecutorService executorService = Executors.newFixedThreadPool(NUM_EXECUTIONS);
+        int executionCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(executionCount);
         CompletionService<byte[]> completionService = new ExecutorCompletionService<>(executorService);
 
-        for (int i = 0; i < NUM_EXECUTIONS; i++) {
+        for (int i = 0; i < executionCount; i++) {
             completionService.submit(() -> {
                 URL distributionUrl = requireNonNull(RemoteFileTest.class.getClassLoader().getResource("gradle-wrapper.properties"));
 
@@ -73,15 +73,15 @@ class RemoteFileTest {
                     distributionUrl.toURI()
                   )
                   .build();
-                
+
                 return readAll(remoteFile.getInputStream(ctx));
             });
         }
 
-        for (int i = 0; i < NUM_EXECUTIONS; i++) {
+        for (int i = 0; i < executionCount; i++) {
             Future<byte[]> result = completionService.take();
             byte[] actual = result.get();
-            assertThat(actual).hasSizeGreaterThanOrEqualTo(223);
+            assertThat(actual).hasSizeGreaterThan(800);
         }
 
         executorService.shutdown();

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
@@ -50,7 +50,7 @@ class RemoteFileTest {
           .build();
 
         byte[] actual = readAll(remoteFile.getInputStream(ctx));
-        assertThat(actual).hasSizeGreaterThanOrEqualTo(223);
+        assertThat(actual).hasSizeGreaterThanOrEqualTo(800);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.remote;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.ExecutionContext;
@@ -32,59 +33,57 @@ import java.util.concurrent.*;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RemoteArchiveTest {
+class RemoteFileTest {
 
-    @ParameterizedTest
-    @ValueSource(strings = {"7.4.2", "7.5-rc-1", "7.6"})
-    void gradleWrapper(String version) throws Exception {
-        URL distributionUrl = requireNonNull(RemoteArchiveTest.class.getClassLoader().getResource("gradle-" + version + "-bin.zip"));
+    @Test
+    void gradleWrapperProperties() throws Exception {
+        URL distributionUrl = requireNonNull(RemoteFileTest.class.getClassLoader().getResource("gradle-wrapper.properties"));
         ExecutionContext ctx = new InMemoryExecutionContext();
         HttpSenderExecutionContextView.view(ctx)
           .setLargeFileHttpSender(new MockHttpSender(distributionUrl::openStream));
 
-        RemoteArchive remoteArchive = Remote
+        RemoteFile remoteFile = Remote
           .builder(
-            Paths.get("gradle/wrapper/gradle-wrapper.jar"),
+            Paths.get("gradle/wrapper/gradle-wrapper.properties"),
             distributionUrl.toURI()
           )
-          .build("gradle-[^\\/]+\\/(?:.*\\/)+gradle-wrapper-(?!shared).*\\.jar");
+          .build();
 
-        byte[] actual = readAll(remoteArchive.getInputStream(ctx));
-        assertThat(actual).hasSizeGreaterThan(50_000);
+        byte[] actual = readAll(remoteFile.getInputStream(ctx));
+        assertThat(actual).hasSizeGreaterThanOrEqualTo(223);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"7.4.2", "7.5-rc-1", "7.6"})
-    void gradleWrapperConcurrent(String version) throws Exception {
+    @Test
+    void gradleWrapperPropertiesConcurrent() throws Exception {
         int NUM_EXECUTIONS = 5;
         ExecutorService executorService = Executors.newFixedThreadPool(NUM_EXECUTIONS);
         CompletionService<byte[]> completionService = new ExecutorCompletionService<>(executorService);
 
         for (int i = 0; i < NUM_EXECUTIONS; i++) {
             completionService.submit(() -> {
-                URL distributionUrl = requireNonNull(RemoteArchiveTest.class.getClassLoader()
-                  .getResource("gradle-" + version + "-bin.zip"));
+                URL distributionUrl = requireNonNull(RemoteFileTest.class.getClassLoader().getResource("gradle-wrapper.properties"));
 
                 ExecutionContext ctx = new InMemoryExecutionContext();
                 HttpSenderExecutionContextView.view(ctx)
                   .setLargeFileHttpSender(new MockHttpSender(distributionUrl::openStream));
 
-                RemoteArchive remoteArchive = Remote
+                RemoteFile remoteFile = Remote
                   .builder(
-                    Paths.get("gradle/wrapper/gradle-wrapper.jar"),
+                    Paths.get("gradle/wrapper/gradle-wrapper.properties"),
                     distributionUrl.toURI()
                   )
-                  .build("gradle-[^\\/]+\\/(?:.*\\/)+gradle-wrapper-(?!shared).*\\.jar");
-
-                return readAll(remoteArchive.getInputStream(ctx));
+                  .build();
+                
+                return readAll(remoteFile.getInputStream(ctx));
             });
         }
 
         for (int i = 0; i < NUM_EXECUTIONS; i++) {
             Future<byte[]> result = completionService.take();
             byte[] actual = result.get();
-            assertThat(actual).hasSizeGreaterThan(50_000);
+            assertThat(actual).hasSizeGreaterThanOrEqualTo(223);
         }
+
         executorService.shutdown();
     }
 

--- a/rewrite-core/src/test/resources/gradle-wrapper.properties
+++ b/rewrite-core/src/test/resources/gradle-wrapper.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
## What's changed?
Each remote download will get a unique UUID so there are no collisions with the downloads.  Added tests for RemoteArchive and RemoteFile

## What's your motivation?
Currently when multiple threads are trying to download through the RemoteArchve or RemoteFile a `java.util.concurrent.ExecutionException` is thrown 

e.g. 
```
java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: Unable to load path [gradle-[^\/]+\/(?:.*\/)+gradle-(plugins|wrapper)-(?!shared).*\.jar, gradle-wrapper.jar] in zip file https://services.gradle.org/distributions/gradle-7.6.2-bin.zip
  java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
  java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
Caused by java.lang.IllegalArgumentException: Unable to load path [gradle-[^\/]+\/(?:.*\/)+gradle-(plugins|wrapper)-(?!shared).*\.jar, gradle-wrapper.jar] in zip file https://services.gradle.org/distributions/gradle-7.6.2-bin.zip
  org.openrewrite.remote.RemoteArchive.readIntoArchive(RemoteArchive.java:144)
  org.openrewrite.remote.RemoteArchive.getInputStream(RemoteArchive.java:104)
  org.openrewrite.remote.Remote$1.visit(Remote.java:119)
  org.openrewrite.remote.Remote$1.visit(Remote.java:113)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:184)
  org.openrewrite.Tree.print(Tree.java:94)
  org.openrewrite.SourceFile.printAll(SourceFile.java:78)
  org.openrewrite.Result.diff(Result.java:175)
  ```

## Any additional context
Related to: https://github.com/moderneinc/customer-requests/issues/25

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
