### PR TITLE
Turn YAML files with unicode into ParseErrors

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -78,8 +78,8 @@ class FormatPreservingReader extends Reader {
             buffer.ensureCapacity(buffer.size() + read);
             for (int i = 0; i < read; i++) {
                 char e = cbuf[i];
-                if (Character.UnicodeBlock.of(e) != Character.UnicodeBlock.BASIC_LATIN && i % 2 == 0) {
-                    bufferIndex--;
+                if (Character.UnicodeBlock.of(e) != Character.UnicodeBlock.BASIC_LATIN) {
+                    throw new IllegalArgumentException("Only ASCII characters are supported for now");
                 }
                 buffer.add(e);
             }


### PR DESCRIPTION
## What's changed?
Turn YAML files with unicode into ParseErrors

## What's your motivation?
#3421 is proving difficult to resolve on short notice, and we'd rather have most of the project parsed rather than none of the project.