### PR TITLE
Update `AutoFormat` to be more generic to support J-extended language like Kotlin

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -19,8 +19,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.openrewrite.formatting.IndentType;
 import org.openrewrite.internal.MetricsHelper;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
@@ -35,6 +37,8 @@ public interface Tree {
     default String getJacksonPolymorphicTypeTag() {
         return getClass().getName();
     }
+
+    default IndentType getIndentType() { return IndentType.NONE; }
 
     static UUID randomId() {
         //noinspection ConstantConditions

--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -38,7 +38,9 @@ public interface Tree {
         return getClass().getName();
     }
 
-    default IndentType getIndentType() { return IndentType.NONE; }
+    default IndentType getIndentType() {
+        return IndentType.NONE;
+    }
 
     static UUID randomId() {
         //noinspection ConstantConditions

--- a/rewrite-core/src/main/java/org/openrewrite/formatting/IndentType.java
+++ b/rewrite-core/src/main/java/org/openrewrite/formatting/IndentType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.formatting;
+
+public enum IndentType {
+    NONE,
+    ALIGN,
+    INDENT,
+    CONTINUATION_INDENT
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -1563,8 +1563,8 @@ class TabsAndIndentsTest implements RewriteTest {
               public class Test {
                   public Test method(int n) {
                       return n > 0 ?
-                          this :
-                          method(n).method(n);
+                       this :
+                                method(n).method(n);
                   }
               }
               """,
@@ -1572,8 +1572,8 @@ class TabsAndIndentsTest implements RewriteTest {
               public class Test {
                   public Test method(int n) {
                       return n > 0 ?
-                              this :
-                              method(n).method(n);
+                          this :
+                          method(n).method(n);
                   }
               }
               """
@@ -1769,8 +1769,8 @@ class TabsAndIndentsTest implements RewriteTest {
                         ::
                         plus;
                       if (x
-                        >
-                        0) {
+                          >
+                          0) {
                           int someVariable = a ?
                             x :
                             y;
@@ -1781,7 +1781,7 @@ class TabsAndIndentsTest implements RewriteTest {
                             y;
                       }
                       x
-                        ++;
+                          ++;
                       X
                         [
                         1

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -1572,8 +1572,8 @@ class TabsAndIndentsTest implements RewriteTest {
               public class Test {
                   public Test method(int n) {
                       return n > 0 ?
-                          this :
-                          method(n).method(n);
+                              this :
+                              method(n).method(n);
                   }
               }
               """
@@ -1769,8 +1769,8 @@ class TabsAndIndentsTest implements RewriteTest {
                         ::
                         plus;
                       if (x
-                          >
-                          0) {
+                        >
+                        0) {
                           int someVariable = a ?
                             x :
                             y;
@@ -1781,7 +1781,7 @@ class TabsAndIndentsTest implements RewriteTest {
                             y;
                       }
                       x
-                          ++;
+                        ++;
                       X
                         [
                         1

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -1563,8 +1563,8 @@ class TabsAndIndentsTest implements RewriteTest {
               public class Test {
                   public Test method(int n) {
                       return n > 0 ?
-                       this :
-                                method(n).method(n);
+                          this :
+                          method(n).method(n);
                   }
               }
               """,

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -44,14 +44,14 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
 
     @Override
     public boolean isAcceptable(SourceFile sourceFile, P p) {
-        return sourceFile instanceof J.CompilationUnit;
+        return sourceFile instanceof JavaSourceFile;
     }
 
     @Override
     public J visit(@Nullable Tree tree, P p, Cursor cursor) {
-        JavaSourceFile cu = (tree instanceof JavaSourceFile) ?
-                (JavaSourceFile) tree :
-                cursor.firstEnclosingOrThrow(JavaSourceFile.class);
+        SourceFile cu = (tree instanceof SourceFile) ?
+                (SourceFile) tree :
+                cursor.firstEnclosingOrThrow(SourceFile.class);
 
         J t = new NormalizeFormatVisitor<>(stopAfter).visit(tree, p, cursor.fork());
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutodetectGeneralFormatStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutodetectGeneralFormatStyle.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.format;
 
+import org.openrewrite.SourceFile;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Space;
@@ -26,7 +27,7 @@ public class AutodetectGeneralFormatStyle extends JavaIsoVisitor<LineEndingsCoun
      * Makes a best-effort attempt to determine whether windows-style (CRLF) line endings or unix-style (LF) are
      * more common in the supplied AST.
      */
-    public static GeneralFormatStyle autodetectGeneralFormatStyle(JavaSourceFile j) {
+    public static GeneralFormatStyle autodetectGeneralFormatStyle(SourceFile j) {
         LineEndingsCount count = new LineEndingsCount();
         new AutodetectGeneralFormatStyle().visit(j, count);
         if(count.lf >= count.crlf) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaks.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaks.java
@@ -46,8 +46,8 @@ public class NormalizeLineBreaks extends Recipe {
     private static class LineBreaksFromCompilationUnitStyle extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
-            if (tree instanceof JavaSourceFile) {
-                JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+            if (tree instanceof SourceFile) {
+                SourceFile cu = (SourceFile) requireNonNull(tree);
                 GeneralFormatStyle generalFormatStyle = ((SourceFile) cu).getStyle(GeneralFormatStyle.class);
                 if (generalFormatStyle == null) {
                     generalFormatStyle = autodetectGeneralFormatStyle(cu);

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.format;
 
 import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
+import org.openrewrite.formatting.IndentType;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -78,25 +79,9 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
     @Override
     @Nullable
     public J preVisit(@Nullable J tree, P p) {
-        if (tree instanceof JavaSourceFile ||
-                tree instanceof J.Package ||
-                tree instanceof J.Import ||
-                tree instanceof J.Label ||
-                tree instanceof J.DoWhileLoop ||
-                tree instanceof J.ArrayDimension ||
-                tree instanceof J.ClassDeclaration) {
-            getCursor().putMessage("indentType", IndentType.ALIGN);
-        } else if (tree instanceof J.Block ||
-                tree instanceof J.If ||
-                tree instanceof J.If.Else ||
-                tree instanceof J.ForLoop ||
-                tree instanceof J.ForEachLoop ||
-                tree instanceof J.WhileLoop ||
-                tree instanceof J.Case ||
-                tree instanceof J.EnumValueSet) {
-            getCursor().putMessage("indentType", IndentType.INDENT);
-        } else {
-            getCursor().putMessage("indentType", IndentType.CONTINUATION_INDENT);
+        IndentType indentType = tree != null ? tree.getIndentType() : IndentType.NONE;
+        if (indentType != IndentType.NONE) {
+            getCursor().putMessage("indentType", indentType);
         }
 
         return tree;
@@ -623,11 +608,5 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
             return (J) tree;
         }
         return super.visit(tree, p);
-    }
-
-    private enum IndentType {
-        ALIGN,
-        INDENT,
-        CONTINUATION_INDENT
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
+import org.openrewrite.formatting.IndentType;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.LoathingOfOthers;
 import org.openrewrite.internal.SelfLoathing;
@@ -70,6 +72,9 @@ public interface J extends Tree {
     }
 
     <J2 extends J> J2 withPrefix(Space space);
+
+    @Override
+    default IndentType getIndentType() { return IndentType.CONTINUATION_INDENT; }
 
     Space getPrefix();
 
@@ -767,6 +772,11 @@ public interface J extends Tree {
             return v.visitBlock(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.INDENT;
+        }
+
         @Transient
         public CoordinateBuilder.Block getCoordinates() {
             return new CoordinateBuilder.Block(this);
@@ -934,6 +944,11 @@ public interface J extends Tree {
 
         public Type getType() {
             return type == null ? Type.Statement : type;
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.INDENT;
         }
 
         /**
@@ -1140,6 +1155,11 @@ public interface J extends Tree {
 
         public ClassDeclaration withTypeParameters(@Nullable List<TypeParameter> typeParameters) {
             return getPadding().withTypeParameters(JContainer.withElementsNullable(this.typeParameters, typeParameters));
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.ALIGN;
         }
 
         @Nullable
@@ -1677,6 +1697,11 @@ public interface J extends Tree {
             return new CoordinateBuilder.Statement(this);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.ALIGN;
+        }
+
         public Padding getPadding() {
             Padding p;
             if (this.padding == null) {
@@ -1826,6 +1851,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitEnumValueSet(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.INDENT;
         }
 
         @Override
@@ -2036,6 +2066,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitForEachLoop(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.INDENT;
         }
 
         @Override
@@ -2433,6 +2468,11 @@ public interface J extends Tree {
         }
 
         @Override
+        public IndentType getIndentType() {
+            return IndentType.INDENT;
+        }
+
+        @Override
         @Transient
         public CoordinateBuilder.Statement getCoordinates() {
             return new CoordinateBuilder.Statement(this);
@@ -2474,6 +2514,11 @@ public interface J extends Tree {
             @Override
             public <P> J acceptJava(JavaVisitor<P> v, P p) {
                 return v.visitElse(this, p);
+            }
+
+            @Override
+            public IndentType getIndentType() {
+                return IndentType.INDENT;
             }
 
             public Padding getPadding() {
@@ -2564,6 +2609,11 @@ public interface J extends Tree {
 
         @Nullable
         JLeftPadded<J.Identifier> alias;
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.ALIGN;
+        }
 
         public boolean isStatic() {
             return statik.getElement();
@@ -2890,6 +2940,11 @@ public interface J extends Tree {
          * Right padded before the ':'
          */
         JRightPadded<Identifier> label;
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.ALIGN;
+        }
 
         public Identifier getLabel() {
             return label.getElement();
@@ -4045,6 +4100,11 @@ public interface J extends Tree {
             return v.visitArrayDimension(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.ALIGN;
+        }
+
         public Padding getPadding() {
             Padding p;
             if (this.padding == null) {
@@ -4270,6 +4330,10 @@ public interface J extends Tree {
         @With
         List<Annotation> annotations;
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.ALIGN;
+        }
 
         public String getPackageName() {
             return expression.withPrefix(Space.EMPTY).print(new Cursor(null,
@@ -5705,6 +5769,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitWhileLoop(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.INDENT;
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -667,6 +667,11 @@ public interface J extends Tree {
             return v.visitBinary(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
         @Transient
         public CoordinateBuilder.Expression getCoordinates() {
             return new CoordinateBuilder.Expression(this);
@@ -2431,11 +2436,6 @@ public interface J extends Tree {
             return v.visitIdentifier(this, p);
         }
 
-        @Override
-        public IndentType getIndentType() {
-            return IndentType.CONTINUATION_INDENT;
-        }
-
         @Transient
         public CoordinateBuilder.Identifier getCoordinates() {
             return new CoordinateBuilder.Identifier(this);
@@ -3338,6 +3338,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitMemberReference(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         public Padding getPadding() {
@@ -4966,6 +4971,11 @@ public interface J extends Tree {
             return v.visitTernary(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
         public Padding getPadding() {
             Padding p;
             if (this.padding == null) {
@@ -5473,6 +5483,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitUnary(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -74,7 +74,9 @@ public interface J extends Tree {
     <J2 extends J> J2 withPrefix(Space space);
 
     @Override
-    default IndentType getIndentType() { return IndentType.CONTINUATION_INDENT; }
+    default IndentType getIndentType() {
+        return IndentType.NONE;
+    }
 
     Space getPrefix();
 
@@ -216,6 +218,11 @@ public interface J extends Tree {
             return v.visitAnnotation(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
         @Transient
         public CoordinateBuilder.Annotation getCoordinates() {
             return new CoordinateBuilder.Annotation(this);
@@ -283,6 +290,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitArrayAccess(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         @Transient
@@ -435,6 +447,11 @@ public interface J extends Tree {
         }
 
         @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
+        @Override
         @Transient
         public List<J> getSideEffects() {
             return singletonList(this);
@@ -522,6 +539,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitAssignmentOperation(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         @Override
@@ -2409,6 +2431,11 @@ public interface J extends Tree {
             return v.visitIdentifier(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
         @Transient
         public CoordinateBuilder.Identifier getCoordinates() {
             return new CoordinateBuilder.Identifier(this);
@@ -3036,6 +3063,11 @@ public interface J extends Tree {
         }
 
         @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
+        @Override
         @Transient
         public CoordinateBuilder.Statement getCoordinates() {
             return new CoordinateBuilder.Statement(this);
@@ -3159,6 +3191,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitLiteral(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         @Transient
@@ -3503,6 +3540,11 @@ public interface J extends Tree {
             return v.visitMethodDeclaration(this, p);
         }
 
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
         public boolean isAbstract() {
             return body == null;
         }
@@ -3759,6 +3801,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitMethodInvocation(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         @Override
@@ -4026,6 +4073,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitNewArray(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         @Transient
@@ -4760,6 +4812,11 @@ public interface J extends Tree {
         }
 
         @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
+        @Override
         @Transient
         public CoordinateBuilder.Statement getCoordinates() {
             return new CoordinateBuilder.Statement(this);
@@ -5052,6 +5109,11 @@ public interface J extends Tree {
         }
 
         @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
+        @Override
         @Transient
         public CoordinateBuilder.Statement getCoordinates() {
             return new CoordinateBuilder.Statement(this);
@@ -5260,6 +5322,11 @@ public interface J extends Tree {
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitTypeParameter(this, p);
+        }
+
+        @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
         }
 
         public Padding getPadding() {
@@ -5537,6 +5604,11 @@ public interface J extends Tree {
         }
 
         @Override
+        public IndentType getIndentType() {
+            return IndentType.CONTINUATION_INDENT;
+        }
+
+        @Override
         @Transient
         public CoordinateBuilder.VariableDeclarations getCoordinates() {
             return new CoordinateBuilder.VariableDeclarations(this);
@@ -5644,6 +5716,11 @@ public interface J extends Tree {
             @Override
             public <P> J acceptJava(JavaVisitor<P> v, P p) {
                 return v.visitVariable(this, p);
+            }
+
+            @Override
+            public IndentType getIndentType() {
+                return IndentType.CONTINUATION_INDENT;
             }
 
             public Cursor getDeclaringScope(Cursor cursor) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -15,14 +15,16 @@
  */
 package org.openrewrite.java.tree;
 
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.SourceFile;
+import org.openrewrite.formatting.IndentType;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.TypesInUse;
 
 import java.nio.file.Path;
 import java.util.List;
 
-public interface JavaSourceFile extends J {
+public interface JavaSourceFile extends SourceFile, J {
     TypesInUse getTypesInUse();
 
     @Nullable
@@ -30,9 +32,9 @@ public interface JavaSourceFile extends J {
 
     JavaSourceFile withPackageDeclaration(J.Package pkg);
 
-    List<Import> getImports();
+    List<J.Import> getImports();
 
-    JavaSourceFile withImports(List<Import> imports);
+    JavaSourceFile withImports(List<J.Import> imports);
 
     List<J.ClassDeclaration> getClasses();
 
@@ -51,8 +53,13 @@ public interface JavaSourceFile extends J {
 
     SourceFile withSourcePath(Path path);
 
+    @Override
+    default IndentType getIndentType() {
+        return IndentType.ALIGN;
+    }
+
     interface Padding {
-        List<JRightPadded<Import>> getImports();
-        JavaSourceFile withImports(List<JRightPadded<Import>> imports);
+        List<JRightPadded<J.Import>> getImports();
+        JavaSourceFile withImports(List<JRightPadded<J.Import>> imports);
     }
 }


### PR DESCRIPTION
As we know, currently, `AutoFormat` doesn't support Kotlin well.
This PR is intended to update `AutoFormat` to be more generic to support J-extended language like Kotlin.


