### PR TITLE
Restore now deprecated constructors pending module migrations

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2349,6 +2349,7 @@ public interface J extends Tree {
 
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @AllArgsConstructor
     @With
     class Identifier implements J, TypeTree, Expression {
         @Getter
@@ -3798,6 +3799,7 @@ public interface J extends Tree {
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @AllArgsConstructor
     @Data
     final class Modifier implements J {
         public static boolean hasModifier(Collection<Modifier> modifiers, Modifier.Type modifier) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2371,6 +2371,20 @@ public interface J extends Tree {
         @Nullable
         JavaType.Variable fieldType;
 
+        /**
+         * @deprecated Use {@link #Identifier(UUID, Space, Markers, List, String, JavaType, JavaType.Variable)} instead.
+         */
+        @Deprecated
+        public Identifier(UUID id, Space prefix, Markers markers, String simpleName, @Nullable JavaType type, @Nullable JavaType.Variable fieldType) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.annotations = emptyList();
+            this.simpleName = simpleName;
+            this.type = type;
+            this.fieldType = fieldType;
+        }
+
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {
             return v.visitIdentifier(this, p);
@@ -3814,6 +3828,19 @@ public interface J extends Tree {
         @With
         @Getter
         List<Annotation> annotations;
+
+        /**
+         * @deprecated Use {@link #Modifier(UUID, Space, Markers, String, Type, List)} instead.
+         */
+        @Deprecated
+        public Modifier(UUID id, Space prefix, Markers markers, Type type, List<Annotation> annotations) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.keyword = null;
+            this.type = type;
+            this.annotations = annotations;
+        }
 
         @Override
         public String toString() {


### PR DESCRIPTION
## What's changed?
Restore constructors as they were before https://github.com/openrewrite/rewrite/commit/df5478b8592d90bba65923878b08ae0a412fdbc9 to aid migration of modules and allow gradual adoption.

## What's your motivation?
Reported errors with deployed snapshots.

## Anything in particular you'd like reviewers to focus on?
Can't imagine this would trip up serialization, but pointing it out just in case.

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
Fix it everywhere, but since it's on the weekend and I'm about to head out this was easier.

## Any additional context
https://github.com/openrewrite/rewrite/commit/df5478b8592d90bba65923878b08ae0a412fdbc9\