### PR TITLE
Prevent NPE on null Space of unknown origin

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -151,7 +151,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
 
     @SuppressWarnings("unused")
     public Space visitSpace(Space space, Space.Location loc, P p) {
-        return space == Space.EMPTY || space == Space.SINGLE_SPACE ? space :
+        return space == Space.EMPTY || space == Space.SINGLE_SPACE || space == null ? space :
                 space.withComments(ListUtils.map(space.getComments(), comment -> {
                     if (comment instanceof Javadoc) {
                         if (javadocVisitor == null) {


### PR DESCRIPTION
## What's changed?
Prevent NPE on Space.getComments

## What's your motivation?
Seen in CLI tests; not clear where the error originates, so perhaps easiest to not blow up here over it.
```
Running recipe in github.com/Netflix/conductor@main
org.openrewrite.internal.RecipeRunException: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.Space.getComments()" because "space" is null
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:329)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:184)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.lambda$editSources$3(RecipeScheduler.java:231)
	at io.micrometer.core.instrument.AbstractTimer.recordCallable(AbstractTimer.java:147)
	at org.openrewrite.table.RecipeRunStats.recordEdit(RecipeRunStats.java:56)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.lambda$editSources$4(RecipeScheduler.java:228)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.lambda$mapForRecipeRecursively$5(RecipeScheduler.java:330)
	at io.moderne.serialization.ModerneLargeSourceSet.edit(Unknown Source)
	at io.moderne.serialization.ModerneLargeSourceSet.edit(Unknown Source)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.mapForRecipeRecursively(RecipeScheduler.java:323)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.editSources(RecipeScheduler.java:201)
	at org.openrewrite.RecipeScheduler.scheduleRun(RecipeScheduler.java:76)
	at org.openrewrite.Recipe.run(Recipe.java:279)
	at org.openrewrite.Recipe.run(Recipe.java:275)
	at org.openrewrite.Recipe.run(Recipe.java:271)
	at io.moderne.modjava.commands.run.Run.call(Run.java:151)
	at io.moderne.modjava.commands.run.Run.call(Run.java:38)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at io.moderne.modjava.ModJava.main(ModJava.java:28)
Caused by: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.Space.getComments()" because "space" is null
	at org.openrewrite.java.JavaVisitor.visitSpace(JavaVisitor.java:155)
	at org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1293)
	at org.openrewrite.java.JavaVisitor.visitCompilationUnit(JavaVisitor.java:463)
	at org.openrewrite.java.tree.J$CompilationUnit.acceptJava(J.java:1520)
	at org.openrewrite.java.tree.J.accept(J.java:59)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
	... 25 more
Error:  java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.Space.getComments()" because "space" is null
org.openrewrite.internal.RecipeRunException: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.Space.getComments()" because "space" is null
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:329)
	at io.moderne.serialization.ModerneLargeSourceSet.a(Unknown Source)
	at io.moderne.serialization.ModerneLargeSourceSet.edit(Unknown Source)
	at io.moderne.serialization.ModerneLargeSourceSet.edit(Unknown Source)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.mapForRecipeRecursively(RecipeScheduler.java:323)
	at org.openrewrite.RecipeScheduler$RecipeRunCycle.editSources(RecipeScheduler.java:201)
	at org.openrewrite.RecipeScheduler.scheduleRun(RecipeScheduler.java:76)
	at org.openrewrite.Recipe.run(Recipe.java:279)
	at org.openrewrite.Recipe.run(Recipe.java:275)
	at org.openrewrite.Recipe.run(Recipe.java:271)
	at io.moderne.modjava.commands.run.Run.call(Run.java:151)
	at io.moderne.modjava.commands.run.Run.call(Run.java:38)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at io.moderne.modjava.ModJava.main(ModJava.java:28)
Caused by: java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.Space.getComments()" because "space" is null
	at org.openrewrite.java.JavaVisitor.visitSpace(JavaVisitor.java:155)
	at org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1293)
	at org.openrewrite.java.JavaVisitor.visitCompilationUnit(JavaVisitor.java:463)
	at org.openrewrite.java.tree.J$CompilationUnit.acceptJava(J.java:1520)
	at org.openrewrite.java.tree.J.accept(J.java:59)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
	... 20 more
```

## Anything in particular you'd like reviewers to focus on?
Might it blow up elsewhere next?

## Have you considered any alternatives or workarounds?
Could try to fix it at the source, but that's unknown at this time, and potentially not the last time this will happen.