### PR TITLE
Added unpinned version test

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -99,7 +99,11 @@ public class ChangeDependency extends Recipe {
     Boolean overrideManagedVersion;
 
 
-    // Added constructor for compatibility with previous API
+    /**
+     * Keeping this constructor just for compatibility purposes
+     * @deprecated Use {@link ChangeDependency#ChangeDependency(String, String, String, String, String, String, Boolean)}
+     */
+    @Deprecated
     public ChangeDependency(String oldGroupId, String oldArtifactId, @Nullable String newGroupId, @Nullable String newArtifactId, @Nullable String newVersion, @Nullable String versionPattern) {
         this(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, null);
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -209,8 +209,7 @@ public class ChangeDependency extends Recipe {
                     }
                 } else if (m.getArguments().get(0) instanceof G.GString) {
                     List<J> strings = ((G.GString) depArgs.get(0)).getStrings();
-                    if (strings.size() >= 2 &&
-                            strings.get(0) instanceof J.Literal) {
+                    if (strings.size() >= 2 && strings.get(0) instanceof J.Literal) {
                         Dependency original = DependencyStringNotationConverter.parse((String) ((J.Literal) strings.get(0)).getValue());
                         if (depMatcher.matches(original.getGroupId(), original.getArtifactId())) {
                             Dependency updated = original;
@@ -278,7 +277,7 @@ public class ChangeDependency extends Recipe {
                             version = valueValue;
                         }
                     }
-                    if (groupId == null || artifactId == null || version == null) {
+                    if (groupId == null || artifactId == null) {
                         return m;
                     }
                     if (!depMatcher.matches(groupId, artifactId)) {
@@ -293,7 +292,7 @@ public class ChangeDependency extends Recipe {
                         updatedArtifactId = newArtifactId;
                     }
                     String updatedVersion = version;
-                    if (!StringUtils.isBlank(newVersion)) {
+                    if (!StringUtils.isBlank(newVersion) && (!StringUtils.isBlank(version) || Boolean.TRUE.equals(overrideManagedVersion))) {
                         List<MavenRepository> repositories = "classpath".equals(m.getSimpleName()) ?
                                 gradleProject.getMavenPluginRepositories() :
                                 gradleProject.getMavenRepositories();
@@ -309,7 +308,7 @@ public class ChangeDependency extends Recipe {
                         }
                     }
 
-                    if (!updatedGroupId.equals(groupId) || !updatedArtifactId.equals(artifactId) || !updatedVersion.equals(version)) {
+                    if (!updatedGroupId.equals(groupId) || !updatedArtifactId.equals(artifactId) || updatedVersion != null && !updatedVersion.equals(version)) {
                         G.MapEntry finalGroup = groupEntry;
                         String finalGroupIdValue = updatedGroupId;
                         G.MapEntry finalArtifact = artifactEntry;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@AllArgsConstructor(onConstructor_ = {@JsonCreator})
 @EqualsAndHashCode(callSuper = true)
 public class ChangeDependency extends Recipe {
     @Option(displayName = "Old groupId",
@@ -103,6 +102,17 @@ public class ChangeDependency extends Recipe {
     // Added constructor for compatibility with previous API
     public ChangeDependency(String oldGroupId, String oldArtifactId, @Nullable String newGroupId, @Nullable String newArtifactId, @Nullable String newVersion, @Nullable String versionPattern) {
         this(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, null);
+    }
+
+    @JsonCreator
+    public ChangeDependency(String oldGroupId, String oldArtifactId, @Nullable String newGroupId, @Nullable String newArtifactId, @Nullable String newVersion, @Nullable String versionPattern, @Nullable Boolean overrideManagedVersion) {
+        this.oldGroupId = oldGroupId;
+        this.oldArtifactId = oldArtifactId;
+        this.newGroupId = newGroupId;
+        this.newArtifactId = newArtifactId;
+        this.newVersion = newVersion;
+        this.versionPattern = versionPattern;
+        this.overrideManagedVersion = overrideManagedVersion;
     }
 
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -246,6 +246,44 @@ class ChangeDependencyTest implements RewriteTest {
     }
 
     @Test
+    void doNotPinWhenNotVersionedOnMap() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null, null)),
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly group: 'mysql', name: 'mysql-connector-java'
+              }
+              """,
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly group: 'com.mysql', name: 'mysql-connector-j'
+              }
+              """)
+        );
+    }
+
+    @Test
     void pinWhenOverrideManagedVersion() {
         rewriteRun(
           spec -> spec.recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null, true)),

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -33,7 +33,7 @@ class ChangeDependencyTest implements RewriteTest {
     @Test
     void relocateDependency() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", "commons-lang3", "3.11.x", null)),
+          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", "commons-lang3", "3.11.x", null, null)),
           buildGradle(
             """
               plugins {
@@ -70,7 +70,7 @@ class ChangeDependencyTest implements RewriteTest {
     @Test
     void changeGroupIdOnly() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", null, null, null)),
+          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", null, null, null, null)),
           buildGradle(
             """
               plugins {
@@ -107,7 +107,7 @@ class ChangeDependencyTest implements RewriteTest {
     @Test
     void changeArtifactIdOnly() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", null, "commons-lang3", null, null)),
+          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", null, "commons-lang3", null, null, null)),
           buildGradle(
             """
               plugins {
@@ -144,7 +144,7 @@ class ChangeDependencyTest implements RewriteTest {
     @Test
     void worksWithPlatform() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", "commons-lang3", "3.11.x", null)),
+          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", "commons-lang3", "3.11.x", null, null)),
           buildGradle(
             """
               plugins {
@@ -179,7 +179,7 @@ class ChangeDependencyTest implements RewriteTest {
     @Test
     void changeDependencyWithLowerVersionAfter() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependency("org.openrewrite", "plugin", "io.moderne", "moderne-gradle-plugin", "0.x", null)),
+          spec -> spec.recipe(new ChangeDependency("org.openrewrite", "plugin", "io.moderne", "moderne-gradle-plugin", "0.x", null, null)),
           buildGradle(
             """
               buildscript {
@@ -210,7 +210,7 @@ class ChangeDependencyTest implements RewriteTest {
     @Test
     void doNotPinWhenNotVersioned() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null)),
+          spec -> spec.recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null, null)),
           buildGradle(
             """
               plugins {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -177,6 +177,43 @@ class ChangeDependencyTest implements RewriteTest {
     }
 
     @Test
+    void worksWithGString() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependency("commons-lang", "commons-lang", "org.apache.commons", "commons-lang3", "3.11.x", null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              def version = '2.6'
+              dependencies {
+                  implementation platform("commons-lang:commons-lang:${version}")
+              }
+              """,
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+
+              def version = '2.6'
+              dependencies {
+                  implementation platform("org.apache.commons:commons-lang3:3.11")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void changeDependencyWithLowerVersionAfter() {
         rewriteRun(
           spec -> spec.recipe(new ChangeDependency("org.openrewrite", "plugin", "io.moderne", "moderne-gradle-plugin", "0.x", null, null)),

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -206,4 +206,42 @@ class ChangeDependencyTest implements RewriteTest {
           )
         );
     }
+    
+    @Test
+    void doNotPinWhenNotVersioned() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null)),
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'mysql:mysql-connector-java'
+              }
+              """,
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'com.mysql:mysql-connector-j'
+              }
+              """)
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -244,4 +244,42 @@ class ChangeDependencyTest implements RewriteTest {
               """)
         );
     }
+
+    @Test
+    void pinWhenOverrideManagedVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null, true)),
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'mysql:mysql-connector-java'
+              }
+              """,
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
+              }
+              """)
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
@@ -68,7 +68,7 @@ class ChangePluginTest implements RewriteTest {
     void changeApplyPluginSyntax() {
         rewriteRun(
           spec -> spec.recipes(
-            new ChangeDependency("org.openrewrite", "plugin", "io.moderne", "moderne-gradle-plugin", "0.x", null),
+            new ChangeDependency("org.openrewrite", "plugin", "io.moderne", "moderne-gradle-plugin", "0.x", null, null),
             new ChangePlugin("org.openrewrite.rewrite", "io.moderne.rewrite", null)
           ),
           buildGradle(


### PR DESCRIPTION
## What's changed?
Added a new test to validate the behavior of ChangeDependency on unpinned dependencies.
Although we cannot check managed versions of Gradle right now, if the previous dependency is managed, we are going to assume that the new one will be managed too, and do not add a version tag. That was the previous behavior of the recipe before recent changes.
However, with the the new parameter `overrideManagedVersion` it will always add the tag version to the new dependency. 
This way we can force to add the newVersion, but we keep the default previous behavior. 

## What's your motivation?
This recipe is also used in rewrite-java-dependencies and rewrite-spring, and it was not clear the behavior of the individual recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
