### PR TITLE
Adding the Moderne CLI as a valid build tool

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/BuildTool.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/BuildTool.java
@@ -34,6 +34,7 @@ public class BuildTool implements Marker {
     public enum Type {
         Gradle,
         Maven,
-        Bazel
+        Bazel,
+        ModerneCli
     }
 }


### PR DESCRIPTION
## What's changed?
The build tool enumeration to support the Moderne CLI option, which is required for non Java repositories.

## What's your motivation?
Being able to report the same markers from the Moderne CLI than from build tools

## Anyone you would like to review specifically?
@joanvr 
@timtebeek 

