### PR TITLE
Ensure that system-installed artifacts can be resolved while constructing JavaParser classpath

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -83,7 +83,7 @@ public interface JavaParser extends Parser {
         List<Path> artifacts = new ArrayList<>(artifactNames.length);
         List<String> missingArtifactNames = new ArrayList<>(artifactNames.length);
         for (String artifactName : artifactNames) {
-            Pattern jarPattern = Pattern.compile(artifactName + "-.*?\\.jar$");
+            Pattern jarPattern = Pattern.compile(artifactName + "(?:" + "-.*?" + ")?" + "\\.jar$");
             // In a multi-project IDE classpath, some classpath entries aren't jars
             Pattern explodedPattern = Pattern.compile("/" + artifactName + "/");
             boolean lacking = true;
@@ -104,7 +104,8 @@ public interface JavaParser extends Parser {
 
         if (!missingArtifactNames.isEmpty()) {
             throw new IllegalArgumentException("Unable to find runtime dependencies beginning with: " +
-                                               missingArtifactNames.stream().map(a -> "'" + a + "'").sorted().collect(joining(", ")));
+                                               missingArtifactNames.stream().map(a -> "'" + a + "'").sorted().collect(joining(", ")) +
+                                               ", classpath: " + runtimeClasspath);
         }
 
         return artifacts;


### PR DESCRIPTION
When running Maven on Linux from a system maintainer-installed package and adding a dependency to a recipe that is also a dependency of Maven itself (e.g. `slf4j-api`), then the system-installed version is used (e.g. `file:/usr/share/java/slf4j-api.jar`). Unfortunately, this path is not matched be the regular expression, since no version is added to the file name. This results in an incomprehensible error "Unable to find runtime dependencies beginning with: slf4j-api" that gives no clue what's wrong. Therefore, its better to also output the current class path being scanned.

In the situation described above, the following template cannot be built, because the dependency `slf4j-api` cannot be resolved because the artifact cannot be found on the class path:
```
private static JavaTemplate createTemplate() {
    return JavaTemplate.builder("#{} static final Logger LOG = LoggerFactory.getLogger(#{any(java.lang.Class)});")
        .javaParser(JavaParser.fromJavaVersion().classpath(dependenciesFromClasspath("slf4j-api")))
        .imports("org.slf4j.LoggerFactory", "org.slf4j.Logger")
        .build();
}
```

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Bug in class path scanning code while constructing a JavaParser fixed. Allow to find the artifact `slf4j-api` from a class path entry like `file:/usr/share/java/slf4j-api.jar`. Made the version optional in the artifact pattern.

## What's your motivation?
Create a recipe that uses SLF4J classes (that are in the dependencies of Maven itself and therefore system-installed).

## Have you considered any alternatives or workarounds?
One can copy the classpath scanning code to the recipes code and fix it there, but makes no sense at all.

## Any additional context
Had a hard time debugging this - more context information in error messages is always a win.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
