### PR TITLE
Take license header into account when adding gradle plugin

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -29,10 +29,7 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.FindMethods;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Space;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.tree.GroupArtifact;
@@ -41,6 +38,7 @@ import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.semver.*;
 
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,6 +97,41 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                         repositories);
     }
 
+    private static @Nullable Comment getLicenseHeader(G.CompilationUnit cu) {
+        if (!cu.getStatements().isEmpty()) {
+            Statement firstStatement = cu.getStatements().get(0);
+            if (!firstStatement.getComments().isEmpty()) {
+                Comment firstComment = firstStatement.getComments().get(0);
+                if (isLicenseHeader(firstComment)) {
+                    return firstComment;
+                }
+            }
+        } else if (cu.getEof() != null && !cu.getEof().getComments().isEmpty()) {
+            Comment firstComment = cu.getEof().getComments().get(0);
+            if (isLicenseHeader(firstComment)) {
+                // Adding suffix so when we later use it, formats well.
+                return firstComment.withSuffix("\n\n");
+            }
+        }
+        return null;
+    }
+
+    private static boolean isLicenseHeader(Comment comment) {
+        return comment instanceof TextComment && comment.isMultiline() &&
+                ((TextComment) comment).getText().contains("License");
+    }
+
+    private static G.CompilationUnit removeLicenseHeader(G.CompilationUnit cu) {
+        if (!cu.getStatements().isEmpty()) {
+            return cu.withStatements(ListUtils.mapFirst(cu.getStatements(),
+                    s -> s.withComments(s.getComments().subList(1, s.getComments().size()))
+            ));
+        } else {
+            List<Comment> eofComments = cu.getEof().getComments();
+            return cu.withEof(cu.getEof().withComments(eofComments.subList(1, eofComments.size())));
+        }
+    }
+
     @Override
     public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
         if (FindPlugins.find(cu, pluginId).isEmpty()) {
@@ -154,7 +187,6 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                     .get(0);
 
             if (FindMethods.find(cu, "RewriteGradleProject plugins(..)").isEmpty() && FindMethods.find(cu, "RewriteSettings plugins(..)").isEmpty()) {
-                Space leadingSpace = Space.firstPrefix(cu.getStatements());
                 if (cu.getSourcePath().endsWith(Paths.get("settings.gradle"))
                     && !cu.getStatements().isEmpty()
                     && cu.getStatements().get(0) instanceof J.MethodInvocation
@@ -170,7 +202,16 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                         }
                     }
                     if (insertAtIdx == 0) {
-                        return cu.withStatements(ListUtils.insert(Space.formatFirstPrefix(cu.getStatements(), leadingSpace.withWhitespace("\n\n" + leadingSpace.getWhitespace())), autoFormat(statement, ctx, getCursor()), insertAtIdx));
+                        Comment licenseHeader = getLicenseHeader(cu);
+                        if (licenseHeader != null) {
+                            cu = removeLicenseHeader(cu);
+                            statement = statement.withComments(Collections.singletonList(licenseHeader));
+                        }
+                        Space leadingSpace = Space.firstPrefix(cu.getStatements());
+                        return cu.withStatements(ListUtils.insert(
+                                Space.formatFirstPrefix(cu.getStatements(), leadingSpace.withWhitespace("\n\n" + leadingSpace.getWhitespace())),
+                                autoFormat(statement, ctx, getCursor()),
+                                insertAtIdx));
                     } else {
                         return cu.withStatements(ListUtils.insert(cu.getStatements(), autoFormat(statement.withPrefix(Space.format("\n\n")), ctx, getCursor()), insertAtIdx));
                     }
@@ -178,11 +219,11 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
             } else {
                 MethodMatcher buildPluginsMatcher = new MethodMatcher("RewriteGradleProject plugins(groovy.lang.Closure)");
                 MethodMatcher settingsPluginsMatcher = new MethodMatcher("RewriteSettings plugins(groovy.lang.Closure)");
+                J.MethodInvocation pluginDef = (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) ((J.MethodInvocation) autoFormat(statement, ctx, getCursor())).getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
                 return cu.withStatements(ListUtils.map(cu.getStatements(), stat -> {
                     if (stat instanceof J.MethodInvocation) {
                         J.MethodInvocation m = (J.MethodInvocation) stat;
                         if (buildPluginsMatcher.matches(m) || settingsPluginsMatcher.matches(m)) {
-                            J.MethodInvocation pluginDef = (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) ((J.MethodInvocation) autoFormat(statement, ctx, getCursor())).getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
                             m = m.withArguments(ListUtils.map(m.getArguments(), a -> {
                                 if (a instanceof J.Lambda) {
                                     J.Lambda l = (J.Lambda) a;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -81,7 +81,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
     }
 
     private static Optional<String> findNewerVersion(String groupId, String artifactId, String version, VersionComparator versionComparator,
-                                              List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
+                                                     List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
         try {
             MavenMetadata mavenMetadata = downloadMetadata(groupId, artifactId, repositories, ctx);
             return versionComparator.upgrade(version, mavenMetadata.getVersioning().getVersions());
@@ -175,8 +175,8 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
                     .parseInputs(
                             singletonList(
                                     Parser.Input.fromString("plugins {\n" +
-                                                            "    id " + delimiter + pluginId + delimiter + (version.map(s -> " version " + delimiter + s + delimiter).orElse("")) + "\n" +
-                                                            "}")),
+                                            "    id " + delimiter + pluginId + delimiter + (version.map(s -> " version " + delimiter + s + delimiter).orElse("")) + "\n" +
+                                            "}")),
                             null,
                             ctx
                     )
@@ -188,9 +188,9 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
 
             if (FindMethods.find(cu, "RewriteGradleProject plugins(..)").isEmpty() && FindMethods.find(cu, "RewriteSettings plugins(..)").isEmpty()) {
                 if (cu.getSourcePath().endsWith(Paths.get("settings.gradle"))
-                    && !cu.getStatements().isEmpty()
-                    && cu.getStatements().get(0) instanceof J.MethodInvocation
-                    && ((J.MethodInvocation) cu.getStatements().get(0)).getSimpleName().equals("pluginManagement")) {
+                        && !cu.getStatements().isEmpty()
+                        && cu.getStatements().get(0) instanceof J.MethodInvocation
+                        && ((J.MethodInvocation) cu.getStatements().get(0)).getSimpleName().equals("pluginManagement")) {
                     return cu.withStatements(ListUtils.insert(cu.getStatements(), autoFormat(statement.withPrefix(Space.format("\n\n")), ctx, getCursor()), 1));
                 } else {
                     int insertAtIdx = 0;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
@@ -17,11 +17,12 @@ package org.openrewrite.gradle.plugins;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.marker.BuildTool;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.gradle.Assertions.*;
 
 class AddBuildPluginTest implements RewriteTest {
     @Override
@@ -137,6 +138,95 @@ class AddBuildPluginTest implements RewriteTest {
               buildscript {
               }
               
+              plugins {
+                  id 'com.jfrog.bintray' version '1.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addPluginToNewBlockWithLicenseHeader() {
+        rewriteRun(
+          spec -> {
+              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null));
+              spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")));
+          },
+          buildGradle(
+            """
+              /*
+               * License header
+               */
+               
+              dependencies {
+              }
+              """, """
+              /*
+               * License header
+               */
+
+              plugins {
+                  id 'com.jfrog.bintray' version '1.0'
+              }
+
+              dependencies {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addPluginToNewBlockWithLicenseHeaderAndComment() {
+        rewriteRun(
+          spec -> {
+              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null));
+              spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")));
+          },
+          buildGradle(
+            """
+              /*
+               * License header
+               */
+               
+              // Comment
+              dependencies {
+              }
+              """, """
+              /*
+               * License header
+               */
+
+              plugins {
+                  id 'com.jfrog.bintray' version '1.0'
+              }
+
+              // Comment
+              dependencies {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addPluginToNewBlockWithOnlyLicenseHeader() {
+        rewriteRun(
+          spec -> {
+              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null));
+              spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")));
+          },
+          buildGradle(
+            """
+              /*
+               * License header
+               */
+              """, """
+              /*
+               * License header
+               */
+
               plugins {
                   id 'com.jfrog.bintray' version '1.0'
               }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePluginTest.java
@@ -279,7 +279,7 @@ class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
               plugins {
                   id 'com.gradle.enterprise' version '%s'
               }
-              
+                            
               rootProject.name = 'my-project'
               """
             )

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePluginTest.java
@@ -255,4 +255,35 @@ class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addNewSettingsPluginsBlockWithLicenseHeader() {
+        rewriteRun(
+          spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1"))),
+          buildGradle(
+            ""
+          ),
+          settingsGradle(
+            """
+              /*
+               * Licensed to...
+               */
+               
+              rootProject.name = 'my-project'
+              """,
+            interpolateResolvedVersion("""
+              /*
+               * Licensed to...
+               */
+               
+              plugins {
+                  id 'com.gradle.enterprise' version '%s'
+              }
+              
+              rootProject.name = 'my-project'
+              """
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
When adding a new gradle plugin, we need to take into consideration the license header if we are creating a new plugins block as the first statement. For empty files with no statements and just the license header, the license header is in a comment at EOF.

## What's your motivation?
AddGradleEnterpriseGradlePlugin recipe was producing unexpected results with license header duplicated or after the plugins block.
That's why I've added a test in this recipe too.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've used the IntelliJ auto-formatter on affected files
