### PR TITLE
fixed valid values and docs for Gradle Enterprise recipes

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePlugin.java
@@ -97,8 +97,8 @@ public class AddGradleEnterpriseGradlePlugin extends Recipe {
     Boolean uploadInBackground;
 
     @Option(displayName = "Publish Criteria",
-            description = "When set to `always` the plugin will publish build scans of every single build. " +
-                    "When set to `failure` the plugin will only publish build scans when the build fails. " +
+            description = "When set to `Always` the plugin will publish build scans of every single build. " +
+                    "When set to `Failure` the plugin will only publish build scans when the build fails. " +
                     "When omitted scans will be published only when the `--scan` option is passed to the build.",
             required = false,
             valid = {"Always", "Failure"},

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddGradleEnterpriseMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddGradleEnterpriseMavenExtension.java
@@ -103,13 +103,13 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
     Boolean uploadInBackground;
 
     @Option(displayName = "Publish Criteria",
-            description = "When set to `always` the extension will publish build scans of every single build. " +
+            description = "When set to `Always` the extension will publish build scans of every single build. " +
                           "This is the default behavior when omitted." +
-                          "When set to `failure` the extension will only publish build scans when the build fails. " +
-                          "When set to `demand` the extension will only publish build scans when explicitly requested.",
+                          "When set to `Failure` the extension will only publish build scans when the build fails. " +
+                          "When set to `Demand` the extension will only publish build scans when explicitly requested.",
             required = false,
-            valid = {"always", "failure", "demand"},
-            example = "true")
+            valid = {"Always", "Failure", "Demand"},
+            example = "Always")
     @Nullable
     PublishCriteria publishCriteria;
 


### PR DESCRIPTION
## What's changed?
Example and valid values for PublishCriteria on recipe AddGradleEnterpriseMavenExtension were wrong, thus causing the SaaS to display them all in lowercase and then failing to assign the proper value on recipe execution. Also improved this in the description and on the other related recipe AddGradleEnterpriseGradlePlugin.java

## What's your motivation?
On the SaaS, the enum values of PublishCriteria were wrongly displayed, and the recipe execution failed when a value was choosen.

## Have you considered any alternatives or workarounds?
We could also improve the ObjectMapper on the SaaS to accept case insensitive enums, but anyway, I think that this fix here is also good to have.

### Checklist
- [x] I've updated the documentation (if applicable)
