### PR TITLE
Fix CRLF newlines in AddImport

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -1142,4 +1142,24 @@ class AddImportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void crlfNewLines() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false))),
+          java(
+            """
+              package a;
+              class A {}
+              """.replace("\n", "\r\n"),
+            """
+              package a;
+                            
+              import java.util.List;
+                            
+              class A {}
+              """.replace("\n", "\r\n")
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -1144,7 +1144,7 @@ class AddImportTest implements RewriteTest {
     }
 
     @Test
-    void crlfNewLines() {
+    void crlfNewLinesWithoutPreviousImports() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false))),
           java(
@@ -1158,6 +1158,89 @@ class AddImportTest implements RewriteTest {
               import java.util.List;
                             
               class A {}
+              """.replace("\n", "\r\n")
+          )
+        );
+    }
+
+    @Test
+    void crlfNewLinesWithPreviousImports() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false))),
+          java(
+            """
+              package a;
+              
+              import java.util.Set;
+              
+              class A {}
+              """.replace("\n", "\r\n"),
+            """
+              package a;
+                            
+              import java.util.List;
+              import java.util.Set;
+                            
+              class A {}
+              """.replace("\n", "\r\n")
+          )
+        );
+    }
+
+    @Test
+    void crlfNewLinesWithPreviousImportsNoPackage() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false))),
+          java(
+            """
+              import java.util.Set;
+              
+              class A {}
+              """.replace("\n", "\r\n"),
+            """        
+              import java.util.List;
+              import java.util.Set;
+                            
+              class A {}
+              """.replace("\n", "\r\n")
+          )
+        );
+    }
+
+    @Test
+    void crlfNewLinesWithPreviousImportsNoClass() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false))),
+          java(
+            """
+              package a;
+              
+              import java.util.Arrays;
+              import java.util.Set;
+              """.replace("\n", "\r\n"),
+            """
+              package a;
+              
+              import java.util.Arrays;
+              import java.util.List;
+              import java.util.Set;
+              """.replace("\n", "\r\n")
+          )
+        );
+    }
+    @Test
+    void crlfNewLinesWithPreviousImportsNoPackageNoClass() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.util.List", null, false))),
+          java(
+            """
+              import java.util.Arrays;
+              import java.util.Set;
+              """.replace("\n", "\r\n"),
+            """
+              import java.util.Arrays;
+              import java.util.List;
+              import java.util.Set;
               """.replace("\n", "\r\n")
           )
         );

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -171,8 +171,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
         if (generalFormatStyle.isUseCRLFNewLines()) {
             return ListUtils.map(newImports, rp -> rp.map(
                     i -> i.withPrefix(i.getPrefix().withWhitespace(i.getPrefix().getWhitespace()
-                            .replace("\n", "\r\n")
-                            .replaceAll("\r+", "\r")))
+                            .replaceAll("(?<!\r)\n", "\r\n")))
             ));
         }
         return newImports;

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -170,7 +170,9 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                 .orElse(autodetectGeneralFormatStyle(cu));
         if (generalFormatStyle.isUseCRLFNewLines()) {
             return ListUtils.map(newImports, rp -> rp.map(
-                    i -> i.withPrefix(i.getPrefix().withWhitespace(i.getPrefix().getWhitespace().replace("\n", "\r\n")))
+                    i -> i.withPrefix(i.getPrefix().withWhitespace(i.getPrefix().getWhitespace()
+                            .replace("\n", "\r\n")
+                            .replaceAll("\r+", "\r")))
             ));
         }
         return newImports;

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.style.GeneralFormatStyle;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.tree.TypeUtils.isOfClassType;
+import static org.openrewrite.java.format.AutodetectGeneralFormatStyle.autodetectGeneralFormatStyle;
 
 /**
  * A Java refactoring visitor that can be used to add an import (or static import) to a given compilation unit.
@@ -132,15 +134,9 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                             .withComments(ListUtils.map(firstClassPrefix.getComments(), comment -> comment instanceof Javadoc ? null : comment))
                             .withWhitespace(""));
 
-                    cu = cu.withClasses(ListUtils.map(cu.getClasses(), (i, clazz) -> {
-                        Space prefix = clazz.getPrefix();
-                        return i == 0 ?
-                                clazz.withPrefix(prefix.withComments(ListUtils.map(prefix.getComments(),
-                                        comment -> comment instanceof Javadoc ? comment : null))) :
-                                clazz;
-                    }));
-                } else {
-                    importToAdd = importToAdd.withPrefix(Space.format("\n\n"));
+                    cu = cu.withClasses(ListUtils.mapFirst(cu.getClasses(), clazz ->
+                            clazz.withComments(ListUtils.map(clazz.getComments(), comment -> comment instanceof Javadoc ? comment : null))
+                    ));
                 }
             }
 
@@ -151,21 +147,33 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                     .map(JavaSourceSet::getClasspath)
                     .orElse(Collections.emptyList());
 
-            cu = cu.getPadding().withImports(layoutStyle.addImport(cu.getPadding().getImports(), importToAdd,
-                    cu.getPackageDeclaration(), classpath));
+            List<JRightPadded<J.Import>> newImports = layoutStyle.addImport(cu.getPadding().getImports(), importToAdd, cu.getPackageDeclaration(), classpath);
+
+            // ImportLayoutStile::addImport adds always `\n` as newlines. Checking if we need to fix them
+            newImports = checkCRLF(cu, newImports);
+
+            cu = cu.getPadding().withImports(newImports);
 
             JavaSourceFile c = cu;
-            cu = cu.withClasses(ListUtils.map(cu.getClasses(), (i, clazz) -> {
-                if (i == 0) {
-                    J.ClassDeclaration cl = autoFormat(clazz, clazz.getName(), p, new Cursor(null, c));
-                    clazz = clazz.withPrefix(clazz.getPrefix().withWhitespace(cl.getPrefix().getWhitespace()));
-                }
-                return clazz;
+            cu = cu.withClasses(ListUtils.mapFirst(cu.getClasses(), clazz -> {
+                J.ClassDeclaration cl = autoFormat(clazz, clazz.getName(), p, new Cursor(null, c));
+                return clazz.withPrefix(clazz.getPrefix().withWhitespace(cl.getPrefix().getWhitespace()));
             }));
 
             j = cu;
         }
         return j;
+    }
+
+    private List<JRightPadded<J.Import>> checkCRLF(JavaSourceFile cu, List<JRightPadded<J.Import>> newImports) {
+        GeneralFormatStyle generalFormatStyle = Optional.ofNullable(((SourceFile) cu).getStyle(GeneralFormatStyle.class))
+                .orElse(autodetectGeneralFormatStyle(cu));
+        if (generalFormatStyle.isUseCRLFNewLines()) {
+            return ListUtils.map(newImports, rp -> rp.map(
+                    i -> i.withPrefix(i.getPrefix().withWhitespace(i.getPrefix().getWhitespace().replace("\n", "\r\n")))
+            ));
+        }
+        return newImports;
     }
 
     private boolean isTypeReference(NameTree t) {


### PR DESCRIPTION
## What's changed?
AddImport does not respect new line styling when adding new imports. It is related to `ImportLayoutStyle::addImport` works, because it can override whatever prefix we add to the new import.

Maybe we should fix addImport and instead of always adding \n to consider CRLF based on a parameter? 

Also changed some ListUtils.map to ListUtils.mapFirst equivalent when only changing the first element, and withPrefix(getPrefix().withComments) for withComments directly in import. Probably those "helpers" weren't available at the time of building this recipe.

## Have you considered any alternatives or workarounds?
I thought about adding an extra parameter to addImport (or to ImportLayoutStyle builder?) so it adds \n or \r\n according to the provided preference. But this may require adding a "default" value with the same signature to not affect the public signature of the class (don't know if it's widely used in other recipes).

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've used the IntelliJ auto-formatter on affected files
