### PR TITLE
Add JavaTemplate.Builder Collection overloads

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java;
 
+import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import org.openrewrite.Cursor;
@@ -29,12 +30,15 @@ import org.openrewrite.template.SourceTemplate;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "LombokGetterMayBeUsed"})
 public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
+    @Getter
     private final String code;
     private final int parameterCount;
     private final Consumer<String> onAfterVariableSubstitution;
@@ -46,10 +50,6 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         this.onAfterVariableSubstitution = onAfterVariableSubstitution;
         this.parameterCount = StringUtils.countOccurrences(code, "#{");
         this.templateParser = new JavaTemplateParser(contextSensitive, javaParser, onAfterVariableSubstitution, onBeforeParseTemplate, imports);
-    }
-
-    public String getCode() {
-        return code;
     }
 
     @Override
@@ -143,6 +143,10 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         }
 
         public Builder imports(String... fullyQualifiedTypeNames) {
+            return imports(Arrays.asList(fullyQualifiedTypeNames));
+        }
+
+        public Builder imports(Collection<String> fullyQualifiedTypeNames) {
             for (String typeName : fullyQualifiedTypeNames) {
                 validateImport(typeName);
                 this.imports.add("import " + typeName + ";\n");
@@ -151,6 +155,10 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         }
 
         public Builder staticImports(String... fullyQualifiedMemberTypeNames) {
+            return staticImports(Arrays.asList(fullyQualifiedMemberTypeNames));
+        }
+
+        public Builder staticImports(Collection<String> fullyQualifiedMemberTypeNames) {
             for (String typeName : fullyQualifiedMemberTypeNames) {
                 validateImport(typeName);
                 this.imports.add("import static " + typeName + ";\n");


### PR DESCRIPTION
## What's changed?

Overload the following methods with `Collection` accepting variants:
 - `imports`
 - `staticImports`

## What's your motivation?

Make the API more friendly to work with when you need to add multiple imports.

## Have you considered any alternatives or workarounds?

The prior alternative was to use the following syntax, assuming a `imports` is a collection of strings: `builder.imports(imports.toArray(new String[0]);`

Not the most friendly user-experience.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
