### PR TITLE
Require parse-to-print idempotence

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -34,7 +34,7 @@ public interface ExecutionContext {
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
     String DATA_TABLES = "org.openrewrite.dataTables";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
-    String REQUIRE_PRINT_IDEMPOTENCE = "org.openrewrite.requirePrintIdempotence";
+    String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
 
     @Incubating(since = "7.20.0")
     default ExecutionContext addObserver(TreeObserver.Subscription observer) {

--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -34,6 +34,7 @@ public interface ExecutionContext {
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
     String DATA_TABLES = "org.openrewrite.dataTables";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
+    String REQUIRE_PRINT_IDEMPOTENCE = "org.openrewrite.requirePrintIdempotence";
 
     @Incubating(since = "7.20.0")
     default ExecutionContext addObserver(TreeObserver.Subscription observer) {

--- a/rewrite-core/src/main/java/org/openrewrite/Parser.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Parser.java
@@ -39,9 +39,10 @@ import java.util.stream.StreamSupport;
 import static java.util.stream.Collectors.toList;
 
 public interface Parser {
-    default SourceFile requirePrintIdempotence(SourceFile sourceFile, Parser.Input input, @Nullable Path relativeTo, ExecutionContext ctx) {
-        if (ctx.getMessage(ExecutionContext.REQUIRE_PRINT_IDEMPOTENCE, true) &&
-            !sourceFile.isPrintIdempotent(input, ctx)) {
+    @Incubating(since = "8.2.0")
+    default SourceFile requirePrintEqualsInput(SourceFile sourceFile, Parser.Input input, @Nullable Path relativeTo, ExecutionContext ctx) {
+        if (ctx.getMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, true) &&
+            !sourceFile.printEqualsInput(input, ctx)) {
             return ParseError.build(
                     this,
                     input,

--- a/rewrite-core/src/main/java/org/openrewrite/Parser.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Parser.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.openrewrite.internal.EncodingDetectingInputStream;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.io.*;
@@ -38,6 +39,20 @@ import java.util.stream.StreamSupport;
 import static java.util.stream.Collectors.toList;
 
 public interface Parser {
+    default SourceFile requirePrintIdempotence(SourceFile sourceFile, Parser.Input input, @Nullable Path relativeTo, ExecutionContext ctx) {
+        if (ctx.getMessage(ExecutionContext.REQUIRE_PRINT_IDEMPOTENCE, true) &&
+            !sourceFile.isPrintIdempotent(input, ctx)) {
+            return ParseError.build(
+                    this,
+                    input,
+                    relativeTo,
+                    ctx,
+                    new IllegalStateException(sourceFile.getSourcePath() + " is not print idempotent.")
+            ).withErroneous(sourceFile);
+        }
+        return sourceFile;
+    }
+
     default Stream<SourceFile> parse(Iterable<Path> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         return parseInputs(StreamSupport
                         .stream(sourceFiles.spliterator(), false)

--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -19,24 +19,23 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
-import org.openrewrite.tree.ParseError;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 public interface SourceFile extends Tree {
 
     /**
-     * Does this source file, when printed produce a byte-for-byte identical result to the input?
+     * Does this source file represented as an LST, when printed, produce a byte-for-byte identical
+     * result to the original input source file?
      *
      * @param input The input source.
      * @return <code>true</code> if the parse-to-print loop is idempotent, <code>false</code> otherwise.
      */
-    default boolean isPrintIdempotent(Parser.Input input, ExecutionContext ctx) {
+    default boolean printEqualsInput(Parser.Input input, ExecutionContext ctx) {
         return printAll().equals(StringUtils.readFully(input.getSource(ctx)));
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -15,17 +15,31 @@
  */
 package org.openrewrite;
 
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
+import org.openrewrite.tree.ParseError;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 public interface SourceFile extends Tree {
+
+    /**
+     * Does this source file, when printed produce a byte-for-byte identical result to the input?
+     *
+     * @param input The input source.
+     * @return <code>true</code> if the parse-to-print loop is idempotent, <code>false</code> otherwise.
+     */
+    default boolean isPrintIdempotent(Parser.Input input, ExecutionContext ctx) {
+        return printAll().equals(StringUtils.readFully(input.getSource(ctx)));
+    }
+
     /**
      * @return An absolute or relative file path.
      */

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.table.DependenciesInUse;
+import org.openrewrite.maven.table.DependencyGraph;
 import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.ResolvedDependency;
@@ -44,6 +45,7 @@ import static java.util.Objects.requireNonNull;
 @EqualsAndHashCode(callSuper = true)
 public class DependencyInsight extends Recipe {
     transient DependenciesInUse dependenciesInUse = new DependenciesInUse(this);
+    transient DependencyGraph dependencyGraph = new DependencyGraph(this);
 
     private static final MethodMatcher DEPENDENCY_CONFIGURATION_MATCHER = new MethodMatcher("DependencyHandlerSpec *(..)");
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -159,7 +159,7 @@ public class GroovyParser implements Parser {
                             gcu = gcu.withMarkers(m);
                         }
                         pctx.getParsingListener().parsed(compiled.getInput(), gcu);
-                        return requirePrintIdempotence(gcu, input, relativeTo, ctx);
+                        return requirePrintEqualsInput(gcu, input, relativeTo, ctx);
                     } catch (Throwable t) {
                         ctx.getOnError().accept(t);
                         return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -159,7 +159,7 @@ public class GroovyParser implements Parser {
                             gcu = gcu.withMarkers(m);
                         }
                         pctx.getParsingListener().parsed(compiled.getInput(), gcu);
-                        return gcu;
+                        return requirePrintIdempotence(gcu, input, relativeTo, ctx);
                     } catch (Throwable t) {
                         ctx.getOnError().accept(t);
                         return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
@@ -70,7 +70,7 @@ public class HclParser implements Parser {
                 configFile = configFile.withMarkers(Markers.build(styles));
 
                 parsingListener.parsed(input, configFile);
-                return requirePrintIdempotence(configFile, input, relativeTo, ctx);
+                return requirePrintEqualsInput(configFile, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
@@ -46,34 +46,34 @@ public class HclParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(sourceFile -> {
+        return acceptedInputs(sourceFiles).map(input -> {
             try {
-                EncodingDetectingInputStream is = sourceFile.getSource(ctx);
+                EncodingDetectingInputStream is = input.getSource(ctx);
                 String sourceStr = is.readFully();
 
                 HCLLexer lexer = new HCLLexer(CharStreams.fromString(sourceStr));
                 lexer.removeErrorListeners();
-                lexer.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                lexer.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 
                 HCLParser parser = new HCLParser(new CommonTokenStream(lexer));
                 parser.removeErrorListeners();
-                parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 
                 Hcl.ConfigFile configFile = (Hcl.ConfigFile) new HclParserVisitor(
-                        sourceFile.getRelativePath(relativeTo),
+                        input.getRelativePath(relativeTo),
                         sourceStr,
                         is.getCharset(),
                         is.isCharsetBomMarked(),
-                        sourceFile.getFileAttributes()
+                        input.getFileAttributes()
                 ).visitConfigFile(parser.configFile());
 
                 configFile = configFile.withMarkers(Markers.build(styles));
 
-                parsingListener.parsed(sourceFile, configFile);
-                return (SourceFile) configFile;
+                parsingListener.parsed(input, configFile);
+                return requirePrintIdempotence(configFile, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
-                return ParseError.build(this, sourceFile, relativeTo, ctx, t);
+                return ParseError.build(this, input, relativeTo, ctx, t);
             }
         });
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -169,7 +169,7 @@ public class ReloadableJava11Parser implements JavaParser {
                 J.CompilationUnit cu = (J.CompilationUnit) parser.scan(cuByPath.getValue(), Space.EMPTY);
                 cuByPath.setValue(null); // allow memory used by this JCCompilationUnit to be released
                 parsingListener.parsed(input, cu);
-                return cu;
+                return requirePrintIdempotence(cu, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -169,7 +169,7 @@ public class ReloadableJava11Parser implements JavaParser {
                 J.CompilationUnit cu = (J.CompilationUnit) parser.scan(cuByPath.getValue(), Space.EMPTY);
                 cuByPath.setValue(null); // allow memory used by this JCCompilationUnit to be released
                 parsingListener.parsed(input, cu);
-                return requirePrintIdempotence(cu, input, relativeTo, ctx);
+                return requirePrintEqualsInput(cu, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -165,7 +165,7 @@ public class ReloadableJava17Parser implements JavaParser {
                 J.CompilationUnit cu = (J.CompilationUnit) parser.scan(cuByPath.getValue(), Space.EMPTY);
                 cuByPath.setValue(null); // allow memory used by this JCCompilationUnit to be released
                 parsingListener.parsed(input, cu);
-                return requirePrintIdempotence(cu, input, relativeTo, ctx);
+                return requirePrintEqualsInput(cu, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -165,7 +165,7 @@ public class ReloadableJava17Parser implements JavaParser {
                 J.CompilationUnit cu = (J.CompilationUnit) parser.scan(cuByPath.getValue(), Space.EMPTY);
                 cuByPath.setValue(null); // allow memory used by this JCCompilationUnit to be released
                 parsingListener.parsed(input, cu);
-                return cu;
+                return requirePrintIdempotence(cu, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -192,7 +192,7 @@ class ReloadableJava8Parser implements JavaParser {
                 J.CompilationUnit cu = (J.CompilationUnit) parser.scan(cuByPath.getValue(), Space.EMPTY);
                 cuByPath.setValue(null); // allow memory used by this JCCompilationUnit to be released
                 parsingListener.parsed(input, cu);
-                return requirePrintIdempotence(cu, input, relativeTo, ctx);
+                return requirePrintEqualsInput(cu, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -192,7 +192,7 @@ class ReloadableJava8Parser implements JavaParser {
                 J.CompilationUnit cu = (J.CompilationUnit) parser.scan(cuByPath.getValue(), Space.EMPTY);
                 cuByPath.setValue(null); // allow memory used by this JCCompilationUnit to be released
                 parsingListener.parsed(input, cu);
-                return (SourceFile) cu;
+                return requirePrintIdempotence(cu, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -234,6 +234,7 @@ public class JavaTemplateParser {
     private JavaSourceFile compileTemplate(@Language("java") String stub) {
         ExecutionContext ctx = new InMemoryExecutionContext();
         ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true);
+        ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
         JavaParser jp = parser.clone().build();
         return (stub.contains("@SubAnnotation") ?
                 jp.reset().parse(ctx, stub, SUBSTITUTED_ANNOTATION) :

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -235,10 +235,13 @@ public class JavaTemplateParser {
         ExecutionContext ctx = new InMemoryExecutionContext();
         ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true);
         JavaParser jp = parser.clone().build();
-        return (JavaSourceFile) (stub.contains("@SubAnnotation") ?
+        return (stub.contains("@SubAnnotation") ?
                 jp.reset().parse(ctx, stub, SUBSTITUTED_ANNOTATION) :
-                jp.reset().parse(ctx, stub)
-        ).findFirst().orElseThrow(() -> new IllegalArgumentException("Could not parse as Java"));
+                jp.reset().parse(ctx, stub))
+                .findFirst()
+                .filter(JavaSourceFile.class::isInstance) // Filters out ParseErrors
+                .map(JavaSourceFile.class::cast)
+                .orElseThrow(() -> new IllegalArgumentException("Could not parse as Java"));
     }
 
     /**

--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
@@ -50,7 +50,7 @@ public class JsonParser implements Parser {
                         input.getSource(ctx)
                 ).visitJson5(parser.json5());
                 parsingListener.parsed(input, document);
-                return requirePrintIdempotence(document, input, relativeTo, ctx);
+                return requirePrintEqualsInput(document, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
@@ -36,24 +36,24 @@ public class JsonParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(sourceFile -> {
-            try (InputStream sourceStream = sourceFile.getSource(ctx)) {
+        return acceptedInputs(sourceFiles).map(input -> {
+            try (InputStream sourceStream = input.getSource(ctx)) {
                 JSON5Parser parser = new JSON5Parser(new CommonTokenStream(new JSON5Lexer(
                         CharStreams.fromStream(sourceStream))));
 
                 parser.removeErrorListeners();
-                parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 
                 Json.Document document = new JsonParserVisitor(
-                        sourceFile.getRelativePath(relativeTo),
-                        sourceFile.getFileAttributes(),
-                        sourceFile.getSource(ctx)
+                        input.getRelativePath(relativeTo),
+                        input.getFileAttributes(),
+                        input.getSource(ctx)
                 ).visitJson5(parser.json5());
-                parsingListener.parsed(sourceFile, document);
-                return document;
+                parsingListener.parsed(input, document);
+                return requirePrintIdempotence(document, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
-                return ParseError.build(this, sourceFile, relativeTo, ctx, t);
+                return ParseError.build(this, input, relativeTo, ctx, t);
             }
         });
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependencyGraph.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependencyGraph.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.table;
+
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+public class DependencyGraph extends DataTable<DependencyGraph.Row> {
+
+    public DependencyGraph(Recipe recipe) {
+        super(recipe, DependencyGraph.Row.class,
+                DependenciesInUse.class.getName(),
+                "Dependency graph", "Relationships between dependencies.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Project name",
+                description = "The name of the project that contains the dependency.")
+        String projectName;
+
+        @Column(displayName = "Source set",
+                description = "The source set that contains the dependency.")
+        String sourceSet;
+
+        @Column(displayName = "From dependency",
+                description = "A dependency that depends on the 'to' dependency.")
+        String from;
+
+        @Column(displayName = "From dependency",
+                description = "A dependency that depends on the 'to' dependency.")
+        String to;
+    }
+}

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -41,16 +41,16 @@ public class PropertiesParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(sourceFile -> {
-            Path path = sourceFile.getRelativePath(relativeTo);
-            try (EncodingDetectingInputStream is = sourceFile.getSource(ctx)) {
+        return acceptedInputs(sourceFiles).map(input -> {
+            Path path = input.getRelativePath(relativeTo);
+            try (EncodingDetectingInputStream is = input.getSource(ctx)) {
                 Properties.File file = parseFromInput(path, is)
-                        .withFileAttributes(sourceFile.getFileAttributes());
-                parsingListener.parsed(sourceFile, file);
-                return file;
+                        .withFileAttributes(input.getFileAttributes());
+                parsingListener.parsed(input, file);
+                return requirePrintIdempotence(file, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
-                return ParseError.build(this, sourceFile, relativeTo, ctx, t);
+                return ParseError.build(this, input, relativeTo, ctx, t);
             }
         });
     }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -47,7 +47,7 @@ public class PropertiesParser implements Parser {
                 Properties.File file = parseFromInput(path, is)
                         .withFileAttributes(input.getFileAttributes());
                 parsingListener.parsed(input, file);
-                return requirePrintIdempotence(file, input, relativeTo, ctx);
+                return requirePrintEqualsInput(file, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/ProtoParser.java
+++ b/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/ProtoParser.java
@@ -61,7 +61,7 @@ public class ProtoParser implements Parser {
                                 is.isCharsetBomMarked()
                         ).visitProto(parser.proto());
                         parsingListener.parsed(input, document);
-                        return requirePrintIdempotence(document, input, relativeTo, ctx);
+                        return requirePrintEqualsInput(document, input, relativeTo, ctx);
                     } catch (Throwable t) {
                         ctx.getOnError().accept(t);
                         return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/ProtoParser.java
+++ b/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/ProtoParser.java
@@ -38,16 +38,16 @@ public class ProtoParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(sourceFile -> {
-                    Path path = sourceFile.getRelativePath(relativeTo);
+        return acceptedInputs(sourceFiles).map(input -> {
+                    Path path = input.getRelativePath(relativeTo);
                     try {
-                        EncodingDetectingInputStream is = sourceFile.getSource(ctx);
+                        EncodingDetectingInputStream is = input.getSource(ctx);
                         String sourceStr = is.readFully();
                         Protobuf2Parser parser = new Protobuf2Parser(new CommonTokenStream(new Protobuf2Lexer(
                                 CharStreams.fromString(sourceStr))));
 
                         parser.removeErrorListeners();
-                        parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                        parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 
                         if (sourceStr.contains("proto3")) {
                             return null;
@@ -55,16 +55,16 @@ public class ProtoParser implements Parser {
 
                         Proto.Document document = new ProtoParserVisitor(
                                 path,
-                                sourceFile.getFileAttributes(),
+                                input.getFileAttributes(),
                                 sourceStr,
                                 is.getCharset(),
                                 is.isCharsetBomMarked()
                         ).visitProto(parser.proto());
-                        parsingListener.parsed(sourceFile, document);
-                        return document;
+                        parsingListener.parsed(input, document);
+                        return requirePrintIdempotence(document, input, relativeTo, ctx);
                     } catch (Throwable t) {
                         ctx.getOnError().accept(t);
-                        return ParseError.build(this, sourceFile, relativeTo, ctx, t);
+                        return ParseError.build(this, input, relativeTo, ctx, t);
                     }
                 })
                 // filter out the nulls produced for `proto3` sources

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -55,7 +55,7 @@ public class XmlParser implements Parser {
                         is.isCharsetBomMarked()
                 ).visitDocument(parser.document());
                 parsingListener.parsed(input, document);
-                return requirePrintIdempotence(document, input, relativeTo, ctx);
+                return requirePrintEqualsInput(document, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -36,29 +36,29 @@ public class XmlParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(sourceFile -> {
-            Path path = sourceFile.getRelativePath(relativeTo);
-            try (EncodingDetectingInputStream is = sourceFile.getSource(ctx)) {
+        return acceptedInputs(sourceFiles).map(input -> {
+            Path path = input.getRelativePath(relativeTo);
+            try (EncodingDetectingInputStream is = input.getSource(ctx)) {
                 String sourceStr = is.readFully();
 
                 XMLParser parser = new XMLParser(new CommonTokenStream(new XMLLexer(
                         CharStreams.fromString(sourceStr))));
 
                 parser.removeErrorListeners();
-                parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 
                 Xml.Document document = new XmlParserVisitor(
                         path,
-                        sourceFile.getFileAttributes(),
+                        input.getFileAttributes(),
                         sourceStr,
                         is.getCharset(),
                         is.isCharsetBomMarked()
                 ).visitDocument(parser.document());
-                parsingListener.parsed(sourceFile, document);
-                return document;
+                parsingListener.parsed(input, document);
+                return requirePrintIdempotence(document, input, relativeTo, ctx);
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
-                return ParseError.build(this, sourceFile, relativeTo, ctx, t);
+                return ParseError.build(this, input, relativeTo, ctx, t);
             }
         });
     }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -67,7 +67,7 @@ public class YamlParser implements org.openrewrite.Parser {
                         parsingListener.parsed(input, yaml);
                         yaml = yaml.withFileAttributes(input.getFileAttributes());
                         yaml = unwrapPrefixedMappings(yaml);
-                        return requirePrintIdempotence(yaml, input, relativeTo, ctx);
+                        return requirePrintEqualsInput(yaml, input, relativeTo, ctx);
                     } catch (Throwable t) {
                         ctx.getOnError().accept(t);
                         return ParseError.build(this, input, relativeTo, ctx, t);

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -66,13 +66,13 @@ public class YamlParser implements org.openrewrite.Parser {
                         Yaml.Documents yaml = parseFromInput(path, is);
                         parsingListener.parsed(input, yaml);
                         yaml = yaml.withFileAttributes(input.getFileAttributes());
+                        yaml = unwrapPrefixedMappings(yaml);
                         return requirePrintIdempotence(yaml, input, relativeTo, ctx);
                     } catch (Throwable t) {
                         ctx.getOnError().accept(t);
                         return ParseError.build(this, input, relativeTo, ctx, t);
                     }
                 })
-                .map(this::unwrapPrefixedMappings)
                 .map(sourceFile -> {
                     if (sourceFile instanceof Yaml.Documents) {
                         Yaml.Documents docs = (Yaml.Documents) sourceFile;
@@ -527,10 +527,7 @@ public class YamlParser implements org.openrewrite.Parser {
         }
     }
 
-    private SourceFile unwrapPrefixedMappings(SourceFile y) {
-        if (!(y instanceof Yaml.Documents)) {
-            return y;
-        }
+    private Yaml.Documents unwrapPrefixedMappings(Yaml.Documents y) {
         //noinspection ConstantConditions
         return (Yaml.Documents) new YamlIsoVisitor<Integer>() {
             @Override

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/AppendToSequenceTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/AppendToSequenceTest.java
@@ -40,17 +40,17 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
               """,
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
-                      - strawberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
+                  - strawberry
               """
           )
         );
@@ -68,17 +68,17 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - 'apple'
-                      - 'blueberry'
+              things:
+                fruit:
+                  - 'apple'
+                  - 'blueberry'
               """,
             """
-                  things:
-                    fruit:
-                      - 'apple'
-                      - 'blueberry'
-                      - 'strawberry'
+              things:
+                fruit:
+                  - 'apple'
+                  - 'blueberry'
+                  - 'strawberry'
               """
           )
         );
@@ -96,17 +96,17 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
               """,
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
-                      - strawberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
+                  - strawberry
               """
           )
         );
@@ -124,17 +124,17 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
               """,
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
-                      - strawberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
+                  - strawberry
               """
           )
         );
@@ -152,10 +152,10 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - apple
-                      - blueberry
+              things:
+                fruit:
+                  - apple
+                  - blueberry
               """
           )
         );
@@ -173,23 +173,23 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - name: apple
-                      - name: blueberry
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit:
+                  - name: apple
+                  - name: blueberry
+                animals:
+                  - cat
+                  - dog
               """,
             """
-                  things:
-                    fruit:
-                      - name: apple
-                      - name: blueberry
-                      - name: strawberry
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit:
+                  - name: apple
+                  - name: blueberry
+                  - name: strawberry
+                animals:
+                  - cat
+                  - dog
               """
           )
         );
@@ -207,23 +207,23 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit:
-                      - name: apple
-                      - name: blueberry
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit:
+                  - name: apple
+                  - name: blueberry
+                animals:
+                  - cat
+                  - dog
               """,
             """
-                  things:
-                    fruit:
-                      - name: apple
-                      - name: blueberry
-                      - name: strawberry
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit:
+                  - name: apple
+                  - name: blueberry
+                  - name: strawberry
+                animals:
+                  - cat
+                  - dog
               """
           )
         );
@@ -241,18 +241,18 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit: [apple, blueberry]
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit: [apple, blueberry]
+                animals:
+                  - cat
+                  - dog
               """,
             """
-                  things:
-                    fruit: [apple, blueberry, strawberry]
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit: [apple, blueberry, strawberry]
+                animals:
+                  - cat
+                  - dog
               """
           )
         );
@@ -270,18 +270,18 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit: ['apple', 'blueberry']
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit: ['apple', 'blueberry']
+                animals:
+                  - cat
+                  - dog
               """,
             """
-                  things:
-                    fruit: ['apple', 'blueberry', 'strawberry']
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit: ['apple', 'blueberry', 'strawberry']
+                animals:
+                  - cat
+                  - dog
               """
           )
         );
@@ -299,18 +299,18 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit: ["apple", "blueberry"]
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit: ["apple", "blueberry"]
+                animals:
+                  - cat
+                  - dog
               """,
             """
-                  things:
-                    fruit: ["apple", "blueberry", "strawberry"]
-                    animals:
-                      - cat
-                      - dog
+              things:
+                fruit: ["apple", "blueberry", "strawberry"]
+                animals:
+                  - cat
+                  - dog
               """
           )
         );
@@ -328,12 +328,12 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  things:
-                    fruit: []
+              things:
+                fruit: []
               """,
             """
-                  things:
-                    fruit: [strawberry]
+              things:
+                fruit: [strawberry]
               """
           )
         );
@@ -351,21 +351,21 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  prod:
-                    regions:
-                      - name: us-bar-1
-                      - name: us-foo-1
-                    other:
-                      - name: outerspace-1
+              prod:
+                regions:
+                  - name: us-bar-1
+                  - name: us-foo-1
+                other:
+                  - name: outerspace-1
               """,
             """
-                  prod:
-                    regions:
-                      - name: us-bar-1
-                      - name: us-foo-1
-                      - name: us-foo-2
-                    other:
-                      - name: outerspace-1
+              prod:
+                regions:
+                  - name: us-bar-1
+                  - name: us-foo-1
+                  - name: us-foo-2
+                other:
+                  - name: outerspace-1
               """
           )
         );
@@ -383,13 +383,13 @@ class AppendToSequenceTest implements RewriteTest {
             )),
           yaml(
             """
-                  prod:
-                    regions:
-                      - name: us-bar-1
-                      - name: us-foo-1
-                      - name: us-foo-2
-                    other:
-                      - name: outerspace-1
+              prod:
+                regions:
+                  - name: us-bar-1
+                  - name: us-foo-1
+                  - name: us-foo-2
+                other:
+                  - name: outerspace-1
               """
           )
         );


### PR DESCRIPTION
## What's changed?

Parsers should prove that their printed representation matches the original source code to prevent patch apply failures on commit. The lack of parse-to-print idempotence can otherwise go unnoticed until a commit.