### PR TITLE
Fix array annotations

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2118,11 +2118,16 @@ public class GroovyParserVisitor {
         return expr.withPrefix(prefix);
     }
 
-    private List<JRightPadded<Space>> arrayDimensionsFrom(ClassNode classNode) {
-        List<JRightPadded<Space>> result = new ArrayList<>();
+    private List<J.ArrayType.AnnotatedDimension> arrayDimensionsFrom(ClassNode classNode) {
+        List<J.ArrayType.AnnotatedDimension> result = new ArrayList<>();
         while(classNode != null && classNode.isArray()) {
             classNode = classNode.getComponentType();
-            result.add(JRightPadded.build(sourceBefore("[")).withAfter(sourceBefore("]")));
+
+            // TODO: add support for getting each dimensions' annotations from classNode
+            result.add(new J.ArrayType.AnnotatedDimension (
+                emptyList(),
+                JRightPadded.build(sourceBefore("[")).withAfter(sourceBefore("]"))
+            ));
         }
         return result;
     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1220,8 +1220,6 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             throw new IllegalArgumentException("Unexpected Tree subtype " + node.getClass().getName());
         }
         Tree currentNode = node;
-        // traverse tree to leaf identifier to get identifier
-        // repass again from top to collect annotations + brackets
         while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
             if (currentNode instanceof ArrayTypeTree) {
                 currentNode = ((ArrayTypeTree) currentNode).getType();

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -171,31 +171,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitArrayType(ArrayTypeTree node, Space fmt) {
-        Tree typeIdent = node.getType();
-        int dimCount = 1;
-
-        while (typeIdent instanceof ArrayTypeTree) {
-            dimCount++;
-            typeIdent = ((ArrayTypeTree) typeIdent).getType();
-        }
-
-        TypeTree elemType = convert(typeIdent);
-
-        List<JRightPadded<Space>> dimensions = emptyList();
-        if (dimCount > 0) {
-            dimensions = new ArrayList<>(dimCount);
-            for (int n = 0; n < dimCount; n++) {
-                dimensions.add(padRight(sourceBefore("["), sourceBefore("]")));
-            }
-        }
-
-        return new J.ArrayType(
-                randomId(),
-                fmt,
-                Markers.EMPTY,
-                elemType,
-                dimensions
-        );
+        return visitAnnotatedArrayType(node, fmt);
     }
 
     @Override
@@ -1232,8 +1208,55 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
+        if (node.getUnderlyingType() instanceof ArrayTypeTree) {
+            return visitAnnotatedArrayType(node, fmt);
+        }
         return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, convertAll(node.getAnnotations()),
                 convert(node.getUnderlyingType()));
+    }
+
+    private J visitAnnotatedArrayType(Tree node, Space fmt) {
+        if (!(node instanceof ArrayTypeTree) && !(node instanceof AnnotatedTypeTree)) {
+            throw new IllegalArgumentException("Unexpected Tree subtype " + node.getClass().getName());
+        }
+        Tree currentNode = node;
+        // traverse tree to leaf identifier to get identifier
+        // repass again from top to collect annotations + brackets
+        while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
+            if (currentNode instanceof ArrayTypeTree) {
+                currentNode = ((ArrayTypeTree) currentNode).getType();
+            } else {
+                currentNode = ((AnnotatedTypeTree) currentNode).getUnderlyingType();
+            }
+        }
+
+        TypeTree elemType = convert(currentNode);
+
+        List<J.ArrayType.AnnotatedDimension> dimensions = new ArrayList<>();
+        currentNode = node;
+        while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
+            List<J.Annotation> annotations = new ArrayList<>();
+            if (currentNode instanceof AnnotatedTypeTree) {
+                annotations = convertAll(((AnnotatedTypeTree) currentNode).getAnnotations());
+                currentNode = ((AnnotatedTypeTree) currentNode).getUnderlyingType();
+            }
+
+            if (currentNode instanceof ArrayTypeTree) {
+                JRightPadded<Space> dimension = padRight(sourceBefore("["), sourceBefore("]"));
+                dimensions.add(new J.ArrayType.AnnotatedDimension(annotations, dimension));
+                currentNode = ((ArrayTypeTree) currentNode).getType();
+            }
+
+
+        }
+
+        return new J.ArrayType(
+                randomId(),
+                fmt,
+                Markers.EMPTY,
+                elemType,
+                dimensions
+        );
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1296,8 +1296,6 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             throw new IllegalArgumentException("Unexpected Tree subtype " + node.getClass().getName());
         }
         Tree currentNode = node;
-        // traverse tree to leaf identifier to get identifier
-        // repass again from top to collect annotations + brackets
         while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
             if (currentNode instanceof ArrayTypeTree) {
                 currentNode = ((ArrayTypeTree) currentNode).getType();

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -168,31 +168,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitArrayType(ArrayTypeTree node, Space fmt) {
-        Tree typeIdent = node.getType();
-        int dimCount = 1;
-
-        while (typeIdent instanceof ArrayTypeTree) {
-            dimCount++;
-            typeIdent = ((ArrayTypeTree) typeIdent).getType();
-        }
-
-        TypeTree elemType = convert(typeIdent);
-
-        List<JRightPadded<Space>> dimensions = emptyList();
-        if (dimCount > 0) {
-            dimensions = new ArrayList<>(dimCount);
-            for (int n = 0; n < dimCount; n++) {
-                dimensions.add(padRight(sourceBefore("["), sourceBefore("]")));
-            }
-        }
-
-        return new J.ArrayType(
-                randomId(),
-                fmt,
-                Markers.EMPTY,
-                elemType,
-                dimensions
-        );
+        return visitAnnotatedArrayType(node, fmt);
     }
 
     @Override
@@ -1223,8 +1199,55 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
+        if (node.getUnderlyingType() instanceof ArrayTypeTree) {
+            return visitAnnotatedArrayType(node, fmt);
+        }
         return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, convertAll(node.getAnnotations()),
                 convert(node.getUnderlyingType()));
+    }
+
+    private J visitAnnotatedArrayType(Tree node, Space fmt) {
+        if (!(node instanceof ArrayTypeTree) && !(node instanceof AnnotatedTypeTree)) {
+            throw new IllegalArgumentException("Unexpected Tree subtype " + node.getClass().getName());
+        }
+        Tree currentNode = node;
+        // traverse tree to leaf identifier to get identifier
+        // repass again from top to collect annotations + brackets
+        while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
+            if (currentNode instanceof ArrayTypeTree) {
+                currentNode = ((ArrayTypeTree) currentNode).getType();
+            } else {
+                currentNode = ((AnnotatedTypeTree) currentNode).getUnderlyingType();
+            }
+        }
+
+        TypeTree elemType = convert(currentNode);
+
+        List<J.ArrayType.AnnotatedDimension> dimensions = new ArrayList<>();
+        currentNode = node;
+        while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
+            List<J.Annotation> annotations = new ArrayList<>();
+            if (currentNode instanceof AnnotatedTypeTree) {
+                annotations = convertAll(((AnnotatedTypeTree) currentNode).getAnnotations());
+                currentNode = ((AnnotatedTypeTree) currentNode).getUnderlyingType();
+            }
+
+            if (currentNode instanceof ArrayTypeTree) {
+                JRightPadded<Space> dimension = padRight(sourceBefore("["), sourceBefore("]"));
+                dimensions.add(new J.ArrayType.AnnotatedDimension(annotations, dimension));
+                currentNode = ((ArrayTypeTree) currentNode).getType();
+            }
+
+
+        }
+
+        return new J.ArrayType(
+                randomId(),
+                fmt,
+                Markers.EMPTY,
+                elemType,
+                dimensions
+        );
     }
 
     @Override

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -977,7 +977,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                     convert(dim, t -> sourceBefore("]"))));
         }
 
-        while(true) {
+        while (true) {
             int beginBracket = indexOfNextNonWhitespace(cursor, source);
             if (source.charAt(beginBracket) == '[') {
                 int endBracket = indexOfNextNonWhitespace(beginBracket + 1, source);
@@ -1211,8 +1211,6 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
             throw new IllegalArgumentException("Unexpected Tree subtype " + node.getClass().getName());
         }
         Tree currentNode = node;
-        // traverse tree to leaf identifier to get identifier
-        // repass again from top to collect annotations + brackets
         while (currentNode instanceof ArrayTypeTree || currentNode instanceof AnnotatedTypeTree) {
             if (currentNode instanceof ArrayTypeTree) {
                 currentNode = ((ArrayTypeTree) currentNode).getType();
@@ -1722,7 +1720,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                     char c2 = source.charAt(delimIndex + 1);
                     switch (c1) {
                         case '/':
-                            switch(c2) {
+                            switch (c2) {
                                 case '/':
                                     inSingleLineComment = true;
                                     delimIndex++;
@@ -1734,7 +1732,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                             }
                             break;
                         case '*':
-                            if(c2 == '/') {
+                            if (c2 == '/') {
                                 inMultiLineComment = false;
                                 delimIndex += 2;
                             }
@@ -1843,7 +1841,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 } else {
                     leadingAnnotations.add(annotation);
                 }
-                i = cursor -1;
+                i = cursor - 1;
                 lastAnnotationPosition = cursor;
                 continue;
             }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -68,6 +68,26 @@ class JavaParserTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3453")
+    @Test
+    void annotationBetweenDimensions() {
+        rewriteRun(
+          java(
+            """
+              import javax.annotation.Nonnull;
+
+              class ArrayNotNull {
+                  int[][] ints = new int[2][2];
+
+                  public int   @Nonnull    [] @Nonnull [] getInts() {
+                      return ints;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2313")
     @Test
     void annotationCommentWithSpaceParsesCorrectly() {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -78,6 +78,10 @@ class JavaParserTest implements RewriteTest {
 
               class ArrayNotNull {
                   int[][] ints = new int[2][2];
+                  
+                  Integer[] @Nonnull [] integers = new Integer[1][1];
+                  
+                  Integer @Nonnull [] foo = new Integer[1];
 
                   public int   @Nonnull    [] @Nonnull [] getInts() {
                       return ints;

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -176,10 +176,11 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
     public J visitArrayType(ArrayType arrayType, PrintOutputCapture<P> p) {
         beforeSyntax(arrayType, Space.Location.ARRAY_TYPE_PREFIX, p);
         visit(arrayType.getElementType(), p);
-        for (JRightPadded<Space> d : arrayType.getDimensions()) {
-            visitSpace(d.getElement(), Space.Location.DIMENSION, p);
+        for (ArrayType.AnnotatedDimension d : arrayType.getDimensions()) {
+            d.getAnnotations().forEach(ann -> visitAnnotation(ann, p));
+            visitSpace(d.getSpace().getElement(), Space.Location.DIMENSION, p);
             p.append('[');
-            visitSpace(d.getAfter(), Space.Location.DIMENSION_SUFFIX, p);
+            visitSpace(d.getSpace().getAfter(), Space.Location.DIMENSION_SUFFIX, p);
             p.append(']');
         }
         afterSyntax(arrayType, p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -264,9 +264,14 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         a = a.withElementType(visitTypeName(a.getElementType(), p));
         a = a.withDimensions(
                 ListUtils.map(a.getDimensions(), dim ->
-                        visitRightPadded(dim.withElement(
-                                visitSpace(dim.getElement(), Space.Location.DIMENSION, p)
-                        ), JRightPadded.Location.DIMENSION, p)
+                        dim.withAnnotations(
+                                ListUtils.map(dim.getAnnotations(), ann ->
+                                        (J.Annotation) visitAnnotation(ann, p))
+                        ).withSpace(
+                                visitRightPadded(dim.getSpace().withElement(
+                                        visitSpace(dim.getSpace().getElement(), Space.Location.DIMENSION, p)
+                                ), JRightPadded.Location.DIMENSION, p)
+                        )
                 )
         );
         return a;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
 
 import static java.util.Objects.requireNonNull;
 
@@ -111,9 +112,9 @@ public class NoWhitespaceAfter extends Recipe {
         public J.ArrayType visitArrayType(J.ArrayType arrayType, ExecutionContext ctx) {
             J.ArrayType a = super.visitArrayType(arrayType, ctx);
             if (Boolean.TRUE.equals(noWhitespaceAfterStyle.getArrayDeclarator())) {
-                if (a.getDimensions().stream().anyMatch(d -> d.getElement().getWhitespace().contains(" "))) {
+                if (a.getDimensions().stream().anyMatch(d -> d.getSpace().getElement().getWhitespace().contains(" "))) {
                     a = a.withDimensions(ListUtils.map(a.getDimensions(), d -> {
-                        d = d.withElement(d.getElement().withWhitespace(""));
+                        d = d.withSpace(d.getSpace().withElement(d.getSpace().getElement().withWhitespace("")));
                         return d;
                     }));
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -309,7 +309,7 @@ public interface J extends Tree {
         TypeTree elementType;
 
         @With
-        List<JRightPadded<Space>> dimensions;
+        List<AnnotatedDimension> dimensions;
 
         @Override
         public JavaType getType() {
@@ -337,6 +337,23 @@ public interface J extends Tree {
         public CoordinateBuilder.Expression getCoordinates() {
             return new CoordinateBuilder.Expression(this);
         }
+
+        /**
+         * The annotation for a single ArrayType's dimension. e.g:
+         * int   @NotNull    [   ]
+         *    (1)        (2)  (3)
+         * (1) is stored in Annotation.before
+         * (2) is stored in Space
+         * (3) is stored in JRightPadded.after
+         */
+        @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+        @Data
+        public static class AnnotatedDimension {
+            @With
+            List<Annotation> annotations;
+            @With
+            JRightPadded<Space> space;
+        };
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -339,7 +339,9 @@ public interface J extends Tree {
         }
 
         /**
-         * The annotation for a single ArrayType's dimension. e.g:
+         * The annotation and whitespace for a single array dimension.
+         * Each of the three whitespace elements are stored as follows:
+         *
          * int   @NotNull    [   ]
          *    (1)        (2)  (3)
          * (1) is stored in Annotation.before


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Fixes parsing for annotated array types

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Fixes https://github.com/openrewrite/rewrite/issues/3453
Fixes https://github.com/openrewrite/rewrite/issues/2911
Fixes https://github.com/openrewrite/rewrite/issues/3440
Fixes #3667 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

I add a new `J.ArrayType.AnnotatedDimension` auxiliary structure to store everything needed to represent a single dimension (e.g. `<annotations> []`)

## Anyone you would like to review specifically?
<!-- @mention them here -->

@timtebeek @kunli2 

### Additional context
- https://github.com/openrewrite/rewrite/issues/3453
- https://github.com/openrewrite/rewrite/issues/2911
- https://github.com/openrewrite/rewrite/issues/3440
- #3667 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
