### PR TITLE
Add `JavaSourceFile#service(Class)` and `ImportService`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
@@ -228,7 +228,7 @@ public class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
               @SuppressWarnings("DataFlowIssue")
               public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                   if (method.getSimpleName().equals("m1")) {
-                      return (J.MethodDeclaration) new ShortenFullyQualifiedTypeReferences().getVisitor().visit(method, ctx);
+                      return (J.MethodDeclaration) new ShortenFullyQualifiedTypeReferences().getVisitor().visit(method, ctx, getCursor().getParent());
                   }
                   return super.visitMethodDeclaration(method, ctx);
               }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ExtractInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ExtractInterface.java
@@ -17,6 +17,7 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.search.FindAnnotations;
@@ -116,7 +117,9 @@ public class ExtractInterface {
             JavaType.ShallowClass type = JavaType.ShallowClass.build(fullyQualifiedInterfaceName);
 
             J.Block body = classDecl.getBody();
-            J.ClassDeclaration implementing = (J.ClassDeclaration) new ImplementInterface<>(classDecl, type).visitNonNull(classDecl, ctx);
+            Cursor parent = getCursor().getParent();
+            assert parent != null;
+            J.ClassDeclaration implementing = (J.ClassDeclaration) new ImplementInterface<>(classDecl, type).visitNonNull(classDecl, ctx, parent);
 
             return (J.ClassDeclaration) new JavaIsoVisitor<ExecutionContext>() {
                 @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -15,7 +15,10 @@
  */
 package org.openrewrite.java;
 
-import org.openrewrite.*;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.format.AutoFormatVisitor;

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -15,13 +15,11 @@
  */
 package org.openrewrite.java;
 
-import org.openrewrite.Cursor;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.format.AutoFormatVisitor;
+import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -122,9 +120,10 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     public void maybeAddImport(String fullyQualifiedName, @Nullable String statik, boolean onlyIfReferenced) {
-        AddImport<P> op = new AddImport<>(fullyQualifiedName, statik, onlyIfReferenced);
-        if (!getAfterVisit().contains(op)) {
-            doAfterVisit(op);
+        ImportService service = getCursor().firstEnclosingOrThrow(JavaSourceFile.class).service(ImportService.class);
+        JavaVisitor<P> visitor = service.addImportVisitor(fullyQualifiedName, statik, onlyIfReferenced);
+        if (!getAfterVisit().contains(visitor)) {
+            doAfterVisit(visitor);
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/MigrateRecipeToRewrite8.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/MigrateRecipeToRewrite8.java
@@ -345,7 +345,7 @@ public class MigrateRecipeToRewrite8 extends Recipe {
                             }
                             return memberRef;
                         }
-                    }.visitNonNull(visitMethod, ctx);
+                    }.visitNonNull(visitMethod, ctx, getCursor().getParent());
 
                     maybeAddImport("org.openrewrite.internal.lang.Nullable");
                     maybeAddImport("org.openrewrite.Tree");

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
@@ -16,13 +16,14 @@
 package org.openrewrite.java.service;
 
 import org.openrewrite.Incubating;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.AddImport;
 import org.openrewrite.java.JavaVisitor;
 
 @Incubating(since = "8.1.16")
 public class ImportService {
 
-    public <P> JavaVisitor<P> addImportVisitor(String packageName, String typeName, boolean onlyIfReferenced) {
+    public <P> JavaVisitor<P> addImportVisitor(String packageName, @Nullable String typeName, boolean onlyIfReferenced) {
         return new AddImport<>(packageName, typeName, onlyIfReferenced);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.service;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.JavaVisitor;
+
+@Incubating(since = "8.1.16")
+public class ImportService {
+
+    public <P> JavaVisitor<P> addImportVisitor(String packageName, String typeName, boolean onlyIfReferenced) {
+        return new AddImport<>(packageName, typeName, onlyIfReferenced);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/package-info.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.java.service;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -15,9 +15,11 @@
  */
 package org.openrewrite.java.tree;
 
+import org.openrewrite.Incubating;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.service.ImportService;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -50,6 +52,15 @@ public interface JavaSourceFile extends J {
     Path getSourcePath();
 
     SourceFile withSourcePath(Path path);
+
+    @Incubating(since = "8.1.16")
+    @SuppressWarnings("unchecked")
+    default <S> S service(Class<S> service) {
+        if (service == ImportService.class) {
+            return (S) new ImportService();
+        }
+        throw new UnsupportedOperationException("Service " + service + " not supported");
+    }
 
     interface Padding {
         List<JRightPadded<Import>> getImports();

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -53,7 +53,7 @@ public interface JavaSourceFile extends J {
 
     SourceFile withSourcePath(Path path);
 
-    @Incubating(since = "8.1.16")
+    @Incubating(since = "8.2.0")
     @SuppressWarnings("unchecked")
     default <S> S service(Class<S> service) {
         if (service == ImportService.class) {


### PR DESCRIPTION
Let `JavaSourceFile` act as a service registry, so that other JVM languages (like Kotlin or Groovy) can override some central "services" which require a different implementation than the standard Java implementation.

An example is imports: Kotlin doesn't really have static imports, it has more implicitly imported types, and also the concept of aliases. With the indirection via an `ImportService` (which Kotlin can extend), the existing Java recipes can continue using `JavaVisitor#maybeAddImport()` and will end up using the Kotlin-specific implementation when visiting Kotlin sources.

The `ImportService` can also be extended to provide a visitor to remove imports (`RemoveImport`) and other import-related operations, if required.