### PR TITLE
Change `J.Modifier` to be visitable by JavaVisitor

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -92,7 +92,8 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
         }
     }
 
-    protected void visitModifier(Modifier mod, PrintOutputCapture<P> p) {
+    @Override
+    public J visitModifier(Modifier mod, PrintOutputCapture<P> p) {
         visit(mod.getAnnotations(), p);
         String keyword = "";
         switch (mod.getType()) {
@@ -142,6 +143,7 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
         beforeSyntax(mod, Space.Location.MODIFIER_PREFIX, p);
         p.append(keyword);
         afterSyntax(mod, p);
+        return mod;
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -858,6 +858,12 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         return m;
     }
 
+    public J visitModifier(J.Modifier modifier, P p) {
+        J.Modifier m = modifier;
+        m = m.withAnnotations(ListUtils.map(m.getAnnotations(), mod -> visitAndCast(mod, p)));
+        return m;
+    }
+
     public J visitMultiCatch(J.MultiCatch multiCatch, P p) {
         J.MultiCatch m = multiCatch;
         m = m.withPrefix(visitSpace(m.getPrefix(), Space.Location.MULTI_CATCH_PREFIX, p));

--- a/rewrite-java/src/main/java/org/openrewrite/java/UpdateSourcePositions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UpdateSourcePositions.java
@@ -66,7 +66,7 @@ public class UpdateSourcePositions extends Recipe {
             }
 
             @Override
-            protected void visitModifier(J.Modifier modifier, PrintOutputCapture<ExecutionContext> p) {
+            public J visitModifier(J.Modifier modifier, PrintOutputCapture<ExecutionContext> p) {
                 PositionPrintOutputCapture prefix = new PositionPrintOutputCapture(ppoc.pos, ppoc.line, ppoc.column);
                 spacePrinter.visitSpace(modifier.getPrefix(), Space.Location.ANY, prefix);
 
@@ -74,6 +74,7 @@ public class UpdateSourcePositions extends Recipe {
                 super.visitModifier(modifier, p);
                 Range.Position endPosition = new Range.Position(ppoc.pos, ppoc.line, ppoc.column);
                 positionMap.put(modifier, new Range(randomId(), startPosition, endPosition));
+                return modifier;
             }
 
         };

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3849,6 +3849,11 @@ public interface J extends Tree {
             return type.toString().toLowerCase();
         }
 
+        @Override
+        public <P> J acceptJava(JavaVisitor<P> v, P p) {
+            return v.visitModifier(this, p);
+        }
+
         /**
          * These types are sorted in order of their recommended appearance in a list of modifiers, as defined in the
          * <a href="https://rules.sonarsource.com/java/tag/convention/RSPEC-1124">JLS</a>.


### PR DESCRIPTION
Visitors like Kotlin auto-format need to visit `J.Modifiers` and internal a list of annotations `List<Annotation> J.Modifiers.annotations`, and spaces as well.
Currently, it's not visitable in JavaVisitor, this PR updates it to be visitable.
