### PR TITLE
Supporting yaml "collapsed" keys

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -113,7 +113,7 @@ public class ChangePropertyKey extends Recipe {
                     String value = propertyEntry.getKey().getValue() + ".";
 
                     if ((!propertyToTest.startsWith(value) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext()))
-                        && hasNonExcludedValues(propertyEntry)) {
+                            && hasNonExcludedValues(propertyEntry)) {
                         doAfterVisit(new InsertSubpropertyVisitor<>(
                                 propertyEntry,
                                 propertyToTest,

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -112,7 +112,7 @@ public class ChangePropertyKey extends Recipe {
                     Yaml.Mapping.Entry propertyEntry = propertyEntriesLeftToRight.next();
                     String value = propertyEntry.getKey().getValue() + ".";
 
-                    if ((!propertyToTest.startsWith(value ) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext()))
+                    if ((!propertyToTest.startsWith(value) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext()))
                         && hasNonExcludedValues(propertyEntry)) {
                         doAfterVisit(new InsertSubpropertyVisitor<>(
                                 propertyEntry,
@@ -133,7 +133,7 @@ public class ChangePropertyKey extends Recipe {
                         Yaml.Mapping.Entry propertyEntry = propertyEntriesLeftToRight.next();
                         String value = propertyEntry.getKey().getValue() + ".";
 
-                        if (!propertyToTest.startsWith(value ) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext())) {
+                        if (!propertyToTest.startsWith(value) || (propertyToTest.startsWith(value) && !propertyEntriesLeftToRight.hasNext())) {
                             doAfterVisit(new InsertSubpropertyVisitor<>(
                                     propertyEntry,
                                     propertyToTest + prop.substring(oldPropertyKey.length()),

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -110,13 +110,13 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                     if (keyMatches(existingEntry, testKey)) {
                         String remainingKey = getRelativeKey(incomingEntry.getKey().getValue(), testKey);
 
-                            return existingEntry.withValue((Yaml.Block) new MergeYamlVisitor<>(existingEntry.getValue(),
-                                    remainingKey.isEmpty() ? incomingEntry.getValue() :
-                                            m2.withEntries(Collections.singletonList(
-                                                    incomingEntry.withKey(keyWithValue(incomingEntry.getKey(), remainingKey))
-                                            )),
-                                    acceptTheirs, objectIdentifyingProperty, shouldAutoFormat)
-                                    .visit(existingEntry.getValue(), p, new Cursor(cursor, existingEntry)));
+                        return existingEntry.withValue((Yaml.Block) new MergeYamlVisitor<>(existingEntry.getValue(),
+                                remainingKey.isEmpty() ? incomingEntry.getValue() :
+                                        m2.withEntries(Collections.singletonList(
+                                                incomingEntry.withKey(keyWithValue(incomingEntry.getKey(), remainingKey))
+                                        )),
+                                acceptTheirs, objectIdentifyingProperty, shouldAutoFormat)
+                                .visit(existingEntry.getValue(), p, new Cursor(cursor, existingEntry)));
                     }
                     testKey = getParentKey(testKey);
                 }
@@ -222,12 +222,11 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                     Tree.randomId(),
                     original.getPrefix(),
                     original.getMarkers(),
-                    ((Yaml.Scalar)original).getStyle(),
-                    ((Yaml.Scalar)original).getAnchor(),
+                    ((Yaml.Scalar) original).getStyle(),
+                    ((Yaml.Scalar) original).getAnchor(),
                     newValue
             );
-        }
-        else {
+        } else {
             // Right now, only Anchor, which makes no sense
             throw new UnsupportedOperationException("Cannot change value of " + original.getClass().getSimpleName() + " key");
         }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -841,4 +841,26 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
+    @Test
+    void collapsedKey() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            "management.endpoints.jmx.unique-names: true",
+            true,
+            null
+          )),
+          yaml(
+            """
+              management:
+                context-path: /admin
+              """, """
+              management:
+                context-path: /admin
+                endpoints.jmx.unique-names: true
+              """
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -842,7 +842,7 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
-    void collapsedKey() {
+    void incomingCollapsedKey() {
         rewriteRun(
           spec -> spec.recipe(new MergeYaml(
             "$",
@@ -859,6 +859,31 @@ class MergeYamlTest implements RewriteTest {
               management:
                 context-path: /admin
                 endpoints.jmx.unique-names: true
+              """
+          )
+        );
+    }
+
+    @Disabled("fix not implemented yet, but potentially an issue")
+    @Test
+    void existingCollapsedKeyOn() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            "management.endpoints.jmx.unique-names: true",
+            true,
+            null
+          )),
+          yaml(
+            """
+              management:
+                endpoints.jmx.other: /admin
+              """, """
+              management:
+                endpoints.jmx:
+                  other: /admin
+                  unique-names: true
               """
           )
         );


### PR DESCRIPTION
## What's changed?
When checking if the incomingEntry matches an existingEntry, we need to break the incoming intro prefixes splitted by `.` to check if we have any match instead of just checking equality of the whole key string. Otherwise, we cannot detect if we need to "split" the full collapsed key and insert it as a child.

## What's your motivation?
We are using this recipe in ChangePropertyKey that is used in Spring Migrations, and it happens quite a lot that we have and incomingEntry that needs to be partially matched inside and existing tree of entries. Otherwise, it's being inserted in the root, and causing an invalid merged yaml due to duplicated key.

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
Some scenario not covered yet is that the incomingEntry key partially matches an existing collapsed key partially, needing to split the existing key into a mapping and adding the two entries:
existing:
```
management:
    endpoints.jmx.other: /admin
```
incoming: `management.endpoints.jmx.unique-names: true`,

expected:
```
management:
    endpoints.jmx:
        other: /admin
        unique-names: true
```
actual:
```
management:
    endpoints.jmx.other: /admin
    endpoints.jmx.unique-names: true
```

I've created a disabled test for this one, but not fixed yet, since it does not seem to have any impact yet.



### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've used the IntelliJ auto-formatter on affected files
