### PR TITLE
Fix version matching issue in ChangeNamespaceValue and added test

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeNamespaceValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeNamespaceValue.java
@@ -137,7 +137,7 @@ public class ChangeNamespaceValue extends Recipe {
             private boolean isXmlnsAttribute(Xml.Attribute attribute) {
                 boolean searchAll = searchAllNamespaces == null || Boolean.TRUE.equals(searchAllNamespaces);
                 return searchAll && attribute.getKeyAsString().startsWith(XMLNS_PREFIX) ||
-                        !searchAll && attribute.getKeyAsString().equals(XMLNS_PREFIX);
+                       !searchAll && attribute.getKeyAsString().equals(XMLNS_PREFIX);
             }
 
             private boolean isVersionAttribute(Xml.Attribute attribute) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeNamespaceValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeNamespaceValue.java
@@ -23,10 +23,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.semver.Semver;
 import org.openrewrite.xml.tree.Xml;
-
-import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -152,7 +149,25 @@ public class ChangeNamespaceValue extends Recipe {
             }
 
             private boolean isVersionMatch(Xml.Attribute attribute) {
-                return versionMatcher == null || Semver.validate(attribute.getValueAsString(), versionMatcher).isValid();
+                String[] versions = versionMatcher.split(",");
+                double dversion = Double.parseDouble(attribute.getValueAsString());
+                for (String splitVersion : versions) {
+                    boolean checkGreaterThan = false;
+                    double dversionExpected;
+                    if (splitVersion.endsWith("+")) {
+                        splitVersion = splitVersion.substring(0, splitVersion.length() - 1);
+                        checkGreaterThan = true;
+                    }
+                    try {
+                        dversionExpected = Double.parseDouble(splitVersion);
+                    } catch (NumberFormatException e) {
+                        return false;
+                    }
+                    if (!checkGreaterThan && dversionExpected == dversion || checkGreaterThan && dversionExpected <= dversion) {
+                        return true;
+                    }
+                }
+                return false;
             }
         };
     }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeNamespaceValueTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeNamespaceValueTest.java
@@ -148,6 +148,23 @@ public class ChangeNamespaceValueTest implements RewriteTest {
     }
 
     @Test
+    void invalidVersionTest() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/j2ee", "2.5", false)),
+          xml(
+            """
+                  <web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.4"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+                      id="WebApp_ID">
+                      <display-name>testWebDDNamespace</display-name>
+                  </web-app>
+              """
+          )
+        );
+    }
+
+    @Test
     void namespaceWithPrefixMatched() {
         rewriteRun(
           spec -> spec.recipe(new ChangeNamespaceValue(null, "http://old.namespace", "https://new.namespace", null, true)),

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeNamespaceValueTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeNamespaceValueTest.java
@@ -20,7 +20,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.xml.Assertions.xml;
 
-public class ChangeNamespaceValueTest implements RewriteTest {
+class ChangeNamespaceValueTest implements RewriteTest {
 
     @Test
     void replaceVersion24Test() {
@@ -153,12 +153,12 @@ public class ChangeNamespaceValueTest implements RewriteTest {
           spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/j2ee", "2.5", false)),
           xml(
             """
-                  <web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.4"
-                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                      xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-                      id="WebApp_ID">
-                      <display-name>testWebDDNamespace</display-name>
-                  </web-app>
+              <web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.4"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+                  id="WebApp_ID">
+                  <display-name>testWebDDNamespace</display-name>
+              </web-app>
               """
           )
         );


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This pull request fixes the version matching issue in ChangeNamespaceValue

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
This changes was necessary to resolve failures in rewrite-liberty repo.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
