### PR TITLE
Add `maybeAddImport(String, String, String, boolean)`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -536,7 +536,7 @@ class AddImportTest implements RewriteTest {
             );
 
             rewriteRun(
-              spec -> spec.recipe(toRecipe(() -> new AddImport<>(pkg + ".B", null, false))),
+              spec -> spec.recipe(toRecipe(() -> new AddImport<>(pkg, "B", null, false))),
               sources.toArray(new SourceSpecs[0])
             );
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -21,6 +21,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
@@ -115,8 +116,8 @@ public class ChangeType extends Recipe {
         }
 
         @Override
-        public J visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-            J.ClassDeclaration cd = (J.ClassDeclaration) super.visitClassDeclaration(classDecl, executionContext);
+        public J visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            J.ClassDeclaration cd = (J.ClassDeclaration) super.visitClassDeclaration(classDecl, ctx);
             if (cd.getType() != null) {
                 topLevelClassnames.add(getTopLevelClassName(cd.getType()).getFullyQualifiedName());
             }
@@ -124,7 +125,7 @@ public class ChangeType extends Recipe {
         }
 
         @Override
-        public J visitImport(J.Import import_, ExecutionContext executionContext) {
+        public J visitImport(J.Import import_, ExecutionContext ctx) {
             // visitCompilationUnit() handles changing the imports.
             // If we call super.visitImport() then visitFieldAccess() will change the imports before AddImport/RemoveImport see them.
             // visitFieldAccess() doesn't have the import-specific formatting logic that AddImport/RemoveImport do.
@@ -132,13 +133,13 @@ public class ChangeType extends Recipe {
         }
 
         @Override
-        public @Nullable JavaType visitType(@Nullable JavaType javaType, ExecutionContext executionContext) {
+        public @Nullable JavaType visitType(@Nullable JavaType javaType, ExecutionContext ctx) {
             return updateType(javaType);
         }
 
         @Override
-        public @Nullable J postVisit(J tree, ExecutionContext executionContext) {
-            J j = super.postVisit(tree, executionContext);
+        public @Nullable J postVisit(J tree, ExecutionContext ctx) {
+            J j = super.postVisit(tree, ctx);
             if (j instanceof J.MethodDeclaration) {
                 J.MethodDeclaration method = (J.MethodDeclaration) j;
                 j = method.withMethodType(updateType(method.getMethodType()));
@@ -162,26 +163,33 @@ public class ChangeType extends Recipe {
                         if (maybeType instanceof JavaType.FullyQualified) {
                             JavaType.FullyQualified type = (JavaType.FullyQualified) maybeType;
                             if (originalType.getFullyQualifiedName().equals(type.getFullyQualifiedName())) {
-                                sf = (JavaSourceFile) new RemoveImport<ExecutionContext>(originalType.getFullyQualifiedName()).visit(sf, executionContext, getCursor());
+                                sf = (JavaSourceFile) new RemoveImport<ExecutionContext>(originalType.getFullyQualifiedName()).visit(sf, ctx, getCursor());
                             } else if (originalType.getOwningClass() != null && originalType.getOwningClass().getFullyQualifiedName().equals(type.getFullyQualifiedName())) {
-                                sf = (JavaSourceFile) new RemoveImport<ExecutionContext>(originalType.getOwningClass().getFullyQualifiedName()).visit(sf, executionContext, getCursor());
+                                sf = (JavaSourceFile) new RemoveImport<ExecutionContext>(originalType.getOwningClass().getFullyQualifiedName()).visit(sf, ctx, getCursor());
                             }
                         }
                     }
                 }
 
                 JavaType.FullyQualified fullyQualifiedTarget = TypeUtils.asFullyQualified(targetType);
-                if (fullyQualifiedTarget != null && !(fullyQualifiedTarget.getOwningClass() != null && topLevelClassnames.contains(getTopLevelClassName(fullyQualifiedTarget).getFullyQualifiedName()))) {
-                    if (fullyQualifiedTarget.getOwningClass() != null && !"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
-                        sf = (JavaSourceFile) new AddImport<>(fullyQualifiedTarget.getOwningClass().getFullyQualifiedName(), null, true).visit(sf, executionContext, getCursor());
-                    }
-                    if (!"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
-                        sf = (JavaSourceFile) new AddImport<>(fullyQualifiedTarget.getFullyQualifiedName(), null, true).visit(sf, executionContext, getCursor());
+                if (fullyQualifiedTarget != null) {
+                    JavaType.FullyQualified owningClass = fullyQualifiedTarget.getOwningClass();
+                    if (!(owningClass != null && topLevelClassnames.contains(getTopLevelClassName(fullyQualifiedTarget).getFullyQualifiedName()))) {
+                        if (owningClass != null && !"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
+                            assert sf != null;
+                            sf = (JavaSourceFile) sf.service(ImportService.class).addImportVisitor(owningClass.getPackageName(), owningClass.getClassName(), null, true)
+                                    .visit(sf, ctx, getCursor());
+                        }
+                        if (!"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
+                            assert sf != null;
+                            sf = (JavaSourceFile) sf.service(ImportService.class).addImportVisitor(fullyQualifiedTarget.getPackageName(), fullyQualifiedTarget.getClassName(), null, true)
+                                    .visit(sf, ctx, getCursor());
+                        }
                     }
                 }
 
                 if (sf != null) {
-                    sf = sf.withImports(ListUtils.map(sf.getImports(), i -> visitAndCast(i, executionContext, super::visitImport)));
+                    sf = sf.withImports(ListUtils.map(sf.getImports(), i -> visitAndCast(i, ctx, super::visitImport)));
                 }
 
                 j = sf;
@@ -477,7 +485,7 @@ public class ChangeType extends Recipe {
         }
 
         @Override
-        public J.Package visitPackage(J.Package pkg, ExecutionContext executionContext) {
+        public J.Package visitPackage(J.Package pkg, ExecutionContext ctxext) {
             String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
             if (original.equals(originalType.getPackageName())) {
                 JavaType.FullyQualified fq = TypeUtils.asFullyQualified(targetType);
@@ -497,17 +505,17 @@ public class ChangeType extends Recipe {
         }
 
         @Override
-        public J.Import visitImport(J.Import _import, ExecutionContext executionContext) {
+        public J.Import visitImport(J.Import _import, ExecutionContext ctx) {
             Boolean updatePrefix = getCursor().pollNearestMessage("UPDATE_PREFIX");
             if (updatePrefix != null && updatePrefix) {
                 _import = _import.withPrefix(Space.EMPTY);
             }
-            return super.visitImport(_import, executionContext);
+            return super.visitImport(_import, ctx);
         }
 
         @Override
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
             Boolean updatePrefix = getCursor().pollNearestMessage("UPDATE_PREFIX");
             if (updatePrefix != null && updatePrefix) {
                 cd = cd.withPrefix(Space.EMPTY);
@@ -522,12 +530,12 @@ public class ChangeType extends Recipe {
         }
 
         @Override
-        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             if (method.isConstructor() && originalConstructor.matches(method.getMethodType())) {
                 method = method.withName(method.getName().withSimpleName(targetType.getClassName()));
                 method = method.withMethodType(updateType(method.getMethodType()));
             }
-            return super.visitMethodDeclaration(method, executionContext);
+            return super.visitMethodDeclaration(method, ctx);
         }
 
         private String getNewClassName(JavaType.FullyQualified fq) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -112,19 +112,26 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      * is idempotent and calling this method multiple times with the same arguments will only add an import once.
      *
      * @param fullyQualifiedName Fully-qualified name of the class.
-     * @param statik             The static method or field to be imported. A wildcard "*" may also be used to statically import all methods/fields.
+     * @param member             The static method or field to be imported. A wildcard "*" may also be used to statically import all methods/fields.
      */
-    public void maybeAddImport(String fullyQualifiedName, String statik) {
-        maybeAddImport(fullyQualifiedName, statik, true);
+    public void maybeAddImport(String fullyQualifiedName, String member) {
+        maybeAddImport(fullyQualifiedName, member, true);
     }
 
     public void maybeAddImport(String fullyQualifiedName, boolean onlyIfReferenced) {
         maybeAddImport(fullyQualifiedName, null, onlyIfReferenced);
     }
 
-    public void maybeAddImport(String fullyQualifiedName, @Nullable String statik, boolean onlyIfReferenced) {
+    public void maybeAddImport(String fullyQualifiedName, @Nullable String member, boolean onlyIfReferenced) {
+        int lastDotIdx = fullyQualifiedName.lastIndexOf('.');
+        String packageName = lastDotIdx != -1 ? fullyQualifiedName.substring(0, lastDotIdx) : null;
+        String typeName = lastDotIdx != -1 ? fullyQualifiedName.substring(lastDotIdx + 1) : fullyQualifiedName;
+        maybeAddImport(packageName, typeName, member, onlyIfReferenced);
+    }
+
+    public void maybeAddImport(@Nullable String packageName, String typeName, @Nullable String member, boolean onlyIfReferenced) {
         ImportService service = getCursor().firstEnclosingOrThrow(JavaSourceFile.class).service(ImportService.class);
-        JavaVisitor<P> visitor = service.addImportVisitor(fullyQualifiedName, statik, onlyIfReferenced);
+        JavaVisitor<P> visitor = service.addImportVisitor(packageName, typeName, member, onlyIfReferenced);
         if (!getAfterVisit().contains(visitor)) {
             doAfterVisit(visitor);
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
@@ -20,10 +20,10 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.AddImport;
 import org.openrewrite.java.JavaVisitor;
 
-@Incubating(since = "8.1.16")
+@Incubating(since = "8.2.0")
 public class ImportService {
 
-    public <P> JavaVisitor<P> addImportVisitor(String packageName, @Nullable String typeName, boolean onlyIfReferenced) {
-        return new AddImport<>(packageName, typeName, onlyIfReferenced);
+    public <P> JavaVisitor<P> addImportVisitor(@Nullable String packageName, String typeName, @Nullable String member, boolean onlyIfReferenced) {
+        return new AddImport<>(packageName, typeName, member, onlyIfReferenced);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -46,7 +46,7 @@ public class TypeUtils {
         return fqn1 == null && fqn2 == null;
     }
 
-    public static Predicate<String> fullyQualifiedNamesAreEqualAsPredicate (@Nullable String fqn1) {
+    public static Predicate<String> fullyQualifiedNamesAreEqualAsPredicate(@Nullable String fqn1) {
         return (fqn2) -> fullyQualifiedNamesAreEqual(fqn1, fqn2);
     }
 
@@ -130,7 +130,7 @@ public class TypeUtils {
      */
     public static boolean isOfClassType(@Nullable JavaType type, String fqn) {
         if (type instanceof JavaType.FullyQualified) {
-            return TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) type).getFullyQualifiedName(), (fqn));
+            return TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) type).getFullyQualifiedName(), fqn);
         } else if (type instanceof JavaType.Variable) {
             return isOfClassType(((JavaType.Variable) type).getType(), fqn);
         } else if (type instanceof JavaType.Method) {
@@ -144,7 +144,7 @@ public class TypeUtils {
     }
 
     /**
-     * @param type The declaring type of the method invocation or constructor.
+     * @param type          The declaring type of the method invocation or constructor.
      * @param matchOverride Whether to match the {@code Object} type.
      * @return True if the declaring type matches the criteria of this matcher.
      */
@@ -154,29 +154,29 @@ public class TypeUtils {
             boolean matchOverride,
             Predicate<String> matcher
     ) {
-       if (type == null || type instanceof JavaType.Unknown) {
-           return false;
-       }
-       if (matcher.test(type.getFullyQualifiedName())) {
-           return true;
-       }
-       if (matchOverride) {
-           if (!"java.lang.Object".equals(type.getFullyQualifiedName()) &&
-               isOfTypeWithName(TYPE_OBJECT, true, matcher)) {
-               return true;
-           }
+        if (type == null || type instanceof JavaType.Unknown) {
+            return false;
+        }
+        if (matcher.test(type.getFullyQualifiedName())) {
+            return true;
+        }
+        if (matchOverride) {
+            if (!"java.lang.Object".equals(type.getFullyQualifiedName()) &&
+                isOfTypeWithName(TYPE_OBJECT, true, matcher)) {
+                return true;
+            }
 
-           if (isOfTypeWithName(type.getSupertype(), true, matcher)) {
-               return true;
-           }
+            if (isOfTypeWithName(type.getSupertype(), true, matcher)) {
+                return true;
+            }
 
-           for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
-               if (isOfTypeWithName(anInterface, true, matcher)) {
-                   return true;
-               }
-           }
-       }
-       return false;
+            for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+                if (isOfTypeWithName(anInterface, true, matcher)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public static boolean isAssignableTo(@Nullable JavaType to, @Nullable JavaType from) {


### PR DESCRIPTION
This canonical form accepts separate strings for the package name, type name (qualified in case of nested classes), and member. This way there is no confusion about what constitutes the package name or an owning class.
