### PR TITLE
Add columns for type and method to `MethodCalls` datatable produced by `FindMethods`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.java.table.MethodCalls;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -203,6 +204,43 @@ class FindMethodsTest implements RewriteTest {
                  public static class C {
                      public void foo() {}
                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void datatableFormat() {
+        rewriteRun(
+          spec -> spec.dataTableAsCsv(MethodCalls.class.getName(),
+            """
+              sourceFile,method,className,methodName
+              A.java,"new B.C().foo()","B$C",foo
+              """
+          ).recipe(new FindMethods("B.C foo()", false)),
+          java(
+            """
+              public class B {
+                 public static class C {
+                     public void foo() {}
+                 }
+              }
+              """
+          ),
+          java(
+            """
+              public class A {
+                   void test() {
+                       new B.C().foo();
+                   }
+              }
+              """,
+            """
+              public class A {
+                   void test() {
+                       /*~~>*/new B.C().foo();
+                   }
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
@@ -215,15 +215,15 @@ class FindMethodsTest implements RewriteTest {
         rewriteRun(
           spec -> spec.dataTableAsCsv(MethodCalls.class.getName(),
             """
-              sourceFile,method,className,methodName
-              A.java,"new B.C().foo()","B$C",foo
+              sourceFile,method,className,methodName,argumentTypes
+              A.java,"new B.C().foo(bar, 123)","B$C",foo,"java.lang.String, int"
               """
-          ).recipe(new FindMethods("B.C foo()", false)),
+          ).recipe(new FindMethods("B.C foo(..)", false)),
           java(
             """
               public class B {
                  public static class C {
-                     public void foo() {}
+                     public void foo(String bar, int baz) {}
                  }
               }
               """
@@ -231,15 +231,15 @@ class FindMethodsTest implements RewriteTest {
           java(
             """
               public class A {
-                   void test() {
-                       new B.C().foo();
+                   void test(String bar) {
+                       new B.C().foo(bar, 123);
                    }
               }
               """,
             """
               public class A {
-                   void test() {
-                       /*~~>*/new B.C().foo();
+                   void test(String bar) {
+                       /*~~>*/new B.C().foo(bar, 123);
                    }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -28,7 +28,6 @@ import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -83,8 +82,7 @@ public class FindMethods extends Recipe {
                                 method.getSimpleName(),
                                 method.getArguments().stream()
                                         .map(Expression::getType)
-                                        .filter(Objects::nonNull)
-                                        .map(Object::toString)
+                                        .map(String::valueOf)
                                         .collect(Collectors.joining(", "))
                         ));
                     }
@@ -106,8 +104,7 @@ public class FindMethods extends Recipe {
                                 memberRef.getMethodType().getName(),
                                 memberRef.getArguments().stream()
                                         .map(Expression::getType)
-                                        .filter(Objects::nonNull)
-                                        .map(Object::toString)
+                                        .map(String::valueOf)
                                         .collect(Collectors.joining(", "))
                         ));
                     }
@@ -129,8 +126,7 @@ public class FindMethods extends Recipe {
                                 "<constructor>",
                                 newClass.getArguments().stream()
                                         .map(Expression::getType)
-                                        .filter(Objects::nonNull)
-                                        .map(Object::toString)
+                                        .map(String::valueOf)
                                         .collect(Collectors.joining(", "))
                         ));
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -76,7 +76,9 @@ public class FindMethods extends Recipe {
                     if (javaSourceFile != null) {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
-                                method.printTrimmed(getCursor())
+                                method.printTrimmed(getCursor()),
+                                m.getMethodType().getDeclaringType().getFullyQualifiedName(),
+                                m.getSimpleName()
                         ));
                     }
                     m = SearchResult.found(m);
@@ -92,7 +94,9 @@ public class FindMethods extends Recipe {
                     if (javaSourceFile != null) {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
-                                memberRef.printTrimmed(getCursor())
+                                memberRef.printTrimmed(getCursor()),
+                                m.getMethodType().getDeclaringType().getFullyQualifiedName(),
+                                m.getMethodType().getName()
                         ));
                     }
                     m = m.withReference(SearchResult.found(m.getReference()));
@@ -108,7 +112,9 @@ public class FindMethods extends Recipe {
                     if (javaSourceFile != null) {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
-                                newClass.printTrimmed(getCursor())
+                                newClass.printTrimmed(getCursor()),
+                                n.getType().toString(),
+                                "<constructor>"
                         ));
                     }
                     n = SearchResult.found(n);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -22,11 +22,13 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.table.MethodCalls;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -77,8 +79,13 @@ public class FindMethods extends Recipe {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
                                 method.printTrimmed(getCursor()),
-                                m.getMethodType().getDeclaringType().getFullyQualifiedName(),
-                                m.getSimpleName()
+                                method.getMethodType().getDeclaringType().getFullyQualifiedName(),
+                                method.getSimpleName(),
+                                method.getArguments().stream()
+                                        .map(Expression::getType)
+                                        .filter(Objects::nonNull)
+                                        .map(Object::toString)
+                                        .collect(Collectors.joining(", "))
                         ));
                     }
                     m = SearchResult.found(m);
@@ -95,8 +102,13 @@ public class FindMethods extends Recipe {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
                                 memberRef.printTrimmed(getCursor()),
-                                m.getMethodType().getDeclaringType().getFullyQualifiedName(),
-                                m.getMethodType().getName()
+                                memberRef.getMethodType().getDeclaringType().getFullyQualifiedName(),
+                                memberRef.getMethodType().getName(),
+                                memberRef.getArguments().stream()
+                                        .map(Expression::getType)
+                                        .filter(Objects::nonNull)
+                                        .map(Object::toString)
+                                        .collect(Collectors.joining(", "))
                         ));
                     }
                     m = m.withReference(SearchResult.found(m.getReference()));
@@ -113,8 +125,13 @@ public class FindMethods extends Recipe {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
                                 newClass.printTrimmed(getCursor()),
-                                n.getType().toString(),
-                                "<constructor>"
+                                newClass.getType().toString(),
+                                "<constructor>",
+                                newClass.getArguments().stream()
+                                        .map(Expression::getType)
+                                        .filter(Objects::nonNull)
+                                        .map(Object::toString)
+                                        .collect(Collectors.joining(", "))
                         ));
                     }
                     n = SearchResult.found(n);

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/MethodCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/MethodCalls.java
@@ -39,5 +39,13 @@ public class MethodCalls extends DataTable<MethodCalls.Row> {
         @Column(displayName = "Method call",
                 description = "The text of the method call.")
         String method;
+
+        @Column(displayName = "Class name",
+                description = "The class name of the method call.")
+        String className;
+
+        @Column(displayName = "Method name",
+                description = "The method name of the method call.")
+        String methodName;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/MethodCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/MethodCalls.java
@@ -47,5 +47,9 @@ public class MethodCalls extends DataTable<MethodCalls.Row> {
         @Column(displayName = "Method name",
                 description = "The method name of the method call.")
         String methodName;
+
+        @Column(displayName = "Argument types",
+                description = "The argument types of the method call.")
+        String argumentTypes;
     }
 }


### PR DESCRIPTION
## What's changed?
Add two columns to the data table produced by FindMethods

## What's your motivation?
Particularly helps cases with wildcards, as `*..*Utils *(..)` does not always produce a data table row that can be traced back without context. Having the type and method name available, and split out from additional context, makes it easier to sort & filter on values as opposed to the usage line only.

## Anything in particular you'd like reviewers to focus on?
Called out below.

## Any additional context
Helps prioritize replacements applied at scale, as it's now somewhat annoying to pull from the usage columns only, which contains a mix of qualified and unqualified method calls, using different or even no select.