### PR TITLE
Rely on parser to catch print inequality

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -78,9 +78,6 @@ class FormatPreservingReader extends Reader {
             buffer.ensureCapacity(buffer.size() + read);
             for (int i = 0; i < read; i++) {
                 char e = cbuf[i];
-                if (Character.UnicodeBlock.of(e) != Character.UnicodeBlock.BASIC_LATIN) {
-                    throw new IllegalArgumentException("Only ASCII characters are supported for now");
-                }
                 buffer.add(e);
             }
         }


### PR DESCRIPTION
## What's changed?
Remove specific exception thrown when unicode is detected in Yaml in favor of generic catch when printed file is unequal.

## What's your motivation?
Similar handling & reporting across parsers.

## Any additional context
- https://github.com/openrewrite/rewrite/issues/2062
- https://github.com/openrewrite/rewrite/pull/3419
- https://github.com/openrewrite/rewrite/pull/3421