### PR TITLE
Change AutoFormatter to be dynamically provided by the tree root SourceFile

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -107,6 +107,10 @@ public interface SourceFile extends Tree {
         throw new UnsupportedOperationException("SourceFile implementations should override this method");
     }
 
+    default <P> TreeVisitor<?, P> autoFormatter(Cursor cursor, @Nullable Tree stopAfter) {
+        throw new UnsupportedOperationException("SourceFile implementations should override this method");
+    }
+
     /**
      * A measure of the size of the AST by count of number of AST nodes or some other similar measure. Because perfect referential
      * uniqueness is space inefficient, this weight will always be approximate and is best used for comparative size between two ASTs

--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -82,8 +82,11 @@ public interface Tree {
     <P> boolean isAcceptable(TreeVisitor<?, P> v, P p);
 
     default <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
-
         return cursor.firstEnclosingOrThrow(SourceFile.class).printer(cursor);
+    }
+
+    default <P> TreeVisitor<?, P> autoFormatter(Cursor cursor, @Nullable Tree stopAfter) {
+        return cursor.firstEnclosingOrThrow(SourceFile.class).autoFormatter(cursor, stopAfter);
     }
 
     default String print(Cursor cursor) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -22,6 +22,7 @@ import org.openrewrite.*;
 import org.openrewrite.groovy.GroovyPrinter;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -185,6 +186,11 @@ public interface G extends J {
         @Override
         public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
             return new GroovyPrinter<>();
+        }
+
+        @Override
+        public <P> TreeVisitor<?, P> autoFormatter(Cursor cursor, @Nullable Tree stopAfter) {
+            return new AutoFormatVisitor<>(stopAfter);
         }
 
         @Transient

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -21,7 +21,6 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -92,7 +91,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
 
     @SuppressWarnings({"ConstantConditions", "unchecked"})
     public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, P p, Cursor cursor) {
-        return (J2) new AutoFormatVisitor<>(stopAfter).visit(j, p, cursor);
+        return (J2) j.autoFormatter(getCursor(), stopAfter).visit(j, p, cursor);
     }
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.JavaTypeVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.marker.Markers;
@@ -1527,6 +1528,11 @@ public interface J extends Tree {
         @Override
         public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
             return new JavaPrinter<>();
+        }
+
+        @Override
+        public <P> TreeVisitor<?, P> autoFormatter(Cursor cursor, @Nullable Tree stopAfter) {
+            return new AutoFormatVisitor<>(stopAfter);
         }
 
         @Transient


### PR DESCRIPTION
To support language-specific autoFormat like Kotlin, we need to change AutoFormatter to be dynamically provided using the same way as the language-specific printer.