### PR TITLE
Upgrade Maven plugin dependencies

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -38,6 +38,7 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
 @SuppressWarnings("NotNullFieldNotInitialized")
 public class MavenVisitor<P> extends XmlVisitor<P> {
     static final XPathMatcher DEPENDENCY_MATCHER = new XPathMatcher("/project/dependencies/dependency");
+    static final XPathMatcher PLUGIN_DEPENDENCY_MATCHER = new XPathMatcher("/project/*/plugins/plugin/dependencies/dependency");
     static final XPathMatcher MANAGED_DEPENDENCY_MATCHER = new XPathMatcher("/project/dependencyManagement/dependencies/dependency");
     static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
     static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/*/plugins/plugin");
@@ -118,6 +119,15 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
             }
         }
         return false;
+    }
+
+    public boolean isPluginDependencyTag(String groupId, String artifactId) {
+        if (!PLUGIN_DEPENDENCY_MATCHER.matches(getCursor())) {
+            return false;
+        }
+        Xml.Tag tag = getCursor().getValue();
+        return matchesGlob(tag.getChildValue("groupId").orElse(null), groupId) &&
+                matchesGlob(tag.getChildValue("artifactId").orElse(null), artifactId);
     }
 
     public boolean isManagedDependencyTag() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -302,7 +302,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<Set<GroupArtifact>>
                 }
                 return version;
             }
-            
+
             @Nullable
             public TreeVisitor<Xml, ExecutionContext> upgradeVersion(ExecutionContext ctx, Xml.Tag tag, @Nullable String requestedVersion, String groupId, String artifactId, String version2) throws MavenDownloadingException {
                 String newerVersion = findNewerVersion(groupId, artifactId, version2, ctx);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -142,6 +142,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<Set<GroupArtifact>>
         assert versionComparator != null;
 
         return new MavenIsoVisitor<ExecutionContext>() {
+            private final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
+
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 Xml.Tag t = super.visitTag(tag, ctx);
@@ -158,6 +160,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<Set<GroupArtifact>>
                                 maybeUpdateModel();
                             }
                         }
+                    } else if (isPluginDependencyTag(groupId, artifactId)) {
+                        // TODO handle plugin dependencies
                     }
                 } catch (MavenDownloadingException e) {
                     return e.warn(t);
@@ -320,8 +324,4 @@ public class UpgradeDependencyVersion extends ScanningRecipe<Set<GroupArtifact>>
             }
         };
     }
-
-    private static final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
-    private static final String DEPENDENCIES_XPATH = "/project/dependencies";
-    private static final String DEPENDENCY_MANAGEMENT_XPATH = "/project/dependencyManagement";
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -579,6 +579,72 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void upgradePluginDependenciesOnProperty() {
+        rewriteRun(
+          // Using latest.patch to validate the version property resolution, since it's needed for matching the valid patch.
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.openrewrite.recipe", "rewrite-spring", "latest.patch", "", null, null)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <properties>
+                    <rewrite-spring.version>4.33.0</rewrite-spring.version>
+                </properties>
+                
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>5.4.1</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.openrewrite.recipe</groupId>
+                          <artifactId>rewrite-spring</artifactId>
+                          <version>${rewrite-spring.version}</version>
+                        </dependency>
+                      </dependencies>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <properties>
+                    <rewrite-spring.version>4.33.2</rewrite-spring.version>
+                </properties>
+                
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>5.4.1</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.openrewrite.recipe</groupId>
+                          <artifactId>rewrite-spring</artifactId>
+                          <version>${rewrite-spring.version}</version>
+                        </dependency>
+                      </dependencies>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1334")
     void upgradeGuavaWithExplicitBlankVersionPattern() {
         rewriteRun(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -526,7 +526,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Test
     void upgradePluginDependencies() {
         rewriteRun(
-          spec -> spec.recipe(new UpgradeDependencyVersion("org.openrewrite.recipe", "rewrite-spring", "5.0.6", "-android", null, null)),
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.openrewrite.recipe", "rewrite-spring", "5.0.6", "", null, null)),
           pomXml(
             """
               <project>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -524,6 +524,61 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void upgradePluginDependencies() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.openrewrite.recipe", "rewrite-spring", "5.0.6", "-android", null, null)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>5.4.1</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.openrewrite.recipe</groupId>
+                          <artifactId>rewrite-spring</artifactId>
+                          <version>5.0.5</version>
+                        </dependency>
+                      </dependencies>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>5.4.1</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.openrewrite.recipe</groupId>
+                          <artifactId>rewrite-spring</artifactId>
+                          <version>5.0.6</version>
+                        </dependency>
+                      </dependencies>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1334")
     void upgradeGuavaWithExplicitBlankVersionPattern() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
First attempt at upgrading plugin dependency versions.

## What's your motivation?
Maven plugins can have dependencies themselves, as the rewrite-maven-plugin does.
We want to support upgrading those dependencies too.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
