### PR TITLE
For language-specific services, change to compare class-name to get r…

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -21,7 +21,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.format.AutoFormatVisitor;
+import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -92,7 +92,8 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
 
     @SuppressWarnings({"ConstantConditions", "unchecked"})
     public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, P p, Cursor cursor) {
-        return (J2) new AutoFormatVisitor<>(stopAfter).visit(j, p, cursor);
+        AutoFormatService service = getCursor().firstEnclosingOrThrow(JavaSourceFile.class).service(AutoFormatService.class);
+        return (J2) service.autoFormatVisitor(stopAfter).visit(j, p, cursor);
     }
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AutoFormatService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AutoFormatService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.service;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.Tree;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.format.AutoFormatVisitor;
+
+@Incubating(since = "8.2.0")
+public class AutoFormatService {
+
+    public <P> JavaVisitor<P> autoFormatVisitor(@Nullable Tree stopAfter) {
+        return new AutoFormatVisitor<>(stopAfter);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -19,6 +19,7 @@ import org.openrewrite.Incubating;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.service.ImportService;
 
 import java.nio.file.Path;
@@ -56,8 +57,10 @@ public interface JavaSourceFile extends J {
     @Incubating(since = "8.2.0")
     @SuppressWarnings("unchecked")
     default <S> S service(Class<S> service) {
-        if (service == ImportService.class) {
+        if (ImportService.class.getName().equals(service.getName())) {
             return (S) new ImportService();
+        } else if (AutoFormatService.class.getName().equals(service.getName())) {
+            return (S) new AutoFormatService();
         }
         throw new UnsupportedOperationException("Service " + service + " not supported");
     }


### PR DESCRIPTION
This is an alternative change of https://github.com/openrewrite/rewrite/pull/3478
to address @knutwannheden 's [comment](https://github.com/openrewrite/rewrite/pull/3478#discussion_r1295442458) to keep the existing way of language-specific service declaration.
but changed to compare class-name instead of referential equality on the class to avoid potential class-loading problems.

Also, add support language-specific autoFormat using the same way.
