### PR TITLE
Changing method type in ReorderMethodArguments

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ReorderMethodArgumentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ReorderMethodArgumentsTest.java
@@ -16,13 +16,9 @@
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class ReorderMethodArgumentsTest implements RewriteTest {
 
@@ -76,7 +72,7 @@ class ReorderMethodArgumentsTest implements RewriteTest {
     void reorderArgumentsWithNoSourceAttachment() {
         rewriteRun(
           spec -> spec.recipe(new ReorderMethodArguments("a.A foo(String,..)",
-              new String[]{"s", "n"}, new String[]{"n", "s"}, null, null)),
+            new String[]{"s", "n"}, new String[]{"n", "s"}, null, null)),
           java(
             """
               package a;
@@ -113,7 +109,7 @@ class ReorderMethodArgumentsTest implements RewriteTest {
     void reorderArgumentsWhereOneOfTheOriginalArgumentsIsVararg() {
         rewriteRun(
           spec -> spec.recipe(new ReorderMethodArguments("a.A foo(String,Integer,..)",
-              new String[]{"s", "o", "n"}, null, null, null)),
+            new String[]{"s", "o", "n"}, null, null, null)),
           java(
             """
               package a;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ReorderMethodArgumentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ReorderMethodArgumentsTest.java
@@ -31,17 +31,7 @@ class ReorderMethodArgumentsTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipes(
             new ReorderMethodArguments("a.A foo(String, Integer, Integer)",
-              new String[]{"n", "m", "s"}, null, null, null),
-            toRecipe(() -> new JavaVisitor<>() {
-                @Override
-                public J visitLiteral(J.Literal literal, ExecutionContext p) {
-                    if (literal.getType() == JavaType.Primitive.String) {
-                        doAfterVisit(new ChangeLiteral<>(literal, l -> "anotherstring"));
-                    }
-                    return super.visitLiteral(literal, p);
-                }
-            })
-          ).cycles(1).expectedCyclesThatMakeChanges(1),
+              new String[]{"n", "m", "s"}, null, null, null)),
           java(
             """
               package a;
@@ -73,7 +63,7 @@ class ReorderMethodArgumentsTest implements RewriteTest {
                      a.foo(
                          2,
                          1,
-                         "anotherstring"
+                         "mystring"
                      );
                  }
               }
@@ -85,9 +75,8 @@ class ReorderMethodArgumentsTest implements RewriteTest {
     @Test
     void reorderArgumentsWithNoSourceAttachment() {
         rewriteRun(
-          spec -> spec.recipe(new ReorderMethodArguments("a.A foo(..)",
-              new String[]{"s", "n"}, new String[]{"n", "s"}, null, null))
-            .cycles(1).expectedCyclesThatMakeChanges(1),
+          spec -> spec.recipe(new ReorderMethodArguments("a.A foo(String,..)",
+              new String[]{"s", "n"}, new String[]{"n", "s"}, null, null)),
           java(
             """
               package a;
@@ -123,15 +112,14 @@ class ReorderMethodArgumentsTest implements RewriteTest {
     @Test
     void reorderArgumentsWhereOneOfTheOriginalArgumentsIsVararg() {
         rewriteRun(
-          spec -> spec.recipe(new ReorderMethodArguments("a.A foo(..)",
-              new String[]{"s", "o", "n"}, null, null, null))
-            .cycles(1).expectedCyclesThatMakeChanges(1),
+          spec -> spec.recipe(new ReorderMethodArguments("a.A foo(String,Integer,..)",
+              new String[]{"s", "o", "n"}, null, null, null)),
           java(
             """
               package a;
               public class A {
                  public void foo(String s, Integer n, Object... o) {}
-                 public void bar(String s, Object... o) {}
+                 public void foo(String s, Object... o) {}
               }
               """
           ),

--- a/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
@@ -25,7 +25,9 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -135,6 +137,7 @@ public class ReorderMethodArguments extends Recipe {
 
                 int i = 0;
                 List<JRightPadded<Expression>> reordered = new ArrayList<>(originalArgs.size());
+                List<JavaType> reorderedTypes = new ArrayList<>(originalArgs.size());
                 List<Space> formattings = new ArrayList<>(originalArgs.size());
                 List<Space> rightFormattings = new ArrayList<>(originalArgs.size());
 
@@ -144,12 +147,15 @@ public class ReorderMethodArguments extends Recipe {
                         // this is a varargs argument
                         List<JRightPadded<Expression>> varargs = originalArgs.subList(fromPos, originalArgs.size());
                         reordered.addAll(varargs);
+                        reorderedTypes.addAll(varargs.stream().map(e -> e.getElement().getType()).collect(Collectors.toList()));
                         for (JRightPadded<Expression> exp : originalArgs.subList(i, (i++) + varargs.size())) {
                             formattings.add(exp.getElement().getPrefix());
                             rightFormattings.add(exp.getAfter());
                         }
                     } else if (fromPos >= 0 && originalArgs.size() > fromPos) {
-                        reordered.add(originalArgs.get(fromPos));
+                        JRightPadded<Expression> originalArg = originalArgs.get(fromPos);
+                        reordered.add(originalArg);
+                        reorderedTypes.add(originalArg.getElement().getType());
                         formattings.add(originalArgs.get(i).getElement().getPrefix());
                         rightFormattings.add(originalArgs.get(i++).getAfter());
                     }
@@ -169,7 +175,9 @@ public class ReorderMethodArguments extends Recipe {
                 }
 
                 if (changed) {
-                    m = m.getPadding().withArguments(m.getPadding().getArguments().getPadding().withElements(reordered));
+                    m = m.getPadding()
+                            .withArguments(m.getPadding().getArguments().getPadding().withElements(reordered))
+                            .withMethodType(m.getMethodType().withParameterTypes(reorderedTypes));
                 }
             }
             return m;


### PR DESCRIPTION
## What's changed?
This recipe was not changing the method type, so even when changing the order of the arguments, it was matching again the next cycle and "reordering" the arguments again. If we update the methodType of the methodInvocation it's not needed to "hack" the tests forcing one cycle only, and thus we can check the idempotency of the recipe.

## What's your motivation?
I was using this recipe in another recipe, and not getting the expected results, because the recipe was applied two times (one in each cycle).

## Anyone you would like to review specifically?
@knutwannheden @timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've used the IntelliJ auto-formatter on affected files
