### PR TITLE
Fix AddGradleEnterpriseMavenExtension optional version to get the latest

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddGradleEnterpriseMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddGradleEnterpriseMavenExtension.java
@@ -26,9 +26,21 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.PathUtils;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.internal.MavenXmlMapper;
+import org.openrewrite.maven.tree.GroupArtifact;
+import org.openrewrite.maven.tree.MavenMetadata;
+import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.semver.LatestRelease;
+import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.XPathMatcher;
@@ -38,7 +50,11 @@ import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 
@@ -60,12 +76,6 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
                                                         "  <artifactId>gradle-enterprise-maven-extension</artifactId>\n" +
                                                         "  <version>%s</version>\n" +
                                                         "</extension>";
-
-    @Language("xml")
-    private static final String ENTERPRISE_TAG_FORMAT_WITHOUT_VERSION = "<extension>\n" +
-                                                                        "  <groupId>com.gradle</groupId>\n" +
-                                                                        "  <artifactId>gradle-enterprise-maven-extension</artifactId>\n" +
-                                                                        "</extension>";
 
     @Option(displayName = "Extension version",
             description = "A maven-compatible version number to select the gradle-enterprise-maven-extension version.",
@@ -127,7 +137,7 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
 
     @Override
     public String getDisplayName() {
-        return "Add Gradle Enterprise Maven extension to maven projects";
+        return "Add Gradle Enterprise Maven extension";
     }
 
     @Override
@@ -325,10 +335,27 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
      */
     private Xml.Document addEnterpriseExtension(Xml.Document extensionsXml, ExecutionContext ctx) {
         @Language("xml")
-        String tagSource = version != null ? String.format(ENTERPRISE_TAG_FORMAT, version) : ENTERPRISE_TAG_FORMAT_WITHOUT_VERSION;
+        String tagSource = version != null ? String.format(ENTERPRISE_TAG_FORMAT, version) : String.format(ENTERPRISE_TAG_FORMAT, getLatestVersion(ctx));
         AddToTagVisitor<ExecutionContext> addToTagVisitor = new AddToTagVisitor<>(
                 extensionsXml.getRoot(),
                 Xml.Tag.build(tagSource));
         return (Xml.Document) addToTagVisitor.visitNonNull(extensionsXml, ctx);
+    }
+
+    private String getLatestVersion(ExecutionContext ctx) {
+        MavenPomDownloader pomDownloader = new MavenPomDownloader(Collections.emptyMap(), ctx, null, null);
+        VersionComparator versionComparator = new LatestRelease(null);
+        GroupArtifact gradleEnterpriseExtension = new GroupArtifact("com.gradle", "gradle-enterprise-maven-extension");
+        try {
+            MavenMetadata extensionMetadata = pomDownloader.downloadMetadata(gradleEnterpriseExtension, null, Collections.singletonList(MavenRepository.MAVEN_CENTRAL));
+        return extensionMetadata.getVersioning()
+            .getVersions()
+            .stream()
+            .filter(v -> versionComparator.isValid(null, v))
+            .max((v1, v2) -> versionComparator.compare(null, v1, v2))
+            .orElseThrow(() -> new IllegalStateException("Expected to find at least one Gradle Enterprise Maven extension version to select from."));
+        } catch (MavenDownloadingException e) {
+            throw new IllegalStateException("Could not download Maven metadata", e);
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Changes to `AddGradleEnterpriseMavenExtension` recipe:
- fetch the latest Gradle Enterprise Maven extension version when the version attribute is not set.
- recipe display name is also changed to align with the `AddGradleEnterpriseGradlePlugin` recipe.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The `AddGradleEnterpriseMavenExtension` version attribute is optional but when not set it results in a extensions.xml with no version for the Gradle Enterprise extension, causing a subsequent build failure.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
