### PR TITLE
Allow rewrite-static-analysis to reuse `SimplifyBooleanExpressionVisitor`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -94,7 +94,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                     j = asBinary.getRight().withPrefix(asBinary.getRight().getPrefix().withWhitespace(""));
                 }
             } else if (isLiteralTrue(asBinary.getRight())) {
-                if (shouldSimplifyEqualsOn(asBinary.getRight())) {
+                if (shouldSimplifyEqualsOn(asBinary.getLeft())) {
                     maybeUnwrapParentheses();
                     j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(" "));
                 }
@@ -108,7 +108,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                     j = asBinary.getRight().withPrefix(asBinary.getRight().getPrefix().withWhitespace(""));
                 }
             } else if (isLiteralFalse(asBinary.getRight())) {
-                if (shouldSimplifyEqualsOn(asBinary.getRight())) {
+                if (shouldSimplifyEqualsOn(asBinary.getLeft())) {
                     maybeUnwrapParentheses();
                     j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(" "));
                 }


### PR DESCRIPTION
## What's changed?
Add `shouldSimplifyEqualsOn` to `SimplifyBooleanExpressionVisitor`, which a subclass in rewrite-static-analysis can override to accommodate Kotlin.

## What's your motivation?
Such that we don't have to maintain two separate copies while we wait for rewrite-kotlin to merge into OpenRewrite/rewrite.

## Anything in particular you'd like reviewers to focus on?
Do we need additional such calls for comparison to `null` in `maybeReplaceCompareWithNull`?

## Any additional context
Method modeled after what we already have in
https://github.com/openrewrite/rewrite-static-analysis/blob/772c82062d277e3cab1a1006904817a84b484c8c/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpression.java#L200-L213