### PR TITLE
Do not trim actual either with no trim

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -82,7 +82,7 @@ public class CreateTextFile extends ScanningRecipe<AtomicBoolean> {
     @Override
     public Collection<SourceFile> generate(AtomicBoolean shouldCreate, ExecutionContext ctx) {
         if(shouldCreate.get()) {
-            return new PlainTextParser().parse(fileContents)
+            return PlainTextParser.builder().build().parse(fileContents)
                     .map(brandNewFile -> (SourceFile) brandNewFile.withSourcePath(Paths.get(relativeFileName)))
                     .collect(Collectors.toList());
         }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -382,7 +382,8 @@ public interface RewriteTest extends SourceSpecs {
                                 .as("Expected a new file for the source path but there was an existing file already present: " +
                                     sourceSpec.getSourcePath())
                                 .isNull();
-                        String actual = result.getAfter().printAll(out.clone()).trim();
+                        String actual = result.getAfter().printAll(out.clone());
+                        actual = sourceSpec.noTrim ? actual : actual.trim();
                         String expected = sourceSpec.noTrim ?
                                 sourceSpec.after.apply(actual) :
                                 trimIndentPreserveCRLF(sourceSpec.after.apply(actual));
@@ -648,6 +649,7 @@ class DelegateSourceFileForDiff implements SourceFile {
         return out.getOut();
     }
 
+    @SuppressWarnings("unused") // Lombok delegate exclude
     interface PrintAll {
         <P> String printAll(PrintOutputCapture<P> out);
     }

--- a/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
@@ -35,6 +35,18 @@ class CreateTextFileTest implements RewriteTest {
         );
     }
 
+    @Test
+    void hasCreatedFileWithTrailingNewline() {
+        rewriteRun(
+          spec -> spec.recipe(new CreateTextFile("foo\n", ".github/CODEOWNERS", false)),
+          text(
+            null,
+            "foo\n",
+            spec -> spec.path(".github/CODEOWNERS").noTrim()
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void hasOverwrittenFile() {


### PR DESCRIPTION
## What's changed?
When `SourceSpec.noTrim = true` do not trim the actual output either, as this tripped up tests in #3491 .

## What's your motivation?
- #3491 
- https://github.com/openrewrite/rewrite-jenkins/compare/main...bugfix/generate-codeowners-with-newline