### PR TITLE
Use tag groupId and artifactId to change version

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -45,17 +45,22 @@ public class UpgradePluginVersion extends Recipe {
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 
     @Option(displayName = "Group",
-            description = "The first part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'.",
+            description = "The first part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'. " +
+                          "Supports globs.",
             example = "org.openrewrite.maven")
     String groupId;
 
     @Option(displayName = "Artifact",
-            description = "The second part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'.",
+            description = "The second part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'. " +
+                          "Supports globs.",
             example = "rewrite-maven-plugin")
     String artifactId;
 
     @Option(displayName = "New version",
-            description = "An exact version number or node-style semver selector used to select the version number.",
+            description = "An exact version number or node-style semver selector used to select the version number. " +
+                          "You can also use `latest.release` for the latest available version and `latest.patch` if " +
+                          "the current version is a valid semantic version. For more details, you can look at the documentation " +
+                          "page of [version selectors](https://docs.openrewrite.org/reference/dependency-version-selectors)",
             example = "29.X")
     String newVersion;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -122,7 +122,7 @@ public class UpgradePluginVersion extends Recipe {
                                 assert tagGroupId != null;
                                 assert tagArtifactId != null;
                                 findNewerDependencyVersion(tagGroupId, tagArtifactId, versionLookup, ctx).ifPresent(newer -> {
-                                    ChangePluginVersionVisitor changeDependencyVersion = new ChangePluginVersionVisitor(groupId, artifactId, newer);
+                                    ChangePluginVersionVisitor changeDependencyVersion = new ChangePluginVersionVisitor(tagGroupId, tagArtifactId, newer);
                                     doAfterVisit(changeDependencyVersion);
                                 });
                             } catch (MavenDownloadingException e) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
@@ -468,4 +468,68 @@ class UpgradePluginVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void upgradeMultiplePluginsWithDifferentVersions() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion(
+            "*",
+            "*",
+            "2.4.x",
+            null,
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-maven-plugin</artifactId>
+                      <version>1.13.3.Final</version>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>1.0.0</version>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-maven-plugin</artifactId>
+                      <version>2.4.2.Final</version>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>2.4.13</version>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
@@ -532,4 +532,77 @@ class UpgradePluginVersionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void upgradePluginsVersionOnProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion(
+            "*",
+            "*",
+            "2.4.x",
+            null,
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <properties>
+                  <quarkus-maven-plugin.version>1.13.3.Final</quarkus-maven-plugin.version>
+                  <rewrite-maven-plugin.version>1.0.0</rewrite-maven-plugin.version>
+                </properties>
+
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-maven-plugin</artifactId>
+                      <version>${quarkus-maven-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>${rewrite-maven-plugin.version}</version>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <properties>
+                  <quarkus-maven-plugin.version>2.4.2.Final</quarkus-maven-plugin.version>
+                  <rewrite-maven-plugin.version>2.4.13</rewrite-maven-plugin.version>
+                </properties>
+
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-maven-plugin</artifactId>
+                      <version>${quarkus-maven-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                      <version>${rewrite-maven-plugin.version}</version>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Instead of using the parameter groupId and artifactId for the ChangePluginVersionVisitor, use the actual ones found in the tag. Otherwise, when using globs with wildcard characters, it just replaces all versions for every match everytime.

## What's your motivation?
When trying the recipe with globs (that are supported by the underlying MavenVisitor), if we found multiple matches, all the matches get the same version (the last one applied).
A valid use case would be to update all plugins to it's latest versions. To accomplish that one could use this recipe with `groupId=*`, `artifactId=*`, `newVersion=latest.release`, but then it replaces all the versions of all plugins to the latest version of the last plugin found. 

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
In the test, to avoid breaking the change when a new version is released of any of the used plugins in the test, I used `newVersion=2.4.x` since both plugins have versions in the version selector, but with different value. This way, before the fix, the recipe was updating the versions incorrectly (both with the same value), and after the fix it resolves correctly both plugins versions.
Also added a test to check that versions are updated in properties too, since the only tests that where checking this are disabled right now.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
