### PR TITLE
Make `Space#flyweights` synchronized once again

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Space.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Space.java
@@ -23,10 +23,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 
@@ -49,7 +46,7 @@ public class Space {
      * e.g.: a single space between keywords, or the common indentation of every line in a block.
      * So use flyweights to avoid storing many instances of functionally identical spaces
      */
-    private static final Map<String, Space> flyweights = new WeakHashMap<>();
+    private static final Map<String, Space> flyweights = Collections.synchronizedMap(new WeakHashMap<>());
 
     private Space(@Nullable String whitespace, List<Comment> comments) {
         this.comments = comments;
@@ -63,7 +60,7 @@ public class Space {
                 return Space.EMPTY;
             } else if (whitespace.length() <= 100) {
                 //noinspection StringOperationCanBeSimplified
-                return flyweights.computeIfAbsent(new String(whitespace), k -> new Space(whitespace, comments));
+                return flyweights.computeIfAbsent(whitespace, k -> new Space(new String(whitespace), comments));
             }
         }
         return new Space(whitespace, comments);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
@@ -20,10 +20,7 @@ import lombok.EqualsAndHashCode;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 
@@ -46,7 +43,7 @@ public class Space {
      * e.g.: a single space between keywords, or the common indentation of every line in a block.
      * So use flyweights to avoid storing many instances of functionally identical spaces
      */
-    private static final Map<String, Space> flyweights = new WeakHashMap<>();
+    private static final Map<String, Space> flyweights = Collections.synchronizedMap(new WeakHashMap<>());
 
     static {
         flyweights.put(" ", SINGLE_SPACE);

--- a/rewrite-json/src/main/java/org/openrewrite/json/tree/Space.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/tree/Space.java
@@ -22,10 +22,7 @@ import lombok.EqualsAndHashCode;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 
@@ -48,7 +45,7 @@ public class Space {
      * e.g.: a single space between keywords, or the common indentation of every line in a block.
      * So use flyweights to avoid storing many instances of functionally identical spaces
      */
-    private static final Map<String, Space> flyweights = new WeakHashMap<>();
+    private static final Map<String, Space> flyweights = Collections.synchronizedMap(new WeakHashMap<>());
 
     private Space(@Nullable String whitespace, List<Comment> comments) {
         this.comments = comments;
@@ -62,7 +59,7 @@ public class Space {
                 return Space.EMPTY;
             } else if (whitespace.length() <= 100) {
                 //noinspection StringOperationCanBeSimplified
-                return flyweights.computeIfAbsent(new String(whitespace), k -> new Space(whitespace, comments));
+                return flyweights.computeIfAbsent(whitespace, k -> new Space(new String(whitespace), comments));
             }
         }
         return new Space(whitespace, comments);

--- a/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/tree/Space.java
+++ b/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/tree/Space.java
@@ -22,10 +22,7 @@ import lombok.EqualsAndHashCode;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 
@@ -48,7 +45,7 @@ public class Space {
      * e.g.: a single space between keywords, or the common indentation of every line in a block.
      * So use flyweights to avoid storing many instances of functionally identical spaces
      */
-    private static final Map<String, Space> flyweights = new WeakHashMap<>();
+    private static final Map<String, Space> flyweights = Collections.synchronizedMap(new WeakHashMap<>());
 
     private Space(@Nullable String whitespace, List<Comment> comments) {
         this.comments = comments;
@@ -62,7 +59,7 @@ public class Space {
                 return Space.EMPTY;
             } else if (whitespace.length() <= 100) {
                 //noinspection StringOperationCanBeSimplified
-                return flyweights.computeIfAbsent(new String(whitespace), k -> new Space(whitespace, comments));
+                return flyweights.computeIfAbsent(whitespace, k -> new Space(new String(whitespace), comments));
             }
         }
         return new Space(whitespace, comments);

--- a/tools/language-parser-builder/src/main/java/org/openrewrite/toml/tree/Space.java
+++ b/tools/language-parser-builder/src/main/java/org/openrewrite/toml/tree/Space.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import lombok.EqualsAndHashCode;
 import org.openrewrite.internal.lang.Nullable;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -40,7 +41,7 @@ public class Space {
      * e.g.: a single space between keywords, or the common indentation of every line in a block.
      * So use flyweights to avoid storing many instances of functionally identical spaces
      */
-    private static final Map<String, Space> flyweights = new WeakHashMap<>();
+    private static final Map<String, Space> flyweights = Collections.synchronizedMap(new WeakHashMap<>());
 
     private Space(@Nullable String whitespace) {
         this.whitespace = whitespace == null || whitespace.isEmpty() ? null : whitespace;
@@ -53,10 +54,10 @@ public class Space {
                 return Space.EMPTY;
             } else if (whitespace.length() <= 100) {
                 //noinspection StringOperationCanBeSimplified
-                return flyweights.computeIfAbsent(new String(whitespace), k -> new Space(whitespace, comments));
+                return flyweights.computeIfAbsent(whitespace, k -> new Space(new String(whitespace), comments));
             }
         }
-        return flyweights.computeIfAbsent(whitespace, k -> new Space(whitespace));
+        return new Space(whitespace, comments);
     }
 
     public String getIndent() {


### PR DESCRIPTION
Using a `HashMap` (or `WeakHashMap`) concurrently can cause infinite loops.

At the same time also move the string allocation to the value provider for the `computeIfAbsent()` call to save some object allocations.
