### PR TITLE
Add `ShortenFullyQualifiedTypeReferences#modifyOnly(J)`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
@@ -421,4 +421,47 @@ public class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void subtree() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                  if (method.getSimpleName().equals("m1")) {
+                      doAfterVisit(ShortenFullyQualifiedTypeReferences.modifyOnly(method));
+                  }
+                  return super.visitMethodDeclaration(method, ctx);
+              }
+          })),
+          java(
+            """
+              import java.util.Collection;
+              import java.util.function.Function;
+
+              class T {
+                  Function<Collection<?>, Integer> m() {
+                      return java.util.Collection::size;
+                  }
+                  Function<Collection<?>, Integer> m1() {
+                      return java.util.Collection::size;
+                  }
+              }
+              """,
+            """
+              import java.util.Collection;
+              import java.util.function.Function;
+
+              class T {
+                  Function<Collection<?>, Integer> m() {
+                      return java.util.Collection::size;
+                  }
+                  Function<Collection<?>, Integer> m1() {
+                      return Collection::size;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferences.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferences.java
@@ -15,13 +15,14 @@
  */
 package org.openrewrite.java;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.DefaultJavaTypeSignatureBuilder;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -50,9 +51,20 @@ public class ShortenFullyQualifiedTypeReferences extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return getVisitor(null);
+    }
+
+    public static TreeVisitor<?, ExecutionContext> modifyOnly(J subtree) {
+        return getVisitor(subtree);
+    }
+
+    @NonNull
+    private static JavaVisitor<ExecutionContext> getVisitor(@Nullable J scope) {
         return new JavaVisitor<ExecutionContext>() {
             final Map<String, JavaType> usedTypes = new HashMap<>();
             final JavaTypeSignatureBuilder signatureBuilder = new DefaultJavaTypeSignatureBuilder();
+
+            boolean modify = scope == null;
 
             private void ensureInitialized() {
                 if (!usedTypes.isEmpty()) {
@@ -95,6 +107,22 @@ public class ShortenFullyQualifiedTypeReferences extends Recipe {
             }
 
             @Override
+            public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                @SuppressWarnings("DataFlowIssue")
+                boolean subtreeRoot = !modify && (scope.equals(tree) || scope.isScope(tree));
+                if (subtreeRoot) {
+                    modify = true;
+                }
+                try {
+                    return super.visit(tree, ctx);
+                } finally {
+                    if (subtreeRoot) {
+                        modify = false;
+                    }
+                }
+            }
+
+            @Override
             public J visitImport(J.Import import_, ExecutionContext ctx) {
                 // stop recursion
                 return import_;
@@ -108,6 +136,10 @@ public class ShortenFullyQualifiedTypeReferences extends Recipe {
 
             @Override
             public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
+                if (!modify) {
+                    return super.visitFieldAccess(fieldAccess, ctx);
+                }
+
                 JavaType type = fieldAccess.getType();
                 if (fieldAccess.getName().getFieldType() == null && type instanceof JavaType.Class && ((JavaType.Class) type).getOwningClass() == null) {
                     ensureInitialized();


### PR DESCRIPTION
This method can be called to construct a visitor which is designed to be registered using `doAfterVisit()` and will modify the given subtree only.
