### PR TITLE
Delay the resolution of classpath in `JavaParser.Builder`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -205,7 +205,9 @@ public class GroovyParser implements Parser {
     @SuppressWarnings("unused")
     public static class Builder extends Parser.Builder {
         @Nullable
-        private Collection<Path> classpath = JavaParser.runtimeClasspath();
+        private Collection<Path> classpath = Collections.emptyList();
+        @Nullable
+        protected Collection<String> artifactNames = Collections.emptyList();
 
         private JavaTypeCache typeCache = new JavaTypeCache();
         private boolean logCompilationWarningsAndErrors = false;
@@ -219,6 +221,7 @@ public class GroovyParser implements Parser {
         public Builder(Builder base) {
             super(G.CompilationUnit.class);
             this.classpath = base.classpath;
+            this.artifactNames = base.artifactNames;
             this.typeCache = base.typeCache;
             this.logCompilationWarningsAndErrors = base.logCompilationWarningsAndErrors;
             this.styles.addAll(base.styles);
@@ -231,16 +234,19 @@ public class GroovyParser implements Parser {
         }
 
         public Builder classpath(@Nullable Collection<Path> classpath) {
+            this.artifactNames = null;
             this.classpath = classpath;
             return this;
         }
 
-        public Builder classpath(@Nullable String... classpath) {
-            this.classpath = JavaParser.dependenciesFromClasspath(classpath);
+        public Builder classpath(@Nullable String... artifactNames) {
+            this.artifactNames = Arrays.asList(artifactNames);
+            this.classpath = null;
             return this;
         }
 
         public Builder classpathFromResource(ExecutionContext ctx, String... artifactNamesWithVersions) {
+            this.artifactNames = null;
             this.classpath = JavaParser.dependenciesFromResources(ctx, artifactNamesWithVersions);
             return this;
         }
@@ -270,8 +276,17 @@ public class GroovyParser implements Parser {
             return this;
         }
 
+        @Nullable
+        private Collection<Path> resolvedClasspath() {
+            if (artifactNames != null && !artifactNames.isEmpty()) {
+                classpath = JavaParser.dependenciesFromClasspath(artifactNames.toArray(new String[0]));
+                artifactNames = null;
+            }
+            return classpath;
+        }
+
         public GroovyParser build() {
-            return new GroovyParser(classpath, styles, logCompilationWarningsAndErrors, typeCache, compilerCustomizers);
+            return new GroovyParser(resolvedClasspath(), styles, logCompilationWarningsAndErrors, typeCache, compilerCustomizers);
         }
 
         @Override

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/Java11Parser.java
@@ -19,7 +19,6 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.JavaTypeCache;
-import org.openrewrite.java.tree.J;
 
 import java.lang.reflect.Constructor;
 import java.net.URI;
@@ -90,7 +89,7 @@ public class Java11Parser implements JavaParser {
                 parserConstructor.setAccessible(true);
 
                 JavaParser delegate = (JavaParser) parserConstructor
-                        .newInstance(logCompilationWarningsAndErrors, classpath, classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
+                        .newInstance(logCompilationWarningsAndErrors, resolvedClasspath(), classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
 
                 return new Java11Parser(delegate);
             } catch (Exception e) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -331,7 +331,7 @@ public class ReloadableJava11Parser implements JavaParser {
     public static class Builder extends JavaParser.Builder<ReloadableJava11Parser, Builder> {
         @Override
         public ReloadableJava11Parser build() {
-            return new ReloadableJava11Parser(logCompilationWarningsAndErrors, classpath, classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
+            return new ReloadableJava11Parser(logCompilationWarningsAndErrors, resolvedClasspath(), classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
         }
     }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/Java17Parser.java
@@ -89,7 +89,7 @@ public class Java17Parser implements JavaParser {
                 parserConstructor.setAccessible(true);
 
                 JavaParser delegate = (JavaParser) parserConstructor
-                        .newInstance(logCompilationWarningsAndErrors, classpath, classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
+                        .newInstance(logCompilationWarningsAndErrors, resolvedClasspath(), classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
 
                 return new Java17Parser(delegate);
             } catch (Exception e) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -301,7 +301,7 @@ public class ReloadableJava17Parser implements JavaParser {
     public static class Builder extends JavaParser.Builder<ReloadableJava17Parser, Builder> {
         @Override
         public ReloadableJava17Parser build() {
-            return new ReloadableJava17Parser(logCompilationWarningsAndErrors, classpath, classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
+            return new ReloadableJava17Parser(logCompilationWarningsAndErrors, resolvedClasspath(), classBytesClasspath, dependsOn, charset, styles, javaTypeCache);
         }
     }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/Java8Parser.java
@@ -135,7 +135,7 @@ public class Java8Parser implements JavaParser {
                 delegateParserConstructor.setAccessible(true);
 
                 JavaParser delegate = (JavaParser) delegateParserConstructor
-                        .newInstance(classpath, classBytesClasspath, dependsOn, charset, logCompilationWarningsAndErrors, styles, javaTypeCache);
+                        .newInstance(resolvedClasspath(), classBytesClasspath, dependsOn, charset, logCompilationWarningsAndErrors, styles, javaTypeCache);
 
                 return new Java8Parser(delegate);
             } catch (Exception e) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -300,6 +300,7 @@ public interface JavaParser extends Parser {
     @SuppressWarnings("unchecked")
     abstract class Builder<P extends JavaParser, B extends Builder<P, B>> extends Parser.Builder {
         protected Collection<Path> classpath = Collections.emptyList();
+        protected Collection<String> artifactNames = Collections.emptyList();
         protected Collection<byte[]> classBytesClasspath = Collections.emptyList();
         protected JavaTypeCache javaTypeCache = new JavaTypeCache();
 
@@ -343,17 +344,20 @@ public interface JavaParser extends Parser {
         }
 
         public B classpath(Collection<Path> classpath) {
+            this.artifactNames = Collections.emptyList();
             this.classpath = classpath;
             return (B) this;
         }
 
-        public B classpath(String... classpath) {
-            this.classpath = dependenciesFromClasspath(classpath);
+        public B classpath(String... artifactNames) {
+            this.artifactNames = Arrays.asList(artifactNames);
+            this.classpath = Collections.emptyList();
             return (B) this;
         }
 
         @SuppressWarnings("UnusedReturnValue")
         public B classpathFromResources(ExecutionContext ctx, String... classpath) {
+            this.artifactNames = Collections.emptyList();
             this.classpath = dependenciesFromResources(ctx, classpath);
             return (B) this;
         }
@@ -368,6 +372,14 @@ public interface JavaParser extends Parser {
                 this.styles.add(style);
             }
             return (B) this;
+        }
+
+        protected Collection<Path> resolvedClasspath() {
+            if (!artifactNames.isEmpty()) {
+                classpath = JavaParser.dependenciesFromClasspath(artifactNames.toArray(new String[0]));
+                artifactNames = Collections.emptyList();
+            }
+            return classpath;
         }
 
         public abstract P build();


### PR DESCRIPTION
Instead of directly resolving artifact names to classpath entries inside `JavaParser.Builder#classpath(String...)` this is now delayed until `build()` is called for the first time. This has the advantage that constructing a builder is cheap even when the `classpath(String...)` method gets invoked. As a result a recipe can initialize a `JavaTemplate` (with a customized `JavaBuilder`) in a field initializer of its visitor without incurring a rather big overhead.

Also, as was done for `JavaParser.Builder` in https://github.com/openrewrite/rewrite/commit/5413da97869c6fd75742d2b53211a831ae99eef4 the initial value for `GroovyParser.Builder#classpath` should also be the empty list, rather than the runtime classpath.
