### PR TITLE
Standardize line break recipe name

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaks.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeLineBreaks.java
@@ -29,7 +29,7 @@ public class NormalizeLineBreaks extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Normalize the line breaks";
+        return "Normalize line breaks";
     }
 
     @Override


### PR DESCRIPTION
Right now we have a recipe with the display name of `Normalize the line breaks` and a recipe with the display name of `Normalize line breaks` (one for Java and one for XML). Let's make them both say the same thing since they do the same thing in their respective language.
