### PR TITLE
yaml parser support unicode

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -55,16 +55,10 @@ class FormatPreservingReader extends Reader {
 
         while (cursor < source.length()) {
             int newCursor = source.offsetByCodePoints(cursor, 1);
-            int start = cursor;
-            int offset = 0;
-
             if (newCursor > cursor + 1) {
                 hasUnicodes = true;
-                offset = newCursor - cursor - 1;
             }
-
-            int end = start + 1 + offset;
-            pos[i++] = end;
+            pos[i++] = newCursor;
             cursor = newCursor;
         }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -15,32 +15,70 @@
  */
 package org.openrewrite.yaml;
 
+import lombok.Data;
 import lombok.Getter;
 import org.openrewrite.internal.lang.NonNull;
 import org.yaml.snakeyaml.events.Event;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Maintains a sliding buffer of characters used to determine format prefixes of
  * YAML AST elements.
  */
 class FormatPreservingReader extends Reader {
-
     private final Reader delegate;
+    private final Map<Integer, Range> indexMapping = new HashMap<>();
+    private final int characterCount;
+
+    @Data
+    public static class Range {
+        private final int start;
+        private final int end;
+    }
 
     private ArrayList<Character> buffer = new ArrayList<>();
 
     @Getter
     private int bufferIndex = 0;
 
-    FormatPreservingReader(Reader delegate) {
-        this.delegate = delegate;
+    FormatPreservingReader(String source) {
+        this.delegate = new StringReader(source);
+
+        int index = 0;
+        int cursor = 0;
+        while (cursor < source.length()) {
+            int newCursor = source.offsetByCodePoints(cursor, 1);
+            int start = cursor;
+            int offset = 0;
+
+            if (newCursor > cursor + 1) {
+                offset = newCursor - cursor - 1;
+            }
+
+            int end = start + offset;
+            indexMapping.put(index, new Range(start, end));
+            index++;
+            cursor = newCursor;
+        }
+
+        indexMapping.put(index, new Range(cursor, cursor));
+        characterCount = index;
     }
 
     String prefix(int lastEnd, int startIndex) {
+        if (lastEnd >= characterCount) {
+            return "";
+        }
+
+        lastEnd = indexMapping.get(lastEnd).getStart();
+        startIndex = indexMapping.get(startIndex).getStart();
+
         assert lastEnd <= startIndex;
 
         int prefixLen = startIndex - lastEnd;
@@ -65,6 +103,13 @@ class FormatPreservingReader extends Reader {
     }
 
     public String readStringFromBuffer(int start, int end) {
+        if (end < start) {
+            return "";
+        }
+
+        start = indexMapping.get(start).getStart();
+        end = indexMapping.get(end).getEnd();
+
         int length = end - start + 1;
         char[] readBuff = new char[length];
         for (int i = 0; i < length; i++) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.yaml;
 
-import lombok.Data;
 import lombok.Getter;
 import org.openrewrite.internal.lang.NonNull;
 import org.yaml.snakeyaml.events.Event;
@@ -38,12 +37,6 @@ class FormatPreservingReader extends Reader {
     // Snake yaml parser is based on characters index and reader is based on source index. If there are any >2 bytes
     // unicode characters in source code, it will make the index mismatch.
     private final int[] indexes;
-
-    @Data
-    public static class Range {
-        private final int start;
-        private final int end;
-    }
 
     private ArrayList<Character> buffer = new ArrayList<>();
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -37,7 +37,8 @@ class FormatPreservingReader extends Reader {
     // whether the source has multi bytes (> 2 bytes) unicode characters
     private final boolean hasMultiBytesUnicode;
     // Characters index to source index mapping, valid only when `hasMultiBytesUnicode` is true.
-    // Snake yaml parser is based on characters index and reader is based on source index.
+    // Snake yaml parser is based on characters index and reader is based on source index. If there are any >2 bytes
+    // unicode characters in source code, it will make the index unmatch.
     private final Map<Integer, Range> indexMapping;
     private final int characterCount;
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -107,8 +107,7 @@ public class YamlParser implements org.openrewrite.Parser {
             yamlSourceWithVariablePlaceholders.append(yamlSource, pos, yamlSource.length());
         }
 
-        try (StringReader stringReader = new StringReader(yamlSourceWithVariablePlaceholders.toString());
-             FormatPreservingReader reader = new FormatPreservingReader(stringReader)) {
+        try (FormatPreservingReader reader = new FormatPreservingReader(yamlSourceWithVariablePlaceholders.toString())) {
             StreamReader streamReader = new StreamReader(reader);
             Scanner scanner = new ScannerImpl(streamReader, new LoaderOptions());
             Parser parser = new ParserImpl(scanner);

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/FormatPreservingReaderTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/FormatPreservingReaderTest.java
@@ -28,7 +28,7 @@ class FormatPreservingReaderTest {
     @Test
     void allInCurrentBuffer() throws IOException {
         var text = "0123456789";
-        var formatPreservingReader = new FormatPreservingReader(new StringReader(text));
+        var formatPreservingReader = new FormatPreservingReader(text);
 
         char[] charArray = new char[10];
         formatPreservingReader.read(charArray, 0, 10);
@@ -38,7 +38,7 @@ class FormatPreservingReaderTest {
     @Test
     void allInPreviousBuffer() throws IOException {
         var text = "0123456789";
-        var formatPreservingReader = new FormatPreservingReader(new StringReader(text));
+        var formatPreservingReader = new FormatPreservingReader(text);
 
         char[] charArray = new char[10];
 
@@ -51,7 +51,7 @@ class FormatPreservingReaderTest {
     @Test
     void splitBetweenPrevAndCurrentBuffer() throws IOException {
         var text = "0123456789";
-        var formatPreservingReader = new FormatPreservingReader(new StringReader(text));
+        var formatPreservingReader = new FormatPreservingReader(text);
 
         char[] charArray = new char[10];
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -15,9 +15,11 @@
  */
 package org.openrewrite.yaml;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.Issue;
 import org.openrewrite.SourceFile;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.tree.ParseError;
@@ -49,15 +51,69 @@ class YamlParserTest implements RewriteTest {
         assertThat(title.getValue()).isEqualTo("b");
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-      "🛠",
-      "🛠🛠",
-      "🛠 🛠"
-    })
-    void unicodeParseError(String input ) {
-        Stream<SourceFile> yamlSources = YamlParser.builder().build().parse("a: %s\n".formatted(input));
-        assertThat(yamlSources).singleElement().isInstanceOf(ParseError.class);
+    @Issue("https://github.com/openrewrite/rewrite/issues/2062")
+    @Test
+    void fourBytesUnicode() {
+        rewriteRun(
+          yaml(
+            """
+              root:
+                - value1: 🛠
+                  value2: check
+              """
+          )
+        );
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "b",
+      "🛠",
+      "🛠🛠",
+      "🛠 🛠",
+      "hello🛠world",
+      "你好世界",
+      "你好🛠世界"
+    })
+    void parseYamlWithUnicode(String input) {
+        Stream<SourceFile> yamlSources = YamlParser.builder().build().parse("a: %s\n".formatted(input));
+        SourceFile sourceFile = yamlSources.findFirst().get();
+        assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+
+        Yaml.Documents documents = (Yaml.Documents) sourceFile;
+        Yaml.Document document = documents.getDocuments().get(0);
+
+        // Assert that end is parsed correctly
+        Yaml.Mapping mapping = (Yaml.Mapping) document.getBlock();
+        Yaml.Mapping.Entry entry = mapping.getEntries().get(0);
+        Yaml.Scalar title = (Yaml.Scalar) entry.getValue();
+        assertThat(title.getValue()).isEqualTo(input);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "🛠 :  🛠",
+      "你a好b🛠世c界d :  你a🛠好b🛠世c🛠界d"
+    })
+    void unicodeCharacterSpanningMultipleBytes(@Language("yml") String input) {
+        rewriteRun(
+          yaml(input)
+        );
+    }
+
+    @Test
+    void newlinesCombinedWithUnniCode() {
+        rewriteRun(
+          yaml(
+            """
+              {
+                "data": {
+                  "pro🛠metheus.y🛠ml": "global:\\n  scrape_🛠interval: 10s🛠\\n  sc🛠rape_timeout: 9s"
+                }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -69,8 +69,8 @@ class YamlParserTest implements RewriteTest {
     @ParameterizedTest
     @ValueSource(strings = {
       "b",
-      "🛠",
-      "🛠🛠",
+      " 🛠",
+      " 🛠🛠",
       "🛠 🛠",
       "hello🛠world",
       "你好世界",
@@ -88,7 +88,7 @@ class YamlParserTest implements RewriteTest {
         Yaml.Mapping mapping = (Yaml.Mapping) document.getBlock();
         Yaml.Mapping.Entry entry = mapping.getEntries().get(0);
         Yaml.Scalar title = (Yaml.Scalar) entry.getValue();
-        assertThat(title.getValue()).isEqualTo(input);
+        assertThat(title.getValue()).isEqualTo(input.trim());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Update the YAML parser to support multiple bytes (> 2) unicode characters.

Root cause: Snake-yaml parser is based on the characters index and the reader (prefix parsing is based on the reader index) is based on the source index.
If there are any >2 bytes of Unicode characters in the source code, it will make the index mismatch and cause problem.

fixes https://github.com/openrewrite/rewrite/issues/2062