### PR TITLE
RewriteTest / YamlResourceLoader Enhancements

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -99,6 +99,16 @@ public class ClasspathScanningLoader implements ResourceLoader {
                 .acceptPaths("META-INF/rewrite"), properties, dependencyResourceLoaders, classLoader);
     }
 
+    public static ClasspathScanningLoader onlyYaml(Properties properties) {
+        ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader();
+        classpathScanningLoader.scanYaml(new ClassGraph().acceptPaths("META-INF/rewrite"),
+                properties, emptyList(), null);
+        return classpathScanningLoader;
+    }
+
+    private ClasspathScanningLoader() {
+    }
+
     /**
      * This must be called _after_ scanClasses or the descriptors of declarative recipes will be missing any
      * non-declarative recipes they depend on that would be discovered by scanClasses

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -120,14 +120,8 @@ public class DeclarativeRecipe extends Recipe {
         uninitializedRecipes.add(recipe);
     }
 
-    public void addUninitialized(String recipeName, @Nullable ClassLoader classLoader) {
-        try {
-            uninitializedRecipes.add((Recipe) Class.forName(recipeName, true, classLoader != null ? classLoader : this.getClass().getClassLoader())
-                    .getDeclaredConstructor()
-                    .newInstance());
-        } catch (Exception e) {
-            uninitializedRecipes.add(new DeclarativeRecipe.LazyLoadedRecipe(recipeName));
-        }
+    public void addUninitialized(String recipeName) {
+        uninitializedRecipes.add(new DeclarativeRecipe.LazyLoadedRecipe(recipeName));
     }
 
     public void addValidation(Validated<Object> validated) {

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -229,6 +229,10 @@ public class Environment {
             return load(new ClasspathScanningLoader(properties, classLoader));
         }
 
+        public Builder scanYamlResources() {
+            return load(ClasspathScanningLoader.onlyYaml(properties));
+        }
+
         /**
          * @param jar         A path to a jar file to scan.
          * @param classLoader A classloader that is populated with the transitive dependencies of the jar.

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
@@ -95,12 +95,20 @@ public class NullUtils {
         for (Field field : fields) {
             field.setAccessible(true);
             if(fieldHasNonNullableAnnotation(field) ||
-                    (defaultNonNull && !fieldHasNullableAnnotation(field))) {
+                    (defaultNonNull && !fieldHasNullableAnnotation(field)) ||
+                    fieldIsRequiredOption(field)) {
                 nonNullFields.add(field);
             }
         }
         nonNullFields.sort(Comparator.comparing(Field::getName));
         return nonNullFields;
+    }
+
+    private static boolean fieldIsRequiredOption(Field field) {
+        Option annotation = field.getAnnotation(Option.class);
+        if (annotation != null)
+            return annotation.required();
+        return false;
     }
 
     private static boolean fieldHasNonNullableAnnotation(Field field) {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
@@ -15,6 +15,9 @@
  */
 package org.openrewrite.internal.lang;
 
+import org.openrewrite.Option;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.*;
 
@@ -48,7 +51,7 @@ public class NullUtils {
      * <li>org.checkerframework.checker.nullness.qual.NonNull</li>
      * <li>javax.validation.constraints.NotNull</li>
      */
-    private static List<String> FIELD_LEVEL_NON_NULL_ANNOTATIONS = Arrays.asList(
+    private static final List<String> FIELD_LEVEL_NON_NULL_ANNOTATIONS = Arrays.asList(
             "NonNull",
             "Nonnull",
             "NotNull"
@@ -67,7 +70,7 @@ public class NullUtils {
      * <li>org.checkerframework.checker.nullness.qual.Nullable</li>
      * <li>javax.validation.constraints.NotNull</li>
      */
-    private static List<String> FIELD_LEVEL_NULLABLE_ANNOTATIONS = Collections.singletonList(
+    private static final List<String> FIELD_LEVEL_NULLABLE_ANNOTATIONS = Collections.singletonList(
             "Nullable"
     );
 
@@ -112,13 +115,21 @@ public class NullUtils {
     }
 
     private static boolean fieldHasNonNullableAnnotation(Field field) {
-        return Arrays.stream(field.getDeclaredAnnotations())
-                .map(a -> a.annotationType().getSimpleName())
-                .anyMatch(FIELD_LEVEL_NON_NULL_ANNOTATIONS::contains);
+        for (Annotation a : field.getDeclaredAnnotations()) {
+            String simpleName = a.annotationType().getSimpleName();
+            if (FIELD_LEVEL_NON_NULL_ANNOTATIONS.contains(simpleName)) {
+                return true;
+            }
+        }
+        return false;
     }
     private static boolean fieldHasNullableAnnotation(Field field) {
-        return Arrays.stream(field.getDeclaredAnnotations())
-                .map(a -> a.annotationType().getSimpleName())
-                .anyMatch(FIELD_LEVEL_NULLABLE_ANNOTATIONS::contains);
+        for (Annotation a : field.getDeclaredAnnotations()) {
+            String simpleName = a.annotationType().getSimpleName();
+            if (FIELD_LEVEL_NULLABLE_ANNOTATIONS.contains(simpleName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
@@ -76,8 +76,11 @@ public class NullUtils {
 
     /**
      * The method uses reflection to find all declared fields of a class that have been marked (via commonly used
-     * annotations) as being Non-Null. This method will also look at the class's package level to see if the API
-     * for that package is defaulted as Non-Null. ANY annotation that has runtime retention and matches on of the simple
+     * annotations) as being Non-Null, or a required {@link Option}.
+     * This method will also look at the class's package level to see if the API
+     * for that package is defaulted as Non-Null.
+     * Fields with explicit Nullable annotations will be excluded.
+     * Any other annotation that has runtime retention and matches one of the simple
      * annotation names (minus any package) will be considered a match.
      *
      * @param _class The class to reflect over
@@ -97,9 +100,10 @@ public class NullUtils {
         List<Field> nonNullFields = new ArrayList<>(fields.length);
         for (Field field : fields) {
             field.setAccessible(true);
-            if(fieldHasNonNullableAnnotation(field) ||
-                    (defaultNonNull && !fieldHasNullableAnnotation(field)) ||
-                    fieldIsRequiredOption(field)) {
+            if (fieldHasNullableAnnotation(field)) {
+                continue;
+            }
+            if (defaultNonNull || fieldHasNonNullableAnnotation(field) || fieldIsRequiredOption(field)) {
                 nonNullFields.add(field);
             }
         }

--- a/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
@@ -79,6 +79,7 @@ public class FindAndReplace extends Recipe {
                           "Multiple patterns may be specified, separated by a semicolon `;`. " +
                           "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
                           "When not set, all source files are searched. ",
+            required = false,
             example = "**/*.java")
     @Nullable
     String filePattern;

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -363,6 +363,31 @@ class RecipeLifecycleTest implements RewriteTest {
             .activateRecipes("test.recipe.a")),
           text("Hi", "NoArgRecipeHi"));
     }
+
+    @Test
+    void declarativeRecipeChainFromResources() {
+        rewriteRun(spec -> spec.recipeFromResources("test.declarative.sample.a"),
+          text("Hi", "after"));
+    }
+
+    @Test
+    void declarativeRecipeChainFromResourcesIncludesImperativeRecipesInDescriptors() {
+        rewriteRun(spec -> spec.recipeFromResources("test.declarative.sample.a")
+            .afterRecipe(recipeRun -> assertThat(recipeRun.getChangeset().getAllResults().get(0)
+              .getRecipeDescriptorsThatMadeChanges().get(0).getRecipeList().get(0).getRecipeList().get(0)
+              .getDisplayName()).isEqualTo("Change text")),
+          text("Hi", "after"));
+    }
+
+    @Test
+    void declarativeRecipeChainFromResourcesLongList() {
+        rewriteRun(spec -> spec.recipe(Environment.builder()
+            .load(new YamlResourceLoader(RecipeLifecycleTest.class.getResourceAsStream("/META-INF/rewrite/test-sample-a.yml"), URI.create("rewrite.yml"), new Properties()))
+            .load(new YamlResourceLoader(RecipeLifecycleTest.class.getResourceAsStream("/META-INF/rewrite/test-sample-b.yml"), URI.create("rewrite.yml"), new Properties()))
+            .build()
+            .activateRecipes("test.declarative.sample.a")),
+          text("Hi", "after"));
+    }
 }
 
 class DefaultConstructorRecipe extends Recipe {

--- a/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-a.yml
+++ b/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-a.yml
@@ -1,3 +1,19 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: test.declarative.sample.a

--- a/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-a.yml
+++ b/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-a.yml
@@ -1,0 +1,6 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: test.declarative.sample.a
+displayName: Test Recipe
+recipeList:
+  - test.declarative.sample.b

--- a/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-b.yml
+++ b/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-b.yml
@@ -1,0 +1,7 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: test.declarative.sample.b
+displayName: Test Recipe
+recipeList:
+  - org.openrewrite.text.ChangeText:
+      toText: after

--- a/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-b.yml
+++ b/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-b.yml
@@ -1,3 +1,19 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: test.declarative.sample.b

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
@@ -47,6 +47,7 @@ public class AddSettingsPluginRepository extends Recipe {
 
     @Option(displayName = "URL",
             description = "The url of the artifact repository",
+            required = false,
             example = "https://repo.spring.io")
     String url;
 

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -127,6 +127,13 @@ public class RecipeSpec {
         return recipe(Objects.requireNonNull(RecipeSpec.class.getResourceAsStream(yamlResource)), activeRecipes);
     }
 
+    public RecipeSpec recipeFromResources(String... activeRecipes) {
+        return recipe(Environment.builder()
+                .scanYamlResources()
+                .build()
+                .activateRecipes(activeRecipes));
+    }
+
     /**
      * @param parser The parser supplier to use when a matching source file is found.
      * @return The current recipe spec.

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -19,13 +19,11 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.intellij.lang.annotations.Language;
 import org.openrewrite.*;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.YamlResourceLoader;
-import org.openrewrite.internal.InMemoryLargeSourceSet;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -116,7 +114,6 @@ public class RecipeSpec {
 
     public RecipeSpec recipe(InputStream yaml, String... activeRecipes) {
         return recipe(Environment.builder()
-                .scanRuntimeClasspath() // Slow but required to find recipe classes the yaml recipe may depend on
                 .load(new YamlResourceLoader(yaml, URI.create("rewrite.yml"), new Properties()))
                 .build()
                 .activateRecipes(activeRecipes));


### PR DESCRIPTION
## What's changed?
- YamlResourceLoader now uses jackson to try to instantiate imperative recipes with zero args if basic reflection fails. And, reverted change to RecipeSpec which made it scanRuntimeClasspath unnecessarily for yaml recipes. Fixes #3414
- adding RewriteTest/RecipeSpec recipeFromResources option to scan all rewrite yamls on classpath (ignoring classes. Fixes #3096

## Anything in particular you'd like reviewers to focus on?
- In `ClasspathScanningLoader`, the constructor overloads were starting to get diverse in functionality, so I opted for a factory method for this new scenario. Open to changing it
- In `ClasspathScanningLoader`, there's this comment, which I'm not sure is accurate today; I think the new case `RecipeLifecycleTest::declarativeRecipeChainFromResourcesIncludesImperativeRecipesInDescriptors` disproves it https://github.com/openrewrite/rewrite/blob/1834d4e3fd3253a6f604f7b34cfc14d02ee66662/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java#L102-L106
- I considered removing the reflective attempt to instantiate the recipe and only using jackson, but that led to a regression with recipes like this, because jackson (for some reason) picked the 1-arg constructor (passing a null value) instead of the annotated zero-arg constructor (which would have set the required field by default) https://github.com/openrewrite/rewrite-migrate-java/blame/main/src/main/java/org/openrewrite/java/migrate/UseJavaUtilBase64.java

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
- Scanning the full runtime classpath when you're just looking for Yaml files is slow and doesn't seem beneficial
- You can also explicitly list the yamls you care about when defining your `RecipeSpec`, but with recursive validation, if you're testing a recipe which chains to many recipes across many files, then that becomes painful to maintain

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
