### PR TITLE
Recipe validation / RecipeIntrospectionUtils changes for String fields

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -291,7 +291,7 @@ public abstract class Recipe implements Cloneable {
     /**
      * The default implementation of validate on the recipe will look for package and field level annotations that
      * indicate a field is not-null. The annotations must have run-time retention and the simple name of the annotation
-     * must match one of the common names defined in {@link NullUtils}. Non-null Strings must also not be blank.
+     * must match one of the common names defined in {@link NullUtils}
      *
      * @return A validated instance based using non-null/nullable annotations to determine which fields of the recipe are required.
      */
@@ -300,10 +300,7 @@ public abstract class Recipe implements Cloneable {
         List<Field> requiredFields = NullUtils.findNonNullFields(this.getClass());
         for (Field field : requiredFields) {
             try {
-                validated = validated.and(
-                        field.getType().equals(String.class)
-                                ? Validated.notBlank(field.getName(), (String) field.get(this))
-                                : Validated.required(field.getName(), field.get(this)));
+                validated = validated.and(Validated.required(field.getName(), field.get(this)));
             } catch (IllegalAccessException e) {
                 logger.warn("Unable to validate the field [{}] on the class [{}]", field.getName(), this.getClass().getName());
             }

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -291,7 +291,7 @@ public abstract class Recipe implements Cloneable {
     /**
      * The default implementation of validate on the recipe will look for package and field level annotations that
      * indicate a field is not-null. The annotations must have run-time retention and the simple name of the annotation
-     * must match one of the common names defined in {@link NullUtils}
+     * must match one of the common names defined in {@link NullUtils}. Non-null Strings must also not be blank.
      *
      * @return A validated instance based using non-null/nullable annotations to determine which fields of the recipe are required.
      */
@@ -300,7 +300,10 @@ public abstract class Recipe implements Cloneable {
         List<Field> requiredFields = NullUtils.findNonNullFields(this.getClass());
         for (Field field : requiredFields) {
             try {
-                validated = validated.and(Validated.required(field.getName(), field.get(this)));
+                validated = validated.and(
+                        field.getType().equals(String.class)
+                                ? Validated.notBlank(field.getName(), (String) field.get(this))
+                                : Validated.required(field.getName(), field.get(this)));
             } catch (IllegalAccessException e) {
                 logger.warn("Unable to validate the field [{}] on the class [{}]", field.getName(), this.getClass().getName());
             }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
@@ -112,7 +112,10 @@ public class RecipeIntrospectionUtils {
             java.lang.reflect.Parameter param = primaryConstructor.getParameters()[i];
             if (param.getType().isPrimitive()) {
                 constructorArgs[i] = getPrimitiveDefault(param.getType());
-            } else if (param.getType().equals(String.class)) {
+            } else if (param.getType().equals(String.class) && isKotlin(clazz)) {
+                // Default Recipe::validate is more valuable if we pass null for unconfigured Strings.
+                // But, that's not safe for Kotlin non-null types, so use an empty String for those
+                // (though it will sneak through default recipe validation)
                 constructorArgs[i] = "";
             } else if (Enum.class.isAssignableFrom(param.getType())) {
                 try {
@@ -135,6 +138,15 @@ public class RecipeIntrospectionUtils {
             // Should never happen
             throw getRecipeIntrospectionException(clazz, e);
         }
+    }
+
+    private static boolean isKotlin(Class<?> clazz) {
+        for (Annotation a : clazz.getAnnotations()) {
+            if (a.annotationType().getName().equals("kotlin.Metadata")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @NonNull

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RecipeIntrospectionUtils.java
@@ -112,6 +112,8 @@ public class RecipeIntrospectionUtils {
             java.lang.reflect.Parameter param = primaryConstructor.getParameters()[i];
             if (param.getType().isPrimitive()) {
                 constructorArgs[i] = getPrimitiveDefault(param.getType());
+            } else if (param.getType().equals(String.class)) {
+                constructorArgs[i] = "";
             } else if (Enum.class.isAssignableFrom(param.getType())) {
                 try {
                     Object[] values = (Object[]) param.getType().getMethod("values").invoke(null);

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -70,6 +70,13 @@ public class ChangePackage extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return Validated.none()
+                .and(Validated.notBlank("oldPackageName", oldPackageName))
+                .and(Validated.required("newPackageName", newPackageName));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaIsoVisitor<ExecutionContext> condition = new JavaIsoVisitor<ExecutionContext>() {
             @Override

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -59,6 +59,13 @@ public class AddProperty extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return Validated.none()
+                .and(Validated.required("property", property))
+                .and(Validated.required("value", value));
+    }
+
+    @Override
     public PropertiesIsoVisitor<ExecutionContext> getVisitor() {
         return new PropertiesIsoVisitor<ExecutionContext>() {
             @Override


### PR DESCRIPTION
## What's your motivation?
Fixes #3508, preserves intent of #3404

## Anything in particular you'd like reviewers to focus on?
This makes the default validation slightly more strict, and may break some existing recipes for which a blank String is a valid argument for some field. I've fixed a few such recipes in this same PR.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
