### PR TITLE
Issue 3275/fix remove used param v2

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -31,7 +31,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new RemoveUnusedImports());
+        spec.recipe(new RemoveUnusedImports(true));
     }
 
     @Test
@@ -1195,6 +1195,70 @@ class RemoveUnusedImportsTest implements RewriteTest {
                   }
               }
               """,
+            """
+              package com.test;
+
+              import com.Source.mine.Record;
+              import com.Source.mine.A;
+              import com.Source.mine.B;
+              import com.Source.mine.C;
+
+              class Test {
+                  void f(Record r) {
+                    A a = r.theOne();
+                    B b = r.theOther1();
+                    C c = r.theOther2();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3275")
+    @Test
+    void doesNotUnfoldWildCardImport() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveUnusedImports(false)),
+          java(
+            """
+              package com.Source.mine;
+
+              public class A {
+                  public void f() {}
+              }
+              """
+          ),
+          java(
+            """
+              package com.Source.mine;
+
+              public class B {
+                  public void f() {}
+              }
+              """
+          ),
+          java(
+            """
+              package com.Source.mine;
+
+              public class C {
+                  public void f() {}
+              }
+              """
+          ),
+          java(
+            """
+              package com.Source.mine;
+
+              public class Record {
+                  public A theOne() { return new A(); }
+                  public B theOther1() { return new B(); }
+                  public C theOther2() { return new C(); }
+              }
+              """
+          ),
+          java(
             """
               package com.test;
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1138,6 +1138,83 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3275")
+    @Test
+    void doesNotRemoveWildCardImport() {
+        rewriteRun(
+          java(
+            """
+              package com.Source.mine;
+
+              public class A {
+                  public void f() {}
+              }
+              """
+          ),
+          java(
+            """
+              package com.Source.mine;
+
+              public class B {
+                  public void f() {}
+              }
+              """
+          ),
+          java(
+            """
+              package com.Source.mine;
+
+              public class C {
+                  public void f() {}
+              }
+              """
+          ),
+          java(
+            """
+              package com.Source.mine;
+
+              public class Record {
+                  public A theOne() { return new A(); }
+                  public B theOther1() { return new B(); }
+                  public C theOther2() { return new C(); }
+              }
+              """
+          ),
+          java(
+            """
+              package com.test;
+
+              import com.Source.mine.Record;
+              import com.Source.mine.*;
+
+              class Test {
+                  void f(Record r) {
+                    A a = r.theOne();
+                    B b = r.theOther1();
+                    C c = r.theOther2();
+                  }
+              }
+              """,
+            """
+              package com.test;
+
+              import com.Source.mine.Record;
+              import com.Source.mine.A;
+              import com.Source.mine.B;
+              import com.Source.mine.C;
+
+              class Test {
+                  void f(Record r) {
+                    A a = r.theOne();
+                    B b = r.theOther1();
+                    C c = r.theOther2();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void removeImportUsedAsLambdaParameter() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
@@ -96,7 +96,7 @@ public class OrderImports extends Recipe {
                 }
 
                 if (Boolean.TRUE.equals(removeUnused)) {
-                    doAfterVisit(new RemoveUnusedImports().getVisitor());
+                    doAfterVisit(new RemoveUnusedImports(true).getVisitor());
                 } else if (changed) {
                     doAfterVisit(new FormatFirstClassPrefix<>());
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -38,10 +38,14 @@ public class TypeUtils {
                );
     }
 
+    public static String getFullyQualifiedClassPath(String fqn) {
+        return fqn.replace('$', '.');
+    }
+
     public static boolean fullyQualifiedNamesAreEqual(@Nullable String fqn1, @Nullable String fqn2) {
         if (fqn1 != null && fqn2 != null) {
             return fqn1.equals(fqn2) || fqn1.length() == fqn2.length()
-                                        && fqn1.replace('$', '.').equals(fqn2.replace('$', '.'));
+                                        && getFullyQualifiedClassPath(fqn1).equals(getFullyQualifiedClassPath(fqn2));
         }
         return fqn1 == null && fqn2 == null;
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This is a follow on to https://github.com/openrewrite/rewrite/pull/3397 which attempted to address https://github.com/openrewrite/rewrite/issues/3275. 

This change attempts to bridge the gap between static fully qualified paths and non-static imports. In addition it addresses one concern about unfolding wildcard imports by introducing an a boolean option to "Unfold wildcard imports".

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
My motivation is to resolve https://github.com/openrewrite/rewrite/issues/3275 and make the RemoveUnusedImports recipe more reliable for wider adoption.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Could you double check that I added the boolean option to this recipe correctly? I attempted to copy the pattern from other recipes. Does any documentation need to be updated or is that done as part of the build? 

## Anyone you would like to review specifically?
<!-- @mention them here -->
Any maintainer 😄

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
n/a

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
n/a

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable) (unsure about this one)
