### PR TITLE
Add support for `relativePath` change on `ChangeParentPom`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.MavenMetadata;
@@ -27,6 +28,7 @@ import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.maven.utilities.RetainVersions;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
+import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
@@ -84,6 +86,20 @@ public class ChangeParentPom extends Recipe {
             description = "An exact version number or node-style semver selector used to select the version number.",
             example = "29.X")
     String newVersion;
+
+    @Option(displayName = "Old relative path",
+            description = "The relativePath of the maven parent pom to be changed away from.",
+            example = "../../pom.xml",
+            required = false)
+    @Nullable
+    String oldRelativePath;
+
+    @Option(displayName = "New relative path",
+            description = "New relative path attribute for parent lookup.",
+            example = "../pom.xml",
+            required = false)
+    @Nullable
+    String newRelativePath;
 
     @Option(displayName = "Version pattern",
             description = "Allows version selection to be extended beyond the original Node Semver semantics. So for example," +
@@ -161,11 +177,13 @@ public class ChangeParentPom extends Recipe {
                     ResolvedPom resolvedPom = getResolutionResult().getPom();
 
                     if (matchesGlob(resolvedPom.getValue(tag.getChildValue("groupId").orElse(null)), oldGroupId) &&
-                        matchesGlob(resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null)), oldArtifactId)) {
+                        matchesGlob(resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null)), oldArtifactId) &&
+                        (oldRelativePath == null || matchesGlob(resolvedPom.getValue(tag.getChildValue("relativePath").orElse(null)), oldRelativePath))) {
                         String oldVersion = resolvedPom.getValue(tag.getChildValue("version").orElse(null));
                         assert oldVersion != null;
                         String targetGroupId = newGroupId == null ? tag.getChildValue("groupId").orElse(oldGroupId) : newGroupId;
                         String targetArtifactId = newArtifactId == null ? tag.getChildValue("artifactId").orElse(oldArtifactId) : newArtifactId;
+                        String targetRelativePath = newRelativePath == null ? tag.getChildValue("relativePath").orElse(oldRelativePath) : newRelativePath;
                         try {
                             Optional<String> targetVersion = findNewerDependencyVersion(targetGroupId, targetArtifactId, oldVersion, ctx);
                             if (targetVersion.isPresent()) {
@@ -180,6 +198,19 @@ public class ChangeParentPom extends Recipe {
 
                                 if (!oldVersion.equals(targetVersion.get())) {
                                     changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("version").get(), targetVersion.get()));
+                                }
+
+                                // Update or add relativePath
+                                if (oldRelativePath != null && !oldRelativePath.equals(targetRelativePath)) {
+                                    changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("relativePath").get(), targetRelativePath));
+                                }
+                                else if (tag.getChildValue("relativePath").orElse(null) == null && targetRelativePath != null) {
+                                    if (StringUtils.isBlank(targetRelativePath)) {
+                                        changeParentTagVisitors.add(new AddToTagVisitor<>(t, Xml.Tag.build("<relativePath />")));
+                                    }
+                                    else {
+                                        changeParentTagVisitors.add(new AddToTagVisitor<>(t, Xml.Tag.build("<relativePath>" + targetRelativePath + "</relativePath>")));
+                                    }
                                 }
 
                                 if (changeParentTagVisitors.size() > 0) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -91,7 +91,7 @@ public class UpgradeParentVersion extends Recipe {
     }
 
     private ChangeParentPom changeParentPom() {
-        return new ChangeParentPom(groupId, null, artifactId, null, newVersion,
+        return new ChangeParentPom(groupId, null, artifactId, null, newVersion, null, null,
                 versionPattern, false, retainVersions);
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -42,6 +42,8 @@ class ChangeParentPomTest implements RewriteTest {
             "jackson-parent",
             "2.12",
             null,
+            null,
+            null,
             false,
             null
           )),
@@ -81,6 +83,160 @@ class ChangeParentPomTest implements RewriteTest {
     }
 
     @Test
+    void changeParentWithRelativePath() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom(
+            "org.springframework.boot",
+            "com.fasterxml.jackson",
+            "spring-boot-starter-parent",
+            "jackson-parent",
+            "2.12",
+            "",
+            "../../pom.xml",
+            null,
+            false,
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>1.5.12.RELEASE</version>
+                  <relativePath/>
+                </parent>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>com.fasterxml.jackson</groupId>
+                  <artifactId>jackson-parent</artifactId>
+                  <version>2.12</version>
+                  <relativePath>../../pom.xml</relativePath>
+                </parent>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeParentAddRelativePathEmptyValue() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom(
+            "org.springframework.boot",
+            "com.fasterxml.jackson",
+            "spring-boot-starter-parent",
+            "jackson-parent",
+            "2.12",
+            null,
+            "",
+            null,
+            false,
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>1.5.12.RELEASE</version>
+                </parent>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>com.fasterxml.jackson</groupId>
+                  <artifactId>jackson-parent</artifactId>
+                  <version>2.12</version>
+                  <relativePath />
+                </parent>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeParentAddRelativePathNonEmptyValue() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom(
+            "org.springframework.boot",
+            "com.fasterxml.jackson",
+            "spring-boot-starter-parent",
+            "jackson-parent",
+            "2.12",
+            null,
+            "../pom.xml",
+            null,
+            false,
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>1.5.12.RELEASE</version>
+                </parent>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>com.fasterxml.jackson</groupId>
+                  <artifactId>jackson-parent</artifactId>
+                  <version>2.12</version>
+                  <relativePath>../pom.xml</relativePath>
+                </parent>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void upgradeVersion() {
         rewriteRun(
           spec -> spec.recipe(new ChangeParentPom(
@@ -89,6 +245,8 @@ class ChangeParentPomTest implements RewriteTest {
             "spring-boot-starter-parent",
             null,
             "~1.5",
+            null,
+            null,
             null,
             false,
             null
@@ -140,6 +298,8 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "1.5.22.RELEASE",
             null,
+            null,
+            null,
             false,
             null
           )),
@@ -190,6 +350,8 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "1.5.12.RELEASE",
             null,
+            null,
+            null,
             false,
             null
           )),
@@ -223,6 +385,8 @@ class ChangeParentPomTest implements RewriteTest {
             "spring-boot-starter-parent",
             null,
             "1.5.12.RELEASE",
+            null,
+            null,
             null,
             true,
             null
@@ -274,6 +438,8 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "~1.5",
             null,
+            null,
+            null,
             false,
             null
           )),
@@ -323,6 +489,8 @@ class ChangeParentPomTest implements RewriteTest {
             "junit-bom",
             null,
             "5.9.1",
+            null,
+            null,
             null,
             false,
             null
@@ -389,6 +557,8 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "5.9.1",
             null,
+            null,
+            null,
             false,
             null
           )),
@@ -454,6 +624,8 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "5.9.1",
             null,
+            null,
+            null,
             false,
             null
           )),
@@ -513,7 +685,7 @@ class ChangeParentPomTest implements RewriteTest {
     @Test
     void upgradeNonSemverVersion() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-starter-parent", null, "2021.0.5", null, false, null)),
+          spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-starter-parent", null, "2021.0.5", null, null, null, false, null)),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -556,7 +728,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void dependencyWithExplicitVersionRemovedFromDepMgmt() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null,
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null,
                 List.of("com.jcraft:jsch"))),
               pomXml(
                 """
@@ -612,7 +784,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void dependencyWithoutExplicitVersionRemovedFromDepMgmt() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null,
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null,
                 Collections.singletonList("com.jcraft:jsch"))),
               pomXml(
                 """
@@ -667,7 +839,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void dependencyWithoutExplicitVersionRemovedFromDepMgmtRetainSpecificVersion() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null,
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null,
                 Collections.singletonList("com.jcraft:jsch:0.1.50"))),
               pomXml(
                 """
@@ -722,7 +894,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void multipleRetainVersions() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, true,
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true,
                 Lists.newArrayList("com.jcraft:jsch", "org.springframework.cloud:spring-cloud-schema-registry-*:1.1.1"))),
               pomXml(
                 """
@@ -786,7 +958,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void globGavWithNoVersion() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, true,
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true,
                 Lists.newArrayList("org.springframework.cloud:spring-cloud-schema-registry-*"))),
               pomXml(
                 """
@@ -841,7 +1013,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void preservesExplicitVersionIfNotRequested() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, true,
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true,
                 Lists.newArrayList("org.springframework.cloud:spring-cloud-schema-registry-*"))),
               pomXml(
                 """
@@ -898,7 +1070,7 @@ class ChangeParentPomTest implements RewriteTest {
     @RepeatedTest(10)
     @Issue("https://github.com/openrewrite/rewrite/issues/1753")
     void multiModule() {
-        ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, true, null);
+        ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, null, null, true, null);
         rewriteRun(
           spec -> spec.recipe(recipe),
           mavenProject("parent",


### PR DESCRIPTION
## What's changed?

Add support for update/adding `relativePath` on `UpdateParentPom` receipe

Fixes https://github.com/openrewrite/rewrite/issues/3536

## What's your motivation?

Refactoring multi-module Maven projects

## Have you considered any alternatives or workarounds?

None found

## Any additional context

Tested with

I've added 3 unit tests to cover 3 new use case

- Update relative path
- Add new relative path if not set (empty value)
- Add new relative path if not set (non-empty value)

```
./gradlew :rewrite-maven:test --info --tests '*ChangeParentPomTest' --continue
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)

Let me know if ok. I can also update the documentation if needed