### PR TITLE
AddPlugin changes; make `version` optional and add `filePattern`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -107,10 +107,9 @@ public class AddPlugin extends Recipe {
         @Override
         public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
             if (filePattern != null) {
-                return PathUtils.matchesGlob(sourceFile.getSourcePath(), filePattern);
-            } else {
-                return sourceFile instanceof Xml.Document;
+                return PathUtils.matchesGlob(sourceFile.getSourcePath(), filePattern) && super.isAcceptable(sourceFile, executionContext);
             }
+            return super.isAcceptable(sourceFile, executionContext);
         }
 
         @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -83,7 +83,7 @@ public class AddPlugin extends Recipe {
                     "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
                     "When not set, all source files are searched. ",
             required = false,
-            example = "**/*.java")
+            example = "**/*-parent/grpc-*/pom.xml")
     @Nullable
     String filePattern;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -48,7 +48,9 @@ public class AddPlugin extends Recipe {
 
     @Option(displayName = "Version",
             description = "A fixed version of the plugin to add.",
-            example = "1.0.0")
+            example = "1.0.0",
+            required = false)
+    @Nullable
     String version;
 
     @Language("xml")
@@ -125,7 +127,7 @@ public class AddPlugin extends Recipe {
 
                 if (maybePlugin.isPresent()) {
                     Xml.Tag plugin = maybePlugin.get();
-                    if (!version.equals(plugin.getChildValue("version").orElse(null))) {
+                    if (version != null && !version.equals(plugin.getChildValue("version").orElse(null))) {
                         //noinspection OptionalGetWithoutIsPresent
                         t = (Xml.Tag) new ChangeTagValueVisitor<>(plugin.getChild("version").get(), version).visitNonNull(t, ctx, getCursor().getParentOrThrow());
                     }
@@ -133,7 +135,7 @@ public class AddPlugin extends Recipe {
                     Xml.Tag pluginTag = Xml.Tag.build("<plugin>\n" +
                             "<groupId>" + groupId + "</groupId>\n" +
                             "<artifactId>" + artifactId + "</artifactId>\n" +
-                            "<version>" + version + "</version>\n" +
+                            (version != null ? "<version>" + version + "</version>\n" : "") +
                             (executions != null ? executions.trim() + "\n" : "") +
                             (configuration != null ? configuration.trim() + "\n" : "") +
                             (dependencies != null ? dependencies.trim() + "\n" : "") +

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
@@ -251,4 +251,35 @@ public class AddPluginTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addPluginWithoutVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
@@ -26,7 +26,7 @@ public class AddPluginTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", "100.0", null, null, null));
+        spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", "100.0", null, null, null, null));
     }
 
     @DocumentExample
@@ -35,7 +35,7 @@ public class AddPluginTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", "100.0",
             "<configuration>\n<activeRecipes>\n<recipe>io.moderne.FindTest</recipe>\n</activeRecipes>\n</configuration>",
-            null, null)),
+            null, null, null)),
           pomXml(
             """
               <project>
@@ -81,7 +81,7 @@ public class AddPluginTest implements RewriteTest {
                           <version>1.0.0</version>
                       </dependency>
                   </dependencies>
-              """, null)),
+              """, null, null)),
           pomXml(
             """
               <project>
@@ -137,7 +137,7 @@ public class AddPluginTest implements RewriteTest {
                       </configuration>
                     </execution>
                   </executions>
-              """)),
+              """, null)),
           pomXml(
             """
               <project>
@@ -255,7 +255,7 @@ public class AddPluginTest implements RewriteTest {
     @Test
     void addPluginWithoutVersion() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null)),
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, null)),
           pomXml(
             """
               <project>
@@ -279,6 +279,55 @@ public class AddPluginTest implements RewriteTest {
                 </build>
               </project>
               """
+          )
+        );
+    }
+
+    @Test
+    void addPluginWithMatchingFilePattern() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, "dir/pom.xml")),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.openrewrite.maven</groupId>
+                      <artifactId>rewrite-maven-plugin</artifactId>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            spec -> spec.path("dir/pom.xml")
+          )
+        );
+    }
+
+    @Test
+    void addPluginWithNonMatchingFilePattern() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, "dir/pom.xml")),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            spec -> spec.path("pom.xml")
           )
         );
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
- `version` is now optional, this is useful for example when inheriting it from a parent.
- Added `filePattern` , this is useful in many cases but for me when working with a multi module maven project.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
See section above.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
Authors of addPlugin.
@jkschneider 
@sambsnyd
@BoykoAlex 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
