### PR TITLE
Prevent NPE on `namedStyle.styles.iterator()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
@@ -56,13 +56,16 @@ public class NamedStyles implements Marker {
                                             Iterable<? extends NamedStyles> namedStyles) {
         S merged = null;
         for (NamedStyles namedStyle : namedStyles) {
-            for (Style style : namedStyle.styles) {
-                if (styleClass.isInstance(style)) {
-                    style = style.applyDefaults();
-                    if (merged == null) {
-                        merged = (S) style;
-                    } else {
-                        merged = (S) merged.merge(style);
+            Collection<Style> styles = namedStyle.styles;
+            if (styles != null) {
+                for (Style style : styles) {
+                    if (styleClass.isInstance(style)) {
+                        style = style.applyDefaults();
+                        if (merged == null) {
+                            merged = (S) style;
+                        } else {
+                            merged = (S) merged.merge(style);
+                        }
                     }
                 }
             }
@@ -78,20 +81,20 @@ public class NamedStyles implements Marker {
      */
     @Nullable
     public static NamedStyles merge(List<NamedStyles> styles) {
-        if(styles.isEmpty()) {
+        if (styles.isEmpty()) {
             return null;
-        } else if(styles.size() == 1) {
+        } else if (styles.size() == 1) {
             return styles.get(0);
         }
         Set<Class<? extends Style>> styleClasses = new HashSet<>();
-        for(NamedStyles namedStyles : styles) {
-            for(Style style : namedStyles.getStyles()) {
+        for (NamedStyles namedStyles : styles) {
+            for (Style style : namedStyles.getStyles()) {
                 styleClasses.add(style.getClass());
             }
         }
 
         List<Style> mergedStyles = new ArrayList<>(styleClasses.size());
-        for(Class<? extends Style> styleClass : styleClasses) {
+        for (Class<? extends Style> styleClass : styleClasses) {
             mergedStyles.add(NamedStyles.merge(styleClass, styles));
         }
 


### PR DESCRIPTION
Merely to start a discussion; I'd rather have it fixed at the source than with this workaround.

Seen when running `Add missing @Override to overriding and implementing methods` against OpenRewrite org.
https://app.moderne.io/results/t0GqaF80q

## Error:
```java
  public TreeVisitor<?, ExecutionContext> getVisitor() {
      return new RemoveToStringFromArraysVisitor();
  }
```

## Message:
```
Cannot invoke "java.util.Collection.iterator()" because "namedStyle.styles" is null
```

## Detail:
```
java.lang.NullPointerException: Cannot invoke "java.util.Collection.iterator()" because "namedStyle.styles" is null
org.openrewrite.style.NamedStyles.merge(NamedStyles.java:59)
org.openrewrite.SourceFile.getStyle(SourceFile.java:75)
org.openrewrite.java.format.AutoFormatVisitor.visit(AutoFormatVisitor.java:60)
org.openrewrite.java.format.AutoFormatVisitor.visit(AutoFormatVisitor.java:33)
org.openrewrite.java.JavaVisitor.autoFormat(JavaVisitor.java:93)
org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitMethodDeclaration(JavaTemplateJavaExtension.java:297)
org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitMethodDeclaration(JavaTemplateJavaExtension.java:56)
org.openrewrite.java.tree.J$MethodDeclaration.acceptJava(J.java:3465)
...
```