### PR TITLE
Fix issue with duplicate `relativePath` on `ChangeParentPom`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -205,12 +205,15 @@ public class ChangeParentPom extends Recipe {
                                     changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("relativePath").get(), targetRelativePath));
                                 }
                                 else if (tag.getChildValue("relativePath").orElse(null) == null && targetRelativePath != null) {
+                                    Xml.Tag relativePathTag = null;
                                     if (StringUtils.isBlank(targetRelativePath)) {
-                                        changeParentTagVisitors.add(new AddToTagVisitor<>(t, Xml.Tag.build("<relativePath />")));
+                                        relativePathTag = Xml.Tag.build("<relativePath />");
                                     }
                                     else {
-                                        changeParentTagVisitors.add(new AddToTagVisitor<>(t, Xml.Tag.build("<relativePath>" + targetRelativePath + "</relativePath>")));
+                                        relativePathTag = Xml.Tag.build("<relativePath>" + targetRelativePath + "</relativePath>");
                                     }
+                                    doAfterVisit(new AddToTagVisitor<>(t, relativePathTag, new MavenTagInsertionComparator(t.getChildren())));
+                                    maybeUpdateModel();
                                 }
 
                                 if (changeParentTagVisitors.size() > 0) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -205,7 +205,7 @@ public class ChangeParentPom extends Recipe {
                                     changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("relativePath").get(), targetRelativePath));
                                 }
                                 else if (tag.getChildValue("relativePath").orElse(null) == null && targetRelativePath != null) {
-                                    Xml.Tag relativePathTag = null;
+                                    final Xml.Tag relativePathTag;
                                     if (StringUtils.isBlank(targetRelativePath)) {
                                         relativePathTag = Xml.Tag.build("<relativePath />");
                                     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenTagInsertionComparator.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenTagInsertionComparator.java
@@ -36,6 +36,7 @@ public class MavenTagInsertionComparator implements Comparator<Content> {
             "groupId",
             "artifactId",
             "version",
+            "relativePath",
             "packaging",
             "name",
             "description",

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -236,7 +236,6 @@ class ChangeParentPomTest implements RewriteTest {
         );
     }
 
-    @Test
     @RepeatedTest(10)
     void multiModuleRelativePath() {
       ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, "", null, false, null);
@@ -321,7 +320,6 @@ class ChangeParentPomTest implements RewriteTest {
       );
   }
 
-  @Test
   @RepeatedTest(10)
   void multiModuleRelativePathChangeChildrens() {
     ChangeParentPom recipe = new ChangeParentPom("org.sample", "org.springframework.boot", "sample", "spring-boot-starter-parent", "2.5.0", null, "", null, true, null);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -237,6 +237,181 @@ class ChangeParentPomTest implements RewriteTest {
     }
 
     @Test
+    @RepeatedTest(10)
+    void multiModuleRelativePath() {
+      ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, "", null, false, null);
+      rewriteRun(
+        spec -> spec.recipe(recipe),
+        mavenProject("parent",
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.5.0</version>
+                </parent>
+                
+                <modules>
+                  <module>module1</module>
+                  <module>module2</module>
+                </modules>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.6.7</version>
+                  <relativePath />
+                </parent>
+
+                <modules>
+                  <module>module1</module>
+                  <module>module2</module>
+                </modules>
+              </project>
+              """
+          ),
+          mavenProject("module1",
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                  </parent>
+                  <artifactId>module1</artifactId>
+                </project>
+                """
+            )),
+          mavenProject("module2",
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                  </parent>
+                  <artifactId>module2</artifactId>
+                </project>
+                """
+            )
+          )
+        )
+      );
+  }
+
+  @Test
+  @RepeatedTest(10)
+  void multiModuleRelativePathChangeChildrens() {
+    ChangeParentPom recipe = new ChangeParentPom("org.sample", "org.springframework.boot", "sample", "spring-boot-starter-parent", "2.5.0", null, "", null, true, null);
+    rewriteRun(
+      spec -> spec.recipe(recipe),
+      mavenProject("parent",
+        pomXml(
+          """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>org.sample</groupId>
+              <artifactId>sample</artifactId>
+              <version>1.0.0</version>
+              
+              <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>2.5.0</version>
+              </parent>
+              
+              <modules>
+                <module>module1</module>
+                <module>module2</module>
+              </modules>
+            </project>
+            """
+        ),
+        mavenProject("module1",
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                </parent>
+                <artifactId>module1</artifactId>
+              </project>
+              """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.0</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>module1</artifactId>
+                </project>
+                """
+          )),
+        mavenProject("module2",
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                </parent>
+                <artifactId>module2</artifactId>
+              </project>
+              """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.0</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>module2</artifactId>
+                </project>
+                """
+          )
+        )
+      )
+    );
+}
+
+    @Test
     void upgradeVersion() {
         rewriteRun(
           spec -> spec.recipe(new ChangeParentPom(


### PR DESCRIPTION
Found issue when testing https://github.com/openrewrite/rewrite/pull/3537 in real use case.

I ended-up with duplicate `relativePath` tag on maven pom.

I'm not sure why, I was not able to reproduce with unit test. I think the model need to be refreshed earlier.

In any case I've added a tentative fix and increase the test coverage for multi module

- Changing parent module only
- Changing child module to point to a different external pom

I've also ensured the relativePath is added after the version on the parent pom-

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
