### PR TITLE
No recursive application of Maven mirrors

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -90,10 +90,10 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
      * @return The mirrors to use for dependency resolution.
      */
     public Collection<MavenRepositoryMirror> getMirrors(@Nullable MavenSettings mavenSettings) {
-        if (mavenSettings != null) {
+        if (mavenSettings != null && !mavenSettings.equals(getSettings())) {
             return mapMirrors(mavenSettings);
         }
-        return getMessage(MAVEN_MIRRORS, emptyList());
+        return getMirrors();
     }
 
     public MavenExecutionContextView setCredentials(Collection<MavenRepositoryCredentials> credentials) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
@@ -94,15 +94,13 @@ public class MavenRepositoryMirror {
     }
 
     public static MavenRepository apply(Collection<MavenRepositoryMirror> mirrors, MavenRepository repo) {
-        MavenRepository mapped = repo;
-        MavenRepository next = null;
-        while (next != mapped) {
-            next = mapped;
-            for (MavenRepositoryMirror mirror : mirrors) {
-                mapped = mirror.apply(mapped);
+        for (MavenRepositoryMirror mirror : mirrors) {
+            MavenRepository mapped = mirror.apply(repo);
+            if (mapped != repo) {
+                return  mapped;
             }
         }
-        return mapped;
+        return repo;
     }
 
     public MavenRepository apply(MavenRepository repo) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/MavenRepositoryMirrorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/MavenRepositoryMirrorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.tree;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MavenRepositoryMirrorTest {
+
+    MavenRepositoryMirror one = new MavenRepositoryMirror("one", "https://one.org/m2", "*", true, true);
+    MavenRepositoryMirror two = new MavenRepositoryMirror("two", "https://two.org/m2", "*", true, true);
+    MavenRepository foo = new MavenRepository("foo", "https://foo.org/m2", "true", "true", null, null);
+
+    @Test
+    void useFirstMirror() {
+        assertThat(MavenRepositoryMirror.apply(List.of(one, two), foo)).satisfies(repo -> {
+            assertThat(repo.getId()).isEqualTo(one.getId());
+            assertThat(repo.getUri()).isEqualTo(one.getUrl());
+        });
+    }
+}


### PR DESCRIPTION
As [documented](https://maven.apache.org/guides/mini/guide-mirror-settings.html) (and verified by manual testing) it is always the first matching Maven mirror that should get selected, when finding a mirror for a particular repository. I.e. the mirrors should not be applied recursively.

Additionally, this commit will use the precomputed mirrors (from the `ExecutionContext`) whenever possible, as computing the mirrors is somewhat expensive.
