### PR TITLE
Set AddGradleEnterpriseGradlePlugin server URL example

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddGradleEnterpriseGradlePlugin.java
@@ -68,7 +68,7 @@ public class AddGradleEnterpriseGradlePlugin extends Recipe {
     @Option(displayName = "Server URL",
             description = "The URL of the Gradle Enterprise server. If omitted the recipe will set no URL and Gradle will direct scans to https://scans.gradle.com/",
             required = false,
-            example = "https://ge.openrewrite.org/")
+            example = "https://scans.gradle.com/")
     @Nullable
     String server;
 


### PR DESCRIPTION


<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Set `AddGradleEnterpriseGradlePlugin` server URL example to https://scans.gradle.com/

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Align with `AddGradleEnterpriseMavenExtension` recipe

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
