### PR TITLE
Update ChangeType recipe to support kotlin alias import

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -193,13 +193,7 @@ public class ChangeType extends Recipe {
                         if (!"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
                             maybeAddImport(fullyQualifiedTarget.getPackageName(), fullyQualifiedTarget.getClassName(), null, true);
                         }
-
-                        if (importAlias != null) {
-                            JavaVisitor visitor = new UpdateImportAlias(targetType, importAlias);
-                            if (!getAfterVisit().contains(visitor)) {
-                                doAfterVisit(visitor);
-                            }
-                        }
+                        maybeUpdateAlias();
                     }
                 }
 
@@ -299,13 +293,7 @@ public class ChangeType extends Recipe {
                             if (fqn != null && TypeUtils.isOfClassType(fqn, originalType.getFullyQualifiedName()) &&
                                 method.getSimpleName().equals(anImport.getQualid().getSimpleName())) {
                                 maybeAddImport(((JavaType.FullyQualified) targetType).getFullyQualifiedName(), method.getName().getSimpleName());
-
-                                if (importAlias != null) {
-                                    JavaVisitor visitor = new UpdateImportAlias(targetType, importAlias);
-                                    if (!getAfterVisit().contains(visitor)) {
-                                        doAfterVisit(visitor);
-                                    }
-                                }
+                                maybeUpdateAlias();
                                 break;
                             }
                         }
@@ -313,6 +301,15 @@ public class ChangeType extends Recipe {
                 }
             }
             return super.visitMethodInvocation(method, ctx);
+        }
+
+        private void maybeUpdateAlias() {
+            if (importAlias != null) {
+                UpdateImportAlias visitor = new UpdateImportAlias(targetType, importAlias);
+                if (!getAfterVisit().contains(visitor)) {
+                    doAfterVisit(visitor);
+                }
+            }
         }
 
         private Expression updateOuterClassTypes(Expression typeTree) {


### PR DESCRIPTION
The root cause is the addImport service doesn't support Kotlin alias at the moment, so this approach is a workaround fix.

I have 2 test cases below verified in `rewrite-kotlin` repo, it's not able to add to this repo since no dependency.
 
 
```java

    @Test
    void changeTypeTest2() {
        rewriteRun(
          spec -> spec.recipe(new ChangeType("java.util.ArrayList", "java.util.LinkedList", true)),
          kotlin(
            """
              import java.util.ArrayList as MyList

              fun main() {
                  val list = ArrayList<String>()
                  val list2 = MyList<String>()
              }
              """,
            """
              import java.util.LinkedList as MyList

              fun main() {
                  val list = LinkedList<String>()
                  val list2 = MyList<String>()
              }
              """
          )
        );
    }

    @Test
    void changeTypeTest3() {
        rewriteRun(
          spec -> spec.recipe(new ChangeType("java.util.ArrayList", "java.util.LinkedList", true)),
          kotlin(
            """
              import java.util.ArrayList as MyList
              import java.util.LinkedList

              fun main() {
                  val list = ArrayList<String>()
                  val list2 = MyList<String>()
              }
              """,
            """
              import java.util.LinkedList as MyList

              fun main() {
                  val list = LinkedList<String>()
                  val list2 = MyList<String>()
              }
              """
          )
        );
    }
```