### PR TITLE
Update AddImport with alias to support Kotlin alias import

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -536,7 +536,7 @@ class AddImportTest implements RewriteTest {
             );
 
             rewriteRun(
-              spec -> spec.recipe(toRecipe(() -> new AddImport<>(pkg, "B", null, false))),
+              spec -> spec.recipe(toRecipe(() -> new AddImport<>(pkg, "B", null, null, false))),
               sources.toArray(new SourceSpecs[0])
             );
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -72,6 +72,10 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
     @EqualsAndHashCode.Include
     private final boolean onlyIfReferenced;
 
+    @EqualsAndHashCode.Include
+    @Nullable
+    private final String alias;
+
     public AddImport(String type, @Nullable String member, boolean onlyIfReferenced) {
         int lastDotIdx = type.lastIndexOf('.');
         this.packageName = lastDotIdx != -1 ? type.substring(0, lastDotIdx) : null;
@@ -79,14 +83,16 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
         this.fullyQualifiedName = type;
         this.member = member;
         this.onlyIfReferenced = onlyIfReferenced;
+        alias = null;
     }
 
-    public AddImport(@Nullable String packageName, String typeName, @Nullable String member, boolean onlyIfReferenced) {
+    public AddImport(@Nullable String packageName, String typeName, @Nullable String member, @Nullable String alias, boolean onlyIfReferenced) {
         this.packageName = packageName;
         this.typeName = typeName.replace('.', '$');
         this.fullyQualifiedName = packageName == null ? typeName : packageName + "." + typeName;
         this.member = member;
         this.onlyIfReferenced = onlyIfReferenced;
+        this.alias = alias;
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -124,11 +124,11 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         int lastDotIdx = fullyQualifiedName.lastIndexOf('.');
         String packageName = lastDotIdx != -1 ? fullyQualifiedName.substring(0, lastDotIdx) : null;
         String typeName = lastDotIdx != -1 ? fullyQualifiedName.substring(lastDotIdx + 1) : fullyQualifiedName;
-        maybeAddImport(packageName, typeName, member, onlyIfReferenced);
+        maybeAddImport(packageName, typeName, member, null, onlyIfReferenced);
     }
 
-    public void maybeAddImport(@Nullable String packageName, String typeName, @Nullable String member, boolean onlyIfReferenced) {
-        JavaVisitor<P> visitor = service(ImportService.class).addImportVisitor(packageName, typeName, member, onlyIfReferenced);
+    public void maybeAddImport(@Nullable String packageName, String typeName, @Nullable String member, @Nullable String alias, boolean onlyIfReferenced) {
+        JavaVisitor<P> visitor = service(ImportService.class).addImportVisitor(packageName, typeName, member, alias, onlyIfReferenced);
         if (!getAfterVisit().contains(visitor)) {
             doAfterVisit(visitor);
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/ImportService.java
@@ -23,7 +23,11 @@ import org.openrewrite.java.JavaVisitor;
 @Incubating(since = "8.2.0")
 public class ImportService {
 
-    public <P> JavaVisitor<P> addImportVisitor(@Nullable String packageName, String typeName, @Nullable String member, boolean onlyIfReferenced) {
-        return new AddImport<>(packageName, typeName, member, onlyIfReferenced);
+    public <P> JavaVisitor<P> addImportVisitor(@Nullable String packageName,
+                                               String typeName,
+                                               @Nullable String member,
+                                               @Nullable String alias,
+                                               boolean onlyIfReferenced) {
+        return new AddImport<>(packageName, typeName, member,  alias, onlyIfReferenced);
     }
 }


### PR DESCRIPTION
To fix the issue of the `ChangeType` recipe missing the Kotlin alias import.
I have a workaround [solution](https://github.com/openrewrite/rewrite/pull/3558) before but it doesn't solve the problem thoroughly. 
The problem is it's impossible to add two imports (one with an alias, the other one without an alias)
I found the only way to solve this is to update AddImport to support alias.
