### PR TITLE
avoid creating an empty file if nothing will be written to it.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/LocalMavenArtifactCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/LocalMavenArtifactCache.java
@@ -35,7 +35,7 @@ public class LocalMavenArtifactCache implements MavenArtifactCache {
     private final Path cache;
 
     public LocalMavenArtifactCache(Path cache) {
-        if(!cache.toFile().exists() && !cache.toFile().mkdirs()) {
+        if (!cache.toFile().exists() && !cache.toFile().mkdirs()) {
             throw new IllegalStateException("Unable to find or create maven artifact cache at " + cache);
         }
         this.cache = cache;
@@ -51,15 +51,16 @@ public class LocalMavenArtifactCache implements MavenArtifactCache {
     @Override
     @Nullable
     public Path putArtifact(ResolvedDependency dependency, InputStream artifactInputStream, Consumer<Throwable> onError) {
+        if (artifactInputStream == null) {
+            return null;
+        }
         Path path = dependencyPath(dependency);
         try (InputStream is = artifactInputStream;
              OutputStream out = Files.newOutputStream(path)) {
-            if (is != null) {
-                byte[] buffer = new byte[1024];
-                int read;
-                while ((read = is.read(buffer, 0, 1024)) >= 0) {
-                    out.write(buffer, 0, read);
-                }
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = is.read(buffer, 0, 1024)) >= 0) {
+                out.write(buffer, 0, read);
             }
         } catch (Throwable t) {
             onError.accept(t);
@@ -85,8 +86,8 @@ public class LocalMavenArtifactCache implements MavenArtifactCache {
         }
 
         return resolvedPath.resolve(dependency.getArtifactId() + "-" +
-                (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
-                (dependency.getRequested().getClassifier() == null ? "" : dependency.getRequested().getClassifier()) +
-                ".jar");
+                                    (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
+                                    (dependency.getRequested().getClassifier() == null ? "" : dependency.getRequested().getClassifier()) +
+                                    ".jar");
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.maven.cache;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cache/LocalMavenArtifactCacheTest.java
@@ -1,0 +1,75 @@
+package org.openrewrite.maven.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.maven.MavenParser;
+import org.openrewrite.maven.tree.*;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalMavenArtifactCacheTest {
+
+    LocalMavenArtifactCache cache;
+
+    @BeforeEach
+    void setup() {
+
+    }
+
+    @Test
+    void saveFileWhenInputStringExists(@TempDir Path tempDir) {
+        cache = new LocalMavenArtifactCache(tempDir);
+        Path output = cache.putArtifact(findDependency(), new ByteArrayInputStream("hi".getBytes()), Throwable::printStackTrace);
+        assertThat(output).exists();
+    }
+
+    @Test
+    void dontCreateFileWhenInputStringNull(@TempDir Path tempDir) {
+        cache = new LocalMavenArtifactCache(tempDir);
+        Path output = cache.putArtifact(findDependency(), null, Throwable::printStackTrace);
+        assertThat(output).isNull();
+        assertThat(tempDir).isEmptyDirectory();
+    }
+
+    private static ResolvedDependency findDependency() {
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        ResolvedGroupArtifactVersion recipeGav = new ResolvedGroupArtifactVersion(
+          "https://repo1.maven.org/maven2",
+          "org.openrewrite.recipe",
+          "rewrite-testing-frameworks",
+          "1.6.0", null);
+
+        MavenParser mavenParser = MavenParser.builder().build();
+        SourceFile parsed = mavenParser.parse(ctx,
+          String.format(
+            //language=xml
+            """
+              <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>maven-downloader-test</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>%s</groupId>
+                          <artifactId>%s</artifactId>
+                          <version>%s</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(recipeGav.getGroupId(), recipeGav.getArtifactId(), recipeGav.getVersion()))
+        ).findFirst().orElseThrow(() -> new IllegalArgumentException("Could not parse as XML"));
+
+        MavenResolutionResult mavenModel = parsed.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+        assertThat(mavenModel.getDependencies()).isNotEmpty();
+        List<ResolvedDependency> runtimeDependencies = mavenModel.getDependencies().get(Scope.Runtime);
+        return runtimeDependencies.get(0);
+    }
+}


### PR DESCRIPTION
## What's changed?
LocalMavenArtifactCache created an empty file when the input stream is null and then does not write anything to it. This means that a retry will fail on loading this empty file.

## What's your motivation?
During recipe loading a timeout can occur. A retry is put in place to fix this, but these always fail due to the above problem.

## Anything in particular you'd like reviewers to focus on?
Was this a bug or a feature?

## Anyone you would like to review specifically?
no

## Have you considered any alternatives or workarounds?


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
