### PR TITLE
Rewrite escaped groovy method names

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -1210,6 +1210,44 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3559")
+    void defaultConfigurationEscaped() {
+        String onlyIfUsing = "com.google.common.math.IntMath";
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", onlyIfUsing, "default")),
+          mavenProject("project",
+            srcTestJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id 'java'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              """
+                plugins {
+                    id 'java'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencies {
+                    'default' "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
     private AddDependency addDependency(String gav, String onlyIfUsing) {
         return addDependency(gav, onlyIfUsing, null);
     }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1466,9 +1466,18 @@ public class GroovyParserVisitor {
             // closure() has implicitThis set to false
             // So the "select" that was just parsed _may_ have actually been the method name
             J.Identifier name;
-            if (call.getMethodAsString().equals(source.substring(cursor, cursor + call.getMethodAsString().length()))) {
-                name = new J.Identifier(randomId(), sourceBefore(call.getMethodAsString()), Markers.EMPTY,
-                        emptyList(), call.getMethodAsString(), null, null);
+
+            String methodNameExpression = call.getMethodAsString();
+            if (source.charAt(cursor) == '"' || source.charAt(cursor) == '\'') {
+                // we have an escaped groovy method name, commonly used for test `def 'some scenario description'() {}`
+                // or to workaround names that are also keywords in groovy
+                methodNameExpression = source.charAt(cursor) + methodNameExpression + source.charAt(cursor);
+            }
+
+
+            if (methodNameExpression.equals(source.substring(cursor, cursor + methodNameExpression.length()))) {
+                name = new J.Identifier(randomId(), sourceBefore(methodNameExpression), Markers.EMPTY,
+                        emptyList(), methodNameExpression, null, null);
 
             } else if (select != null && select.getElement() instanceof J.Identifier) {
                 name = (J.Identifier) select.getElement();

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 class MethodInvocationTest implements RewriteTest {
-
     @Test
     void gradle() {
         rewriteRun(
@@ -259,6 +258,31 @@ class MethodInvocationTest implements RewriteTest {
                   isEmpty("")
                 }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3559")
+    void escapedMethodNameTest() {
+        rewriteRun(
+          groovy(
+            """
+              def 'default'() {}
+              'default'()
+              """
+          )
+        );
+    }
+
+    @Test
+    void escapedMethodNameWithSpacesTest() {
+        rewriteRun(
+          groovy(
+            """
+              def 'some test scenario description'() {}
+              'some test scenario description'()
               """
           )
         );


### PR DESCRIPTION
And use the escaped groovy method name rewriting to update dependencies with the gradle default scope (although why this scope is being chosen by the java update recipe is unclear).

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added handling for escaped method names in GroovyParserVisitor, then check for configurations that require escaping in the AddDependencyVisitor

## What's your motivation?
This is an enhancement that is also a workaround for https://github.com/openrewrite/rewrite/issues/3559.

A more complete fix would involve determining why the AddJaxbRuntime recipe is selecting certain configurations like default and rewrite to add dependencies to. 


## Anyone you would like to review specifically?
@shanman190 @timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
