### PR TITLE
Handle varargs in `ReloadableJava17JavadocVisitor`

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -1148,7 +1148,11 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             if (dimCount > 0) {
                 dimensions = new ArrayList<>(dimCount);
                 for (int n = 0; n < dimCount; n++) {
-                    dimensions.add(padRight(Space.build(sourceBeforeAsString("["), emptyList()), Space.build(sourceBeforeAsString("]"), emptyList())));
+                    if (!source.substring(cursor).startsWith("...")) {
+                        dimensions.add(padRight(
+                                Space.build(sourceBeforeAsString("["), emptyList()),
+                                Space.build(sourceBeforeAsString("]"), emptyList())));
+                    }
                 }
             }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -1660,4 +1660,51 @@ class JavadocTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3575")
+    void varargsMethod() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  /**
+                   * A dummy main method. This method is not actually called, but we'll use its Javadoc comment to test that
+                   * OpenRewrite can handle references like the following: {@link A#varargsMethod(String...)}.
+                   *
+                   * @param args The arguments to the method.
+                   */
+                  public static void main(String[] args) {
+                      System.out.println("Hello, world! This is my original class' main method.");
+                  }
+                  public static void varargsMethod(String... args) {
+                      System.out.println("Hello, world! This is my original class' varargs method.");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3575")
+    void arrayMethod() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  /**
+                   * A dummy main method. This method is not actually called, but we'll use its Javadoc comment to test that
+                   * OpenRewrite can handle references like the following: {@link A#main(String[])}.
+                   *
+                   * @param args The arguments to the method.
+                   */
+                  public static void main(String[] args) {
+                      System.out.println("Hello, world! This is my original class' main method.");
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Do not look for array dimensions when we encounter varargs in method references in Javadoc.

## What's your motivation?
We failed to parse the file at all
- https://github.com/openrewrite/rewrite/issues/3575

Fixes https://github.com/openrewrite/rewrite/issues/3575

