### PR TITLE
Drop prefixless expressions in POM

### DIFF
--- a/rewrite-maven/src/main/resources/META-INF/rewrite/maven.yml
+++ b/rewrite-maven/src/main/resources/META-INF/rewrite/maven.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.maven.BestPractices
+displayName: Apache Maven best practices
+description: Applies best practices to Maven POMs.
+recipeList:
+  - org.openrewrite.maven.cleanup.PrefixlessExpressions
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.maven.cleanup.PrefixlessExpressions
+displayName: Drop prefixless expressions in POM
+description: MNG-7404 drops support for prefixless in POMs. This recipe will add the `project.` prefix where missing.
+recipeList:
+  - org.openrewrite.maven.RenamePropertyKey:
+      oldKey: version
+      newKey: project.version
+  - org.openrewrite.maven.RenamePropertyKey:
+      oldKey: pom.version
+      newKey: project.version

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/maven4/PrefixlessExpressionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/maven4/PrefixlessExpressionsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.maven4;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class PrefixlessExpressionsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/maven.yml", "org.openrewrite.maven.cleanup.PrefixlessExpressions");
+    }
+
+    @DocumentExample
+    @Test
+    void renamePrefixlessExpressions() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1.0</version>
+                <properties>
+                  <other.version>1.0.0</other.version>
+                </properties>
+                <dependencies>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${pom.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${project.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${other.version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1.0</version>
+                <properties>
+                  <other.version>1.0.0</other.version>
+                </properties>
+                <dependencies>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${project.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${project.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${project.version}</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                    <version>${other.version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add Apache Maven best practices (to be expanded upon still) and a recipe to drop prefixless expressions from pom.xml files ahead of Maven 4.

## What's your motivation?
Fixes #1621

## Any additional context
- https://github.com/apache/maven/pull/696
- https://issues.apache.org/jira/browse/MNG-7404
