### PR TITLE
Maven parent POM insight through data table

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -21,7 +21,6 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.table.ParentPomsInUse;
@@ -66,7 +65,6 @@ public class ParentPomInsight extends Recipe {
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 Xml.Tag t = super.visitTag(tag, ctx);
-
                 if (isParentTag()) {
                     ResolvedPom resolvedPom = getResolutionResult().getPom();
                     if (matchesGlob(resolvedPom.getValue(tag.getChildValue("groupId").orElse(null)), groupIdPattern) &&
@@ -77,16 +75,9 @@ public class ParentPomInsight extends Recipe {
                         String groupId = t.getChildValue("groupId").orElse(null);
                         String artifactId = t.getChildValue("artifactId").orElse(null);
                         String version = tag.getChildValue("version").orElse(null);
-                        String relativePath = t.getChildValue("relativePath").orElse(null);
-
-                        String projectName = getCursor().firstEnclosingOrThrow(Xml.Document.class)
-                                .getMarkers().findFirst(JavaProject.class)
-                                .map(JavaProject::getProjectName).orElse("");
                         inUse.insertRow(ctx, new ParentPomsInUse.Row(
-                                projectName,
                                 groupId, artifactId, version,
-                                resolvedPom.getDatedSnapshotVersion(),
-                                relativePath
+                                resolvedPom.getDatedSnapshotVersion()
                         ));
                     }
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -67,18 +67,13 @@ public class ParentPomInsight extends Recipe {
                 Xml.Tag t = super.visitTag(tag, ctx);
                 if (isParentTag()) {
                     ResolvedPom resolvedPom = getResolutionResult().getPom();
-                    if (matchesGlob(resolvedPom.getValue(tag.getChildValue("groupId").orElse(null)), groupIdPattern) &&
-                        matchesGlob(resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null)), artifactIdPattern)) {
-
-                        t = SearchResult.found(t);
-
-                        String groupId = t.getChildValue("groupId").orElse(null);
-                        String artifactId = t.getChildValue("artifactId").orElse(null);
-                        String version = tag.getChildValue("version").orElse(null);
-                        inUse.insertRow(ctx, new ParentPomsInUse.Row(
-                                groupId, artifactId, version,
-                                resolvedPom.getDatedSnapshotVersion()
-                        ));
+                    String groupId = resolvedPom.getValue(tag.getChildValue("groupId").orElse(null));
+                    String artifactId = resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null));
+                    if (matchesGlob(groupId, groupIdPattern) && matchesGlob(artifactId, artifactIdPattern)) {
+                        String version = resolvedPom.getValue(tag.getChildValue("version").orElse(null));
+                        inUse.insertRow(ctx, new ParentPomsInUse.Row(groupId, artifactId, version,
+                                resolvedPom.getDatedSnapshotVersion()));
+                        return SearchResult.found(t);
                     }
                 }
                 return t;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.maven.table.ParentPomsInUse;
+import org.openrewrite.maven.tree.ResolvedPom;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.UUID;
+
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.internal.StringUtils.matchesGlob;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class ParentPomInsight extends Recipe {
+    transient ParentPomsInUse inUse = new ParentPomsInUse(this);
+
+    @Option(displayName = "Group pattern",
+            description = "Group glob pattern used to match dependencies.",
+            example = "org.springframework.boot")
+    String groupIdPattern;
+
+    @Option(displayName = "Artifact pattern",
+            description = "Artifact glob pattern used to match dependencies.",
+            example = "spring-boot-starter-*")
+    String artifactIdPattern;
+
+    UUID searchId = randomId();
+
+    @Override
+    public String getDisplayName() {
+        return "Maven parent insight";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find Maven parents matching a `groupId` and `artifactId`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
+
+                if (isParentTag()) {
+                    ResolvedPom resolvedPom = getResolutionResult().getPom();
+                    if (matchesGlob(resolvedPom.getValue(tag.getChildValue("groupId").orElse(null)), groupIdPattern) &&
+                        matchesGlob(resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null)), artifactIdPattern)) {
+
+                        t = SearchResult.found(t);
+
+                        String groupId = t.getChildValue("groupId").orElse(null);
+                        String artifactId = t.getChildValue("artifactId").orElse(null);
+                        String version = tag.getChildValue("version").orElse(null);
+                        String relativePath = t.getChildValue("relativePath").orElse(null);
+
+                        String projectName = getCursor().firstEnclosingOrThrow(Xml.Document.class)
+                                .getMarkers().findFirst(JavaProject.class)
+                                .map(JavaProject::getProjectName).orElse("");
+                        inUse.insertRow(ctx, new ParentPomsInUse.Row(
+                                projectName,
+                                groupId, artifactId, version,
+                                resolvedPom.getDatedSnapshotVersion(),
+                                relativePath
+                        ));
+                    }
+                }
+                return t;
+            }
+        };
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -21,6 +21,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.table.ParentPomsInUse;
@@ -71,8 +72,12 @@ public class ParentPomInsight extends Recipe {
                     String artifactId = resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null));
                     if (matchesGlob(groupId, groupIdPattern) && matchesGlob(artifactId, artifactIdPattern)) {
                         String version = resolvedPom.getValue(tag.getChildValue("version").orElse(null));
-                        inUse.insertRow(ctx, new ParentPomsInUse.Row(groupId, artifactId, version,
-                                resolvedPom.getDatedSnapshotVersion()));
+                        String projectName = getCursor().firstEnclosingOrThrow(Xml.Document.class)
+                                .getMarkers().findFirst(JavaProject.class)
+                                .map(JavaProject::getProjectName).orElse("");
+                        String relativePath = tag.getChildValue("relativePath").orElse(null);
+                        inUse.insertRow(ctx, new ParentPomsInUse.Row(
+                                projectName, groupId, artifactId, version, resolvedPom.getDatedSnapshotVersion(), relativePath));
                         return SearchResult.found(t);
                     }
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
@@ -33,10 +33,6 @@ public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
 
     @Value
     public static class Row {
-        @Column(displayName = "Project name",
-                description = "The name of the project that contains the parent.")
-        String projectName;
-
         @Column(displayName = "Group",
                 description = "The first part of a parent coordinate `com.google.guava:guava:VERSION`.")
         String groupId;
@@ -54,10 +50,5 @@ public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
                 description = "The resolved dated snapshot version or `null` if this parent is not a snapshot.")
         @Nullable
         String datedSnapshotVersion;
-
-        @Column(displayName = "Relative path",
-                description = "The relative path to the parent.")
-        @Nullable
-        String relativePath;
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
@@ -28,7 +28,7 @@ public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
     public ParentPomsInUse(Recipe recipe) {
         super(recipe, Row.class,
                 ParentPomsInUse.class.getName(),
-                "Dependencies in use", "Direct and transitive dependencies in use.");
+                "Maven parent POMs in use", "Projects, GAVs and relativePaths for Maven parent POMs in use.");
     }
 
     @Value
@@ -38,11 +38,11 @@ public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
         String projectName;
 
         @Column(displayName = "Group",
-                description = "The first part of a parent coordinate `com.google.guava:guava:VERSION`.")
+                description = "The first part of a parent coordinate `org.springframework.boot`.")
         String groupId;
 
         @Column(displayName = "Artifact",
-                description = "The second part of a parent coordinate `com.google.guava:guava:VERSION`.")
+                description = "The second part of a parent coordinate `spring-boot-starter-*`.")
         String artifactId;
 
         @Column(displayName = "Version",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
@@ -33,6 +33,10 @@ public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
 
     @Value
     public static class Row {
+        @Column(displayName = "Project name",
+                description = "The name of the project that contains the parent.")
+        String projectName;
+
         @Column(displayName = "Group",
                 description = "The first part of a parent coordinate `com.google.guava:guava:VERSION`.")
         String groupId;
@@ -50,5 +54,11 @@ public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
                 description = "The resolved dated snapshot version or `null` if this parent is not a snapshot.")
         @Nullable
         String datedSnapshotVersion;
+
+        @Column(displayName = "Relative path",
+                description = "The relative path to the parent.")
+        @Nullable
+        String relativePath;
+
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/ParentPomsInUse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.lang.Nullable;
+
+@JsonIgnoreType
+public class ParentPomsInUse extends DataTable<ParentPomsInUse.Row> {
+
+    public ParentPomsInUse(Recipe recipe) {
+        super(recipe, Row.class,
+                ParentPomsInUse.class.getName(),
+                "Dependencies in use", "Direct and transitive dependencies in use.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Project name",
+                description = "The name of the project that contains the parent.")
+        String projectName;
+
+        @Column(displayName = "Group",
+                description = "The first part of a parent coordinate `com.google.guava:guava:VERSION`.")
+        String groupId;
+
+        @Column(displayName = "Artifact",
+                description = "The second part of a parent coordinate `com.google.guava:guava:VERSION`.")
+        String artifactId;
+
+        @Column(displayName = "Version",
+                description = "The resolved version.")
+        @Nullable
+        String version;
+
+        @Column(displayName = "Dated snapshot version",
+                description = "The resolved dated snapshot version or `null` if this parent is not a snapshot.")
+        @Nullable
+        String datedSnapshotVersion;
+
+        @Column(displayName = "Relative path",
+                description = "The relative path to the parent.")
+        @Nullable
+        String relativePath;
+    }
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
@@ -86,7 +86,7 @@ class ParentPomInsightTest implements RewriteTest {
         rewriteRun(
           spec -> spec.dataTableAsCsv(ParentPomsInUse.class.getName(), """
             projectName,groupId,artifactId,version,datedSnapshotVersion
-            parent,org.springframework.boot,"spring-boot-starter-parent",2.5.0,
+            org.springframework.boot,"spring-boot-starter-parent",2.5.0,
             """),
           mavenProject("parent",
             pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
@@ -85,7 +85,7 @@ class ParentPomInsightTest implements RewriteTest {
     void multiModuleOnlyRoot() {
         rewriteRun(
           spec -> spec.dataTableAsCsv(ParentPomsInUse.class.getName(), """
-            projectName,groupId,artifactId,version,datedSnapshotVersion
+            groupId,artifactId,version,datedSnapshotVersion
             org.springframework.boot,"spring-boot-starter-parent",2.5.0,
             """),
           mavenProject("parent",

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
@@ -37,7 +37,6 @@ class ParentPomInsightTest implements RewriteTest {
         rewriteRun(
           spec -> spec.dataTable(ParentPomsInUse.Row.class, rows -> {
               assertThat(rows).hasSize(1);
-              assertThat(rows.get(0).getProjectName()).isEqualTo("demo");
               assertThat(rows.get(0).getGroupId()).isEqualTo("org.springframework.boot");
               assertThat(rows.get(0).getArtifactId()).isEqualTo("spring-boot-starter-parent");
               assertThat(rows.get(0).getVersion()).isEqualTo("3.1.4");
@@ -86,8 +85,8 @@ class ParentPomInsightTest implements RewriteTest {
     void multiModuleOnlyRoot() {
         rewriteRun(
           spec -> spec.dataTableAsCsv(ParentPomsInUse.class.getName(), """
-            projectName,groupId,artifactId,version,datedSnapshotVersion,relativePath
-            parent,org.springframework.boot,"spring-boot-starter-parent",2.5.0,,
+            projectName,groupId,artifactId,version,datedSnapshotVersion
+            parent,org.springframework.boot,"spring-boot-starter-parent",2.5.0,
             """),
           mavenProject("parent",
             pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/ParentPomInsightTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.maven.table.ParentPomsInUse;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class ParentPomInsightTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ParentPomInsight("org.springframework.boot", "spring-boot-starter-parent"));
+    }
+
+    @DocumentExample
+    @Test
+    void findParent() {
+        rewriteRun(
+          spec -> spec.dataTable(ParentPomsInUse.Row.class, rows -> {
+              assertThat(rows).hasSize(1);
+              assertThat(rows.get(0).getProjectName()).isEqualTo("demo");
+              assertThat(rows.get(0).getGroupId()).isEqualTo("org.springframework.boot");
+              assertThat(rows.get(0).getArtifactId()).isEqualTo("spring-boot-starter-parent");
+              assertThat(rows.get(0).getVersion()).isEqualTo("3.1.4");
+              assertThat(rows.get(0).getDatedSnapshotVersion()).isNull();
+          }),
+          mavenProject("demo",
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                	<modelVersion>4.0.0</modelVersion>
+                	<parent>
+                		<groupId>org.springframework.boot</groupId>
+                		<artifactId>spring-boot-starter-parent</artifactId>
+                		<version>3.1.4</version>
+                		<relativePath/> <!-- lookup parent from repository -->
+                	</parent>
+                	<groupId>com.example</groupId>
+                	<artifactId>demo</artifactId>
+                	<version>0.0.1-SNAPSHOT</version>
+                </project>
+                """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                	<modelVersion>4.0.0</modelVersion>
+                	<!--~~>--><parent>
+                		<groupId>org.springframework.boot</groupId>
+                		<artifactId>spring-boot-starter-parent</artifactId>
+                		<version>3.1.4</version>
+                		<relativePath/> <!-- lookup parent from repository -->
+                	</parent>
+                	<groupId>com.example</groupId>
+                	<artifactId>demo</artifactId>
+                	<version>0.0.1-SNAPSHOT</version>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void multiModuleOnlyRoot() {
+        rewriteRun(
+          spec -> spec.dataTableAsCsv(ParentPomsInUse.class.getName(), """
+            projectName,groupId,artifactId,version,datedSnapshotVersion,relativePath
+            parent,org.springframework.boot,"spring-boot-starter-parent",2.5.0,,
+            """),
+          mavenProject("parent",
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.0</version>
+                  </parent>
+                  
+                  <modules>
+                    <module>module1</module>
+                    <module>module2</module>
+                  </modules>
+                </project>
+                """,
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+
+                  <!--~~>--><parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.0</version>
+                  </parent>
+
+                  <modules>
+                    <module>module1</module>
+                    <module>module2</module>
+                  </modules>
+                </project>
+                """
+            ),
+            mavenProject("module1",
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                      <groupId>org.sample</groupId>
+                      <artifactId>sample</artifactId>
+                      <version>1.0.0</version>
+                      <relativePath>../</relativePath>
+                    </parent>
+                    <artifactId>module1</artifactId>
+                  </project>
+                  """,
+                spec -> spec.path("module1/pom.xml")
+              )),
+            mavenProject("module2",
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                      <groupId>org.sample</groupId>
+                      <artifactId>sample</artifactId>
+                      <version>1.0.0</version>
+                      <relativePath>../</relativePath>
+                    </parent>
+                    <artifactId>module2</artifactId>
+                  </project>
+                  """,
+                spec -> spec.path("module2/pom.xml")
+              )
+            )
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add ParentPomInsight recipe, test & data table to see what parents and versions of parents are used.

## What's your motivation?
Find & bump parent POMs in Apache Maven and beyond.

## Anything in particular you'd like reviewers to focus on?
There's no explicit limit to just the root project; is that correct or should we add that?

## Any additional context
- https://maven.apache.org/pom/maven/
- org.apache.maven.shared:maven-shared-components
- org.apache.maven:maven-parent
