### PR TITLE
Lazily evaluate chained validations

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/ValidatedTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ValidatedTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.lang.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+class ValidatedTest {
+
+    @Test
+    void andBadAnonymousValidatedMustNotRaiseException() {
+        Validated<String> good = Validated.valid("foo", "bar");
+        Validated<String> bad = new Validated<>() {
+            @Override
+            public boolean isValid() {
+                throw new IllegalStateException("this exception must not be raised by the boolean AND");
+            }
+
+            @Override
+            public Iterator<Validated<String>> iterator() {
+                return null;
+            }
+
+            @Override
+            public @Nullable String getValue() {
+                return null;
+            }
+        };
+        assertThatCode(() -> good.and(bad)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void andBadPropertyTestMustNotRaiseException() {
+        Validated<String> good = Validated.valid("foo", "bar");
+        Validated<String> bad = Validated.test("foo2", "bar2", null, t -> {
+            throw new IllegalStateException("this exception must not be raised by the boolean AND");
+        });
+
+        assertThatCode(() -> good.and(bad)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testProperty() {
+        Validated<String> valid = Validated.test("foo", "bar", null, t -> true);
+        Validated<String> invalid = Validated.test("foo2", "bar2", null, t -> false);
+
+        assertThat(valid.isValid()).isTrue();
+        assertThat(invalid.isValid()).isFalse();
+    }
+
+}


### PR DESCRIPTION
To support lazy evaluation of `someValidation.and(Validate.test(predicate))`, the predicate MUST NOT be evaluated in the test method already. Rather return an anonymous subclass that only evaluates the predicate in isValid().

To still support the reporting of validation failures, the anonymous subclass must be of type Invalid, even though the validation result may be valid.

Out of the 3 new unit tests, the second one fails without this change, showcasing the original problem.

Fixes #3580.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Validate.test() no longer evaluates the given predicate immediately, but only when the isValid() method is called. That allows chaining of someValidation.and(...) respectively someValidation.or(...) to return early, without evaluation the given predicate at all. That's extremely helpful if recipe authors rely on super.validate().and(someMoreValidation), where they access potentially nullable fields in someMoreValidation.

## What's your motivation?
#3580

## Anything in particular you'd like reviewers to focus on?
There is another method `testNone` that has might have the same problem. However, I haven't really understood the `None` concept, therefore I have not touched that code.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files

Side note: The last item is not helpful for non IDEA users. Can you link to some command line execution of the formatter, too (in the PR message template comment)?