### PR TITLE
Avoid NPE in SemanticallyEqual

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -875,7 +875,7 @@ public class SemanticallyEqual {
                 J.MethodInvocation compareTo = (J.MethodInvocation) j;
                 if (!method.getSimpleName().equals(compareTo.getSimpleName()) ||
                     !TypeUtils.isOfType(method.getMethodType(), compareTo.getMethodType()) ||
-                    !(static_ == compareTo.getMethodType().hasFlags(Flag.Static) ||
+                    !(static_ == (compareTo.getMethodType() != null && compareTo.getMethodType().hasFlags(Flag.Static)) ||
                       !nullMissMatch(method.getSelect(), compareTo.getSelect())) ||
                     method.getArguments().size() != compareTo.getArguments().size() ||
                     nullListSizeMissMatch(method.getTypeParameters(), compareTo.getTypeParameters())) {


### PR DESCRIPTION
Fixes #3585.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Same null check as done for the other node in line 874.
