### PR TITLE
Avoid trailing blanks in SingleLineComment

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SingleLineCommentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SingleLineCommentsTest.java
@@ -47,4 +47,17 @@ class SingleLineCommentsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyCommentLineDoesNotGetTrailingBlank() {
+        rewriteRun(
+          java(
+            """
+              // Copyright
+              //
+              // Some long license text
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SingleLineComments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SingleLineComments.java
@@ -42,8 +42,9 @@ public class SingleLineComments extends Recipe {
                 return space.withComments(ListUtils.map(space.getComments(), c -> {
                     if (!c.isMultiline()) {
                         TextComment tc = (TextComment) c;
-                        if (!tc.getText().startsWith(" ")) {
-                            return tc.withText(" " + tc.getText());
+                        String commentText = tc.getText();
+                        if (!commentText.isEmpty() && !commentText.startsWith(" ")) {
+                            return tc.withText(" " + commentText);
                         }
                     }
                     return c;


### PR DESCRIPTION
Fixes #3588.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
No more trailing blanks being added by SingleLineComment

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
