### PR TITLE
Update json parser to support multiple-bytes-unicodes

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
@@ -49,12 +49,49 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
 
     private int cursor = 0;
 
-    public JsonParserVisitor(Path path, @Nullable FileAttributes fileAttributes, EncodingDetectingInputStream source) {
+    // Whether the source has multi bytes (> 2 bytes) unicode characters
+    private final boolean hasMultiBytesUnicode;
+    // Antlr index to source index mapping
+    private final int[] indexes;
+
+    public JsonParserVisitor(Path path,
+                             @Nullable FileAttributes fileAttributes,
+                             EncodingDetectingInputStream sourceInput
+                             ) {
         this.path = path;
         this.fileAttributes = fileAttributes;
-        this.source = source.readFully();
-        this.charset = source.getCharset();
-        this.charsetBomMarked = source.isCharsetBomMarked();
+        this.source = sourceInput.readFully();
+        this.charset = sourceInput.getCharset();
+        this.charsetBomMarked = sourceInput.isCharsetBomMarked();
+
+        boolean hasMultiBytesUnicode = false;
+        int[] pos = new int[source.length() + 1];
+        int cursor = 0;
+        int i = 1;
+        pos[0] = 0;
+
+        while (cursor < source.length()) {
+            int newCursor = source.offsetByCodePoints(cursor, 1);
+            if (newCursor > cursor + 1) {
+                hasMultiBytesUnicode = true;
+            }
+            pos[i++] = newCursor;
+            cursor = newCursor;
+        }
+
+        this.hasMultiBytesUnicode = hasMultiBytesUnicode;
+        this.indexes = hasMultiBytesUnicode ? pos : null;
+    }
+
+    /**
+     * Characters index to source index mapping, valid only when `hasMultiBytesUnicode` is true.
+     * Antlr index is based on characters index and reader is based on source index.
+     * If there are any >2 bytes unicode characters in source code, it will make the index mismatch.
+     * @param index index from Antlr
+     * @return corrected cursor index
+     */
+    private int getCursorIndex(int index) {
+        return hasMultiBytesUnicode ? indexes[index] : index;
     }
 
     @Override
@@ -281,7 +318,7 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
 
         T t = conversion.apply(ctx, prefix(ctx));
         if (ctx.getStop() != null) {
-            cursor = ctx.getStop().getStopIndex() + (Character.isWhitespace(source.charAt(ctx.getStop().getStopIndex())) ? 0 : 1);
+            cursor = getCursorIndex(ctx.getStop().getStopIndex()) + (Character.isWhitespace(source.charAt(getCursorIndex(ctx.getStop().getStopIndex()))) ? 0 : 1);
         }
 
         return t;
@@ -289,7 +326,7 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
 
     private <T> T convert(TerminalNode node, BiFunction<TerminalNode, Space, T> conversion) {
         T t = conversion.apply(node, prefix(node));
-        cursor = node.getSymbol().getStopIndex() + 1;
+        cursor = getCursorIndex(node.getSymbol().getStopIndex())  + 1;
         return t;
     }
 

--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
@@ -301,7 +301,7 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
     }
 
     private Space prefix(Token token) {
-        int start = token.getStartIndex();
+        int start = getCursorIndex(token.getStartIndex());
         if (start < cursor) {
             return Space.EMPTY;
         }

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -146,4 +146,18 @@ public class JsonParserTest implements RewriteTest {
           json("")
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3582")
+    @Test
+    void multiBytesUnicode() {
+        rewriteRun(
+          json(
+            """
+              {
+                "text": "🤖robot"
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -154,7 +154,7 @@ public class JsonParserTest implements RewriteTest {
           json(
             """
               {
-                "🤖": "robot"
+                "🤖"  :   "robot"
               }
               """
           )

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -154,7 +154,7 @@ public class JsonParserTest implements RewriteTest {
           json(
             """
               {
-                "text": "🤖robot"
+                "🤖": "robot"
               }
               """
           )


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite/issues/3582
Currently, the JSON parser doesn't support multiple bytes Unicode characters (> 2 bytes).
The root cause is the index from Antlr is mismatched with the source index.
For example:
```java
{
  "🤖": "robot",
}
```
Tokens from Antlr
```
Got token: [@0,0:0='{',<1>,1:0]
Got token: [@1,4:6='"🤖"',<10>,2:2]
Got token: [@2,7:7=':',<4>,2:5]
Got token: [@3,9:15='"robot"',<10>,2:7]
Got token: [@4,16:16=',',<2>,2:14]
Got token: [@5,18:18='}',<3>,3:0]
Got token: [@6,19:18='<EOF>',<-1>,3:1]
```

we can see `4:6='"🤖"'`. However, the 🤖 has 4 bytes, so the start/end offset in the source code is not [4,6] but [4,7].



I think all Antlr-based parsers will have the same problem ( doesn’t support multiple bytes of Unicode). and this PR is a common pattern to fix this issue.



