### PR TITLE
Remove `JsonParserVisitor#indexes`

### DIFF
--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -154,7 +154,9 @@ public class JsonParserTest implements RewriteTest {
           json(
             """
               {
-                "🤖"  :   "robot"
+                "🤖"    : "robot",
+                "robot" : "🤖",
+                "நடித்த" : 3 /* 🇩🇪 */
               }
               """
           )


### PR DESCRIPTION
The `JsonParserVisitor#indexes` array requires an additional 4 bytes of memory per code point in the source code (only in case the source has at least one surrogate). Rather than doing that, the parser can have two cursors which are kept in sync when advancing through the source code: One code point cursor and one code unit cursor. The former is to align with the indexes of the ANTLR tokens and the latter is to be able to read from the underlying source string.
