### PR TITLE
[TypeUtils.findOverridenMethod] Skip found methods with default access and not same package

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -65,7 +65,7 @@ class TypeUtilsTest implements RewriteTest {
           java(
             """
               class Superclass {
-                  void foo();
+                  void foo() { }
               }
               """
           ),
@@ -76,6 +76,33 @@ class TypeUtilsTest implements RewriteTest {
               }
               """,
             typeIsPresent()
+          )
+        );
+    }
+
+    @Test
+    void isOverrideOnlyVisible() {
+        rewriteRun(
+          java(
+            """
+              package foo;
+              public class Superclass {
+                  void foo() { }
+              }
+              """
+          ),
+          java(
+            """
+              package bar;
+              import foo.Superclass;
+              class Clazz extends Superclass {
+                  public void foo() { }
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                var fooMethodType = ((J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0)).getMethodType();
+                assertThat(TypeUtils.findOverriddenMethod(fooMethodType)).isEmpty();
+            })
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -407,6 +407,12 @@ public class TypeUtils {
                 }
             }
         }
+
+        // Check if access level is default then check if subclass package is the same from parent class
+        if (isDefaultAccessLevel(method.getFlags())) {
+            methodResult = methodResult.filter(m -> m.getDeclaringType().getPackageName().equals(dt.getPackageName()));
+        }
+
         return methodResult.filter(m -> !m.getFlags().contains(Flag.Private) && !m.getFlags().contains(Flag.Static));
     }
 
@@ -524,6 +530,10 @@ public class TypeUtils {
             return JavaType.Unknown.getInstance();
         }
         return t;
+    }
+
+    public static boolean isDefaultAccessLevel(final Set<Flag> flags) {
+        return !flags.contains(Flag.Public) && !flags.contains(Flag.Protected) && !flags.contains(Flag.Private);
     }
 
     static boolean deepEquals(@Nullable List<? extends JavaType> ts1, @Nullable List<? extends JavaType> ts2) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -532,7 +532,7 @@ public class TypeUtils {
         return t;
     }
 
-    public static boolean isDefaultAccessLevel(final Set<Flag> flags) {
+    private static boolean isDefaultAccessLevel(final Set<Flag> flags) {
         return !flags.contains(Flag.Public) && !flags.contains(Flag.Protected) && !flags.contains(Flag.Private);
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -415,12 +415,11 @@ public class TypeUtils {
             }
         }
 
-        // Check if access level is default then check if subclass package is the same from parent class
-        if (isDefaultAccessLevel(method.getFlags())) {
-            methodResult = methodResult.filter(m -> m.getDeclaringType().getPackageName().equals(dt.getPackageName()));
-        }
-
-        return methodResult.filter(m -> !m.getFlags().contains(Flag.Private) && !m.getFlags().contains(Flag.Static));
+        return methodResult
+                .filter(m -> !m.getFlags().contains(Flag.Private))
+                .filter(m -> !m.getFlags().contains(Flag.Static))
+                // If access level is default then check if subclass package is the same from parent class
+                .filter(m -> m.getFlags().contains(Flag.Public) || m.getDeclaringType().getPackageName().equals(dt.getPackageName()));
     }
 
     public static Optional<JavaType.Method> findDeclaredMethod(@Nullable JavaType.FullyQualified clazz, String name, List<JavaType> argumentTypes) {
@@ -537,10 +536,6 @@ public class TypeUtils {
             return JavaType.Unknown.getInstance();
         }
         return t;
-    }
-
-    private static boolean isDefaultAccessLevel(final Set<Flag> flags) {
-        return !flags.contains(Flag.Public) && !flags.contains(Flag.Protected) && !flags.contains(Flag.Private);
     }
 
     static boolean deepEquals(@Nullable List<? extends JavaType> ts1, @Nullable List<? extends JavaType> ts2) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes #3599 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Since it is an utility method that is invoked from different scenarios check if this change can affect any other behaviors.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- It seems affected method is being invoked from another unit tests already so specific test was not added.
- Should add a specific unit test for `MissingOverrideAnnotation` recipe to verify this bugfix.
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- no new files were added
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
