### PR TITLE
Fix parsing of unicode escape sequences in YAML

### DIFF
--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -162,4 +162,18 @@ public class JsonParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void unicodeEscapes() {
+        rewriteRun(
+          json(
+            """
+              {
+                "nul": "\\u0000",
+                "reverse-solidus": "\\u005c",
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/FormatPreservingReader.java
@@ -16,7 +16,6 @@
 package org.openrewrite.yaml;
 
 import lombok.Getter;
-import org.openrewrite.internal.lang.NonNull;
 import org.yaml.snakeyaml.events.Event;
 
 import java.io.IOException;
@@ -115,7 +114,7 @@ class FormatPreservingReader extends Reader {
     }
 
     @Override
-    public int read(@NonNull char[] cbuf, int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         int read = delegate.read(cbuf, off, len);
         if (read > 0) {
             buffer.ensureCapacity(buffer.size() + read);

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -17,7 +17,10 @@ package org.openrewrite.yaml;
 
 import lombok.Getter;
 import org.intellij.lang.annotations.Language;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.FileAttributes;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
 import org.openrewrite.internal.EncodingDetectingInputStream;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -36,7 +39,6 @@ import org.yaml.snakeyaml.scanner.Scanner;
 import org.yaml.snakeyaml.scanner.ScannerImpl;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.*;
@@ -186,15 +188,40 @@ public class YamlParser implements org.openrewrite.Parser {
                         newLine = "";
 
                         ScalarEvent scalar = (ScalarEvent) event;
-                        String scalarValue = scalar.getValue();
-                        if (variableByUuid.containsKey(scalarValue)) {
-                            scalarValue = variableByUuid.get(scalarValue);
-                        }
 
                         Yaml.Anchor anchor = null;
+                        int valueStart;
                         if (scalar.getAnchor() != null) {
                             anchor = buildYamlAnchor(reader, lastEnd, fmt, scalar.getAnchor(), event.getEndMark().getIndex(), true);
                             anchors.put(scalar.getAnchor(), anchor);
+                            valueStart = lastEnd + fmt.length() + scalar.getAnchor().length() + 1 + anchor.getPostfix().length();
+                        } else {
+                            valueStart = lastEnd + fmt.length();
+                        }
+
+                        String scalarValue;
+                        switch (scalar.getScalarStyle()) {
+                            case DOUBLE_QUOTED:
+                            case SINGLE_QUOTED:
+                                scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 2);
+                                break;
+                            case PLAIN:
+                                scalarValue = reader.readStringFromBuffer(valueStart, event.getEndMark().getIndex() - 1);
+                                break;
+                            case LITERAL:
+                                scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 1);
+                                if (scalarValue.endsWith("\n")) {
+                                    newLine = "\n";
+                                    scalarValue = scalarValue.substring(0, scalarValue.length() - 1);
+                                }
+                                break;
+                            case FOLDED:
+                            default:
+                                scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 1);
+                                break;
+                        }
+                        if (variableByUuid.containsKey(scalarValue)) {
+                            scalarValue = variableByUuid.get(scalarValue);
                         }
 
                         Yaml.Scalar.Style style;
@@ -207,22 +234,13 @@ public class YamlParser implements org.openrewrite.Parser {
                                 break;
                             case LITERAL:
                                 style = Yaml.Scalar.Style.LITERAL;
-                                scalarValue = reader.readStringFromBuffer(event.getStartMark().getIndex() + 1, event.getEndMark().getIndex() - 1);
-                                if (scalarValue.endsWith("\n")) {
-                                    newLine = "\n";
-                                    scalarValue = scalarValue.substring(0, scalarValue.length() - 1);
-                                }
                                 break;
                             case FOLDED:
                                 style = Yaml.Scalar.Style.FOLDED;
-                                scalarValue = reader.readStringFromBuffer(event.getStartMark().getIndex() + 1, event.getEndMark().getIndex() - 1);
                                 break;
                             case PLAIN:
                             default:
                                 style = Yaml.Scalar.Style.PLAIN;
-                                if (!scalarValue.startsWith("@") && event.getStartMark().getIndex() >= reader.getBufferIndex()) {
-                                    scalarValue = reader.readStringFromBuffer(event.getStartMark().getIndex(), event.getEndMark().getIndex() - 1);
-                                }
                                 break;
                         }
                         BlockBuilder builder = blockStack.isEmpty() ? null : blockStack.peek();
@@ -347,7 +365,8 @@ public class YamlParser implements org.openrewrite.Parser {
                 lastEnd + eventPrefix.length() + anchorLength, eventEndIndex);
 
         StringBuilder postFix = new StringBuilder();
-        for (char c : whitespaceAndScalar.toCharArray()) {
+        for (int i = 0; i < whitespaceAndScalar.length(); i++) {
+            char c = whitespaceAndScalar.charAt(i);
             if (c != ' ' && c != '\t') {
                 break;
             }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -118,23 +118,7 @@ public class YamlPrinter<P> extends YamlVisitor<PrintOutputCapture<P>> {
         switch (scalar.getStyle()) {
             case DOUBLE_QUOTED:
                 p.append('"')
-                        .append(scalar.getValue()
-                                .replace("\\", "\\\\")
-                                .replace("\0", "\\0")
-                                .replace("\u0007", "\\a")
-                                .replace("\b", "\\b")
-                                .replace("\t", "\\t")
-                                .replace("\n", "\\n")
-                                .replace("\u000B", "\\v")
-                                .replace("\f", "\\f")
-                                .replace("\r", "\\r")
-                                .replace("\u001B", "\\e")
-                                .replace("\"", "\\\"")
-                                .replace("\u0085", "\\N")
-                                .replace("\u00A0", "\\_")
-                                .replace("\u2028", "\\L")
-                                .replace("\u2029", "\\P")
-                        )
+                        .append(scalar.getValue())
                         .append('"');
                 break;
             case SINGLE_QUOTED:

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -116,4 +116,17 @@ class YamlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void unicodeEscapes() {
+        rewriteRun(
+          yaml(
+            """
+              root:
+                "nul": "\\u0000"
+                "reverse-solidus": "\\u005c"
+              """
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
@@ -400,34 +400,30 @@ class MappingTest implements RewriteTest {
       " '\\n' ",
       " '\n' ",
       " \n ",
-      " \"\\.\" ",
       " \"\\0\" ",
       " \"\\0\" ",
       " \"\\a\" ",
       " \"\\a\" ",
       " \"\\b\" ",
-      " \"\b\" ",
       " \"\\t\" ",
       " \"\t\" ",
       " \"\\n\" ",
       " \"\n\" ",
       " \"\\v\" ",
       " \"\\f\" ",
-      " \"\f\" ",
       " \"\\r\" ",
       " \"\r\" ",
       " \"\\e\" ",
       " \"\\\\\" ",
-      " \"\\\" ",
       " \"\\\"\" ",
-      " \"\"\" ",
       " \"\\N\" ",
       " \"\\_\" ",
       " \"\\L\" ",
       " \"\\P\" ",
     })
-    void escapeSequences() {
+    void escapeSequences(String str) {
         rewriteRun(
-          yaml("escaped-value: $string"));
+          yaml("escaped-value: $string".replace("$string", str))
+        );
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/MappingTest.java
@@ -423,7 +423,7 @@ class MappingTest implements RewriteTest {
     })
     void escapeSequences(String str) {
         rewriteRun(
-          yaml("escaped-value: $string".replace("$string", str))
+          yaml("escaped-value: " + str)
         );
     }
 }


### PR DESCRIPTION
A YAML scalar value can contain unicode escape sequences like `\u0051`. Currently, this throws off the parser.
