### PR TITLE
Improve performance of `UsesType`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.SearchResult;
 
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
@@ -31,7 +32,7 @@ public class UsesType<P> extends JavaIsoVisitor<P> {
     @Nullable
     private final String fullyQualifiedType;
     @Nullable
-    private final Pattern typePattern;
+    private final Predicate<JavaType> typePattern;
 
     @Nullable
     private final Boolean includeImplicit;
@@ -39,7 +40,18 @@ public class UsesType<P> extends JavaIsoVisitor<P> {
     public UsesType(String fullyQualifiedType, @Nullable Boolean includeImplicit) {
         if (fullyQualifiedType.contains("*")) {
             this.fullyQualifiedType = null;
-            this.typePattern = Pattern.compile(StringUtils.aspectjNameToPattern(fullyQualifiedType));
+            if (fullyQualifiedType.indexOf('*') == fullyQualifiedType.length() - 1) {
+                int dotdot = fullyQualifiedType.indexOf("..");
+                if (dotdot == -1 && fullyQualifiedType.charAt(fullyQualifiedType.length() - 2) == '.') {
+                    this.typePattern = packagePattern(fullyQualifiedType.substring(0, fullyQualifiedType.length() - 2));
+                } else if (dotdot == fullyQualifiedType.length() - 3) {
+                    this.typePattern = packagePrefixPattern(fullyQualifiedType.substring(0, dotdot));
+                } else {
+                    this.typePattern = genericPattern(Pattern.compile(StringUtils.aspectjNameToPattern(fullyQualifiedType)));
+                }
+            } else {
+                this.typePattern = genericPattern(Pattern.compile(StringUtils.aspectjNameToPattern(fullyQualifiedType)));
+            }
         } else {
             this.fullyQualifiedType = fullyQualifiedType;
             this.typePattern = null;
@@ -98,10 +110,37 @@ public class UsesType<P> extends JavaIsoVisitor<P> {
         }
 
         if (typePattern != null && TypeUtils.isAssignableTo(typePattern, type)
-            || fullyQualifiedType != null && TypeUtils.isAssignableTo(fullyQualifiedType, type)) {
+                || fullyQualifiedType != null && TypeUtils.isAssignableTo(fullyQualifiedType, type)) {
             return SearchResult.found(c);
         }
 
         return c;
     }
+
+    private static Predicate<JavaType> genericPattern(Pattern pattern) {
+        return type -> {
+            if (type instanceof JavaType.FullyQualified) {
+                return pattern.matcher(((JavaType.FullyQualified) type).getFullyQualifiedName()).matches();
+            } else if (type instanceof JavaType.Primitive) {
+                return pattern.matcher(((JavaType.Primitive) type).getKeyword()).matches();
+            }
+            return false;
+        };
+    }
+
+    private static Predicate<JavaType> packagePattern(String name) {
+        return type -> type instanceof JavaType.FullyQualified && ((JavaType.FullyQualified) type).getPackageName().equals(name);
+    }
+
+    private static Predicate<JavaType> packagePrefixPattern(String prefix) {
+        String subPackagePrefix = prefix + ".";
+        return type -> {
+            if (type instanceof JavaType.FullyQualified) {
+                String packageName = ((JavaType.FullyQualified) type).getPackageName();
+                return packageName.equals(prefix) || packageName.startsWith(subPackagePrefix);
+            }
+            return false;
+        };
+    }
+
 }


### PR DESCRIPTION
`UsesType` is extensively used as a predicate by recipes and it is thus important to be efficient.

Typically, `UsesType` is used in one of three ways:
 1. To do an exact match on a type
 2. To match all types in a given package
 3. To match all types in a given package or subpackages

For 1. the code was already optimized in the past (see https://github.com/openrewrite/rewrite/commit/071185a5b10a207bff46c69d16c18db695be0f0d). For 2 and 3 the code currently creates a regex pattern and uses that for the matching. Both the pattern creation and matching can be expensive. Thus, this PR optimizes these two cases by doing a simple prefix match.
