### PR TITLE
Formatter: Fix method parameter alignment bug

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -103,9 +103,10 @@ class TabsAndIndentsTest implements RewriteTest {
           java(
             """
               class Test {
+                  @SuppressWarnings
                   private void firstArgNoPrefix(String first,
-                                                int times,
-                                                String third
+                          int times,
+                          String third
                        ) {
                   }
                   private void firstArgOnNewLine(
@@ -118,6 +119,7 @@ class TabsAndIndentsTest implements RewriteTest {
               """,
             """
               class Test {
+                  @SuppressWarnings
                   private void firstArgNoPrefix(String first,
                                                 int times,
                                                 String third

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -227,7 +227,9 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                                     alignTo = firstArg.getPrefix().getLastWhitespace().length() - 1;
                                 } else {
                                     String source = method.print(getCursor());
-                                    alignTo = source.indexOf(firstArg.print(getCursor())) - 1;
+                                    int firstArgIndex = source.indexOf(firstArg.print(getCursor()));
+                                    int lineBreakIndex = source.lastIndexOf('\n', firstArgIndex);
+                                    alignTo = (firstArgIndex - (lineBreakIndex == -1 ? 0 : lineBreakIndex)) - 1;
                                 }
                                 getCursor().getParentOrThrow().putMessage("lastIndent", alignTo - style.getContinuationIndent());
                                 elem = visitAndCast(elem, p);


### PR DESCRIPTION
The multi-line method parameter alignment which was introduced in #1920 caused excessive indentation when the declaring method had annotations.
