### PR TITLE
Rename Gradle Enterprise recipes

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -50,7 +50,7 @@ import static org.openrewrite.gradle.plugins.AddPluginVisitor.resolvePluginVersi
 @Value
 @EqualsAndHashCode(callSuper = true)
 @Incubating(since = "7.33.0")
-public class AddGradleEnterpriseGradlePlugin extends Recipe {
+public class AddDevelocityGradlePlugin extends Recipe {
     @EqualsAndHashCode.Exclude
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 
@@ -66,7 +66,7 @@ public class AddGradleEnterpriseGradlePlugin extends Recipe {
     String version;
 
     @Option(displayName = "Server URL",
-            description = "The URL of the Gradle Enterprise server. If omitted the recipe will set no URL and Gradle will direct scans to https://scans.gradle.com/",
+            description = "The URL of the Develocity server. If omitted the recipe will set no URL and Gradle will direct scans to https://scans.gradle.com/",
             required = false,
             example = "https://scans.gradle.com/")
     @Nullable
@@ -113,12 +113,12 @@ public class AddGradleEnterpriseGradlePlugin extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Add the Gradle Enterprise Gradle plugin";
+        return "Add the Develocity Gradle plugin";
     }
 
     @Override
     public String getDescription() {
-        return "Add the Gradle Enterprise Gradle plugin to settings.gradle files.";
+        return "Add the Develocity Gradle plugin to settings.gradle files.";
     }
 
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
@@ -36,12 +36,12 @@ import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.Assertions.*;
 import static org.openrewrite.test.SourceSpecs.dir;
 
-class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
+class AddDevelocityGradlePluginTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.beforeRecipe(withToolingApi())
-                .recipe(new AddGradleEnterpriseGradlePlugin("3.x", null, null, null, null, null));
+                .recipe(new AddDevelocityGradlePlugin("3.x", null, null, null, null, null));
     }
 
     private static Consumer<SourceSpec<CompilationUnit>> interpolateResolvedVersion(@Language("groovy") String after) {
@@ -177,7 +177,7 @@ class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
     void withConfigurationInSettings() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
-            .recipe(new AddGradleEnterpriseGradlePlugin("3.x", "https://ge.sam.com/", true, true, true, AddGradleEnterpriseGradlePlugin.PublishCriteria.Always)),
+            .recipe(new AddDevelocityGradlePlugin("3.x", "https://ge.sam.com/", true, true, true, AddDevelocityGradlePlugin.PublishCriteria.Always)),
           buildGradle(
             ""
           ),
@@ -209,7 +209,7 @@ class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
     void withConfigurationOldInputCapture() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
-            .recipe(new AddGradleEnterpriseGradlePlugin("3.6", null, null, true, null, null)),
+            .recipe(new AddDevelocityGradlePlugin("3.6", null, null, true, null, null)),
           buildGradle(
             ""
           ),
@@ -233,7 +233,7 @@ class AddGradleEnterpriseGradlePluginTest implements RewriteTest {
     void defaultsToLatestRelease() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
-            .recipe(new AddGradleEnterpriseGradlePlugin(null, null, null, null, null, null)),
+            .recipe(new AddDevelocityGradlePlugin(null, null, null, null, null, null)),
           buildGradle(
             ""
           ),

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
@@ -60,7 +60,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleEnterpriseMavenExtension.Accumulator> {
+public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMavenExtension.Accumulator> {
     private static final String GRADLE_ENTERPRISE_MAVEN_EXTENSION_ARTIFACT_ID = "gradle-enterprise-maven-extension";
     private static final String EXTENSIONS_XML_PATH = ".mvn/extensions.xml";
     private static final String GRADLE_ENTERPRISE_XML_PATH = ".mvn/gradle-enterprise.xml";
@@ -85,7 +85,7 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
     String version;
 
     @Option(displayName = "Server URL",
-            description = "The URL of the Gradle Enterprise server.",
+            description = "The URL of the Develocity server.",
             example = "https://scans.gradle.com/")
     String server;
 
@@ -138,12 +138,12 @@ public class AddGradleEnterpriseMavenExtension extends ScanningRecipe<AddGradleE
 
     @Override
     public String getDisplayName() {
-        return "Add Gradle Enterprise Maven extension";
+        return "Add the Develocity Maven extension";
     }
 
     @Override
     public String getDescription() {
-        return "To integrate Gradle Enterprise Maven extension into maven projects, ensure that the " +
+        return "To integrate the Develocity Maven extension into Maven projects, ensure that the " +
                "`gradle-enterprise-maven-extension` is added to the `.mvn/extensions.xml` file if not already present. " +
                "Additionally, configure the extension by adding the `.mvn/gradle-enterprise.xml` configuration file.";
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDevelocityMavenExtensionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDevelocityMavenExtensionTest.java
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.xml.Assertions.xml;
 
-class AddGradleEnterpriseMavenExtensionTest implements RewriteTest {
+class AddDevelocityMavenExtensionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AddGradleEnterpriseMavenExtension("1.17", "https://foo", null,
+        spec.recipe(new AddDevelocityMavenExtension("1.17", "https://foo", null,
           null, null, null));
     }
 
@@ -127,7 +127,7 @@ class AddGradleEnterpriseMavenExtensionTest implements RewriteTest {
     @Test
     void noVersionSpecified() {
         rewriteRun(
-          spec -> spec.recipe(new AddGradleEnterpriseMavenExtension(null, "https://foo", null, null, null, null)),
+          spec -> spec.recipe(new AddDevelocityMavenExtension(null, "https://foo", null, null, null, null)),
           POM_XML_SOURCE_SPEC,
           xml(
             null,
@@ -181,7 +181,7 @@ class AddGradleEnterpriseMavenExtensionTest implements RewriteTest {
     @Test
     void allSettings() {
         rewriteRun(
-          spec -> spec.recipe(new AddGradleEnterpriseMavenExtension("1.17", "https://foo", true, true, false, AddGradleEnterpriseMavenExtension.PublishCriteria.Failure)),
+          spec -> spec.recipe(new AddDevelocityMavenExtension("1.17", "https://foo", true, true, false, AddDevelocityMavenExtension.PublishCriteria.Failure)),
           POM_XML_SOURCE_SPEC,
           xml(
             null,


### PR DESCRIPTION


<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Rename `AddGradleEnterpriseGradlePlugin`, `AddGradleEnterpriseMavenExtension` and their metadatas.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Gradle Enterprise was recently renamed to Develocity.

### Checklist
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
