### PR TITLE
Expand assertion to print failure message to make it easier to debug …

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class MavenArtifactDownloaderTest {
 
@@ -70,9 +71,16 @@ class MavenArtifactDownloaderTest {
         MavenResolutionResult mavenModel = parsed.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
         assertThat(mavenModel.getDependencies()).isNotEmpty();
 
-        List<ResolvedDependency> runtimeDependencies = mavenModel.getDependencies().get(Scope.Runtime);
-        for (ResolvedDependency runtimeDependency : runtimeDependencies) {
-            assertThat(downloader.downloadArtifact(runtimeDependency)).isNotNull();
-        }
+    List<ResolvedDependency> runtimeDependencies = mavenModel.getDependencies().get(Scope.Runtime);
+    for (ResolvedDependency runtimeDependency : runtimeDependencies) {
+      assertNotNull(
+          downloader.downloadArtifact(runtimeDependency),
+          String.format(
+              "%s:%s:%s:%s failed to download",
+              runtimeDependency.getGroupId(),
+              runtimeDependency.getArtifactId(),
+              runtimeDependency.getVersion(),
+              runtimeDependency.getType()));
     }
+  }
 }


### PR DESCRIPTION
…the failed test.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

A tiny PR to fix a problem in my environment where my local `.m2` directory contained a commons-lang directory with a POM but no JAR:

```shell
ls -l /Users/dawngerpony/.m2/repository/org/apache/commons/commons-lang3/3.11/commons-lang3-3.11.jar
ls: /Users/dawngerpony/.m2/repository/org/apache/commons/commons-lang3/3.11/commons-lang3-3.11.jar: No such file or directory
```

With the expanded assertion I was able to discover that this JAR was the problem and delete the directory, which made the test pass.

## What's your motivation?

I wanted to raise my first PR against the codebase and felt it should be a small one! This was just me trying to get my build to pass.

Side note/question: why does the state of my local `.m2` directory affect the outcome of what should be a unit test? Surely unit tests should not rely on a particular filesystem configuration?

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
