### PR TITLE
Fix the indentation of parameterized chained method calls

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -339,7 +339,7 @@ class TabsAndIndentsTest implements RewriteTest {
                   Test withData(Object... arg0) {
                       return this;
                   }
-
+              
                   void method(Test t) {
                       t = t.withData(withData()
                               .withData(t
@@ -485,7 +485,7 @@ class TabsAndIndentsTest implements RewriteTest {
                                   return 0;
                               })
                       )
-                              .collect(Collectors.toList());
+                      .collect(Collectors.toList());
                   }
               }
               """
@@ -507,7 +507,7 @@ class TabsAndIndentsTest implements RewriteTest {
                                       0
                               )
                       )
-                              .collect(Collectors.toList());
+                      .collect(Collectors.toList());
                   }
               }
               """
@@ -2320,14 +2320,66 @@ class TabsAndIndentsTest implements RewriteTest {
           java(
             """
               public enum WorkflowStatus {
-                  @SuppressWarnings("value1")
-                  VALUE1,
-                  @SuppressWarnings("value2")
-                  VALUE2,
-                  @SuppressWarnings("value3")
-                  VALUE3,
-                  @SuppressWarnings("value4")
-                  VALUE4
+                  @Nullable
+                  VALUE1
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void longMethodChainWithMultiLineParameters_Correct() {
+        rewriteRun(
+          java(
+            """
+              class Foo {
+                  String test() {
+                      return "foobar"
+                              .substring(
+                                      1
+                              ).substring(
+                                      2
+                              ).substring(
+                                      3
+                              );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void longMethodChainWithMultiLineParameters_Incorrect() {
+        rewriteRun(
+          java(
+            """
+              class Foo {
+              String test() {
+              return "foobar"
+              .substring(
+              1
+              ).substring(
+              2
+              ).substring(
+              3
+              );
+              }
+              }
+              """,
+            """
+              class Foo {
+                  String test() {
+                      return "foobar"
+                              .substring(
+                                      1
+                              ).substring(
+                                      2
+                              ).substring(
+                                      3
+                              );
+                  }
               }
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -131,14 +131,23 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
             return space;
         }
 
+        if (loc == Space.Location.METHOD_SELECT_SUFFIX) {
+            Integer chainedIndent = getCursor().getParentTreeCursor().getMessage("chainedIndent");
+            if (chainedIndent != null) {
+                getCursor().getParentTreeCursor().putMessage("lastIndent", chainedIndent);
+                return indentTo(space, chainedIndent, loc);
+            }
+        }
+
         int indent = getCursor().getNearestMessage("lastIndent", 0);
 
         IndentType indentType = getCursor().getParentOrThrow().getNearestMessage("indentType", IndentType.ALIGN);
 
         // block spaces are always aligned to their parent
+        Object value = getCursor().getValue();
         boolean alignBlockPrefixToParent = loc.equals(Space.Location.BLOCK_PREFIX) && space.getWhitespace().contains("\n") &&
                 // ignore init blocks.
-                (getCursor().getValue() instanceof J.Block && !(getCursor().getParentTreeCursor().getValue() instanceof J.Block));
+                (value instanceof J.Block && !(getCursor().getParentTreeCursor().getValue() instanceof J.Block));
 
         boolean alignBlockToParent = loc.equals(Space.Location.BLOCK_END) ||
                 loc.equals(Space.Location.NEW_ARRAY_INITIALIZER_SUFFIX) ||
@@ -167,8 +176,10 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
         }
 
         Space s = indentTo(space, indent, loc);
-        if (!(getCursor().getValue() instanceof JLeftPadded) && !(getCursor().getValue() instanceof J.EnumValueSet)) {
+        if (value instanceof J && !(value instanceof J.EnumValueSet)) {
             getCursor().putMessage("lastIndent", indent);
+        } else if (loc == Space.Location.METHOD_SELECT_SUFFIX) {
+            getCursor().getParentTreeCursor().putMessage("lastIndent", indent);
         }
 
         return s;
@@ -257,6 +268,15 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                         }
                         elem = visitAndCast(elem, p);
                         after = indentTo(right.getAfter(), indent, loc.getAfterLocation());
+                        if (!after.getComments().isEmpty() || after.getLastWhitespace().contains("\n")) {
+                            Cursor parent = getCursor().getParentTreeCursor();
+                            Cursor grandparent = parent.getParentTreeCursor();
+                            // propagate indentation up in the method chain hierarchy
+                            if (grandparent.getValue() instanceof J.MethodInvocation && ((J.MethodInvocation) grandparent.getValue()).getSelect() == parent.getValue()) {
+                                grandparent.putMessage("lastIndent", indent);
+                                grandparent.putMessage("chainedIndent", indent);
+                            }
+                        }
                         break;
                     case NEW_CLASS_ARGUMENTS:
                     case ARRAY_INDEX:
@@ -264,26 +284,6 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                     case TYPE_PARAMETER: {
                         elem = visitAndCast(elem, p);
                         after = indentTo(right.getAfter(), indent, loc.getAfterLocation());
-                        break;
-                    }
-                    case METHOD_SELECT: {
-                        for (Cursor cursor = getCursor(); ; cursor = cursor.getParentOrThrow()) {
-                            if (cursor.getValue() instanceof JRightPadded) {
-                                cursor = cursor.getParentOrThrow();
-                            }
-                            if (!(cursor.getValue() instanceof J.MethodInvocation)) {
-                                break;
-                            }
-                            Integer methodIndent = cursor.getNearestMessage("lastIndent");
-                            if (methodIndent != null) {
-                                indent = methodIndent;
-                            }
-                        }
-
-                        getCursor().getParentOrThrow().putMessage("lastIndent", indent);
-                        elem = visitAndCast(elem, p);
-                        after = visitSpace(right.getAfter(), loc.getAfterLocation(), p);
-                        getCursor().getParentOrThrow().putMessage("lastIndent", indent + style.getContinuationIndent());
                         break;
                     }
                     case ANNOTATION_ARGUMENT:


### PR DESCRIPTION
Make sure the formatting in the following code remains as is.

```java
  class Foo {
      String test() {
          return "foobar"
                  .substring(
                          1
                  ).substring(
                          2
                  ).substring(
                          3
                  );
      }
  }
```
