### PR TITLE
Maven error handler should not process its own exception

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -91,43 +91,38 @@ public class MavenArtifactDownloader {
             return null;
         }
         return mavenArtifactCache.computeArtifact(dependency, () -> {
-            try {
-                String uri = requireNonNull(dependency.getRepository(),
-                        String.format("Repository for dependency '%s' was null.", dependency)).getUri() + "/" +
-                             dependency.getGroupId().replace('.', '/') + '/' +
-                             dependency.getArtifactId() + '/' +
-                             dependency.getVersion() + '/' +
-                             dependency.getArtifactId() + '-' +
-                             (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
-                             ".jar";
+            String uri = requireNonNull(dependency.getRepository(),
+                    String.format("Repository for dependency '%s' was null.", dependency)).getUri() + "/" +
+                    dependency.getGroupId().replace('.', '/') + '/' +
+                    dependency.getArtifactId() + '/' +
+                    dependency.getVersion() + '/' +
+                    dependency.getArtifactId() + '-' +
+                    (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
+                    ".jar";
 
-                InputStream bodyStream;
+            InputStream bodyStream;
 
-                if (uri.startsWith("~")) {
-                    bodyStream = Files.newInputStream(Paths.get(System.getProperty("user.home") + uri.substring(1)));
-                } else if ("file".equals(URI.create(uri).getScheme())) {
-                    bodyStream = Files.newInputStream(Paths.get(URI.create(uri)));
-                } else {
-                    HttpSender.Request.Builder request = applyAuthentication(dependency.getRepository(), httpSender.get(uri));
-                    try (HttpSender.Response response = sendRequest.apply(request.build());
-                         InputStream body = response.getBody()) {
-                        if (!response.isSuccessful() || body == null) {
-                            onError.accept(new MavenDownloadingException(String.format("Unable to download dependency %s:%s:%s. Response was %d",
-                                    dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(), response.getCode()), null,
-                                    dependency.getRequested().getGav()));
-                            return null;
-                        }
-                        bodyStream = new ByteArrayInputStream(readAllBytes(body));
-                    } catch (Throwable t) {
-                        throw new MavenDownloadingException("Unable to download dependency", t,
-                                dependency.getRequested().getGav());
+            if (uri.startsWith("~")) {
+                bodyStream = Files.newInputStream(Paths.get(System.getProperty("user.home") + uri.substring(1)));
+            } else if ("file".equals(URI.create(uri).getScheme())) {
+                bodyStream = Files.newInputStream(Paths.get(URI.create(uri)));
+            } else {
+                HttpSender.Request.Builder request = applyAuthentication(dependency.getRepository(), httpSender.get(uri));
+                try (HttpSender.Response response = sendRequest.apply(request.build());
+                     InputStream body = response.getBody()) {
+                    if (!response.isSuccessful() || body == null) {
+                        onError.accept(new MavenDownloadingException(String.format("Unable to download dependency %s:%s:%s. Response was %d",
+                                dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion(), response.getCode()), null,
+                                dependency.getRequested().getGav()));
+                        return null;
                     }
+                    bodyStream = new ByteArrayInputStream(readAllBytes(body));
+                } catch (Throwable t) {
+                    throw new MavenDownloadingException("Unable to download dependency", t,
+                            dependency.getRequested().getGav());
                 }
-                return bodyStream;
-            } catch (Throwable t) {
-                onError.accept(t);
             }
-            return null;
+            return bodyStream;
         }, onError);
     }
 


### PR DESCRIPTION
When the error handler given to `MavenArtifactDownloader` handles errors by throwing an exception, then the current logic will have this error handler handle its own exception, because it basically contains two nested `try-catch` statements. This commit removes the inner `try-catch` as it doesn't offer any additional resource closing or similar.
