### PR TITLE
Fixed property usage pattern matching search results

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -76,10 +76,14 @@ public class FindProperties extends Recipe {
         };
     }
 
+    /**
+     *
+     * @param xml The xml document of the pom.xml
+     * @param propertyPattern Regular expression pattern used to match property tag names
+     * @return Set of Maven project property tags that matches the {@code propertyPattern} within a pom.xml
+     */
     public static Set<Xml.Tag> find(Xml.Document xml, String propertyPattern) {
-        Pattern propertyMatcher = Pattern.compile(propertyPattern
-                .replace(".", "\\.")
-                .replace("*", ".*"));
+        Pattern propertyMatcher = Pattern.compile(propertyPattern);
         Set<Xml.Tag> found = new HashSet<>();
         new MavenVisitor<Set<Xml.Tag>>() {
             @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -61,11 +61,11 @@ public class FindProperties extends Recipe {
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext context) {
                 Xml.Tag t = (Xml.Tag) super.visitTag(tag, context);
-                if (isPropertyTag() && propertyMatcher.matcher(tag.getName()).matches()) {
+                if (isPropertyTag() && propertyMatcher.matcher(t.getName()).matches()) {
                     t = SearchResult.found(t);
                 }
 
-                Optional<String> value = tag.getValue();
+                Optional<String> value = t.getValue();
                 if (value.isPresent() && propertyUsageMatcher.matcher(value.get()).matches()) {
                     //noinspection unchecked
                     t = t.withContent(ListUtils.mapFirst((List<Content>) t.getContent(), v ->

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -38,7 +38,7 @@ public class FindProperties extends Recipe {
 
     @Option(displayName = "Property pattern",
             description = "Regular expression pattern used to match property tag names.",
-            example = "guava*")
+            example = "guava.*")
     String propertyPattern;
 
     UUID searchId = randomId();
@@ -55,11 +55,8 @@ public class FindProperties extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        Pattern propertyMatcher = Pattern.compile(propertyPattern
-                .replace(".", "\\.")
-                .replace("*", ".*"));
-        Pattern propertyUsageMatcher = Pattern.compile(
-                ".*\\$\\{" + propertyMatcher.pattern() + "}.*");
+        Pattern propertyMatcher = Pattern.compile(propertyPattern);
+        Pattern propertyUsageMatcher = Pattern.compile(".*\\$\\{" + propertyMatcher.pattern() + "}.*");
         return new MavenVisitor<ExecutionContext>() {
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext context) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -36,7 +36,9 @@ import static org.openrewrite.Tree.randomId;
 @Value
 public class FindProperties extends Recipe {
 
-    @Option(displayName = "Property pattern", description = "Regular expression pattern used to match property tag names.", example = "guava*")
+    @Option(displayName = "Property pattern",
+            description = "Regular expression pattern used to match property tag names.",
+            example = "guava*")
     String propertyPattern;
 
     UUID searchId = randomId();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPropertiesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPropertiesTest.java
@@ -27,7 +27,7 @@ class FindPropertiesTest implements RewriteTest {
     @Test
     void findProperty() {
         rewriteRun(
-          spec -> spec.recipe(new FindProperties("guava*")),
+          spec -> spec.recipe(new FindProperties("guava.*")),
           pomXml(
             """
               <project>
@@ -72,7 +72,7 @@ class FindPropertiesTest implements RewriteTest {
     @Test
     void doesNotMatchOtherPropertyUsages() {
         rewriteRun(
-          spec -> spec.recipe(new FindProperties("guava*")),
+          spec -> spec.recipe(new FindProperties("guava.*")),
           pomXml(
             """
               <project>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPropertiesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPropertiesTest.java
@@ -68,4 +68,51 @@ class FindPropertiesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotMatchOtherPropertyUsages() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperties("guava*")),
+          pomXml(
+            """
+              <project>
+                <properties>
+                  <someNullProp/>
+                  <guava.version>28.2-jre</guava.version>
+                  <other.property>guava</other.property>
+                </properties>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                      <groupId>com.google.guava</groupId>
+                      <artifactId>${other.property}</artifactId>
+                      <version>${guava.version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <properties>
+                  <someNullProp/>
+                  <!--~~>--><guava.version>28.2-jre</guava.version>
+                  <other.property>guava</other.property>
+                </properties>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                      <groupId>com.google.guava</groupId>
+                      <artifactId>${other.property}</artifactId>
+                      <version><!--~~(28.2-jre)~~>-->${guava.version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Previously, all property usages were printed the actual value of the property, not only the ones matching the propertyPattern. Now we also apply the propertyPattern to find usages.

## What's your motivation?
Another recipe is using this recipe to find java.version property, and it was always returning results if there were any property being used in the pom.

## Anyone you would like to review specifically?
@timtebeek @knutwannheden @pstreef 

## Have you considered any alternatives or workarounds?
I've seen that there is a find method at the bottom, that only returns property definitions, but not property usages, that has duplicated code. To avoid propagating a change in behavior down, I've left the method as it is, but I found kinda inconsistent to have this code partially duplicated and with different behavior than in the actual recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
