### PR TITLE
Add missing recurring dependencies to `ResolvedDependency`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -49,6 +49,7 @@ public class ResolvedDependency implements Serializable {
      * Direct dependencies only that survived conflict resolution and exclusion.
      */
     @NonFinal
+    @EqualsAndHashCode.Exclude // dependencies can be circular
     List<ResolvedDependency> dependencies;
 
     List<License> licenses;
@@ -74,6 +75,7 @@ public class ResolvedDependency implements Serializable {
 
     /**
      * Only used by dependency resolution to avoid unnecessary empty list allocations for leaf dependencies.
+     *
      * @param dependencies A dependency list
      */
     void unsafeSetDependencies(List<ResolvedDependency> dependencies) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsDotTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsDotTest.java
@@ -74,9 +74,26 @@ public class PrintMavenAsDotTest implements RewriteTest {
             3 -> 6 [taillabel="Test"];
             3 -> 7 [taillabel="Test"];
             3 -> 8 [taillabel="Test"];
+            8 -> 6 [taillabel="Test"];
             2 -> 4 [taillabel="Test"];
+            4 -> 6 [taillabel="Test"];
+            4 -> 3 [taillabel="Test"];
+            3 -> 6 [taillabel="Test"];
+            3 -> 7 [taillabel="Test"];
+            3 -> 8 [taillabel="Test"];
+            8 -> 6 [taillabel="Test"];
             2 -> 5 [taillabel="Test"];
+            5 -> 6 [taillabel="Test"];
             5 -> 9 [taillabel="Test"];
+            9 -> 6 [taillabel="Test"];
+            9 -> 7 [taillabel="Test"];
+            9 -> 8 [taillabel="Test"];
+            8 -> 6 [taillabel="Test"];
+            5 -> 3 [taillabel="Test"];
+            3 -> 6 [taillabel="Test"];
+            3 -> 7 [taillabel="Test"];
+            3 -> 8 [taillabel="Test"];
+            8 -> 6 [taillabel="Test"];
             })~~>--><project>
               <groupId>com.mycompany.app</groupId>
               <artifactId>my-app</artifactId>


### PR DESCRIPTION
When `ResolvedPom#resolveDependencies()` processes the dependencies, it skips any dependencies it has already seen. But it must still make sure to add them to the list of dependencies of the artifact that requested it.

Also exclude `ResolvedDependency#dependencies` from `hashCode()` since dependencies can be circular (although not within one scope).

Fixes: #3626
