### PR TITLE
Remove unused annotation parameter imports

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationVisitor.java
@@ -18,14 +18,16 @@ package org.openrewrite.java;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -54,9 +56,6 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
                 }
             }
         }
-
-        maybeRemoveAnnotationParameterImports(leadingAnnotations);
-
         return c;
     }
 
@@ -84,9 +83,6 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
                 }
             }
         }
-
-        maybeRemoveAnnotationParameterImports(leadingAnnotations);
-
         return m;
     }
 
@@ -111,8 +107,6 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
             }
         }
 
-        maybeRemoveAnnotationParameterImports(leadingAnnotations);
-
         return v;
     }
 
@@ -121,6 +115,7 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
         if (annotationMatcher.matches(annotation)) {
             getCursor().getParentOrThrow().putMessage("annotationRemoved", annotation);
             maybeRemoveImport(TypeUtils.asFullyQualified(annotation.getType()));
+            maybeRemoveAnnotationParameterImports(annotation);
             //noinspection ConstantConditions
             return null;
         }
@@ -142,23 +137,58 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
                 }
             }
         }
-
         return newLeadingAnnotations;
     }
 
     /**
      * If the annotation has parameters, then the imports for the parameter types may need to be removed.
      *
-     * @param annotations the list of annotations to check
+     * @param annotation the annotation to check
      */
-    private void maybeRemoveAnnotationParameterImports(List<J.Annotation> annotations) {
-        annotations
-                .stream()
-                .filter(a -> a.getArguments() != null && !a.getArguments().isEmpty())
-                .flatMap(a -> a.getArguments().stream())
-                .map(Expression::getType)
-                .map(TypeUtils::asFullyQualified)
-                .filter(Objects::nonNull)
-                .forEach(e -> maybeRemoveImport(TypeUtils.asFullyQualified(e)));
+    private void maybeRemoveAnnotationParameterImports(@NonNull J.Annotation annotation) {
+        if (ListUtils.nullIfEmpty(annotation.getArguments()) == null) {
+            return;
+        }
+
+        List<Expression> arguments = annotation.getArguments();
+
+        arguments.forEach(argument -> {
+            if (argument instanceof J.Assignment) {
+                J.Assignment assignment = (J.Assignment) argument;
+                Expression expression = assignment.getAssignment();
+                maybeRemoveImportFromExpression(expression);
+            } else {
+                maybeRemoveImport(TypeUtils.asFullyQualified(argument.getType()));
+            }
+        });
+    }
+
+    private void maybeRemoveImportFromExpression(Expression expression) {
+        if (expression instanceof J.NewArray) {
+            maybeRemoveAnnotationFromArray((J.NewArray) expression);
+        } else if (expression instanceof J.FieldAccess) {
+            maybeRemoveAnnotationFromFieldAccess((J.FieldAccess) expression);
+        } else if (expression instanceof J.Identifier) {
+            JavaType.Variable fieldType = ((J.Identifier) expression).getFieldType();
+            if (fieldType != null) {
+                maybeRemoveImport(TypeUtils.asFullyQualified(fieldType.getOwner()));
+            }
+        } else {
+            maybeRemoveImport(TypeUtils.asFullyQualified(expression.getType()));
+        }
+    }
+
+    private void maybeRemoveAnnotationFromArray(@NonNull J.NewArray newArray) {
+        List<Expression> initializer = newArray.getInitializer();
+        if (ListUtils.nullIfEmpty(initializer) != null) {
+            initializer.forEach(this::maybeRemoveImportFromExpression);
+        }
+    }
+
+    private void maybeRemoveAnnotationFromFieldAccess(@NonNull J.FieldAccess fa) {
+        JavaType.Variable fieldType = fa.getName().getFieldType();
+        if (fieldType != null && fieldType.getOwner() != null) {
+            maybeRemoveImport(TypeUtils.asFullyQualified(fieldType.getOwner()));
+        }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Expression.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Expression.java
@@ -29,7 +29,7 @@ public interface Expression extends J {
     <T extends J> T withType(@Nullable JavaType type);
 
     /**
-     * @return A list of the side effects emitted by the statement, if the statement was decomposed.
+     * @return A list of the side effects emitted by the statement if the statement was decomposed.
      * So for a binary operation, there are up to two potential side effects (the left and right side) and as
      * few as zero if both sides of the expression are something like constants or variable references.
      */


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

This change the `RemoveAnnotation` recipe/visitor to remove unused annotation parameter imports

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
