### PR TITLE
Check for null anchor in yaml printer.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -157,7 +157,9 @@ public class YamlPrinter<P> extends YamlVisitor<PrintOutputCapture<P>> {
     public Yaml visitAlias(Yaml.Alias alias, PrintOutputCapture<P> p) {
         beforeSyntax(alias, p);
         p.append("*");
-        p.append(alias.getAnchor().getKey());
+        if (alias.getAnchor() != null) {
+            p.append(alias.getAnchor().getKey());
+        }
         afterSyntax(alias, p);
         return alias;
     }


### PR DESCRIPTION
Changes:
- A null anchor in an alias will not cause an NPE.