### PR TITLE
Proof of concept for preconditions on declarative recipes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/PreconditionBellwether.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/PreconditionBellwether.java
@@ -1,0 +1,15 @@
+package org.openrewrite.config;
+
+import org.openrewrite.Recipe;
+
+public class PreconditionBellwether extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Precondition bellwether";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Evaluates a precondition as an implementation detail";
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/PreconditionDecoratedRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/PreconditionDecoratedRecipe.java
@@ -1,0 +1,36 @@
+package org.openrewrite.config;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class PreconditionDecoratedRecipe extends Recipe {
+
+    TreeVisitor<?, ExecutionContext> precondition;
+    Recipe delegate;
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return delegate.getDisplayName();
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(precondition, delegate.getVisitor());
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/PreconditionDecoratedScanningRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/PreconditionDecoratedScanningRecipe.java
@@ -1,0 +1,43 @@
+package org.openrewrite.config;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class PreconditionDecoratedScanningRecipe<T>  extends ScanningRecipe<T> {
+
+    TreeVisitor<?, ExecutionContext> precondition;
+    ScanningRecipe<T> delegate;
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return delegate.getDisplayName();
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public T getInitialValue(ExecutionContext ctx) {
+        return delegate.getInitialValue(ctx);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(T acc) {
+        return delegate.getScanner(acc);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(T acc) {
+        return Preconditions.check(precondition, delegate.getVisitor(acc));
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -1,0 +1,50 @@
+package org.openrewrite.config;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.text.ChangeText;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.openrewrite.test.SourceSpecs.text;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class DeclarativeRecipeTest implements RewriteTest {
+
+    @Test
+    void precondition() {
+        rewriteRun(
+            spec -> {
+                spec.validateRecipeSerialization(false);
+                DeclarativeRecipe dr = new DeclarativeRecipe("test", "test", "test", null,
+                  null, null, true, null);
+                dr.addPrecondition(
+                  toRecipe(() -> new PlainTextVisitor<>() {
+                      @Override
+                      public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+                          if("1".equals(text.getText())) {
+                              return SearchResult.found(text);
+                          }
+                          return text;
+                      }
+                  })
+                );
+                dr.addUninitialized(
+                  new ChangeText("2")
+                );
+                dr.addUninitialized(
+                  new ChangeText("3")
+                );
+                dr.initialize(List.of(), Map.of());
+                spec.recipe(dr);
+            },
+            text("1","3"),
+            text("2")
+        );
+    }
+}


### PR DESCRIPTION
In rewrite 7 "applicability tests" allowed recipe authors to conditionally execute a visitor based on the result of another visitor. This was a `Recipe`-level concept, and it substantially complicated `RecipeScheduler`. 

In rewrite 8 we renamed applicability tests to preconditions, and declarative recipes lost the ability to declare them. This greatly simplified recipe scheduling and allowed us to implement `ScanningRecipe`. 

This proposal brings back the cherished and long-lost ability for declarative recipes to have preconditions, without any impact to `Recipe` or `RecipeScheduler`. Inside `DeclarativeRecipe` I gather up all the preconditions and put one recipe at the beginning of the recipe list to evaluate them, I call this synthetic recipe the "bellwether". Then every subsequent recipe in the list is decorated with a precondition which looks solely at the result of the bellwether. This ensures that the preconditions are evaluated exactly once and at the appropriate time, which is important for both correctness and performance.

There are various ways this is incomplete, pending agreement that this is how we want to proceed:
- `ScanningRecipe` preconditions are not handled. I imagine we would initially disallow them, as supporting them is complex and not necessary for the things we currently use preconditions for.
- `YamlResourceLoader` logic to deserialize yaml preconditions not yet implemented 
- `PreconditionDecoratedRecipe` and its scanning counterpart 
- We could optionally support a separate set of preconditions that apply only to the scanning portion of scanning recipes. Or apply the one set of preconditions both to scanning and visiting. Not entirely clear to me what our desired behavior here is. 