### PR TITLE
fixed inner class

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1765,4 +1765,41 @@ class ChangeTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotModifyInnerClassesIfIgnoreDefinitionTrue() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("Test.InnerA", "Test.InnerB", true)),
+          java(
+            """
+
+              public class Test {
+                  private class InnerA {
+                  }
+                  
+                  private class InnerB {
+                  }
+              
+                  public void test(String s) {
+                      InnerA a = new InnerA();
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  private class InnerA {
+                  }
+                  
+                  private class InnerB {
+                  }
+              
+                  public void test(String s) {
+                      InnerB a = new InnerB();
+                  }
+              }
+              """
+          )
+        );
+
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -259,6 +259,11 @@ public class ChangeType extends Recipe {
 
         @Override
         public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
+            // Do not modify the identifier if it's on a inner class definition.
+            if (Boolean.TRUE.equals(ignoreDefinition) && getCursor().getParent() != null &&
+                getCursor().getParent().getValue() instanceof J.ClassDeclaration) {
+                return super.visitIdentifier(ident, ctx);
+            }
             // if the ident's type is equal to the type we're looking for, and the classname of the type we're looking for is equal to the ident's string representation
             // Then transform it, otherwise leave it alone
             if (TypeUtils.isOfClassType(ident.getType(), originalType.getFullyQualifiedName())) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -192,7 +192,7 @@ public class ChangeType extends Recipe {
                 JavaType.FullyQualified fullyQualifiedTarget = TypeUtils.asFullyQualified(targetType);
                 if (fullyQualifiedTarget != null) {
                     JavaType.FullyQualified owningClass = fullyQualifiedTarget.getOwningClass();
-                    if (!(owningClass != null && topLevelClassnames.contains(getTopLevelClassName(fullyQualifiedTarget).getFullyQualifiedName()))) {
+                    if (!topLevelClassnames.contains(getTopLevelClassName(fullyQualifiedTarget).getFullyQualifiedName())) {
                         if (owningClass != null && !"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
                             addImport(owningClass);
                         }


### PR DESCRIPTION
## What's changed?
When changing a inner class, even with the ignoreDefinition, it still changes it if it's used in the same class where it's defined. I narrow it the issue to the visitIdentifier method, and checking that the identifier it's not in a class definition fix the issue. 
However, it still adds the import even if it's not needed. I've tried to check the logic of when to add the import, but owningClass of Test.InnerB is null, don't know why... maybe because the way we created the type?

## What's your motivation?
Fixes #3598

## Anything in particular you'd like reviewers to focus on?
Fix the add import logic 

## Anyone you would like to review specifically?
@knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
