### PR TITLE
Match `JavaType.GenericTypeVariable` in `TypeUtils#isAssignableTo()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -202,9 +202,12 @@ public class TypeUtils {
                 JavaType.FullyQualified toFq = (JavaType.FullyQualified) to;
                 return isAssignableTo(toFq.getFullyQualifiedName(), from);
             } else if (to instanceof JavaType.GenericTypeVariable) {
-                JavaType.GenericTypeVariable genericTo = (JavaType.GenericTypeVariable) to;
-                if (genericTo.getBounds().isEmpty()) {
-                    return genericTo.getName().equals("?");
+                JavaType.GenericTypeVariable toGeneric = (JavaType.GenericTypeVariable) to;
+                List<JavaType> toBounds = toGeneric.getBounds();
+                if (toBounds.isEmpty()) {
+                    return toGeneric.getName().equals("?");
+                } else if (toBounds.size() == 1) {
+                    return isAssignableTo(toBounds.get(0), from);
                 }
                 return false;
             } else if (to instanceof JavaType.Variable) {


### PR DESCRIPTION
Fix the assignability test for generic type variable types.
