### PR TITLE
Fixed error when no file matcher was present

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
@@ -48,7 +48,7 @@ public class RemoveXmlTag extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(fileMatcher != null ? new HasSourcePath<>(fileMatcher) : TreeVisitor.noop(), new XmlIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(fileMatcher != null ? new HasSourcePath<>(fileMatcher) : new HasSourcePath<>(""), new XmlIsoVisitor<ExecutionContext>() {
             private final XPathMatcher xPathMatcher = new XPathMatcher(xPath);
 
             @Override

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/RemoveXmlTagTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/RemoveXmlTagTest.java
@@ -20,8 +20,6 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.io.File;
-import java.nio.file.Path;
 
 import static org.openrewrite.xml.Assertions.xml;
 
@@ -76,6 +74,27 @@ class RemoveXmlTagTest implements RewriteTest {
             """
               <beans>
                   <bean id='myBean.subpackage.subpackage2'/>
+                  <other id='myBean.subpackage.subpackage2'/>
+              </beans>
+              """,
+            documentSourceSpec -> documentSourceSpec.path("my/project/notBeans.xml")
+          )
+        );
+    }
+
+    @Test
+    void fileMatcherEmpty() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveXmlTag("//bean", null)),
+          xml(
+            """
+              <beans>
+                  <bean id='myBean.subpackage.subpackage2'/>
+                  <other id='myBean.subpackage.subpackage2'/>
+              </beans>
+              """,
+            """
+              <beans>
                   <other id='myBean.subpackage.subpackage2'/>
               </beans>
               """,


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
the noop treevisitor was replaced with a hassource visitor which always matches

## What's your motivation?
the following line
(https://github.com/openrewrite/rewrite/blob/d5ed2c5a1cc64b412afcee87c32ba6ab1b344758/rewrite-core/src/main/java/org/openrewrite/Preconditions.java#L41)
would always result to false on an xml file
`!(tree instanceof SourceFile)` would be false in case of an xml.document which inherits from source file
  `check.visit(tree, ctx) != tree` is false since check is the noop treevisitor which returns the tree
  since both are false the whole check is false

## Any additional context
also added a test for it

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat` (no new files)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files (no since it restructured all the files so better let it be)
