### PR TITLE
update method type on DeleteMethodArgument

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DeleteMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DeleteMethodArgumentTest.java
@@ -37,8 +37,7 @@ class DeleteMethodArgumentTest implements RewriteTest {
     @Test
     void deleteMiddleArgumentDeclarative() {
         rewriteRun(
-          spec -> spec.recipe(new DeleteMethodArgument("B foo(int, int, int)", 1))
-            .cycles(1).expectedCyclesThatMakeChanges(1),
+          spec -> spec.recipes(new DeleteMethodArgument("B foo(int, int, int)", 1)),
           java(b),
           java(
             "public class A {{ B.foo(0, 1, 2); }}",
@@ -50,8 +49,7 @@ class DeleteMethodArgumentTest implements RewriteTest {
     @Test
     void deleteMiddleArgument() {
         rewriteRun(
-          spec -> spec.recipe(new DeleteMethodArgument("B foo(int, int, int)", 1))
-            .cycles(1).expectedCyclesThatMakeChanges(1),
+          spec -> spec.recipe(new DeleteMethodArgument("B foo(int, int, int)", 1)),
           java(b),
           java(
             "public class A {{ B.foo(0, 1, 2); }}",
@@ -65,7 +63,7 @@ class DeleteMethodArgumentTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipes(
             new DeleteMethodArgument("B foo(int, int, int)", 1),
-            new DeleteMethodArgument("B foo(int, int, int)", 1)
+            new DeleteMethodArgument("B foo(int, int)", 1)
           ),
           java(b),
           java("public class A {{ B.foo(0, 1, 2); }}",
@@ -98,8 +96,7 @@ class DeleteMethodArgumentTest implements RewriteTest {
     @Test
     void deleteConstructorArgument() {
         rewriteRun(
-          spec -> spec.recipe(new DeleteMethodArgument("B <constructor>(int)", 0))
-            .cycles(1).expectedCyclesThatMakeChanges(1),
+          spec -> spec.recipe(new DeleteMethodArgument("B <constructor>(int)", 0)),
           java(b),
           java(
             "public class A { B b = new B(0); }",

--- a/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
@@ -19,10 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.MethodCall;
-import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;
@@ -104,6 +101,18 @@ public class DeleteMethodArgument extends Recipe {
                 }
 
                 m = m.withArguments(args);
+
+                JavaType.Method methodType = m.getMethodType();
+                if (methodType != null) {
+                    List<String> parameterNames = new ArrayList<>(methodType.getParameterNames());
+                    parameterNames.remove(argumentIndex);
+                    List<JavaType> parameterTypes = new ArrayList<>(methodType.getParameterTypes());
+                    parameterTypes.remove(argumentIndex);
+
+                    m = m.withMethodType(methodType
+                            .withParameterNames(parameterNames)
+                            .withParameterTypes(parameterTypes));
+                }
             }
             return m;
         }


### PR DESCRIPTION
## What's changed?
Updating method type list of arguments to avoid next calls to the recipe to keep method matching

## What's your motivation?
Right now this recipe is not idempotent, thus we need to specify in the tests that we only want one cycle. This is not very convenient when using this recipe from other recipes, and also leaves the method in an inconsistent state.

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
I had to change a test, that was relying specifically on the fact that the method type is not updated and that subsequent calls to the recipe will still match and delete the parameter. I do not know if this is also used in recipes that are using this one.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
