### PR TITLE
Restrict UseStaticImport to static methods (#3661)

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -20,6 +20,7 @@ import lombok.experimental.FieldDefaults;
 import org.openrewrite.*;
 import org.openrewrite.java.search.DeclaresMethod;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Javadoc;
@@ -73,6 +74,10 @@ public class UseStaticImport extends Recipe {
                     return m;
                 }
                 if (m.getMethodType() != null) {
+                    if (!m.getMethodType().hasFlags(Flag.Static)) {
+                        return m;
+                    }
+
                     JavaType.FullyQualified receiverType = m.getMethodType().getDeclaringType();
                     maybeRemoveImport(receiverType);
 


### PR DESCRIPTION
* add tests for good and bad cases
* fix issue by checking method to be static
* verified that the bad case fails without the fix and passes with the fix

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
