### PR TITLE
fix collision with nested class references

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
@@ -464,4 +464,48 @@ public class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void nestedReferenceCollision() {
+        rewriteRun(
+          java("""            
+            class List {
+                class A {
+                }
+            }
+          """),
+          java("""           
+            import java.util.ArrayList;
+            
+            class Test {
+                void test(List.A l1) {
+                    java.util.List<Integer> l2 = new ArrayList<>();
+                }
+            }
+          """)
+        );
+    }
+
+    @Test
+    void deeperNestedReferenceCollision() {
+        rewriteRun(
+          java("""            
+            class List {
+                class A {
+                    class B {
+                    }
+                }
+            }
+          """),
+          java("""           
+            import java.util.ArrayList;
+            
+            class Test {
+                void test(List.A.B l1) {
+                    java.util.List<Integer> l2 = new ArrayList<>();
+                }
+            }
+          """)
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferences.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferences.java
@@ -19,10 +19,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.DefaultJavaTypeSignatureBuilder;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -83,6 +80,12 @@ public class ShortenFullyQualifiedTypeReferences extends Recipe {
 
                         @Override
                         public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Map<String, JavaType> types) {
+                            Expression target = fieldAccess.getTarget();
+                            if (target instanceof J.Identifier) {
+                                visitIdentifier((J.Identifier) fieldAccess.getTarget(), types);
+                            } else if (target instanceof J.FieldAccess) {
+                                visitFieldAccess((J.FieldAccess) target, types);
+                            }
                             return fieldAccess;
                         }
 


### PR DESCRIPTION
## What's changed?
Checking for the root identifier on fieldAccess to add to usedTypes when referencing a nested type.

## What's your motivation?
https://github.com/moderneinc/support-app/issues/20

## Anyone you would like to review specifically?
@knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
