### PR TITLE
For parsing errors caused by print-idempotent check, add diff to the message of `ParseExceptionResult` marker

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ParseExceptionResult.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ParseExceptionResult.java
@@ -40,18 +40,24 @@ public class ParseExceptionResult implements Marker {
     @Nullable
     String treeType;
 
-    public static ParseExceptionResult build(Class<? extends Parser> parserClass, Throwable t) {
+    public static ParseExceptionResult build(Class<? extends Parser> parserClass,
+                                             Throwable t,
+                                             @Nullable String message) {
         String simpleName = t.getClass().getSimpleName();
         return new ParseExceptionResult(
                 randomId(),
                 parserClass.getSimpleName(),
                 !StringUtils.isBlank(simpleName) ? simpleName : t.getClass().getName(),
-                ExceptionUtils.sanitizeStackTrace(t, parserClass),
+                (message != null ? message : "") + ExceptionUtils.sanitizeStackTrace(t, parserClass),
                 null
         );
     }
 
+    public static ParseExceptionResult build(Parser parser, Throwable t, @Nullable String message) {
+        return build(parser.getClass(), t, message);
+    }
+
     public static ParseExceptionResult build(Parser parser, Throwable t) {
-        return build(parser.getClass(), t);
+        return build(parser.getClass(), t, null);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -16,27 +16,16 @@
 package org.openrewrite;
 
 import lombok.Getter;
-import org.eclipse.jgit.diff.DiffEntry;
-import org.eclipse.jgit.diff.DiffFormatter;
-import org.eclipse.jgit.diff.RawTextComparator;
-import org.eclipse.jgit.internal.storage.dfs.DfsRepositoryDescription;
-import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
 import org.eclipse.jgit.lib.*;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.internal.InMemoryDiffEntry;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.RecipesThatMadeChanges;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 public class Result {
     /**
@@ -180,6 +169,25 @@ public class Result {
         )) {
             return diffEntry.getDiff(ignoreAllWhitespace);
         }
+    }
+
+    @Nullable
+    public static String diff(String before, String after, Path path) {
+        String diff = null;
+        try (InMemoryDiffEntry diffEntry = new InMemoryDiffEntry(
+                path,
+                path,
+                null,
+                before,
+                after,
+                Collections.emptySet(),
+                FileMode.REGULAR_FILE,
+                FileMode.REGULAR_FILE
+        )) {
+            diff = diffEntry.getDiff(Boolean.FALSE);
+        } catch (Exception ignored) {
+        }
+        return diff;
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/tree/ParseError.java
+++ b/rewrite-core/src/main/java/org/openrewrite/tree/ParseError.java
@@ -86,15 +86,25 @@ public class ParseError implements SourceFile {
         return (R) v.adapt(ParseErrorVisitor.class).visitParseError(this, p);
     }
 
+
     public static ParseError build(Parser parser,
                                    Parser.Input input,
                                    @Nullable Path relativeTo,
                                    ExecutionContext ctx,
                                    Throwable t) {
+        return build(parser, input, relativeTo, ctx, t, null);
+    }
+
+    public static ParseError build(Parser parser,
+                                   Parser.Input input,
+                                   @Nullable Path relativeTo,
+                                   ExecutionContext ctx,
+                                   Throwable t,
+                                   @Nullable String message) {
         EncodingDetectingInputStream is = input.getSource(ctx);
         return new ParseError(
                 Tree.randomId(),
-                new Markers(Tree.randomId(), singletonList(ParseExceptionResult.build(parser, t))),
+                new Markers(Tree.randomId(), singletonList(ParseExceptionResult.build(parser, t, message))),
                 input.getRelativePath(relativeTo),
                 input.getFileAttributes(),
                 parser.getCharset(ctx).name(),

--- a/rewrite-core/src/test/java/org/openrewrite/FindParseFailuresTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/FindParseFailuresTest.java
@@ -37,7 +37,7 @@ public class FindParseFailuresTest implements RewriteTest {
 
     @Test
     void findParseFailures() {
-        ParseExceptionResult per = ParseExceptionResult.build(PlainTextParser.class, new RuntimeException("boom"));
+        ParseExceptionResult per = ParseExceptionResult.build(PlainTextParser.class, new RuntimeException("boom"), null);
         rewriteRun(
           spec -> spec.dataTable(ParseFailures.Row.class, rows -> {
               assertThat(rows).hasSize(1);

--- a/rewrite-core/src/test/java/org/openrewrite/ParserTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ParserTest.java
@@ -21,6 +21,10 @@ import org.openrewrite.text.PlainTextParser;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -50,5 +54,40 @@ class ParserTest implements RewriteTest {
           new RuntimeException("bad file!!"));
 
         assertThat(pe.printAll()).isEqualTo("bad file");
+    }
+
+    @Test
+    void printIdempotentDiffPrint() {
+        Parser parser = new PlainTextParser();
+        ExecutionContext ctx = new InMemoryExecutionContext();
+
+        String before = """
+          line 1
+          line 2
+          """;
+        String after = """
+          line 1
+          DIFF HERE
+          line 2
+          """;
+        Path path = Paths.get("1.txt");
+        String expectedDiff = """
+          --- a/1.txt
+          +++ b/1.txt
+          @@ -1,3 +1,2 @@\s
+           line 1
+          -DIFF HERE
+           line 2
+          """;
+
+        Parser.Input input1 = new Parser.Input(path, () -> new ByteArrayInputStream(before.getBytes()));
+        Parser.Input input2 = new Parser.Input(path, () -> new ByteArrayInputStream(after.getBytes()));
+        SourceFile s1 = parser.parse(input1.getSource(ctx).readFully()).toList().get(0);
+        SourceFile out = parser.requirePrintEqualsInput(s1, input2, null, ctx);
+        assertThat(out).isInstanceOf(ParseError.class);
+        ParseExceptionResult parseExceptionResult = out.getMarkers().findFirst(ParseExceptionResult.class).get();
+        int startIndex = parseExceptionResult.getMessage().indexOf(expectedDiff);
+        int endIndex = startIndex + expectedDiff.length();
+        assertThat(parseExceptionResult.getMessage().substring(startIndex, endIndex)).isEqualTo(expectedDiff);
     }
 }


### PR DESCRIPTION
This PR will help us more efficiently when working on parsing to print idempotent issues on new languages.
