### PR TITLE
fix defaultClasspath for GradleParser

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
@@ -44,14 +44,15 @@ public class GradleParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
         if (buildParser == null) {
-            if (base.buildscriptClasspath == null) {
+            Collection<Path> buildscriptClasspath = base.buildscriptClasspath;
+            if (buildscriptClasspath == null) {
                 if (defaultClasspath == null) {
                     defaultClasspath = loadDefaultClasspath();
                 }
-                base.buildscriptClasspath = defaultClasspath;
+                buildscriptClasspath = defaultClasspath;
             }
             buildParser = GroovyParser.builder(base.groovyParser)
-                    .classpath(base.buildscriptClasspath)
+                    .classpath(buildscriptClasspath)
                     .compilerCustomizers(
                             new DefaultImportsCustomizer(),
                             config -> config.setScriptBaseClass("RewriteGradleProject")
@@ -59,14 +60,15 @@ public class GradleParser implements Parser {
                     .build();
         }
         if (settingsParser == null) {
-            if (base.settingsClasspath == null) {
+            Collection<Path> settingsClasspath = base.settingsClasspath;
+            if (settingsClasspath == null) {
                 if (defaultClasspath == null) {
                     defaultClasspath = loadDefaultClasspath();
                 }
-                base.settingsClasspath = defaultClasspath;
+                settingsClasspath = defaultClasspath;
             }
             settingsParser = GroovyParser.builder(base.groovyParser)
-                    .classpath(base.settingsClasspath)
+                    .classpath(settingsClasspath)
                     .compilerCustomizers(
                             new DefaultImportsCustomizer(),
                             config -> config.setScriptBaseClass("RewriteSettings")

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/GradleParser.java
@@ -44,8 +44,10 @@ public class GradleParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sources, @Nullable Path relativeTo, ExecutionContext ctx) {
         if (buildParser == null) {
-            if (base.buildscriptClasspath == null && defaultClasspath == null) {
-                defaultClasspath = loadDefaultClasspath();
+            if (base.buildscriptClasspath == null) {
+                if (defaultClasspath == null) {
+                    defaultClasspath = loadDefaultClasspath();
+                }
                 base.buildscriptClasspath = defaultClasspath;
             }
             buildParser = GroovyParser.builder(base.groovyParser)
@@ -57,8 +59,10 @@ public class GradleParser implements Parser {
                     .build();
         }
         if (settingsParser == null) {
-            if (base.settingsClasspath == null && defaultClasspath == null) {
-                defaultClasspath = loadDefaultClasspath();
+            if (base.settingsClasspath == null) {
+                if (defaultClasspath == null) {
+                    defaultClasspath = loadDefaultClasspath();
+                }
                 base.settingsClasspath = defaultClasspath;
             }
             settingsParser = GroovyParser.builder(base.groovyParser)


### PR DESCRIPTION
## What's changed?
Fixed default classpath for settings parser.

## What's your motivation?
When trying to parse a `settings.gradle` file it was failing with Class not found exceptions due to not properly setting the classpath on the parser.

## Anyone you would like to review specifically?
@knutwannheden @jkschneider 
