### PR TITLE
Do not skip proto3 files, as it warns about out of date LSTs

### DIFF
--- a/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/ProtoParserTest.java
+++ b/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/ProtoParserTest.java
@@ -18,18 +18,16 @@ package org.openrewrite.protobuf;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.text.PlainText;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProtoParserTest implements RewriteTest {
-
+class ProtoParserTest implements RewriteTest {
     @Test
     void noNullsForProto3Files() {
-        List<SourceFile> sources = ProtoParser.builder().build().parse("syntax = \"proto3\";")
-          .collect(Collectors.toList());
-        assertThat(sources).isEmpty();
+        List<SourceFile> sources = ProtoParser.builder().build().parse("syntax = \"proto3\";").toList();
+        assertThat(sources).singleElement().isInstanceOf(PlainText.class);
     }
 }


### PR DESCRIPTION
## What's changed?
Proto3 files are now returned as plain text files, rather than skipped, pending a proper Proto3 parser.

## What's your motivation?
Warning about out of date LSTs, since files where accepted by the parser but skipped, as discussed on Slack.

## Have you considered any alternatives or workarounds?
We could have gone for `ParseError` instead, but that limits the options for folks to target these in search or text replace.