### PR TITLE
CreateTextFile should override files of different type

### DIFF
--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
     implementation("org.slf4j:slf4j-api:1.7.36")
     implementation("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
+
+    testImplementation(project(":rewrite-groovy"))
 }

--- a/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
@@ -17,8 +17,10 @@ package org.openrewrite.text;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.test.SourceSpecs.text;
 
 class CreateTextFileTest implements RewriteTest {
@@ -94,6 +96,33 @@ class CreateTextFileTest implements RewriteTest {
             null,
             "foo",
             spec -> spec.path(".github/CODEOWNERS")
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-jenkins/issues/52")
+    void shouldOverrideDifferentSourceFileType() {
+        String after = """
+          /*
+           See the documentation for more options:
+           https://github.com/jenkins-infra/pipeline-library/
+          */
+          buildPlugin(
+            useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+            configurations: [
+              [platform: 'linux', jdk: 21],
+              [platform: 'windows', jdk: 17],
+          ])""";
+        rewriteRun(
+          spec -> spec.recipe(new CreateTextFile(after, "Jenkinsfile", true)),
+          groovy(
+            """
+              #!groovy
+              buildPlugin()
+              """,
+            after,
+            spec -> spec.path("Jenkinsfile")
           )
         );
     }


### PR DESCRIPTION
## What's changed?
Allow `CreateTextFile` to overwrite files in a different format than `PlainText`.

## What's your motivation?
We recently started parsing `Jenkinsfile` as Groovy, which unfortunately broke the `CreateTextFile` used in `ModernizeJenkinsfile`
https://github.com/openrewrite/rewrite-jenkins/blob/8914ccd62655d65f2c54e2e40ed6289f13f69542/src/main/resources/META-INF/rewrite/rewrite.yml#L53-L70
Fixes https://github.com/openrewrite/rewrite-jenkins/issues/52

## Anything in particular you'd like reviewers to focus on?
Called out below.

## Have you considered any alternatives or workarounds?
Not really; looked towards `FindAndReplace` as that also allows text replace regardless of file type.

## Any additional context
- https://github.com/openrewrite/rewrite-jenkins/issues/52
