### PR TITLE
Add BitbucketBuildEnvironment for better progress indicators

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/BitbucketBuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/BitbucketBuildEnvironment.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.marker.ci;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.marker.GitProvenance;
+
+import java.util.UUID;
+import java.util.function.UnaryOperator;
+
+import static java.util.Collections.emptyList;
+import static org.openrewrite.Tree.randomId;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class BitbucketBuildEnvironment implements BuildEnvironment{
+    @With
+    UUID id;
+    String httpOrigin;
+    String branch;
+    String sha;
+
+    public static BitbucketBuildEnvironment build(UnaryOperator<String> environment) {
+        return new BitbucketBuildEnvironment(
+                randomId(),
+                environment.apply("BITBUCKET_GIT_HTTP_ORIGIN"),
+                environment.apply("BITBUCKET_BRANCH"),
+                environment.apply("BITBUCKET_COMMIT"));
+    }
+
+    @Override
+    public GitProvenance buildGitProvenance() throws IncompleteGitConfigException {
+        if (StringUtils.isBlank(httpOrigin)
+                || StringUtils.isBlank(branch)
+                || StringUtils.isBlank(sha)) {
+            throw new IncompleteGitConfigException();
+        } else {
+            return new GitProvenance(UUID.randomUUID(), httpOrigin, branch, sha,
+                    null, null, emptyList());
+        }
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/marker/ci/BuildEnvironment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/ci/BuildEnvironment.java
@@ -25,20 +25,29 @@ public interface BuildEnvironment extends Marker {
 
     @Nullable
     static BuildEnvironment build(UnaryOperator<String> environment) {
+        if (environment.apply("BITBUCKET_COMMIT") != null) {
+            return BitbucketBuildEnvironment.build(environment);
+        }
         if (environment.apply("CUSTOM_CI") != null) {
             return CustomBuildEnvironment.build(environment);
-        } else if (environment.apply("BUILD_NUMBER") != null && environment.apply("JOB_NAME") != null) {
+        }
+        if (environment.apply("BUILD_NUMBER") != null && environment.apply("JOB_NAME") != null) {
             return JenkinsBuildEnvironment.build(environment);
-        } else if (environment.apply("GITLAB_CI") != null) {
+        }
+        if (environment.apply("GITLAB_CI") != null) {
             return GitlabBuildEnvironment.build(environment);
-        } else if (environment.apply("CI") != null && environment.apply("GITHUB_ACTION") != null
+        }
+        if (environment.apply("CI") != null && environment.apply("GITHUB_ACTION") != null
                 && environment.apply("GITHUB_RUN_ID") != null) {
             return GithubActionsBuildEnvironment.build(environment);
-        } else if (environment.apply("DRONE") != null) {
+        }
+        if (environment.apply("DRONE") != null) {
             return DroneBuildEnvironment.build(environment);
-        } else if (environment.apply("CIRCLECI") != null) {
+        }
+        if (environment.apply("CIRCLECI") != null) {
             return CircleCiBuildEnvironment.build(environment);
-        } else if (environment.apply("TRAVIS") != null) {
+        }
+        if (environment.apply("TRAVIS") != null) {
             return TravisBuildEnvironment.build(environment);
         }
         return null;


### PR DESCRIPTION
## What's changed?
Add Bitbucket BuildEnvironment

## What's your motivation?
Recognize bitbucket CI, such that the CLI progress bar adjusts output.

## Anything in particular you'd like reviewers to focus on?
Any reason we didn't have this before?
Anything we should be mindful of in terms of detection order?

## Have you considered any alternatives or workarounds?
We could detect `CI` only as a catch all CI env; but then we lack input for `GitProvenance`.

## Any additional context
As per https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
