### PR TITLE
do not overwrite the repo if it's not the default local one

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -539,8 +539,7 @@ public class MavenPomDownloader {
                                 }
                             }
 
-                            String fullDefaultMavenLocalUri = MavenRepository.MAVEN_LOCAL_USER_NEUTRAL.getUri().replace("~", System.getProperty("user.home"));
-                            if (repo.getUri().equals(fullDefaultMavenLocalUri)) {
+                            if (repo.getUri().equals(MavenRepository.MAVEN_LOCAL_DEFAULT.getUri())) {
                                 // so that the repository path is the same regardless of username
                                 pom = pom.withRepository(MavenRepository.MAVEN_LOCAL_USER_NEUTRAL);
                             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -526,11 +526,6 @@ public class MavenPomDownloader {
                         if (!f.exists()) {
                             continue;
                         }
-                        String fullDefaultMavenLocalUri = MavenRepository.MAVEN_LOCAL_USER_NEUTRAL.getUri().replace("~", System.getProperty("user.home"));
-                        if (!repo.getUri().equals(MavenRepository.MAVEN_LOCAL_USER_NEUTRAL.getUri()) && !repo.getUri().startsWith(fullDefaultMavenLocalUri)) {
-                            // Non-default local Maven dependencies can not be shared between users, so we skip the repo
-                            continue;
-                        }
 
                         try (FileInputStream fis = new FileInputStream(f)) {
                             RawPom rawPom = RawPom.parse(fis, Objects.equals(versionMaybeDatedSnapshot, gav.getVersion()) ? null : versionMaybeDatedSnapshot);
@@ -544,8 +539,11 @@ public class MavenPomDownloader {
                                 }
                             }
 
-                            // so that the repository path is the same regardless of username
-                            pom = pom.withRepository(MavenRepository.MAVEN_LOCAL_USER_NEUTRAL);
+                            String fullDefaultMavenLocalUri = MavenRepository.MAVEN_LOCAL_USER_NEUTRAL.getUri().replace("~", System.getProperty("user.home"));
+                            if (repo.getUri().equals(fullDefaultMavenLocalUri)) {
+                                // so that the repository path is the same regardless of username
+                                pom = pom.withRepository(MavenRepository.MAVEN_LOCAL_USER_NEUTRAL);
+                            }
 
                             if (!Objects.equals(versionMaybeDatedSnapshot, pom.getVersion())) {
                                 pom = pom.withGav(pom.getGav().withDatedSnapshotVersion(versionMaybeDatedSnapshot));

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -564,7 +564,6 @@ class MavenPomDownloaderTest {
 
     private static GroupArtifactVersion createArtifact(Path repository) throws IOException {
         Path target = repository.resolve(Paths.get("org", "openrewrite", "rewrite", "1.0.0"));
-        Files.createDirectories(target);
         Path pom = target.resolve("rewrite-1.0.0.pom");
         Path jar = target.resolve("rewrite-1.0.0.jar");
         Files.createDirectories(target);


### PR DESCRIPTION
## What's changed?
Do not replace the repo with the user-agnostic ~/.m2/repository if it is not the local default one

## What's your motivation?
If a custom local maven repo is configured, we cannot assume that we can replace it with ~/.m2/repository, because it will point to a different location.

## Anyone you would like to review specifically?
@timtebeek @pstreef 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
