### PR TITLE
Do not log `ClassCastException` in MavenParser in case of malformed POM

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -82,12 +82,18 @@ public class MavenParser implements Parser {
                 pom.getProperties().put("project.basedir", baseDir);
                 pom.getProperties().put("basedir", baseDir);
 
-                Xml.Document xml = (Xml.Document) new MavenXmlParser()
+                SourceFile sourceFile = new MavenXmlParser()
                         .parseInputs(singletonList(source), relativeTo, ctx)
                         .iterator().next();
 
-                projectPoms.put(xml, pom);
-                projectPomsByPath.put(pomPath, pom);
+                if (sourceFile instanceof Xml.Document) {
+                    Xml.Document xml = (Xml.Document) sourceFile;
+
+                    projectPoms.put(xml, pom);
+                    projectPomsByPath.put(pomPath, pom);
+                } else {
+                    parsed.add(sourceFile);
+                }
             } catch (Throwable t) {
                 ctx.getOnError().accept(t);
                 parsed.add(ParseError.build(this, source, relativeTo, ctx, t));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -191,7 +191,7 @@ public class MavenParser implements Parser {
             if (mavenConfig != null && mavenConfig.toFile().exists()) {
                 try {
                     String mavenConfigText = new String(Files.readAllBytes(mavenConfig));
-                    Matcher matcher = Pattern.compile("(?:$|\\s)-P\\s+([^\\s]+)").matcher(mavenConfigText);
+                    Matcher matcher = Pattern.compile("(?:$|\\s)-P\\s+(\\S+)").matcher(mavenConfigText);
                     if (matcher.find()) {
                         String[] profiles = matcher.group(1).split(",");
                         return activeProfiles(profiles);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -27,6 +27,7 @@ import org.openrewrite.Parser;
 import org.openrewrite.maven.internal.MavenParsingException;
 import org.openrewrite.maven.tree.*;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.tree.ParseError;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -2239,25 +2240,23 @@ class MavenParserTest implements RewriteTest {
 
     @Test
     void malformedPom() {
-        rewriteRun(
-          pomXml(
-            """
-              <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-              
-                <dependencies>
-                  <dependency>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                    <version>[4.11]</version>&gt;
-                  </dependency>
-                </dependencies>
-              </project>
-              """
-          )
-        );
+        String malformedPomXml = """
+          <project>
+            <groupId>com.mycompany.app</groupId>
+            <artifactId>my-app</artifactId>
+            <version>1</version>
+                        
+            <dependencies>
+              <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.11</version>&gt;
+              </dependency>
+            </dependencies>
+          </project>
+          """;
+        assertThat(MavenParser.builder().build().parse(malformedPomXml))
+          .singleElement()
+          .isInstanceOf(ParseError.class);
     }
-
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -2237,4 +2237,28 @@ class MavenParserTest implements RewriteTest {
             ))
         );
     }
+
+    @Test
+    void malformedPom() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              
+                <dependencies>
+                  <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>[4.11]</version>&gt;
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -853,7 +853,6 @@ class MavenParserTest implements RewriteTest {
         var password = "password";
         try (MockWebServer mockRepo = new MockWebServer()) {
             mockRepo.setDispatcher(new Dispatcher() {
-                @SuppressWarnings("NullableProblems")
                 @Override
                 public MockResponse dispatch(RecordedRequest request) {
                     MockResponse resp = new MockResponse();


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Wrote the unit test for the case #3699 and proposed fix

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/3699

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
No

## Anyone you would like to review specifically?
<!-- @mention them here -->
No

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
I don't think there are any, but I'm glad to hear about them.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
After this fix, there is no ClassCastException. But the test asserts fails anyway because the POM is changed here - see the results of the tests. And now I don't know what to do with this. Should we suppress it or ignore it in the code itself? So that test would expect such changes or ignore them? Or is here some other way? Correct the parser, so these changes wouldn't appear and there would be no difference? 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
