### PR TITLE
Resolve dependency version after type and classifier

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -769,15 +769,6 @@ public class ResolvedPom {
             return d;
         }
 
-        String version = d.getVersion();
-        if (d.getVersion() == null || depth > 0) {
-            // dependency management overrides transitive dependency versions
-            version = getManagedVersion(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
-            if (version == null) {
-                version = d.getVersion();
-            }
-        }
-
         String scope;
         if (d.getScope() == null) {
             Scope parsedScope = getManagedScope(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
@@ -797,6 +788,15 @@ public class ResolvedPom {
         if (d.getType() != null) {
             d = d.withType(getValue(d.getType()));
         }
+        String version = d.getVersion();
+        if (d.getVersion() == null || depth > 0) {
+            // dependency management overrides transitive dependency versions
+            version = getManagedVersion(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
+            if (version == null) {
+                version = d.getVersion();
+            }
+        }
+
         return d
                 .withGav(d.getGav().withVersion(version))
                 .withScope(scope);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class ResolvedPomTest implements RewriteTest {
+
+    @Test
+    void resolveDependencyWithPlaceholderClassifier() {
+        rewriteRun(
+          pomXml(
+            """
+            <project>
+              <groupId>org.example</groupId>
+              <artifactId>foo-parent</artifactId>
+              <version>1</version>
+              <properties>
+                <netty.version>4.1.101.Final</netty.version>
+                <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
+              </properties>
+              <dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                    <classifier>${netty-transport-native-epoll-classifier}</classifier>
+                    <version>${netty.version}</version>
+                  </dependency>
+                </dependencies>
+              </dependencyManagement>
+            </project>
+            """,
+            spec -> spec.path("pom.xml")
+          ),
+          pomXml(
+            """
+            <project>
+              <groupId>org.example</groupId>
+              <artifactId>foo</artifactId>
+              <version>1</version>
+              <parent>
+                <groupId>org.example</groupId>
+                <artifactId>foo-parent</artifactId>
+                <version>1</version>
+              </parent>
+              <dependencies>
+                <dependency>
+                  <groupId>io.netty</groupId>
+                  <artifactId>netty-transport-native-epoll</artifactId>
+                  <classifier>${netty-transport-native-epoll-classifier}</classifier>
+                </dependency>
+              </dependencies>
+            </project>
+            """,
+            spec -> spec.path("foo/pom.xml")
+          ),
+          pomXml(
+            """
+            <project>
+              <groupId>org.example</groupId>
+              <artifactId>bar</artifactId>
+              <version>1</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1</version>
+                </dependency>
+              </dependencies>
+            </project>
+            """,
+            spec -> spec.path("bar/pom.xml")
+          )
+        );
+    }
+}


### PR DESCRIPTION
When resolving a dependency then a transitive dependency could be a managed dependency with a placeholder classifier. This placeholder must then be resolved before the version can be resolved, as it otherwise won't be found and results in a `MavenDownloadingException`.