### PR TITLE
Ignore methods with type parameters in UseStaticImport

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.RewriteTest;
@@ -73,6 +74,25 @@ class UseStaticImportTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3705")
+    @Test
+    void ignoreMethodsWithTypeParameter() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.util.Collections emptyList()")),
+          java(
+            """
+            import java.util.Collections;
+            import java.util.List;
+
+            public class Reproducer {
+                public void methodWithTypeParameter() {
+                    List<Object> list = Collections.<Object>emptyList();
+                }
+            }
+            """
+          )
+        );
+    }
     @Test
     void methodInvocationsHavingNullSelect() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -59,6 +59,9 @@ public class UseStaticImport extends Recipe {
             MethodMatcher methodMatcher = new MethodMatcher(methodPattern);
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
             if (methodMatcher.matches(m)) {
+                if (m.getTypeParameters() != null && !m.getTypeParameters().isEmpty()) {
+                    return m;
+                }
                 if (m.getMethodType() != null) {
                     JavaType.FullyQualified receiverType = m.getMethodType().getDeclaringType();
                     maybeRemoveImport(receiverType);


### PR DESCRIPTION
Fixes #3705.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Avoids the recipe in case of type parameters, as suggested by @knutwannheden 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
