### PR TITLE
Tentative fix for missing "//" operator on `XPathMatcher`

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.xml;
 
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.Cursor;
 import org.openrewrite.xml.search.FindTags;
 import org.openrewrite.xml.tree.Xml;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,12 +39,20 @@ import java.util.stream.Collectors;
  * As a result, '.' and '..' are not recognized.
  */
 public class XPathMatcher {
+    // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']`
+    private static final Pattern PATTERN = Pattern.compile("([-\\w]+)\\[([-\\w]+)='([-\\w]+)']");
     private final String expression;
 
     public XPathMatcher(String expression) {
         this.expression = expression;
     }
 
+    /**
+     * Checks if the given XPath expression matches the provided cursor.
+     *
+     * @param cursor the cursor representing the XML document
+     * @return true if the expression matches the cursor, false otherwise
+     */
     public boolean matches(Cursor cursor) {
         List<Xml.Tag> path = cursor.getPathAsStream()
                 .filter(p -> p instanceof Xml.Tag)
@@ -59,8 +69,8 @@ public class XPathMatcher {
                 String part = parts.get(i);
                 if (part.startsWith("@")) {
                     if (!(cursor.getValue() instanceof Xml.Attribute &&
-                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
-                            "*".equals(part.substring(1)))) {
+                          (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
+                          "*".equals(part.substring(1)))) {
                         return false;
                     }
 
@@ -78,6 +88,33 @@ public class XPathMatcher {
             Collections.reverse(path);
             String[] parts = expression.substring(1).split("/");
 
+            // Deal with the two forward slashes in the expression; works, but I'm not proud of it.
+            if (expression.contains("//") && Arrays.stream(parts).anyMatch(StringUtils::isBlank)) {
+                int blankPartIndex = Arrays.asList(parts).indexOf("");
+                int doubleSlashIndex = expression.indexOf("//");
+
+                if (path.size() > blankPartIndex && path.size() >= parts.length - 1) {
+                    String newExpression;
+                    /*  */
+                    if (Objects.equals(path.get(blankPartIndex).getName(), parts[blankPartIndex + 1])) {
+                        newExpression = String.format(
+                            "%s/%s",
+                            expression.substring(0, doubleSlashIndex),
+                            expression.substring(doubleSlashIndex + 2)
+                        );
+                    } else {
+                        newExpression = String.format(
+                            "%s/%s/%s",
+                            expression.substring(0, doubleSlashIndex),
+                            path.get(blankPartIndex).getName(),
+                            expression.substring(doubleSlashIndex + 2)
+                        );
+                    }
+
+                    return new XPathMatcher(newExpression).matches(cursor);
+                }
+            }
+
             if (parts.length > path.size() + 1) {
                 return false;
             }
@@ -88,10 +125,7 @@ public class XPathMatcher {
                 Xml.Tag tag = i < path.size() ? path.get(i) : null;
                 String partName;
 
-                // to support conditional tags like `plugin[artifactId='maven-compiler-plugin']`
-                String regex =  "([-\\w]+)\\[([-\\w]+)='([-\\w]+)'\\]";
-                Pattern pattern = Pattern.compile(regex);
-                Matcher matcher = pattern.matcher(part);
+                Matcher matcher = PATTERN.matcher(part);
                 if (tag != null && matcher.matches()) {
                     String name = matcher.group(1);
                     String subTag = matcher.group(2);
@@ -109,14 +143,13 @@ public class XPathMatcher {
                     partName = part;
                 }
 
-
                 if (part.startsWith("@")) {
                     return cursor.getValue() instanceof Xml.Attribute &&
-                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
-                                    "*".equals(part.substring(1)));
+                           (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
+                            "*".equals(part.substring(1)));
                 }
 
-                if (path.size() < i + 1 || (!tag.getName().equals(partName) && !"*".equals(part))) {
+                if (path.size() < i + 1 || (tag != null && !tag.getName().equals(partName) && !"*".equals(part))) {
                     return false;
                 }
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -95,7 +95,6 @@ public class XPathMatcher {
 
                 if (path.size() > blankPartIndex && path.size() >= parts.length - 1) {
                     String newExpression;
-                    /*  */
                     if (Objects.equals(path.get(blankPartIndex).getName(), parts[blankPartIndex + 1])) {
                         newExpression = String.format(
                             "%s/%s",
@@ -110,7 +109,6 @@ public class XPathMatcher {
                             expression.substring(doubleSlashIndex + 2)
                         );
                     }
-
                     return new XPathMatcher(newExpression).matches(cursor);
                 }
             }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -43,7 +43,7 @@ class XPathMatcherTest {
         """
     ).toList().get(0);
 
-    private final SourceFile pomXml = new XmlParser().parse(
+    private final SourceFile pomXml1 = new XmlParser().parse(
       """
         <project>
           <groupId>com.mycompany.app</groupId>
@@ -66,6 +66,30 @@ class XPathMatcherTest {
         """
     ).toList().get(0);
 
+    private final SourceFile pomXml2 = new XmlParser().parse(
+      """
+        <project>
+          <groupId>com.mycompany.app</groupId>
+          <artifactId>my-app</artifactId>
+          <version>1</version>
+          <build>
+            <pluginManagement>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <version>3.8.0</version>
+                  <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </pluginManagement>
+          </build>
+        </project>
+        """
+    ).toList().get(0);
 
     @Test
     void matchAbsolute() {
@@ -102,11 +126,15 @@ class XPathMatcherTest {
     @Test
     void matchPom() {
         assertThat(match("/project/build/plugins/plugin/configuration/source",
-          pomXml)).isTrue();
+          pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[artifactId='maven-compiler-plugin']/configuration/source",
-          pomXml)).isTrue();
+          pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[artifactId='somethingElse']/configuration/source",
-          pomXml)).isFalse();
+          pomXml1)).isFalse();
+        assertThat(match("/project/build//plugins/plugin/configuration/source",
+          pomXml1)).isTrue();
+        assertThat(match("/project/build//plugins/plugin/configuration/source",
+          pomXml2)).isTrue();
     }
 
     private boolean match(String xpath, SourceFile x) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Changes `XPathMatcher` to allow `//` syntax.

## What's your motivation?
https://github.com/openrewrite/rewrite-migrate-java/issues/353

## Anything in particular you'd like reviewers to focus on?
This is just enough to fix the before mentioned issue, definitely needs more testing and a better implementation.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
