### PR TITLE
Remove default `jar` packaging when using `ChangePackaging`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePackaging.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePackaging.java
@@ -73,7 +73,7 @@ public class ChangePackaging extends Recipe {
                     return document;
                 }
                 document = document.withMarkers(document.getMarkers().withMarkers(ListUtils.map(document.getMarkers().getMarkers(), m -> {
-                    if(m instanceof MavenResolutionResult) {
+                    if (m instanceof MavenResolutionResult) {
                         return getResolutionResult().withPom(pom.withRequested(pom.getRequested().withPackaging(packaging)));
                     }
                     return m;
@@ -85,7 +85,7 @@ public class ChangePackaging extends Recipe {
             public Xml visitTag(Xml.Tag tag, ExecutionContext context) {
                 Xml.Tag t = (Xml.Tag) super.visitTag(tag, context);
                 if (PROJECT_MATCHER.matches(getCursor())) {
-                    if (packaging == null) {
+                    if (packaging == null || "jar".equals(packaging)) {
                         t = filterTagChildren(t, it -> !"packaging".equals(it.getName()));
                     } else {
                         t = addOrUpdateChild(t, Xml.Tag.build("\n<packaging>" + packaging + "</packaging>"), getCursor().getParentOrThrow());

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePackagingTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePackagingTest.java
@@ -96,4 +96,28 @@ class ChangePackagingTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changePackagingRemovingDefault() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackaging("*", "*", "jar")),
+          pomXml(
+"""
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+                  <packaging>war</packaging>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -597,6 +597,11 @@ public interface Xml extends Tree {
         public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
             return v.visitComment(this, p);
         }
+
+        @Override
+        public String toString() {
+            return "<!--" + text + "-->";
+        }
     }
 
     @Value


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Omit `jar` packaging on maven pom.xml files (it is the default)

## What's your motivation?
Omit the `<packaging>jar</packaging>` tag on pom.xml files when using the `ChangePackaging` recipe.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
