### PR TITLE
[#3716] Test for an IllegalArgumentException in JavaTemplateJava…

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
@@ -425,40 +425,36 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
         );
     }
 
-	@Test
-	void testAnyIsGenericWithUnknownType() {
-		rewriteRun(
-		  spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
-			  @Override
-			  public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
-				  if (method.getSimpleName().equals("test")) {
-					  var s = method.getBody().getStatements().get(0);
-					  return JavaTemplate.builder("System.out.println(#{any()})")
-						.contextSensitive()
-						.build()
-						.apply(getCursor(), s.getCoordinates().replace(), s);
-				  }
-				  return method;
-			  }
-		  })).cycles(1).expectedCyclesThatMakeChanges(1),
-		  java(
-			"""
-			  import java.util.Map;
-			  class Test {
-				  void test(Map<String, ?> map) {
-					  map.get("test");
-				  }
-			  }
-			  """,
-			"""
-			  import java.util.Map;
-			  class Test {
-				  void test(Map<String, ?> map) {
-					     System.out.println(map.get("test"));
-				  }
-			  }
-			  """
-		  )
-		);
-	}
+    @Test
+    void testAnyIsGenericWithUnknownType() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  return JavaTemplate.builder("System.out.println(#{any()})")
+                    .contextSensitive()
+                    .build()
+                    .apply(getCursor(), method.getCoordinates().replace(), method);
+              }
+          })).cycles(1).expectedCyclesThatMakeChanges(1),
+          java(
+            """
+              import java.util.Map;
+              class Test {
+               void test(Map<String, ?> map) {
+                map.get("test");
+               }
+              }
+              """,
+            """
+              import java.util.Map;
+              class Test {
+               void test(Map<String, ?> map) {
+                   System.out.println(map.get("test"));
+               }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -23,11 +23,11 @@ import org.openrewrite.Issue;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
-
-import java.util.List;
 
 @SuppressWarnings({"ConstantConditions", "PatternVariableCanBeUsed", "UnnecessaryBoxing", "StatementWithEmptyBody", "UnusedAssignment"})
 class JavaTemplateTest implements RewriteTest {
@@ -997,7 +997,9 @@ class JavaTemplateTest implements RewriteTest {
     void addStatementInIfBlock() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-              final MethodMatcher lowerCaseMatcher = new MethodMatcher("java.lang.String toLowerCase()");              @Override
+              final MethodMatcher lowerCaseMatcher = new MethodMatcher("java.lang.String toLowerCase()");
+
+              @Override
               public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
                   J.Block newBlock = super.visitBlock(block, ctx);
                   if (newBlock.getStatements().stream().noneMatch(J.VariableDeclarations.class::isInstance)) {
@@ -1044,131 +1046,123 @@ class JavaTemplateTest implements RewriteTest {
         );
     }
 
-	@Test
-	void replaceMethodCallWithGenericParameterWithUnknowType() {
-		rewriteRun(
-		  spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api"))
-			.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-			  private JavaParser.Builder<?, ?> assertionsParser;
+    @Test
+    void replaceMethodCallWithGenericParameterWithUnknownType() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api"))
+            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                private final JavaParser.Builder<?, ?> assertionsParser = JavaParser.fromJavaVersion()
+                  .classpath("assertj-core");
 
-			  private JavaParser.Builder<?, ?> assertionsParser() {
-				  if (assertionsParser == null) {
-					  assertionsParser = JavaParser.fromJavaVersion()
-						.classpath( "assertj-core");
-				  }
-				  return assertionsParser;
-			  }
+                private static final MethodMatcher JUNIT_ASSERT_EQUALS = new MethodMatcher("org.junit.jupiter.api.Assertions assertEquals(..)");
 
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    if (!JUNIT_ASSERT_EQUALS.matches(method)) {
+                        return method;
+                    }
 
-			  private static final MethodMatcher JUNIT_ASSERT_EQUALS = new MethodMatcher("org.junit.jupiter.api.Assertions" + " assertEquals(..)");
+                    List<Expression> args = method.getArguments();
+                    Expression expected = args.get(0);
+                    Expression actual = args.get(1);
 
-			  @Override
-			  public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-				  if (!JUNIT_ASSERT_EQUALS.matches(method)) {
-					  return method;
-				  }
+                    maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                    maybeRemoveImport("org.junit.jupiter.api.Assertions");
 
-				  List<Expression> args = method.getArguments();
-				  Expression expected = args.get(0);
-				  Expression actual = args.get(1);
-
-				  maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
-				  maybeRemoveImport("org.junit.jupiter.api.Assertions");
-
-				  if (args.size() == 2) {
-					  return JavaTemplate.builder("assertThat(#{any()}).isEqualTo(#{any()});")
-						.staticImports("org.assertj.core.api.Assertions.assertThat")
-						.javaParser(assertionsParser())
-						.build()
-						.apply(getCursor(), method.getCoordinates().replace(), actual, expected);
-				  } else {
-					  return super.visitMethodInvocation(method, ctx);
-				  }
-			  }
-		  })),
-		  java(
-			"""
-            import java.util.Map;
-            import org.junit.jupiter.api.Assertions;
-			
-            class T {
-                void m(String one, Map<String, ?> map) {
-                    Assertions.assertEquals(one, map.get("one"));
+                    if (args.size() == 2) {
+                        return JavaTemplate.builder("assertThat(#{any()}).isEqualTo(#{any()});")
+                          .staticImports("org.assertj.core.api.Assertions.assertThat")
+                          .javaParser(assertionsParser)
+                          .build()
+                          .apply(getCursor(), method.getCoordinates().replace(), actual, expected);
+                    } else {
+                        return super.visitMethodInvocation(method, ctx);
+                    }
                 }
-            }
-            """,
-			"""
-        import java.util.Map;
-   			
-        import static org.assertj.core.api.Assertions.assertThat;
-  
-        class T {
-            void m(String one, Map<String, ?> map) {
-                assertThat(map.get("one")).isEqualTo(one);
-            }
-        }
+            })),
+          java(
             """
-		  )
-		);
-	}
+              import java.util.Map;
+              import org.junit.jupiter.api.Assertions;
+              
+              class T {
+                  void m(String one, Map<String, ?> map) {
+                      Assertions.assertEquals(one, map.get("one"));
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class T {
+                  void m(String one, Map<String, ?> map) {
+                      assertThat(map.get("one")).isEqualTo(one);
+                  }
+              }
+              """
+          )
+        );
+    }
 
-	@Test
-	void replaceCallWithUnknownGenericReturnValue() {
-		rewriteRun(
-		  spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-			  private static final MethodMatcher OBJECTS_EQUALS = new MethodMatcher("java.util.Objects" + " equals(..)");
+    @Test
+    void replaceCallWithUnknownGenericReturnValue() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              private static final MethodMatcher OBJECTS_EQUALS = new MethodMatcher("java.util.Objects equals(..)");
 
-			  @Override
-			  public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-				  if (!OBJECTS_EQUALS.matches(method)) {
-					  return method;
-				  }
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if (!OBJECTS_EQUALS.matches(method)) {
+                      return method;
+                  }
 
-				  List<Expression> args = method.getArguments();
-				  Expression expected = args.get(0);
-				  Expression actual = args.get(1);
+                  List<Expression> args = method.getArguments();
+                  Expression expected = args.get(0);
+                  Expression actual = args.get(1);
 
-				  maybeAddImport("java.util.Objects", "requireNonNull");
+                  maybeAddImport("java.util.Objects", "requireNonNull");
 
-				  if (args.size() == 2) {
-					  return JavaTemplate.builder("requireNonNull(#{any()}).equals(#{any()});")
-						.staticImports("java.util.Objects.requireNonNull")
-						.javaParser(JavaParser.fromJavaVersion())
-						.build()
-						.apply(getCursor(), method.getCoordinates().replace(), actual, expected);
-				  } else {
-					  return super.visitMethodInvocation(method, ctx);
-				  }
-			  }
-		  })),
-		  java(
-			"""
-			import java.util.Objects;
-			import java.util.Map;
-			import java.util.HashMap;
-			
-			class T {
-				void m() {
-					Map<String, ?> map = new HashMap<>();
-					Objects.equals("", map.get("one"));
-				}
-			}
-			""",
-			"""
-		import java.util.Objects;
-		import java.util.Map;
-                        
-		import static java.util.Objects.requireNonNull;
-		import java.util.HashMap;
-  
-		class T {
-			void m() {
-				Map<String, ?> map = new HashMap<>();
-		        requireNonNull(map.get("one")).equals("");
-			}
-		}
-			"""
-		  )
-		);
-	}
+                  if (args.size() == 2) {
+                      return JavaTemplate.builder("requireNonNull(#{any()}).equals(#{any()});")
+                        .staticImports("java.util.Objects.requireNonNull")
+                        .javaParser(JavaParser.fromJavaVersion())
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace(), actual, expected);
+                  } else {
+                      return super.visitMethodInvocation(method, ctx);
+                  }
+              }
+          })),
+          java(
+            """
+              import java.util.Objects;
+              import java.util.Map;
+              import java.util.HashMap;
+              
+              class T {
+              	void m() {
+              		Map<String, ?> map = new HashMap<>();
+              		Objects.equals("", map.get("one"));
+              	}
+              }
+              """,
+            """
+              import java.util.Objects;
+              import java.util.Map;
+              
+              import static java.util.Objects.requireNonNull;
+              import java.util.HashMap;
+              
+              class T {
+              	void m() {
+              		Map<String, ?> map = new HashMap<>();
+                      requireNonNull(map.get("one")).equals("");
+              	}
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -474,7 +474,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             }
                             throw new IllegalArgumentException("Expected a template that would generate exactly one " +
                                                                "statement to replace one statement, but generated " + gen.size() +
-                                                               ". Template:\n" + substitutedTemplate);
+                                                               ". Template:\n" + substitutedTemplate + "\nSubstitutions:\n" + substitutions +
+                                                               "\nStatement:\n" + statement);
                         }
 
                         return autoFormat(gen.get(0).withPrefix(statement.getPrefix()), p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -175,7 +175,8 @@ public class Substitutions {
             }
             return ((JavaType.Parameterized) type).getFullyQualifiedName() + joiner;
         } else if (type instanceof JavaType.GenericTypeVariable) {
-            return ((JavaType.GenericTypeVariable) type).getName();
+            String name = ((JavaType.GenericTypeVariable) type).getName();
+            return "?".equals(name) ? "Object" : name;
         } else if (type instanceof JavaType.FullyQualified) {
             return ((JavaType.FullyQualified) type).getFullyQualifiedName();
         } else if (type instanceof JavaType.Primitive) {


### PR DESCRIPTION
…Extension; not running

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
I wrote the test, but it's not running.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
To fix the ticket and get no exceptions and job done.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Right now, this test can't run. I get 
```
java.lang.IllegalStateException: LST contains missing or invalid type information
Identifier->MethodInvocation->Block->MethodDeclaration->Block->ClassDeclaration->CompilationUnit
/*~~(Identifier type is missing or malformed)~~>*/Assertions

	at org.openrewrite.java.Assertions.assertValidTypes(Assertions.java:87)
	at org.openrewrite.java.Assertions.validateTypes(Assertions.java:57)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:288)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:132)
	at org.openrewrite.java.JavaTemplateTest.replaceAnonymousClassObject1(JavaTemplateTest.java:1050)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```
If I try to analyze this test fixture, it looks like that example analysis starts here (Assertions#assertValidTypes -> FindMissingTypes#findMissingTypes). The compile unit analyze (JavaVisitor#visitCompilationUnit) the imports, but in the next step, analyze the classes, the unit and the imports are lost. So when we recursively land at the identifier, the import and the class are unknown. I don't know how to get it. Some other tests in the test class also have imports, and it looks like it works.

Side note: Gradle can't find org.junit.platform:junit-platform-launcher for the Java17 and Java21 submodules. The maven central repository is here, but it can't see it. I have enough troubles beside this, so I just commented them out. But it would be nice to know how to deal with such trouble. It's not a VPN or corporate network - just checked it.


## Anyone you would like to review specifically?
<!-- @mention them here -->
No

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Not at this stage.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
I just copy-paste another test and copy the whole equals recepie, because I don't know which part of it causes the bug. The same is about the before and after versions of the code. It could be optimized when this test is running. But feel free to change the name and some unimportant parts as soon as this test can run.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
