### PR TITLE
Change TypeParameter to be a Expression, to support kotlin intersection type

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5236,7 +5236,7 @@ public interface J extends Tree {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class TypeParameter implements J {
+    final class TypeParameter implements Expression {
         @Nullable
         @NonFinal
         transient WeakReference<Padding> padding;
@@ -5300,6 +5300,22 @@ public interface J extends Tree {
                 }
             }
             return p;
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public TypeParameter withType(@Nullable JavaType type) {
+            return this;
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
         }
 
         @RequiredArgsConstructor


### PR DESCRIPTION
This change is to support Kotlin intersection type like this

```kotlin
              import java.util.*

              @Suppress("UNUSED_PARAMETER")
              fun <T : Any?> test(n: Optional <  T   &    Any > = Optional.empty<T>()) {}
```

`Optional <  T   &    Any >` is a `J.ParameterizedType`, 
If we parse `T   &    Any` as a `J.TypeParameter`, then it needs to be a `J.Expression` since  `J.ParameterizedType` requires a `JContainer<Expression>` for type parameters.


There is an alternative way to avoid this change, which is to parse `T   &    Any` to a `K.Binary` with a new binary type.