### PR TITLE
fixed possible NPE when required methodPatternChain not provided

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
@@ -61,7 +61,7 @@ public class SimplifyMethodChain extends Recipe {
     public Validated<Object> validate() {
         return super.validate().and(Validated.test("methodPatternChain",
                 "Requires more than one pattern",
-                methodPatternChain, c -> c.size() > 1));
+                methodPatternChain, c -> c != null && c.size() > 1));
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
Checking if the parameter is != null before accessing it. If we do not properly populate the field, it will throw an NPE aside from the validation error.

## What's your motivation?
Fixes #3580

## Anyone you would like to review specifically?
@timtebeek @knutwannheden @Bananeweizen
