### PR TITLE
AutoFormat bug with method parameter alignment when using tabs

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -2387,4 +2387,25 @@ class TabsAndIndentsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void constructorArgumentsContinuation() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true)),
+          java(
+            """
+            import java.util.*;
+            
+            class Foo {
+            	Foo(
+            			String var1,
+            			String var2,
+            			String var3
+            	) {
+            	}
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -173,6 +173,27 @@ class TabsAndIndentsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void alignMethodDeclarationParamsWhenContinuationIndentUsingTabs() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true)),
+          java(
+            """
+            import java.util.*;
+            
+            class Foo {
+            	Foo(
+            			String var1,
+            			String var2,
+            			String var3
+            	) {
+            	}
+            }
+            """
+          )
+        );
+    }
+
     // https://rules.sonarsource.com/java/tag/confusing/RSPEC-3973
     @DocumentExample
     @SuppressWarnings("SuspiciousIndentAfterControlStatement")
@@ -2384,27 +2405,6 @@ class TabsAndIndentsTest implements RewriteTest {
                   }
               }
               """
-          )
-        );
-    }
-
-    @Test
-    void constructorArgumentsContinuation() {
-        rewriteRun(
-          tabsAndIndents(style -> style.withUseTabCharacter(true)),
-          java(
-            """
-            import java.util.*;
-            
-            class Foo {
-            	Foo(
-            			String var1,
-            			String var2,
-            			String var3
-            	) {
-            	}
-            }
-            """
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -235,7 +235,7 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                             if (method != null) {
                                 int alignTo;
                                 if (firstArg.getPrefix().getLastWhitespace().contains("\n")) {
-                                    alignTo = firstArg.getPrefix().getLastWhitespace().length() - 1;
+                                    alignTo = getLengthOfWhitespace(firstArg.getPrefix().getLastWhitespace()) - 1;
                                 } else {
                                     String source = method.print(getCursor());
                                     int firstArgIndex = source.indexOf(firstArg.print(getCursor()));

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -235,7 +235,7 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
                             if (method != null) {
                                 int alignTo;
                                 if (firstArg.getPrefix().getLastWhitespace().contains("\n")) {
-                                    alignTo = getLengthOfWhitespace(firstArg.getPrefix().getLastWhitespace()) - 1;
+                                    alignTo = getLengthOfWhitespace(firstArg.getPrefix().getLastWhitespace());
                                 } else {
                                     String source = method.print(getCursor());
                                     int firstArgIndex = source.indexOf(firstArg.print(getCursor()));


### PR DESCRIPTION
## What's changed?
Test case showing bug with continuation indents improperly being auto formatted.

## Any additional context
I've seen another case related to continuation indents for method arguments as well as method chains, but haven't been able to reproduce that case yet.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
