### PR TITLE
Don't use static import on collision with local method

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -93,6 +93,29 @@ class UseStaticImportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void sameMethodLocallyNoStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.util.Collections emptyList()")),
+          java(
+            """
+            import java.util.Collections;
+            import java.util.List;
+
+            public class SameMethodNameLocally {
+                public void avoidCollision() {
+                    List<Object> list = Collections.emptyList();
+                }
+                
+                private int emptyList(String canHaveDifferentArguments) {
+                }
+            }
+            """
+          )
+        );
+    }
+
     @Test
     void methodInvocationsHavingNullSelect() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.openrewrite.*;
+import org.openrewrite.java.search.DeclaresMethod;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -50,7 +51,10 @@ public class UseStaticImport extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesMethod<>(methodPattern), new UseStaticImportVisitor());
+        int indexSpace = methodPattern.indexOf(' ');
+        int indexBrace = methodPattern.indexOf('(', indexSpace);
+        String identicalMethodName = "* " + methodPattern.substring(indexSpace, indexBrace) + "(..)";
+        return Preconditions.check(Preconditions.and(new UsesMethod<>(methodPattern), Preconditions.not(new DeclaresMethod<>(identicalMethodName))), new UseStaticImportVisitor());
     }
 
     private class UseStaticImportVisitor extends JavaIsoVisitor<ExecutionContext> {


### PR DESCRIPTION
If a class declares a method with the same name as a candidate for a static import, then that will always lead to compile errors if the static import is applied. Therefore the recipe must check for not having any similarly named method locally.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Additional precondition for static import, namely `not(DeclaresMethod("* sameNameAsMethodPattern(..)"`.

## What's your motivation?
Quite some compile errors on larger code bases with UseStaticImport recipe. The included unit test demonstrates this and leads to uncompilable code without the change.

## Anything in particular you'd like reviewers to focus on?
The method pattern is created via String manipulation. Not sure if there are better ways using MethodPattern, MethodPatternParser etc. but that was hard to explore.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
