### PR TITLE
Only run recipe a single cycle when possible

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -83,7 +83,7 @@ public class RecipeScheduler {
                 }
 
                 if (i >= minCycles &&
-                    ((cycle.madeChangesInThisCycle.isEmpty() && !ctxWithWatch.hasNewMessages()) &&
+                    ((cycle.madeChangesInThisCycle.isEmpty() && !ctxWithWatch.hasNewMessages()) ||
                      !anyRecipeCausingAnotherCycle)) {
                     after.afterCycle(true);
                     break;
@@ -136,7 +136,7 @@ public class RecipeScheduler {
 
         long cycleStartTime = System.nanoTime();
         AtomicBoolean thrownErrorOnTimeout = new AtomicBoolean();
-        List<Recipe> madeChangesInThisCycle = new ArrayList<>();
+        Set<Recipe> madeChangesInThisCycle = Collections.newSetFromMap(new IdentityHashMap<>());
 
         public LargeSourceSet scanSources(LargeSourceSet sourceSet, int cycle) {
             return mapForRecipeRecursively(sourceSet, (recipeStack, sourceFile) -> {

--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -83,8 +83,7 @@ public class RecipeScheduler {
                 }
 
                 if (i >= minCycles &&
-                    ((cycle.madeChangesInThisCycle.isEmpty() && !ctxWithWatch.hasNewMessages()) ||
-                     !anyRecipeCausingAnotherCycle)) {
+                    (cycle.madeChangesInThisCycle.isEmpty() || !anyRecipeCausingAnotherCycle)) {
                     after.afterCycle(true);
                     break;
                 }
@@ -128,7 +127,7 @@ public class RecipeScheduler {
         Recipe recipe;
         int cycle;
         Cursor rootCursor;
-        ExecutionContext ctx;
+        WatchableExecutionContext ctx;
         RecipeRunStats recipeRunStats;
         SourcesFileResults sourcesFileResults;
         SourcesFileErrors errorsTable;
@@ -242,6 +241,10 @@ public class RecipeScheduler {
                             return sourceFile;
                         }
                         recipeRunStats.recordSourceFileChanged(sourceFile, after);
+                    } else if (ctx.hasNewMessages()) {
+                        // consider any recipes adding new messages as a changing recipe (which can request another cycle)
+                        madeChangesInThisCycle.add(recipeStack.peek());
+                        ctx.resetHasNewMessages();
                     }
                 } catch (Throwable t) {
                     after = handleError(recipe, sourceFile, after, t);


### PR DESCRIPTION
Partially revert 0902de56473f03f11bf1b2262a0039bec16f40f8 so that the recipe scheduler only runs a single cycle if a _changing recipe_ explicitly requested another cycle. In this context a recipe which adds a message to the `ExecutionContext` is also considered a changing recipe.

Also, use a `Set` (specifically a `Set` based on `IdentityHashMap`) to track the recipes that made changes in a cycle. This improves performance a bit, because the recipe instances are typically the same and then there is no need to query the same recipe repeatedly for `causesAnotherCycle()`.