### PR TITLE
Stop over eager exclude of UseStaticImport

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -117,6 +117,36 @@ class UseStaticImportTest implements RewriteTest {
     }
 
     @Test
+    void doReplaceWhenWildcard() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.util.Collections *()")),
+          java(
+            """
+            import java.util.Collections;
+            import java.util.List;
+
+            class SameMethodNameLocally {
+                void avoidCollision() {
+                    List<Object> list = Collections.emptyList();
+                }
+            }
+            """,
+            """
+            import java.util.List;
+            
+            import static java.util.Collections.emptyList;
+
+            class SameMethodNameLocally {
+                void avoidCollision() {
+                    List<Object> list = emptyList();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void methodInvocationsHavingNullSelect() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -51,10 +51,15 @@ public class UseStaticImport extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        int indexSpace = methodPattern.indexOf(' ');
-        int indexBrace = methodPattern.indexOf('(', indexSpace);
-        String identicalMethodName = "* " + methodPattern.substring(indexSpace, indexBrace) + "(..)";
-        return Preconditions.check(Preconditions.and(new UsesMethod<>(methodPattern), Preconditions.not(new DeclaresMethod<>(identicalMethodName))), new UseStaticImportVisitor());
+        TreeVisitor<?, ExecutionContext> preconditions = new UsesMethod<>(methodPattern);
+        if (!methodPattern.contains(" *(")) {
+            int indexSpace = methodPattern.indexOf(' ');
+            int indexBrace = methodPattern.indexOf('(', indexSpace);
+            String methodNameMatcher = methodPattern.substring(indexSpace, indexBrace);
+            preconditions = Preconditions.and(preconditions,
+                    Preconditions.not(new DeclaresMethod<>("* " + methodNameMatcher + "(..)")));
+        }
+        return Preconditions.check(preconditions, new UseStaticImportVisitor());
     }
 
     private class UseStaticImportVisitor extends JavaIsoVisitor<ExecutionContext> {


### PR DESCRIPTION
Fixes [org.openrewrite.java.testing.junit5.AssertToAssertionsTest#staticallyImportAssertions](https://github.com/openrewrite/rewrite-testing-frameworks/blob/39dc67cab9a2d32ed000e5ad1348d31cae3979cd/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java#L318) after
- https://github.com/openrewrite/rewrite/pull/3729
