### PR TITLE
Ensure SourceSpec text blcks start on a new line

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentationTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class SourceSpecTextBlockIndentationTest implements RewriteTest {
+class SourceSpecTextBlockIndentationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -67,6 +67,58 @@ public class SourceSpecTextBlockIndentationTest implements RewriteTest {
                     rewriteRun(
                        text(
                          \"""
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \"""
+                       )
+                    );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void startsOnNewline() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(\"""
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \"""
+                       )
+                    );
+                  }
+              }
+              """,
+
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(
+                            \"""
                            class Test {
               \s
                               \s

--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentation.java
@@ -21,6 +21,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Arrays;
@@ -77,7 +78,7 @@ public class SourceSpecTextBlockIndentation extends Recipe {
                                     nonSpaceCharacter[0] &&
                                     nonSpaceCharacter[indentations.length - 2] &&
                                     indentations[0] == indentations[indentations.length - 2] &&
-                                    indentations[0] > expectedIndent) {
+                                    indentations[0] >= expectedIndent) {
 
                                     for (int i = 0; i < indentations.length - 1; i++) {
                                         if (nonSpaceCharacter[i] && indentations[i] < indentations[0]) {
@@ -91,14 +92,19 @@ public class SourceSpecTextBlockIndentation extends Recipe {
                                     StringJoiner fixedSource = new StringJoiner("\n");
                                     for (int i = 0; i < lines.length; i++) {
                                         String line = lines[i];
-                                        if(i == 0 || i == lines.length - 1 || indentations[i - 1] < expectedIndent) {
+                                        if (i == 0 || i == lines.length - 1 || indentations[i - 1] < expectedIndent) {
                                             fixedSource.add(line);
                                         } else {
                                             fixedSource.add(line.substring(marginTrim));
                                         }
                                     }
 
-                                    return source.withValueSource(fixedSource.toString());
+                                    J.Literal withFixedSource = source.withValueSource(fixedSource.toString());
+                                    if (withFixedSource.getPrefix().getComments().isEmpty()
+                                        && withFixedSource.getPrefix().getWhitespace().isEmpty()) {
+                                        return maybeAutoFormat(withFixedSource, withFixedSource.withPrefix(Space.format("\n")), ctx);
+                                    }
+                                    return withFixedSource;
                                 }
 
                             }


### PR DESCRIPTION
## What's changed?
Add a newline & autoformat when SourceSpec text block has no whitespace or comment prefix.

## What's your motivation?
Commonly pointed out in review; by automating the code change & review we reduce review burden, and get more consistent code.