### PR TITLE
Added data table for counting mapped types.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypeMappingsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypeMappingsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.table.TypeMappings.*;
+
+class FindTypeMappingsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new FindTypeMappings());
+    }
+
+    @Test
+    void findTypeMappings() {
+        rewriteRun(
+          spec -> spec.dataTable(Row.class, table -> {
+              assertThat(table).hasSize(14);
+              boolean firstCount = false;
+              boolean secondCount = false;
+              for (Row row : table) {
+                  if (row.getTreeName().equals("org.openrewrite.java.tree.J$ClassDeclaration") ||
+                          row.getTreeName().equals("org.openrewrite.java.tree.J$Identifier") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Parameterized") ||
+                          row.getTreeName().equals("org.openrewrite.java.tree.J$Identifier") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Variable") ||
+                          row.getTreeName().equals("org.openrewrite.java.tree.J$NewClass") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Class") ||
+                          row.getTreeName().equals("org.openrewrite.java.tree.J$NewClass") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Method") ||
+                          row.getTreeName().equals("oorg.openrewrite.java.tree.J$VariableDeclarations$NamedVariable") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Parameterized") ||
+                          row.getTreeName().equals("oorg.openrewrite.java.tree.J$VariableDeclarations$NamedVariable") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Variable") ||
+                          row.getTreeName().equals("org.openrewrite.java.tree.J$VariableDeclarations")) {
+                      assertThat(row.getCount()).isEqualTo(1);
+                      firstCount = true;
+                  } else if (row.getTreeName().equals("org.openrewrite.java.tree.J$Identifier") && row.getTypeName().equals("org.openrewrite.java.tree.JavaType$Class")) {
+                      assertThat(row.getCount()).isEqualTo(6);
+                      secondCount = true;
+                  }
+              }
+              assertThat(firstCount).isTrue();
+              assertThat(secondCount).isTrue();
+            }),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              public class Test {
+                  List<String> l = new ArrayList<>();
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypeMappings.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypeMappings.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.table.TypeMappings;
+import org.openrewrite.java.tree.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindTypeMappings extends ScanningRecipe<FindTypeMappings.Accumulator> {
+    transient TypeMappings typeMappingsPerSource = new TypeMappings(this);
+
+    @Override
+    public String getDisplayName() {
+        return "Find type mappings";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find types mapped to J trees.";
+    }
+
+    @Data
+    public static class Accumulator {
+        Map<String, Map<String, Map<String, AtomicInteger>>> sourceToMappedTypeCount = new HashMap<>();
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            String sourcePath = "";
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                sourcePath = cu.getSourcePath().toString();
+                return super.visitCompilationUnit(cu, executionContext);
+            }
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, ExecutionContext executionContext) {
+                if (tree instanceof TypedTree) {
+                    Map<String, AtomicInteger> counts = acc.getSourceToMappedTypeCount()
+                            .computeIfAbsent(sourcePath, k -> new HashMap<>())
+                            .computeIfAbsent(tree.getClass().getName(), k -> new HashMap<>());
+                    if (tree instanceof J.Identifier) {
+                        J.Identifier i = (J.Identifier) tree;
+                        if (i.getFieldType() != null) {
+                            counts.computeIfAbsent(i.getFieldType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        }
+                    } else if (tree instanceof J.MemberReference) {
+                        J.MemberReference m = (J.MemberReference) tree;
+                        if (m.getVariableType() != null) {
+                            counts.computeIfAbsent(m.getVariableType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        } else if (m.getMethodType() != null) {
+                            counts.computeIfAbsent(m.getMethodType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        }
+                    } else if (tree instanceof J.MethodDeclaration) {
+                        J.MethodDeclaration m = (J.MethodDeclaration) tree;
+                        if (m.getMethodType() != null) {
+                            counts.computeIfAbsent(m.getMethodType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        }
+                    } else if (tree instanceof J.MethodInvocation) {
+                        J.MethodInvocation m = (J.MethodInvocation) tree;
+                        if (m.getMethodType() != null) {
+                            counts.computeIfAbsent(m.getMethodType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        }
+                    } else if (tree instanceof J.NewClass) {
+                        J.NewClass m = (J.NewClass) tree;
+                        if (m.getMethodType() != null) {
+                            counts.computeIfAbsent(m.getMethodType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        }
+                    } else if (tree instanceof J.VariableDeclarations.NamedVariable) {
+                        J.VariableDeclarations.NamedVariable n = (J.VariableDeclarations.NamedVariable) tree;
+                        if (n.getVariableType() != null) {
+                            counts.computeIfAbsent(n.getVariableType().getClass().getName(), k -> new AtomicInteger(0))
+                                    .incrementAndGet();
+                        }
+                    }
+                    counts.computeIfAbsent(((TypedTree) tree).getType() == null ?
+                                    "null" :
+                                    ((TypedTree) tree).getType().getClass().getName(), k -> new AtomicInteger(0))
+                            .incrementAndGet();
+                }
+                return super.visit(tree, executionContext);
+            }
+        };
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(Accumulator acc, ExecutionContext ctx) {
+        for (Map.Entry<String, Map<String, Map<String, AtomicInteger>>> sources : acc.getSourceToMappedTypeCount().entrySet()) {
+            for (Map.Entry<String, Map<String, AtomicInteger>> trees : sources.getValue().entrySet()) {
+                for (Map.Entry<String, AtomicInteger> types : trees.getValue().entrySet()) {
+                    typeMappingsPerSource.insertRow(ctx, new TypeMappings.Row(sources.getKey(), trees.getKey(), types.getKey(), types.getValue().get()));
+                }
+            }
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/TypeMappings.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/TypeMappings.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class TypeMappings extends DataTable<TypeMappings.Row> {
+
+    public TypeMappings(Recipe recipe) {
+        super(recipe,
+                "Type mapping",
+                "The types mapped to J trees.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source file",
+                description = "The source file that the method call occurred in.")
+        String sourceFile;
+
+        @Column(displayName = "Tree class name",
+                description = "The class name of the tree.")
+        String treeName;
+
+        @Column(displayName = "Java type class name",
+                description = "The class name of the java type.")
+        String typeName;
+
+        @Column(displayName = "Java type class name",
+                description = "The class name of the java type.")
+        Integer count;
+    }
+}


### PR DESCRIPTION
Changes:

- Added `TypeMappings` data-table to `rewrite-java`.
- Added `FindTypeMappings` ScanningRecipe to count mapped types for J trees.