### PR TITLE
Added a few type validation checks to FindMissingTypes.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest3Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest3Test.java
@@ -369,7 +369,7 @@ class JavaTemplateTest3Test implements RewriteTest {
               public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                   J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                   if (mi.getSimpleName().equals("acceptInteger")) {
-                      return JavaTemplate.builder("acceptString(#{any()}.toString())").contextSensitive()
+                      mi = JavaTemplate.builder("acceptString(#{any()}.toString())").contextSensitive()
                         .javaParser(JavaParser.fromJavaVersion()
                           .dependsOn(
                             """
@@ -384,6 +384,7 @@ class JavaTemplateTest3Test implements RewriteTest {
                         )
                         .build()
                         .apply(updateCursor(mi), mi.getCoordinates().replaceMethod(), mi.getArguments().get(0));
+                      mi = mi.withName(mi.getName().withType(mi.getMethodType()));
                   }
                   return mi;
               }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest5Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest5Test.java
@@ -140,10 +140,11 @@ class JavaTemplateTest5Test implements RewriteTest {
               @Override
               public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                   if (method.getArguments().size() == 1) {
-                      return JavaTemplate.builder("m, Integer.valueOf(n), \"foo\"")
+                      method = JavaTemplate.builder("m, Integer.valueOf(n), \"foo\"")
                         .contextSensitive()
                         .build()
                         .apply(getCursor(), method.getCoordinates().replaceArguments());
+                      method = method.withName(method.getName().withType(method.getMethodType()));
                   }
                   return method;
               }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
@@ -98,7 +98,7 @@ public class ChangeMethodName extends Recipe {
                     if (type != null) {
                         type = type.withName(newMethodName);
                     }
-                    m = m.withName(m.getName().withSimpleName(newMethodName))
+                    m = m.withName(m.getName().withSimpleName(newMethodName).withType(type))
                             .withMethodType(type);
                 }
                 return m;
@@ -112,7 +112,7 @@ public class ChangeMethodName extends Recipe {
                     if (type != null) {
                         type = type.withName(newMethodName);
                     }
-                    m = m.withName(m.getName().withSimpleName(newMethodName))
+                    m = m.withName(m.getName().withSimpleName(newMethodName).withType(type))
                             .withMethodType(type);
                 }
                 return m;

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -149,7 +149,8 @@ public class ChangeMethodTargetToStatic extends Recipe {
                             )
                     );
                 }
-                m = m.withMethodType(transformedType);
+                m = m.withMethodType(transformedType)
+                        .withName(m.getName().withType(transformedType));
             }
             return m;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToVariable.java
@@ -114,7 +114,8 @@ public class ChangeMethodTargetToVariable extends Recipe {
                         variableName,
                         this.variableType,
                         null)
-                ).withMethodType(methodType);
+                ).withMethodType(methodType)
+                        .withName(m.getName().withType(methodType));
             }
             return m;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -198,10 +198,12 @@ public class ChangePackage extends Recipe {
             J j = super.postVisit(tree, executionContext);
             if (j instanceof J.MethodDeclaration) {
                 J.MethodDeclaration m = (J.MethodDeclaration) j;
-                return m.withMethodType(updateType(m.getMethodType()));
+                JavaType.Method mt = updateType(m.getMethodType());
+                return m.withMethodType(mt).withName(m.getName().withType(mt));
             } else if (j instanceof J.MethodInvocation) {
                 J.MethodInvocation m = (J.MethodInvocation) j;
-                return m.withMethodType(updateType(m.getMethodType()));
+                JavaType.Method mt = updateType(m.getMethodType());
+                return m.withMethodType(mt).withName(m.getName().withType(mt));
             } else if (j instanceof J.NewClass) {
                 J.NewClass n = (J.NewClass) j;
                 return n.withConstructorType(updateType(n.getConstructorType()));

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -160,10 +160,14 @@ public class ChangeType extends Recipe {
             J j = super.postVisit(tree, ctx);
             if (j instanceof J.MethodDeclaration) {
                 J.MethodDeclaration method = (J.MethodDeclaration) j;
-                j = method.withMethodType(updateType(method.getMethodType()));
+                JavaType.Method mt = updateType(method.getMethodType());
+                j = method.withMethodType(mt)
+                        .withName(method.getName().withType(mt));
             } else if (j instanceof J.MethodInvocation) {
                 J.MethodInvocation method = (J.MethodInvocation) j;
-                j = method.withMethodType(updateType(method.getMethodType()));
+                JavaType.Method mt = updateType(method.getMethodType());
+                j = method.withMethodType(mt)
+                        .withName(method.getName().withType(mt));
             } else if (j instanceof J.NewClass) {
                 J.NewClass n = (J.NewClass) j;
                 j = n.withConstructorType(updateType(n.getConstructorType()));

--- a/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ImplementInterface.java
@@ -84,7 +84,7 @@ public class ImplementInterface<P> extends JavaIsoVisitor<P> {
                         randomId(),
                         Space.EMPTY,
                         Markers.EMPTY,
-                        impl,
+                        interfaceType instanceof JavaType.Parameterized ? impl.withType(((JavaType.Parameterized) interfaceType).getType()) : impl,
                         JContainer.build(Space.EMPTY, elements, Markers.EMPTY),
                         interfaceType
                 );

--- a/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
@@ -22,6 +22,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,9 +95,10 @@ public class SimplifyMethodChain extends Recipe {
 
                 if (select instanceof J.MethodInvocation) {
                     assert m.getMethodType() != null;
+                    JavaType.Method mt = m.getMethodType().withName(newMethodName);
                     return m.withSelect(((J.MethodInvocation) select).getSelect())
-                            .withName(m.getName().withSimpleName(newMethodName))
-                            .withMethodType(m.getMethodType().withName(newMethodName));
+                            .withName(m.getName().withSimpleName(newMethodName).withType(mt))
+                            .withMethodType(mt);
                 }
 
                 return m;

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
@@ -140,6 +140,9 @@ public class FindMissingTypes extends Recipe {
                 } else if (!type.getName().equals(mi.getSimpleName()) && !type.isConstructor()) {
                     mi = SearchResult.found(mi, "type information has a different method name '" + type.getName() + "'");
                 }
+                if (mi.getName().getType() != null && type != mi.getName().getType()) {
+                    mi = SearchResult.found(mi, "MethodInvocation#name type is not the MethodType of MethodInvocation.");
+                }
             }
             return mi;
         }
@@ -174,6 +177,9 @@ public class FindMissingTypes extends Recipe {
             } else if (!md.getSimpleName().equals(type.getName()) && !type.isConstructor()) {
                 md = SearchResult.found(md, "type information has a different method name '" + type.getName() + "'");
             }
+            if (md.getName().getType() != null && type != md.getName().getType()) {
+                md = SearchResult.found(md, "MethodDeclaration#name type is not the MethodType of MethodDeclaration.");
+            }
             return md;
         }
 
@@ -205,7 +211,21 @@ public class FindMissingTypes extends Recipe {
             if (n == newClass && !isWellFormedType(n.getType(), seenTypes)) {
                 n = SearchResult.found(n, "NewClass type is missing or malformed");
             }
+            if (n.getClazz() instanceof J.Identifier && n.getClazz().getType() != null &&
+                    !(n.getClazz().getType() instanceof JavaType.Class || n.getClazz().getType() instanceof JavaType.Unknown)) {
+                n = SearchResult.found(n, "NewClass#clazz is J.Identifier and the type is is not JavaType$Class.");
+            }
             return n;
+        }
+
+        @Override
+        public J.ParameterizedType visitParameterizedType(J.ParameterizedType type, ExecutionContext executionContext) {
+            J.ParameterizedType p = super.visitParameterizedType(type, executionContext);
+            if (p.getClazz() instanceof J.Identifier && p.getClazz().getType() != null &&
+                    !(p.getClazz().getType() instanceof JavaType.Class || p.getClazz().getType() instanceof JavaType.Unknown)) {
+                p = SearchResult.found(p, "ParameterizedType#clazz is J.Identifier and the type is is not JavaType$Class.");
+            }
+            return p;
         }
 
         private boolean isAllowedToHaveNullType(J.Identifier ident) {


### PR DESCRIPTION
Changes:

- FindMissingTypes will validate the `name` field `MethodInvocation` and `MethodDeclaration` when the method type is not null and the type on the identifier is not null.
- FindMissingTypes will validate the `clazz` field on `J.ParameterizedType` and `J.NewClass` when the clazz is a `J.Identifier` and the type is not null.
- ChangeMethodName, ChangeMethodTargetToStatic, ChangeMethodTargetToVariable, ChangePackage, ChangeType, SimplifyMethodChain, and ImplementInterface will update the old type with the new type on applicable identifiers.

These types occur from the Java compiler and are expected on the LST. The changes help to identify unexpected changes through recipes and misaligned type mappings in other implementations of `J`.
fixes #3739