### PR TITLE
Added quoted marker to represent escaped identifiers.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/Quoted.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/Quoted.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Represents escaped identifiers.
+ */
+@Value
+@With
+public class Quoted implements Marker {
+    UUID id;
+}


### PR DESCRIPTION
This marker will represent quoted identifiers in languages like JavaScript and Kotlin.
The change will allow the identifier text to be correctly represented while preserving the escapes.

Example: ChangeType from Map to List should update the identifiers correctly from:
```
`Map`
```
to
```
`List`
```