### PR TITLE
Fix for #3759

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -977,8 +977,11 @@ public class GroovyParserVisitor {
                             J.Case.Type.Statement,
                             null,
                             JContainer.build(singletonList(JRightPadded.build(visit(statement.getExpression())))),
-                            JContainer.build(sourceBefore(":"),
-                                    convertStatements(((BlockStatement) statement.getCode()).getStatements(), t -> Space.EMPTY), Markers.EMPTY),
+                            statement.getCode() instanceof EmptyStatement?JContainer.build(sourceBefore(":"),
+                                    convertStatements(emptyList(), t -> Space.EMPTY), Markers.EMPTY):JContainer.build(sourceBefore(":"),
+                                    convertStatements(((BlockStatement) statement.getCode()).getStatements(), t -> Space.EMPTY), Markers.EMPTY)
+
+                            ,
                             null
                     )
             );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/SwitchTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/SwitchTest.java
@@ -139,4 +139,20 @@ class SwitchTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void fallthroughCase() {
+        rewriteRun(
+          groovy(
+            """
+              switch("foo") {
+                  case "foo":
+                  case "bar": {
+                     break
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Allow empty statement to support case-fallthrough.



## What's changed?
Groovy parsing case-statement allows empty statement instead of just blockstatement.


## What's your motivation?
We're having Jenkinsfiles we want to change with openrewrite. These contain fallthrough-case statements. Because of #3759 recipes are failing with parsing errors.


## Anything in particular you'd like reviewers to focus on?
I'm not quite sure which kind of other statement may follow a case-statement apart from EmptyStatement and BlockStatement. My code just adds EmptyStatement support.

## Have you considered any alternatives or workarounds?
As I want to change the Jenkinsfiles automatically changing them manually is not an option for me.

### Checklist
- [x ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
