### PR TITLE
Support `@OptionGroup` on `Recipe`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/OptionGroup.java
+++ b/rewrite-core/src/main/java/org/openrewrite/OptionGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package org.openrewrite;
 
-import org.intellij.lang.annotations.Language;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -23,17 +24,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Options are used to configure recipes. They are annotated on fields of recipes and are used to generate
- * documentation and to validate user input.
+ * Nested options are used to configure recipes.
  * <p>
- * For nested options, see {@link OptionGroup}.
+ * They allow for options to be re-used across multiple {@link Recipe} implementations through object composition.
+ * <p>
+ * Fields annotated with this method <i>may</i> also be annotated with {@link JsonUnwrapped} for further configuration
+ * of the deserialized JSON.
  */
+@Incubating(since = "8.12.0")
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Option {
-    @Language("markdown") String displayName() default "";
-    @Language("markdown") String description() default "";
-    String example() default "";
-    String[] valid() default "";
-    boolean required() default true;
+@JsonUnwrapped
+@JacksonAnnotationsInside
+public @interface OptionGroup {
 }

--- a/rewrite-core/src/test/java/org/openrewrite/OptionGroupTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/OptionGroupTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.config.YamlResourceLoader;
+import org.openrewrite.test.RewriteTest;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OptionGroupTest implements RewriteTest {
+
+    @Value
+    public static class AnOptionGroup {
+        @Option(displayName = "Option within a nested class", description = "Option")
+        String aNestedOption;
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    public static class ARecipe extends Recipe {
+
+        @Option(displayName = "An option", description = "Option")
+        String anOption;
+
+        @OptionGroup
+        AnOptionGroup aGroup;
+
+        @Override
+        public String getDisplayName() {
+            return "A Recipe";
+        }
+
+        @Override
+        public String getDescription() {
+            return "A Recipe Description";
+        }
+    }
+
+    @Test
+    public void nestedOption() {
+        ARecipe recipe = new ARecipe(
+                "An option",
+                new AnOptionGroup("A nested option")
+        );
+        RecipeDescriptor descriptor = recipe.getDescriptor();
+        assertEquals(2, descriptor.getOptions().size(), "Option count");
+    }
+
+    @Test
+    void loadingNested() {
+        Environment env = Environment.builder()
+                .load(new YamlResourceLoader(new ByteArrayInputStream(
+                        //language=yml
+                        """
+                                type: specs.openrewrite.org/v1beta/recipe
+                                name: test.LoadNestedRecipe
+                                displayName: Load Nested Recipe
+                                recipeList:
+                                    - org.openrewrite.OptionGroupTest$ARecipe:
+                                        anOption: Hello!
+                                        aNestedOption: World!
+                                """.getBytes()
+                ), URI.create("rewrite.yml"), new Properties()))
+                .build();
+
+        Collection<RecipeDescriptor> yamlRecipeDescriptors = env.listRecipeDescriptors();
+        assertThat(yamlRecipeDescriptors).hasSize(1);
+        RecipeDescriptor descriptor = yamlRecipeDescriptors.iterator().next();
+        Collection<RecipeDescriptor> recipeDescriptorList = descriptor.getRecipeList();
+        assertThat(recipeDescriptorList).hasSize(1);
+        RecipeDescriptor recipeDescriptor = recipeDescriptorList.iterator().next();
+        assertThat(recipeDescriptor.getOptions()).hasSize(2);
+
+        List<Recipe> recipes = env.listRecipes();
+        assertThat(recipes).hasSize(1);
+        Recipe loadRecipe = recipes.iterator().next();
+        assertThat(loadRecipe.getRecipeList()).hasSize(1);
+        Recipe aRecipeUntyped = loadRecipe.getRecipeList().iterator().next();
+        assertThat(aRecipeUntyped).isExactlyInstanceOf(ARecipe.class);
+        ARecipe aRecipe = (ARecipe) aRecipeUntyped;
+        assertThat(aRecipe.getAnOption()).isEqualTo("Hello!");
+        assertThat(aRecipe.getAGroup().getANestedOption()).isEqualTo("World!");
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcherOption.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcherOption.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.Value;
+import org.openrewrite.Incubating;
+import org.openrewrite.Option;
+import org.openrewrite.internal.lang.Nullable;
+
+@Value
+@Incubating(since = "8.12.0")
+public class MethodMatcherOption {
+
+    @Option(displayName = "Method pattern",
+            description = "A method pattern that is used to find matching method declarations/invocations.",
+            example = "org.mockito.Matchers anyVararg()")
+    String methodPattern;
+
+    @Option(displayName = "Match on overrides",
+            description = "When enabled, find methods that are overrides of the method pattern.",
+            required = false)
+    @Nullable
+    Boolean matchOverrides;
+
+    public MethodMatcher methodMatcher() {
+        return new MethodMatcher(methodPattern, matchOverrides);
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/MethodMatcherOptionTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/MethodMatcherOptionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.OptionGroup;
+import org.openrewrite.Recipe;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.OptionDescriptor;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.config.YamlResourceLoader;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class MethodMatcherOptionTest {
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    public static class MethodMatcherOptionRecipe extends Recipe {
+
+        @OptionGroup
+        @JsonUnwrapped(prefix = "a-")
+        MethodMatcherOption aMethodMatcherOption;
+
+        @OptionGroup
+        @JsonUnwrapped(prefix = "b-")
+        MethodMatcherOption bMethodMatcherOption;
+
+        @OptionGroup
+        @JsonUnwrapped(suffix = "-a")
+        MethodMatcherOption methodMatcherOptionA;
+
+        @Override
+        public String getDisplayName() {
+            return "Method Matcher Option Recipe";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Method Matcher Option Recipe Description";
+        }
+    }
+
+    @Test
+    void loadingNested() {
+        Environment env = Environment.builder()
+                .load(new YamlResourceLoader(new ByteArrayInputStream(
+                        //language=yml
+                        """
+                                type: specs.openrewrite.org/v1beta/recipe
+                                name: test.LoadNestedMethodMatcherRecipe
+                                displayName: Load Nested Recipe
+                                recipeList:
+                                    - org.openrewrite.java.MethodMatcherOptionTest$MethodMatcherOptionRecipe:
+                                        a-methodPattern: "java.util.List add(..)"
+                                        a-matchOverrides: True
+                                        b-methodPattern: "java.util.Set add(..)"
+                                        methodPattern-a: "java.util.Map put(..)"
+                                """.getBytes()
+                ), URI.create("rewrite.yml"), new Properties()))
+                .build();
+
+        Collection<RecipeDescriptor> yamlRecipeDescriptors = env.listRecipeDescriptors();
+        // Sanity check
+        assertThat(yamlRecipeDescriptors).hasSize(1);
+        RecipeDescriptor descriptor = yamlRecipeDescriptors.iterator().next();
+        Collection<RecipeDescriptor> recipeDescriptorList = descriptor.getRecipeList();
+        // Sanity check
+        assertThat(recipeDescriptorList).hasSize(1);
+        RecipeDescriptor recipeDescriptor = recipeDescriptorList.iterator().next();
+
+        assertThat(recipeDescriptor.getOptions()).hasSize(6);
+        assertThat(recipeDescriptor.getOptions().stream().map(OptionDescriptor::getName)).contains(
+                "a-methodPattern",
+                "a-matchOverrides",
+                "b-methodPattern",
+                "b-matchOverrides",
+                "methodPattern-a",
+                "matchOverrides-a"
+        );
+
+        List<Recipe> recipes = env.listRecipes();
+        assertThat(recipes).hasSize(1);
+        Recipe loadRecipe = recipes.iterator().next();
+        assertThat(loadRecipe.getRecipeList()).hasSize(1);
+        Recipe aRecipeUntyped = loadRecipe.getRecipeList().iterator().next();
+        assertThat(aRecipeUntyped).isExactlyInstanceOf(MethodMatcherOptionRecipe.class);
+        MethodMatcherOptionRecipe methodMatcherOptionRecipe = (MethodMatcherOptionRecipe) aRecipeUntyped;
+        assertThatNoException().isThrownBy(() -> methodMatcherOptionRecipe.getAMethodMatcherOption().methodMatcher());
+        assertThatNoException().isThrownBy(() -> methodMatcherOptionRecipe.getBMethodMatcherOption().methodMatcher());
+        assertThatNoException().isThrownBy(() -> methodMatcherOptionRecipe.getMethodMatcherOptionA().methodMatcher());
+    }
+
+}


### PR DESCRIPTION
Enables composing `Recipe` of one or more objects annotated with `@OptionGroup` to support
re-use of recipe options between multiple recipes.

Supports serialization/deserialization correctly through the use of Jackson's `@JsonUnwrapped` annotation.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Modifies `Recipe`'s `getOptionDescriptors` to support a new `@NestedOption` annotation.


## What's your motivation?

As I'm building out recipes within `rewrite-java-security` I'm finding a desire to share the same configuration
options between multiple recipes.

In general, for security fix recipe, you only want to apply those recipes when both test and production source is modified.
Before 8.0 that heavily refactored recipes and how many source files were loaded into memory, this was possible with the `anySource` applicability test.

Eg:
```yaml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.SecurityModifyRecipe
displayName: Apply `SecureTempFileCreation`
description: Applies the `SecureTempFileCreation` to non-test sources first, if changes are made, then apply to all sources.
applicability:
  anySource:
    - org.openrewrite.java.search.IsLikelyNotTest
    - org.openrewrite.java.security.SecureTempFileCreation
recipeList:
  - org.openrewrite.java.security.SecureTempFileCreation
```

See: https://github.com/openrewrite/rewrite/discussions/2849

However, in 8.0 this was broken. As such, the current advice is to put this filtering into each security recipe individually.

In order to achive this, and reduce code-duplication, being able to compose recipes with a common set of options, will enable that, while reducing code duplication.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

As this feature will need to integrate with the Moderne SaaS as the interface for how these new composed options are tested, I'd want to sanity check that
SaaS invocation of Recipes uses jackson deserialization to instantiate them as I expect. If that is the case, then this feature should work seemlessly with the Moderne SaaS
without any needed changes there to support this functionality.

This feature should have no impact on any existing recipes or how those recipes are invoked by the SaaS.

I will test and verify this functionality works as-expected by modifying the recipes in `rewrite-java-security` to verify this works with the Moderne SaaS as expected.

## Anyone you would like to review specifically?

@sambsnyd

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

A single base-class with base options doesn't work as the fields on the base-class still need to be surfaced in the constructor of the subclasses for proper deserialization by Jackson. Additionally, `Recipe#getOptionDescriptors` currently uses `Class#getDeclaredFields` which, as documented, does not include inherited fields, so would not be seen when creating the `OptionDescriptor`

Lots of duplicate code, including duplicating option annotations between multiple recipes.
Using multiple hard-coded constants for each duplicated annotation.

This solution is more elegant IMHO.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
