### PR TITLE
Don't push to GE Build Cache without Creds

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,8 +96,8 @@ gradleEnterprise {
     buildCache {
         remote(HttpBuildCache::class) {
             url = uri("https://ge.openrewrite.org/cache/")
-            isPush = isCiServer
             if (!gradleCacheRemoteUsername.isNullOrBlank() && !gradleCacheRemotePassword.isNullOrBlank()) {
+                isPush = isCiServer
                 credentials {
                     username = gradleCacheRemoteUsername
                     password = gradleCacheRemotePassword


### PR DESCRIPTION
This was breaking my attempt to run the CodeQL scanner for OpenRewrite from my fork.
https://github.com/JLLeitschuh/rewrite-1/actions/runs/7094115471/job/19308794549#step:4:98

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
