### PR TITLE
Allow FindAndReplace to remove matches

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/AlreadyReplaced.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/AlreadyReplaced.java
@@ -17,6 +17,7 @@ package org.openrewrite.marker;
 
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.internal.lang.Nullable;
 
 import java.util.UUID;
 
@@ -29,5 +30,6 @@ import java.util.UUID;
 public class AlreadyReplaced implements Marker {
     UUID id;
     String find;
+    @Nullable
     String replace;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
@@ -44,7 +44,9 @@ public class FindAndReplace extends Recipe {
 
     @Option(displayName = "Replace",
             description = "The replacement text for `find`.",
-            example = "denylist")
+            example = "denylist",
+            required = false)
+    @Nullable
     String replace;
 
     @Option(displayName = "Regex",
@@ -106,9 +108,9 @@ public class FindAndReplace extends Recipe {
                     return sourceFile;
                 }
                 for (Marker marker : sourceFile.getMarkers().getMarkers()) {
-                    if(marker instanceof AlreadyReplaced) {
+                    if (marker instanceof AlreadyReplaced) {
                         AlreadyReplaced alreadyReplaced = (AlreadyReplaced) marker;
-                        if(Objects.equals(find, alreadyReplaced.getFind()) && Objects.equals(replace, alreadyReplaced.getReplace())) {
+                        if (Objects.equals(find, alreadyReplaced.getFind()) && Objects.equals(replace, alreadyReplaced.getReplace())) {
                             return sourceFile;
                         }
                     }
@@ -118,13 +120,13 @@ public class FindAndReplace extends Recipe {
                     searchStr = Pattern.quote(searchStr);
                 }
                 int patternOptions = 0;
-                if(!Boolean.TRUE.equals(caseSensitive)) {
+                if (!Boolean.TRUE.equals(caseSensitive)) {
                     patternOptions |= Pattern.CASE_INSENSITIVE;
                 }
-                if(Boolean.TRUE.equals(multiline)) {
+                if (Boolean.TRUE.equals(multiline)) {
                     patternOptions |= Pattern.MULTILINE;
                 }
-                if(Boolean.TRUE.equals(dotAll)) {
+                if (Boolean.TRUE.equals(dotAll)) {
                     patternOptions |= Pattern.DOTALL;
                 }
                 PlainText plainText = PlainTextParser.convert(sourceFile);
@@ -134,7 +136,7 @@ public class FindAndReplace extends Recipe {
                 if (!matcher.find()) {
                     return sourceFile;
                 }
-                String replacement = replace;
+                String replacement = replace == null ? "" : replace;
                 if (!Boolean.TRUE.equals(regex)) {
                     replacement = replacement.replace("$", "\\$");
                 }
@@ -144,7 +146,7 @@ public class FindAndReplace extends Recipe {
             }
         };
         //noinspection DuplicatedCode
-        if(filePattern != null) {
+        if (filePattern != null) {
             //noinspection unchecked
             TreeVisitor<?, ExecutionContext> check = Preconditions.or(Arrays.stream(filePattern.split(";"))
                     .map(FindSourceFiles::new)

--- a/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import static org.openrewrite.test.SourceSpecs.text;
 
 class FindAndReplaceTest implements RewriteTest {
-
     @DocumentExample
     @Test
     void nonTxtExtension() {
@@ -42,6 +41,25 @@ class FindAndReplaceTest implements RewriteTest {
               This is textG
               """,
             spec -> spec.path("test.yml")
+          )
+        );
+    }
+
+    @Test
+    void removeWhenNullOrEmpty() {
+        rewriteRun(
+          spec -> spec.recipe(new FindAndReplace("Bar", null, null, null, null, null, null)),
+          text(
+            """
+              Foo
+              Bar
+              Quz
+              """,
+            """
+              Foo
+              
+              Quz
+              """
           )
         );
     }
@@ -131,6 +149,7 @@ class FindAndReplaceTest implements RewriteTest {
               new FindAndReplace("three", "four", null, null, null, null, null));
         }
     }
+
     @Test
     void successiveReplacement() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Make `FindAndReplace.replacement` nullable, such that it becomes optional in the UI, and can remove matches.

## What's your motivation?
Sometimes you just need to remove a line, as seen in
- https://github.com/openrewrite/rewrite/pull/3765
