### PR TITLE
Replace `org.junit.platform.commons.util.StringUtils` with `org.openrewrite.internal.StringUtils`

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/CreatePropertiesFile.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/CreatePropertiesFile.java
@@ -18,8 +18,8 @@ package org.openrewrite.properties;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
-import org.junit.platform.commons.util.StringUtils;
 import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.properties.tree.Properties;
 
@@ -78,7 +78,7 @@ public class CreatePropertiesFile extends ScanningRecipe<AtomicBoolean> {
     @Override
     public Collection<SourceFile> generate(AtomicBoolean shouldCreate, ExecutionContext ctx) {
         if (shouldCreate.get()) {
-            return PropertiesParser.builder().build().parse(StringUtils.isNotBlank(fileContents) ? fileContents : "")
+            return PropertiesParser.builder().build().parse(!StringUtils.isBlank(fileContents) ? fileContents : "")
                     .map(brandNewFile -> (SourceFile) brandNewFile.withSourcePath(Paths.get(relativeFileName)))
                     .collect(Collectors.toList());
         }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/CreateXmlFile.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/CreateXmlFile.java
@@ -18,8 +18,8 @@ package org.openrewrite.xml;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
-import org.junit.platform.commons.util.StringUtils;
 import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.tree.Xml;
 
@@ -87,7 +87,6 @@ public class CreateXmlFile extends ScanningRecipe<AtomicBoolean> {
         }
         return emptyList();
     }
-
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean created) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CreateYamlFile.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CreateYamlFile.java
@@ -18,8 +18,8 @@ package org.openrewrite.yaml;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
-import org.junit.platform.commons.util.StringUtils;
 import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -84,7 +84,6 @@ public class CreateYamlFile extends ScanningRecipe<AtomicBoolean> {
         }
         return emptyList();
     }
-
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean created) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Replace StringUtils used by the recipes that create files

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Running the recipes with the Maven plugin was showing a `A required class was missing` exception

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->


## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
