### PR TITLE
Added support for continuations in properties.

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/internal/PropertiesPrinter.java
@@ -38,13 +38,13 @@ public class PropertiesPrinter<P> extends PropertiesVisitor<PrintOutputCapture<P
     @Override
     public Properties visitEntry(Properties.Entry entry, PrintOutputCapture<P> p) {
         beforeSyntax(entry, p);
-        p.append(entry.getKey())
+        p.append(entry.getKeySource())
                 .append(entry.getBeforeEquals());
         if (entry.getDelimiter() != Properties.Entry.Delimiter.NONE) {
             p.append(entry.getDelimiter().getCharacter());
         }
         beforeSyntax(entry.getValue().getPrefix(), entry.getValue().getMarkers(), p);
-        p.append(entry.getValue().getText());
+        p.append(entry.getValue().getSource());
         afterSyntax(entry.getValue().getMarkers(), p);
         afterSyntax(entry, p);
         return entry;

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
@@ -17,6 +17,7 @@ package org.openrewrite.properties.tree;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.With;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public interface Properties extends Tree {
 
@@ -144,6 +146,22 @@ public interface Properties extends Tree {
         String prefix;
         Markers markers;
         String key;
+
+        /**
+         * Automatically, removes continuations from the text.
+         * @return the text value without continuations.
+         */
+        public String getKey() {
+            return Continuation.getValue(key);
+        }
+
+        /**
+         * @return the text with continuations.
+         */
+        public String getKeySource() {
+            return key;
+        }
+
         String beforeEquals;
 
         @Nullable
@@ -160,6 +178,7 @@ public interface Properties extends Tree {
             return v.visitEntry(this, p);
         }
 
+        @Getter
         public enum Delimiter {
             COLON(':'), EQUALS('='), NONE('\0');
 
@@ -174,10 +193,6 @@ public interface Properties extends Tree {
                             ":".equals(value.trim()) ? Delimiter.COLON :
                             "".equals(value.trim()) ? Delimiter.NONE :
                                     Delimiter.EQUALS;
-            }
-
-            public Character getCharacter() {
-                return character;
             }
         }
     }
@@ -197,6 +212,21 @@ public interface Properties extends Tree {
         String prefix;
         Markers markers;
         String text;
+
+        /**
+         * Automatically, removes continuations from the text.
+         * @return the text value without continuations.
+         */
+        public String getText() {
+            return Continuation.getValue(text);
+        }
+
+        /**
+         * @return the text with continuations.
+         */
+        public String getSource() {
+            return text;
+        }
     }
 
     @lombok.Value
@@ -216,6 +246,7 @@ public interface Properties extends Tree {
             return v.visitComment(this, p);
         }
 
+        @Getter
         public enum Delimiter {
             HASH_TAG('#'), EXCLAMATION_MARK('!');
 
@@ -224,10 +255,13 @@ public interface Properties extends Tree {
             Delimiter(Character character) {
                 this.character = character;
             }
+        }
+    }
 
-            public Character getCharacter() {
-                return character;
-            }
+    class Continuation {
+        private static final Pattern LINE_CONTINUATION_PATTERN = Pattern.compile("\\\\\\R\\s*");
+        static String getValue(String input) {
+            return LINE_CONTINUATION_PATTERN.matcher(input).replaceAll("");
         }
     }
 }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyTest.java
@@ -18,8 +18,10 @@ package org.openrewrite.properties;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
+import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.properties.Assertions.properties;
 
 @SuppressWarnings("UnusedProperty")
@@ -195,6 +197,34 @@ class AddPropertyTest implements RewriteTest {
               # Management metrics
               management.metrics.enable.process.files=true
               """
+          )
+        );
+    }
+
+    @Test
+    void keepPropertyValueWithLineContinuations() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty(
+            "management.metrics.enable.process.files",
+            "true",
+            null,
+            null
+          )),
+          properties(
+            """
+              management=tr\\
+                ue
+              """,
+            """
+              management=tr\\
+                ue
+              management.metrics.enable.process.files=true
+              """,
+            spec -> spec.afterRecipe(after -> {
+                Properties.Entry entry = (Properties.Entry) after.getContent().get(0);
+                assertThat(entry.getValue().getText()).isEqualTo("true");
+                assertThat(entry.getValue().getSource()).isEqualTo("tr\\\n  ue");
+            })
           )
         );
     }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.properties;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -109,7 +108,6 @@ class PropertiesParserTest implements RewriteTest {
     @SuppressWarnings({"WrongPropertyKeyValueDelimiter", "TrailingSpacesInProperty"})
     @Issue("https://github.com/openrewrite/rewrite/issues/2471")
     @Test
-    @Disabled
     void escapedEndOfLine() {
         rewriteRun(
           properties(
@@ -199,6 +197,37 @@ class PropertiesParserTest implements RewriteTest {
 
                 p.printAll();
 
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3741")
+    @Test
+    void windowsPaths() {
+        rewriteRun(
+          properties(
+            """
+                    ws.gson.debug.dump=true
+                    ws.gson.debug.mode=CONSOLE
+                    ws.gson.debug.path=C:\\\\Temp\\\\dump_foo\\\\
+                    """,
+            containsValues("true", "CONSOLE", "C:\\\\Temp\\\\dump_foo\\\\")
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3741")
+    @Test
+    void trailingDoubleSlash() {
+        rewriteRun(
+          properties(
+            """
+              foo=C:\\
+              
+              """,
+            spec -> spec.afterRecipe(file -> {
+                assertThat(file).isInstanceOf(Properties.File.class);
             })
           )
         );

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/search/FindPropertiesTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/search/FindPropertiesTest.java
@@ -103,4 +103,21 @@ class FindPropertiesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void valueWithLineContinuation() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperties("foo", null)),
+          properties(
+            """
+              foo=tr\\
+                ue
+              """,
+            """
+              foo=~~>tr\\
+                ue
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Changes:

- Continuations are preserved in `Entry#key` and `Value#text`
- Add methods `Entry#getKeySource` and `Value#getSourceText` to retrieve the source text.
- Updated `get` methods to trim continuations from the text.

fixes #2473 
fixes #3741