### PR TITLE
`AddPropery` now accepts a comment

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullUtils.java
@@ -68,7 +68,6 @@ public class NullUtils {
      * <li>org.springframework.lang.Nullable</li>
      * <li>javax.annotations.Nullable</li>
      * <li>org.checkerframework.checker.nullness.qual.Nullable</li>
-     * <li>javax.validation.constraints.NotNull</li>
      */
     private static final List<String> FIELD_LEVEL_NULLABLE_ANNOTATIONS = Collections.singletonList(
             "Nullable"

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddProperty.java
@@ -124,7 +124,7 @@ public class AddProperty extends ScanningRecipe<AddProperty.NeedsProperty> {
                                 sourceFile :
                                 new ChangePropertyValue(key, value, null, false, null)
                                         .getVisitor().visitNonNull(sourceFile, ctx);
-                        return new org.openrewrite.properties.AddProperty(key, value, null)
+                        return new org.openrewrite.properties.AddProperty(key, value, null, null)
                                 .getVisitor()
                                 .visitNonNull(t, ctx);
                     }
@@ -133,7 +133,7 @@ public class AddProperty extends ScanningRecipe<AddProperty.NeedsProperty> {
                             sourceFile :
                             new ChangePropertyValue(key, value, null, false, null)
                                     .getVisitor().visitNonNull(sourceFile, ctx);
-                    return new org.openrewrite.properties.AddProperty(key, value, null)
+                    return new org.openrewrite.properties.AddProperty(key, value, null, null)
                             .getVisitor()
                             .visitNonNull(t, ctx);
                 }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -58,16 +58,6 @@ public class AddProperty extends Recipe {
     @Nullable
     String delimiter;
 
-    /**
-     * Keeping this constructor just for compatibility purposes
-     * @deprecated Use {@link AddProperty#AddProperty(String, String, String, String)}}
-     */
-    @Deprecated
-    public AddProperty(String property, String value, @Nullable String delimiter) {
-        this(property, value, null, delimiter);
-    }
-
-    @JsonCreator
     public AddProperty(String property, String value, @Nullable String comment, @Nullable String delimiter) {
         this.property = property;
         this.value = value;

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.properties;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -25,6 +26,8 @@ import org.openrewrite.marker.Markers;
 import org.openrewrite.properties.search.FindProperties;
 import org.openrewrite.properties.tree.Properties;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -41,12 +44,36 @@ public class AddProperty extends Recipe {
             description = "The value of the new property key.")
     String value;
 
+    @Option(displayName = "Optional comment to be prepended to the property",
+            description = "A comment that will be added to the new property.",
+            required = false,
+            example = "This is a comment")
+    @Nullable
+    String comment;
+
     @Option(displayName = "Optional delimiter",
             description = "Property entries support different delimiters (`=`, `:`, or whitespace). The default value is `=` unless provided the delimiter of the new property entry.",
             required = false,
             example = ":")
     @Nullable
     String delimiter;
+
+    /**
+     * Keeping this constructor just for compatibility purposes
+     * @deprecated Use {@link AddProperty#AddProperty(String, String, String, String)}}
+     */
+    @Deprecated
+    public AddProperty(String property, String value, @Nullable String delimiter) {
+        this(property, value, null, delimiter);
+    }
+
+    @JsonCreator
+    public AddProperty(String property, String value, @Nullable String comment, @Nullable String delimiter) {
+        this.property = property;
+        this.value = value;
+        this.comment = comment;
+        this.delimiter = delimiter;
+    }
 
     @Override
     public String getDisplayName() {
@@ -75,14 +102,19 @@ public class AddProperty extends Recipe {
                     Set<Properties.Entry> properties = FindProperties.find(p, property, false);
                     if (properties.isEmpty()) {
                         Properties.Value propertyValue = new Properties.Value(Tree.randomId(), "", Markers.EMPTY, value);
-                        Properties.Entry.Delimiter delimitedBy = delimiter != null && !delimiter.isEmpty() ? Properties.Entry.Delimiter.getDelimiter(delimiter) : Properties.Entry.Delimiter.EQUALS;
+                        Properties.Entry.Delimiter delimitedBy = StringUtils.isNotEmpty(delimiter) ? Properties.Entry.Delimiter.getDelimiter(delimiter) : Properties.Entry.Delimiter.EQUALS;
                         String beforeEquals = delimitedBy == Properties.Entry.Delimiter.NONE ? delimiter : "";
                         String prefix = "";
                         if (!p.getContent().isEmpty()) {
                             prefix = "\n";
                         }
-                        Properties.Entry entry = new Properties.Entry(Tree.randomId(), prefix, Markers.EMPTY, property, beforeEquals, delimitedBy, propertyValue);
-                        List<Properties.Content> contentList = ListUtils.concat(p.getContent(), entry);
+                        List<Properties.Content> newContent = StringUtils.isNotEmpty(comment)
+                                ? Arrays.asList(
+                                        new Properties.Comment(Tree.randomId(), prefix, Markers.EMPTY, Properties.Comment.Delimiter.HASH_TAG, String.format(" %s%n", comment)),
+                                        new Properties.Entry(Tree.randomId(), "", Markers.EMPTY, property, beforeEquals, delimitedBy, propertyValue)
+                                )
+                                : Collections.singletonList(new Properties.Entry(Tree.randomId(), prefix, Markers.EMPTY, property, beforeEquals, delimitedBy, propertyValue));
+                        List<Properties.Content> contentList = ListUtils.concatAll(p.getContent(), newContent);
                         p = p.withContent(contentList);
                     }
                 }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.properties;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyTest.java
@@ -31,6 +31,7 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "",
             "true",
+            null,
             null
           )),
           properties(
@@ -47,6 +48,7 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "",
+            null,
             null
           )),
           properties(
@@ -63,6 +65,7 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             null
           )),
           properties(
@@ -80,6 +83,7 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             null
           )),
           properties(
@@ -101,6 +105,7 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             ":"
           )),
           properties(
@@ -122,6 +127,7 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             "    "
           )),
           properties(
@@ -142,11 +148,51 @@ class AddPropertyTest implements RewriteTest {
           spec -> spec.recipe(new AddProperty(
             "management.metrics.enable.process.files",
             "true",
+            null,
             null
           )),
           properties(
             "",
             """
+              management.metrics.enable.process.files=true
+              """
+          )
+        );
+    }
+
+    @Test
+    void addCommentedPropertyToEmptyFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty(
+            "management.metrics.enable.process.files",
+            "true",
+            "Management metrics",
+            null
+          )),
+          properties(
+            "",
+            """
+              # Management metrics
+              management.metrics.enable.process.files=true
+              """
+          )
+        );
+    }
+
+    @Test
+    void addCommentedPropertyToExistingFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddProperty(
+            "management.metrics.enable.process.files",
+            "true",
+            "Management metrics",
+            null
+          )),
+          properties(
+            "management=true",
+            """
+              management=true
+              # Management metrics
               management.metrics.enable.process.files=true
               """
           )


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
`AddSpringProperty` from `rewrite-spring` accepts comments, but only applies it's a YAML file. This PR changes `AddProperty` to accept comments.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Add properties to Spring applications.


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->


## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
