### PR TITLE
Updated RenameVariable to not update JavaDoc param names.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
@@ -283,7 +283,7 @@ class RenameVariableTest implements RewriteTest {
             """
               package org.openrewrite;
 
-              /** @noinspection ReassignedVariable*/ public class A {
+              public class A {
                   int fooA() {
                       // refers to class declaration scope.
                       for (v = 0; v < 10; ++v) {


### PR DESCRIPTION
Changes:

- RenameVariable will not update names of `@param` in JavaDocs.

fixes https://github.com/openrewrite/rewrite/issues/3772
