### PR TITLE
Consider templates returning input as no match

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JavaTemplateMatchTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JavaTemplateMatchTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class JavaTemplateMatchTest implements RewriteTest {
+
+
+    @Test
+    void nonJavaCode() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              private final JavaTemplate template = JavaTemplate.builder(
+                "\"a\" + \"b\""
+              ).build();
+
+              @Override
+              public J visitExpression(Expression expression, ExecutionContext ctx) {
+                  return expression.getMarkers().findFirst(SearchResult.class).isEmpty() && template.matches(getCursor()) ?
+                    SearchResult.found(expression) : super.visitExpression(expression, ctx);
+              }
+          })),
+          groovy(
+            //language=groovy
+            """
+              class T {
+                  def foo = "${1}"
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateContextFreeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateContextFreeTest.java
@@ -39,7 +39,8 @@ class JavaTemplateContextFreeTest implements RewriteTest {
           spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
               @Override
               public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                  return method.getBody() != null && JavaTemplate.matches("System.out.println(1);", new Cursor(getCursor(), method.getBody())) ?
+                  return method.getBody() != null && JavaTemplate.matches("System.out.println(1);",
+                    new Cursor(new Cursor(getCursor(), method.getBody()), method.getBody().getStatements().get(0))) ?
                     JavaTemplate.apply("System.out.println(2);", getCursor(), method.getCoordinates().replaceBody()) :
                     super.visitMethodDeclaration(method, ctx);
               }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
@@ -144,6 +144,11 @@ class JavaTemplateSemanticallyEqual extends SemanticallyEqual {
     }
 
     private static TemplateMatchResult matchTemplate(J templateTree, Cursor cursor) {
+        if (templateTree == cursor.getValue()) {
+            // When `JavaTemplate#apply()` returns the input itself, it could not be matched
+            return new TemplateMatchResult(false, Collections.emptyList());
+        }
+
         JavaTemplateSemanticallyEqualVisitor semanticallyEqualVisitor = new JavaTemplateSemanticallyEqualVisitor();
         semanticallyEqualVisitor.visit(templateTree, cursor.getValue(), cursor.getParentOrThrow());
         return new TemplateMatchResult(semanticallyEqualVisitor.isEqual(), new ArrayList<>(


### PR DESCRIPTION
When a `JavaTemplate` is applied to a non-Java LST it may end up returning the input itself. In this case `JavaTemplate#match()` should return `false`.
