### PR TITLE
Add a new `WORKING_DIRECTORY` message to `ExecutionContext`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -34,7 +34,6 @@ public interface ExecutionContext {
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
     String DATA_TABLES = "org.openrewrite.dataTables";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
-    String WORKING_DIRECTORY = "org.openrewrite.workingDirectory";
     String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
 
     @Incubating(since = "7.20.0")

--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -34,6 +34,7 @@ public interface ExecutionContext {
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
     String DATA_TABLES = "org.openrewrite.dataTables";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
+    String WORKING_DIRECTORY = "org.openrewrite.workingDirectory";
     String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
 
     @Incubating(since = "7.20.0")

--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 public interface ExecutionContext {
     String CURRENT_CYCLE = "org.openrewrite.currentCycle";
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
+    String WORKING_DIRECTORY = "org.openrewrite.workingDirectory";
     String DATA_TABLES = "org.openrewrite.dataTables";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
     String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -291,7 +291,10 @@ public abstract class Recipe implements Cloneable {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        } else if (!Files.exists(workingDirectory)) {
+            throw new IllegalArgumentException("Working directory does not exist: " + workingDirectory);
         }
+
         try {
             return new RecipeScheduler().scheduleRun(this, before, ctx, maxCycles, minCycles);
         } finally {

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -33,16 +33,11 @@ import org.openrewrite.table.SourcesFileResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
-import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.internal.RecipeIntrospectionUtils.dataTableDescriptorFromDataTable;
@@ -283,35 +278,7 @@ public abstract class Recipe implements Cloneable {
     }
 
     public final RecipeRun run(LargeSourceSet before, ExecutionContext ctx, int maxCycles, int minCycles) {
-        Path workingDirectory = ctx.getMessage(ExecutionContext.WORKING_DIRECTORY);
-        if (workingDirectory == null) {
-            try {
-                workingDirectory = Files.createTempDirectory("recipe-run");
-                ctx.putMessage(ExecutionContext.WORKING_DIRECTORY, workingDirectory);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        } else if (!Files.exists(workingDirectory)) {
-            throw new IllegalArgumentException("Working directory does not exist: " + workingDirectory);
-        }
-
-        try {
-            return new RecipeScheduler().scheduleRun(this, before, ctx, maxCycles, minCycles);
-        } finally {
-            delete(workingDirectory);
-        }
-    }
-
-    private void delete(Path path) {
-        try {
-            if (Files.isDirectory(path)) {
-                try (Stream<Path> files = Files.list(path)) {
-                    files.forEach(this::delete);
-                }
-            }
-            Files.delete(path);
-        } catch (IOException ignore) {
-        }
+        return new RecipeScheduler().scheduleRun(this, before, ctx, maxCycles, minCycles);
     }
 
     public Validated<Object> validate(ExecutionContext ctx) {

--- a/rewrite-core/src/main/java/org/openrewrite/WorkingDirectoryExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/WorkingDirectoryExecutionContextView.java
@@ -46,6 +46,12 @@ public class WorkingDirectoryExecutionContextView extends DelegatingExecutionCon
         }
     }
 
+    /**
+     * Create a new {@link WorkingDirectoryExecutionContextView} which will create a new temporary directory for the
+     * working directory. This temporary working directory will automatically get deleted once this object is closed.
+     * <p>
+     * For recipes which only want to access the provided working directory, use {@link #getWorkingDirectory(ExecutionContext)}.
+     */
     public static WorkingDirectoryExecutionContextView createNew(ExecutionContext ctx) {
         if (ctx instanceof WorkingDirectoryExecutionContextView) {
             return (WorkingDirectoryExecutionContextView) ctx;
@@ -53,7 +59,14 @@ public class WorkingDirectoryExecutionContextView extends DelegatingExecutionCon
         return new WorkingDirectoryExecutionContextView(ctx, null);
     }
 
-    public static WorkingDirectoryExecutionContextView useExisting(ExecutionContext ctx, Path existing) {
+    /**
+     * Create a new {@link WorkingDirectoryExecutionContextView} using a provided working directory. While the directory
+     * will get created if it doesn't already exist, it is the responsibility of the caller to delete it. Thus, the
+     * {@link #close()} method is a no-op.
+     * <p>
+     * For recipes which only want to access the provided working directory, use {@link #getWorkingDirectory(ExecutionContext)}.
+     */
+    public static WorkingDirectoryExecutionContextView useProvided(ExecutionContext ctx, Path existing) {
         if (ctx instanceof WorkingDirectoryExecutionContextView) {
             return (WorkingDirectoryExecutionContextView) ctx;
         }

--- a/rewrite-core/src/main/java/org/openrewrite/WorkingDirectoryExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/WorkingDirectoryExecutionContextView.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class WorkingDirectoryExecutionContextView extends DelegatingExecutionContext implements AutoCloseable {
+    private static final String WORKING_DIRECTORY = "org.openrewrite.workingDirectory";
+
+    public WorkingDirectoryExecutionContextView(ExecutionContext delegate) {
+        super(delegate);
+    }
+
+    public static WorkingDirectoryExecutionContextView view(ExecutionContext ctx) {
+        if (ctx instanceof WorkingDirectoryExecutionContextView) {
+            return (WorkingDirectoryExecutionContextView) ctx;
+        }
+        return new WorkingDirectoryExecutionContextView(ctx);
+    }
+
+    public WorkingDirectoryExecutionContextView setWorkingDirectory(Path directory) {
+        putMessage(WORKING_DIRECTORY, directory);
+        return this;
+    }
+
+    public Path getWorkingDirectory() {
+        Path workingDirectory = getMessage(WORKING_DIRECTORY);
+        if (workingDirectory == null) {
+            try {
+                workingDirectory = Files.createTempDirectory("recipe-execution-dir");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return workingDirectory;
+    }
+
+    public void deleteWorkingDirectory() {
+        delete(getWorkingDirectory());
+    }
+
+    private void delete(Path path) {
+        try {
+            if (Files.isDirectory(path)) {
+                try (Stream<Path> files = Files.list(path)) {
+                    files.forEach(this::delete);
+                }
+            }
+            Files.delete(path);
+        } catch (IOException ignore) {
+        }
+    }
+
+    @Override
+    public void close() {
+        deleteWorkingDirectory();
+    }
+}

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -341,12 +341,15 @@ public interface RewriteTest extends SourceSpecs {
             lss = new LargeSourceSetCheckingExpectedCycles(expectedCyclesThatMakeChanges, runnableSourceFiles);
         }
 
-        RecipeRun recipeRun = recipe.run(
-                lss,
-                recipeExecutionContext,
-                cycles,
-                expectedCyclesThatMakeChanges + 1
-        );
+        RecipeRun recipeRun;
+        try (WorkingDirectoryExecutionContextView ctx = WorkingDirectoryExecutionContextView.view(recipeExecutionContext)) {
+            recipeRun = recipe.run(
+                    lss,
+                    ctx,
+                    cycles,
+                    expectedCyclesThatMakeChanges + 1
+            );
+        }
 
         for (Consumer<RecipeRun> afterRecipe : testClassSpec.afterRecipes) {
             afterRecipe.accept(recipeRun);

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -342,7 +342,7 @@ public interface RewriteTest extends SourceSpecs {
         }
 
         RecipeRun recipeRun;
-        try (WorkingDirectoryExecutionContextView ctx = WorkingDirectoryExecutionContextView.view(recipeExecutionContext)) {
+        try (WorkingDirectoryExecutionContextView ctx = WorkingDirectoryExecutionContextView.create(recipeExecutionContext)) {
             recipeRun = recipe.run(
                     lss,
                     ctx,

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -342,7 +342,7 @@ public interface RewriteTest extends SourceSpecs {
         }
 
         RecipeRun recipeRun;
-        try (WorkingDirectoryExecutionContextView ctx = WorkingDirectoryExecutionContextView.create(recipeExecutionContext)) {
+        try (WorkingDirectoryExecutionContextView ctx = WorkingDirectoryExecutionContextView.createNew(recipeExecutionContext)) {
             recipeRun = recipe.run(
                     lss,
                     ctx,


### PR DESCRIPTION
This directory can be written to by the recipes being executed. Depending on whether the `createNew()` or `useExisting()` factory method is used, the directory will get automatically deleted again once the `WorkingDirectoryExecutionContextView`.

The idea is that recipes should only have to either directly call `ctx.getMessage(WORKING_DIRECTORY)` or use the static `getWorkingDirectory(ctx)` method to access the current working directory.