### PR TITLE
fix: update `helpText` for `FindAndReplace` recipe to denote support for multiline strings

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
@@ -43,7 +43,7 @@ public class FindAndReplace extends Recipe {
     String find;
 
     @Option(displayName = "Replace",
-            description = "The replacement text for `find`.",
+            description = "The replacement text for `find`. This supports multiline strings.",
             example = "denylist",
             required = false)
     @Nullable


### PR DESCRIPTION
Provides necessary hints for clients understand the capabilities.
