### PR TITLE
`PreconditionBellwether` must call `isAcceptable()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -148,6 +148,11 @@ public class DeclarativeRecipe extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new TreeVisitor<Tree, ExecutionContext>() {
                 @Override
+                public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                    return precondition.isAcceptable(sourceFile, ctx);
+                }
+
+                @Override
                 public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                     Tree t = precondition.visit(tree, ctx);
                     preconditionApplicable = t != tree;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
@@ -15,12 +15,14 @@
  */
 package org.openrewrite.java.search;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.test.SourceSpecs.text;
 
 class HasJavaVersionTest implements RewriteTest {
 
@@ -61,4 +63,23 @@ class HasJavaVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void declarativePrecondition() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.PreconditionTest
+            preconditions:
+              - org.openrewrite.java.search.HasJavaVersion:
+                  version: 11
+            recipeList:
+              - org.openrewrite.text.ChangeText:
+                 toText: 2
+            """, "org.openrewrite.PreconditionTest"),
+          text("1")
+        );
+    }
+
 }


### PR DESCRIPTION
When a precondition visitor extends an `XyzIsoVisitor` class (like `JavaIsoVisitor`) and there overrides the `visit()` method, then this will result in a `ClassCastException` when the visitor is given a source file which is not of that type.
