### PR TITLE
Fixed whitespace on entities and char refs in XmlParser.

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -110,17 +110,19 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
             return charData;
         } else if (ctx.reference() != null) {
             if (ctx.reference().EntityRef() != null) {
-                cursor += ctx.reference().EntityRef().getSymbol().getStopIndex() + 1;
+                String prefix = prefix(ctx);
+                cursor = ctx.reference().EntityRef().getSymbol().getStopIndex() + 1;
                 return new Xml.CharData(randomId(),
-                        "",
+                        prefix,
                         Markers.EMPTY,
                         false,
                         ctx.reference().EntityRef().getText(),
                         "");
             } else if (ctx.reference().CharRef() != null) {
-                cursor += ctx.reference().CharRef().getSymbol().getStopIndex() + 1;
+                String prefix = prefix(ctx);
+                cursor = ctx.reference().CharRef().getSymbol().getStopIndex() + 1;
                 return new Xml.CharData(randomId(),
-                        "",
+                        prefix,
                         Markers.EMPTY,
                         false,
                         ctx.reference().CharRef().getText(),

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -297,7 +297,8 @@ class XmlParserTest implements RewriteTest {
           xml(
             """
               %s<?xml version="1.0" encoding="UTF-8"?><test></test>
-              """.formatted("\uFEFF"))
+              """.formatted("\uFEFF")
+          )
         );
     }
 
@@ -308,7 +309,8 @@ class XmlParserTest implements RewriteTest {
           xml(
             """
               <?xml version = "1.0" encoding    =   "UTF-8" standalone = "no" ?><blah></blah>
-              """)
+              """
+          )
         );
     }
 
@@ -321,7 +323,29 @@ class XmlParserTest implements RewriteTest {
               <?xml version="1.0" encoding="ISO-8859-1"?>
               <?xml-stylesheet type="text/xsl" href="/name/other?link"?>
               <blah></blah>
-              """)
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3442")
+    @Test
+    void preserveWhitespaceOnEntities() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <message><text>&lt;?xml version='1.0' encoding='UTF-8'?&gt;&#13;
+              &lt;note&gt;&#13;
+                  &lt;to&gt;Tove&lt;/to&gt;&#13;
+                  &lt;from&gt;Jani&lt;/from&gt;&#13;
+                  &lt;heading&gt;Reminder&lt;/heading&gt;&#13;
+                  &lt;body&gt;Don't forget me this weekend!&lt;/body&gt;&#13;
+              &lt;/note&gt;&#13;
+              &#13;
+              </text></message>
+              """
+          )
         );
     }
 }


### PR DESCRIPTION
Changes:
- Whitespace is preserved on XML entities and char refs.

fixes https://github.com/openrewrite/rewrite/issues/3442