### PR TITLE
Replaced old method type on names of J.MethodInvocation and J.MethodDeclaration in JavaTemplateJavaExtension.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest4Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest4Test.java
@@ -53,7 +53,8 @@ class JavaTemplateTest4Test implements RewriteTest {
               }
           })).afterRecipe(run -> {
               J.CompilationUnit cu = (J.CompilationUnit) run.getChangeset().getAllResults().get(0).getAfter();
-              JavaType.Method type = ((J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0)).getMethodType();
+              J.MethodDeclaration m = (J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0);
+              JavaType.Method type = m.getMethodType();
               assertThat(type.getParameterNames())
                 .as("Changing the method's parameters should have also updated its type's parameter names")
                 .containsExactly("m", "n");
@@ -67,6 +68,7 @@ class JavaTemplateTest4Test implements RewriteTest {
                                && TypeUtils.asFullyQualified(((JavaType.Parameterized) jt).getTypeParameters().get(0)).getFullyQualifiedName().equals("java.lang.String"),
                   "Changing the method's parameters should have resulted in the second parameter's type being 'List<String>'"
                 );
+              assertThat(m.getName().getType()).isEqualTo(type);
           }),
           java(
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -363,7 +363,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                 type = type.withParameterNames(paramNames).withParameterTypes(paramTypes);
                             }
 
-                            return method.withParameters(parameters).withMethodType(type);
+                            return method.withParameters(parameters).withMethodType(type).withName(method.getName().withType(type));
                         }
                         case THROWS: {
                             J.MethodDeclaration m = method.withThrows(substitutions.unsubstitute(templateParser.parseThrows(getCursor(), substitutedTemplate)));
@@ -382,12 +382,15 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
                             //noinspection ConstantConditions
                             m = m.getPadding().withThrows(m.getPadding().getThrows().withBefore(Space.format(" ")))
-                                    .withMethodType(type);
+                                    .withMethodType(type).withName(method.getName().withType(type));
                             return m;
                         }
                         case TYPE_PARAMETERS: {
                             List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
                             J.MethodDeclaration m = method.withTypeParameters(typeParameters);
+                            if (m.getName().getType() != null) {
+                                m = m.withName(method.getName().withType(m.getMethodType()));
+                            }
                             return autoFormat(m, typeParameters.get(typeParameters.size() - 1), p,
                                     getCursor().getParentOrThrow());
                         }
@@ -427,6 +430,9 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                 .collect(toList());
                         mt = mt.withParameterTypes(argTypes);
                         m = m.withMethodType(mt);
+                    }
+                    if (m.getName().getType() != null) {
+                        m = m.withName(m.getName().withType(m.getType()));
                     }
                     return m;
                 }


### PR DESCRIPTION
Changes:

- JavaTemplate will update names of J.MethodDeclaration and J.MethodInvocation.

fixes #3787