### PR TITLE
Do not parse Jenkinsfiles as Groovy for now

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -180,8 +180,9 @@ public class GroovyParser implements Parser {
 
     @Override
     public boolean accept(Path path) {
-        return path.toString().endsWith(".groovy") ||
-               path.toFile().getName().startsWith("Jenkinsfile");
+        return path.toString().endsWith(".groovy");
+        // Imperfections make it inconvenient to parse Jenkinsfiles for now #3783 #3777 #3737
+        // || path.toFile().getName().startsWith("Jenkinsfile");
     }
 
     @Override


### PR DESCRIPTION
Reverts https://github.com/openrewrite/rewrite/commit/4d74818d9d76eed72af6fc57b937ee6913ebfc57

Fixes #3737
Fixes #3777
Fixes #3783

As discussed internally.