### PR TITLE
Don't remove leading space on omitted parentheses

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/MethodParamPadTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/MethodParamPadTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.format.MethodParamPad;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+public class MethodParamPadTest implements RewriteTest {
+    @SuppressWarnings("GrPackage")
+    @Test
+    void omitParentheses() {
+        rewriteRun(
+          spec -> spec.recipe(new MethodParamPad()),
+          groovy(
+            """
+              library foo
+              """
+          )
+        );
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -20,6 +20,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.style.EmptyForInitializerPadStyle;
 import org.openrewrite.java.style.EmptyForIteratorPadStyle;
 import org.openrewrite.java.style.SpacesStyle;
@@ -69,6 +70,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     <T> JContainer<T> spaceBefore(JContainer<T> container, boolean spaceBefore) {
+        spaceBefore = spaceBefore || container.getMarkers().findFirst(OmitParentheses.class).isPresent();
         if (!container.getBefore().getComments().isEmpty()) {
             // Perform the space rule for the suffix of the last comment only. Same as IntelliJ.
             List<Comment> comments = spaceLastCommentSuffix(container.getBefore().getComments(), spaceBefore);


### PR DESCRIPTION
In Groovy method calls don't always have parentheses around the arguments. In that case the space between the method name and first argument must not be removed.

Fixes: #3783
