### PR TITLE
Change original method types on method invocation names along with methodType field.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseMapNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseMapNotation.java
@@ -156,6 +156,9 @@ public class DependencyUseMapNotation extends Recipe {
                     return m;
                 }
                 mtype = mtype.withParameterTypes(singletonList(JavaType.ShallowClass.build("java.util.Map")));
+                if (m.getName().getType() != null) {
+                    m = m.withName(m.getName().withType(mtype));
+                }
                 return m.withMethodType(mtype);
             }
         });

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
@@ -116,8 +116,14 @@ public class ChangeStaticFieldToMethod extends Recipe {
                     throw new IllegalArgumentException("Error while changing a static field to a method. The generated template using a the new class ["
                                                        + newClass + "] and the method [" + newMethodName + "] resulted in a null method type.");
                 }
-                return tree.getType() == null ? method :
-                        method.withMethodType(method.getMethodType().withReturnType(tree.getType()));
+                if (tree.getType() != null) {
+                    JavaType.Method mt = method.getMethodType().withReturnType(tree.getType());
+                    method = method.withMethodType(mt);
+                    if (method.getName().getType() != null) {
+                        method = method.withName(method.getName().withType(mt));
+                    }
+                }
+                return method;
             }
 
             @NonNull

--- a/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
@@ -112,6 +112,9 @@ public class DeleteMethodArgument extends Recipe {
                     m = m.withMethodType(methodType
                             .withParameterNames(parameterNames)
                             .withParameterTypes(parameterTypes));
+                    if (m instanceof J.MethodInvocation && ((J.MethodInvocation) m).getName().getType() != null) {
+                        m = ((J.MethodInvocation) m).withName(((J.MethodInvocation) m).getName().withType(m.getMethodType()));
+                    }
                 }
             }
             return m;

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImplements.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImplements.java
@@ -99,7 +99,11 @@ public class RemoveImplements extends Recipe {
                     return super.visitMethodDeclaration(md, context);
                 }
                 JavaType.Class cdt = (JavaType.Class) maybeClassType;
-                md = md.withMethodType(md.getMethodType().withDeclaringType(cdt));
+                JavaType.Method mt = md.getMethodType().withDeclaringType(cdt);
+                md = md.withMethodType(mt);
+                if (md.getName().getType() != null) {
+                    md = md.withName(md.getName().withType(mt));
+                }
                 if (md.getAllAnnotations().stream().noneMatch(ann -> isOfClassType(ann.getType(), "java.lang.Override")) || TypeUtils.isOverride(md.getMethodType())) {
                     return super.visitMethodDeclaration(md, context);
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
@@ -186,11 +186,14 @@ public class ReorderMethodArguments extends Recipe {
                 }
 
                 if (changed) {
+                    JavaType.Method mt = m.getMethodType()
+                            .withParameterNames(reorderedNames)
+                            .withParameterTypes(reorderedTypes);
                     m = withPaddedArguments(m, reordered)
-                            .withMethodType(m.getMethodType()
-                                    .withParameterNames(reorderedNames)
-                                    .withParameterTypes(reorderedTypes)
-                            );
+                            .withMethodType(mt);
+                    if (m instanceof J.MethodInvocation && ((J.MethodInvocation) m).getName().getType() != null) {
+                        m = ((J.MethodInvocation) m).withName(((J.MethodInvocation) m).getName().withType(mt));
+                    }
                 }
             }
             return m;


### PR DESCRIPTION
Changes:
The following recipes will update the original method type on the method names to the new method type.
- DeleteMethodArgument.
- ReorderMethodArguments.
- ChangeStaticFieldToMethod.
- DependencyUseMapNotation
- RemoveImplements.