### PR TITLE
Disable Java `SpacesVisitor` for non-Java sources

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -269,13 +269,6 @@ public abstract class TreeVisitor<T extends Tree, P> {
         // Do you visitor take tree and do you tree take visitor?
         boolean isAcceptable = tree.isAcceptable(this, p) && (!(tree instanceof SourceFile) || isAcceptable((SourceFile) tree, p));
 
-        if (isAcceptable && !(tree instanceof SourceFile)) {
-            Cursor root = getCursor().dropParentUntil(it -> it instanceof SourceFile || it == Cursor.ROOT_VALUE);
-            if (root.getValue() instanceof SourceFile && !isAcceptable(root.getValue(), p)) {
-                isAcceptable = false;
-            }
-        }
-
         try {
             if (isAcceptable) {
                 //noinspection unchecked

--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -269,6 +269,13 @@ public abstract class TreeVisitor<T extends Tree, P> {
         // Do you visitor take tree and do you tree take visitor?
         boolean isAcceptable = tree.isAcceptable(this, p) && (!(tree instanceof SourceFile) || isAcceptable((SourceFile) tree, p));
 
+        if (isAcceptable && !(tree instanceof SourceFile)) {
+            Cursor root = getCursor().dropParentUntil(it -> it instanceof SourceFile || it == Cursor.ROOT_VALUE);
+            if (root.getValue() instanceof SourceFile && !isAcceptable(root.getValue(), p)) {
+                isAcceptable = false;
+            }
+        }
+
         try {
             if (isAcceptable) {
                 //noinspection unchecked

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -405,6 +405,34 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
         );
     }
 
+    @Test
+    void preserveComments() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  boolean m(boolean a) {
+                      if (/*a*/!!a) {
+                          return true;
+                      }
+                      return /*a*/!true || !true;
+                  }
+              }
+              """,
+            """
+              public class A {
+                  boolean m(boolean a) {
+                      if (/*a*/a) {
+                          return true;
+                      }
+                      return /*a*/false;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @ParameterizedTest
     @Issue("https://github.com/openrewrite/rewrite-templating/issues/28")
     // Mimic what would be inserted by a Refaster template using two nullable parameters, with the second one a literal

--- a/rewrite-java/src/main/java/org/openrewrite/java/UnwrapParentheses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UnwrapParentheses.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 
 public class UnwrapParentheses<P> extends JavaVisitor<P> {
     private final J.Parentheses<?> scope;
@@ -33,7 +34,7 @@ public class UnwrapParentheses<P> extends JavaVisitor<P> {
             if (tree.getPrefix().isEmpty()) {
                 Object parent = getCursor().getParentOrThrow().getValue();
                 if (parent instanceof J.Return || parent instanceof J.Throw) {
-                    tree = tree.withPrefix(tree.getPrefix().withWhitespace(" "));
+                    tree = tree.withPrefix(Space.SINGLE_SPACE);
                 }
             }
             return tree;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -88,6 +88,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             }
         }
         if (asBinary != j) {
+            j = j.withPrefix(asBinary.getPrefix());
             getCursor().getParentTreeCursor().putMessage(MAYBE_AUTO_FORMAT_ME, "");
         }
         return j;
@@ -133,6 +134,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             }
         }
         if (asUnary != j) {
+            j = j.withPrefix(asUnary.getPrefix());
             getCursor().getParentTreeCursor().putMessage(MAYBE_AUTO_FORMAT_ME, "");
         }
         return j;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -18,19 +18,16 @@ package org.openrewrite.java.cleanup;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
 
 import java.util.Collections;
 
 public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionContext> {
-    private static final String MAYBE_AUTO_FORMAT_ME = "MAYBE_AUTO_FORMAT_ME";
-
     @Override
     public J visitBinary(J.Binary binary, ExecutionContext ctx) {
         J j = super.visitBinary(binary, ctx);
@@ -45,8 +42,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 j = asBinary.getRight();
             } else if (isLiteralTrue(asBinary.getRight())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
-            } else if (removeAllSpace(asBinary.getLeft()).printTrimmed(getCursor())
-                    .equals(removeAllSpace(asBinary.getRight()).printTrimmed(getCursor()))) {
+            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
                 j = asBinary.getLeft();
             }
         } else if (asBinary.getOperator() == J.Binary.Type.Or) {
@@ -58,8 +54,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 j = asBinary.getRight();
             } else if (isLiteralFalse(asBinary.getRight())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
-            } else if (removeAllSpace(asBinary.getLeft()).printTrimmed(getCursor())
-                    .equals(removeAllSpace(asBinary.getRight()).printTrimmed(getCursor()))) {
+            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
                 j = asBinary.getLeft();
             }
         } else if (asBinary.getOperator() == J.Binary.Type.Equal) {
@@ -89,7 +84,6 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         }
         if (asBinary != j) {
             j = j.withPrefix(asBinary.getPrefix());
-            getCursor().getParentTreeCursor().putMessage(MAYBE_AUTO_FORMAT_ME, "");
         }
         return j;
     }
@@ -99,9 +93,6 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         J j = tree;
         if (j instanceof J.Parentheses) {
             j = new UnnecessaryParenthesesVisitor<>().visit(j, ctx, getCursor().getParentOrThrow());
-        }
-        if (j != null && getCursor().pollMessage(MAYBE_AUTO_FORMAT_ME) != null) {
-            j = autoFormat(j, ctx);
         }
         return j;
     }
@@ -135,7 +126,6 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         }
         if (asUnary != j) {
             j = j.withPrefix(asUnary.getPrefix());
-            getCursor().getParentTreeCursor().putMessage(MAYBE_AUTO_FORMAT_ME, "");
         }
         return j;
     }
@@ -216,16 +206,6 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 String.valueOf(value),
                 Collections.emptyList(),
                 JavaType.Primitive.Boolean);
-    }
-
-    private J removeAllSpace(J j) {
-        //noinspection ConstantConditions
-        return new JavaIsoVisitor<Integer>() {
-            @Override
-            public Space visitSpace(Space space, Space.Location loc, Integer integer) {
-                return Space.EMPTY;
-            }
-        }.visit(j, 0);
     }
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MethodParamPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MethodParamPad.java
@@ -52,6 +52,12 @@ public class MethodParamPad extends Recipe {
         MethodParamPadStyle methodParamPadStyle;
 
         @Override
+        public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+            // This visitor causes problems for Groovy sources as the `SpacesVisitor` is not aware of Groovy
+            return sourceFile instanceof J.CompilationUnit;
+        }
+
+        @Override
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 SourceFile cu = (SourceFile) requireNonNull(tree);

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.format;
 
+import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -52,6 +53,11 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         this.emptyForInitializerPadStyle = emptyForInitializerPadStyle;
         this.emptyForIteratorPadStyle = emptyForIteratorPadStyle;
         this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, P p) {
+        return sourceFile instanceof J.CompilationUnit;
     }
 
     <T extends J> T spaceBefore(T j, boolean spaceBefore) {


### PR DESCRIPTION
This is to get rid of breaking change like https://github.com/openrewrite/rewrite/issues/3783
slack discussion : https://moderneinc.slack.com/archives/C067J83AFHB/p1701957313256969