### PR TITLE
Fix for AddPlugin when plugin version is managed

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -148,8 +148,9 @@ public class AddPlugin extends Recipe {
                 if (maybePlugin.isPresent()) {
                     Xml.Tag plugin = maybePlugin.get();
                     if (version != null && !version.equals(plugin.getChildValue("version").orElse(null))) {
-                        //noinspection OptionalGetWithoutIsPresent
-                        t = (Xml.Tag) new ChangeTagValueVisitor<>(plugin.getChild("version").get(), version).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+                        if (plugin.getChild("version").isPresent()) {
+                            t = (Xml.Tag) new ChangeTagValueVisitor<>(plugin.getChild("version").get(), version).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+                        }
                     }
                 } else {
                     Xml.Tag pluginTag = Xml.Tag.build("<plugin>\n" +

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
@@ -331,4 +331,33 @@ public class AddPluginTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addPluginWithExistingPlugin() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null)),
+          pomXml("""
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.1.5</version>
+                </parent>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-maven-plugin</artifactId>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            spec -> spec.path("pom.xml")
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
`AddPlugin` throws exception if the plugin being added is already present on pom.xml and it's version is managed by a parent pom.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
No

## Anyone you would like to review specifically?
<!-- @mention them here -->
No one.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
