### PR TITLE
Find JavaVersion markers on any source file

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.java.Assertions.javaVersion;
 import static org.openrewrite.test.SourceSpecs.text;
 
 class HasJavaVersionTest implements RewriteTest {
@@ -31,18 +31,16 @@ class HasJavaVersionTest implements RewriteTest {
     void matches(String version) {
         rewriteRun(
           spec -> spec.recipe(new HasJavaVersion(version, false)),
-          version(
-            java(
-              """
-                class Test {
-                }
-                """,
-              """
-                /*~~>*/class Test {
-                }
-                """
-            ),
-            11
+          java(
+            """
+              class Test {
+              }
+              """,
+            """
+              /*~~>*/class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
           )
         );
     }
@@ -52,14 +50,12 @@ class HasJavaVersionTest implements RewriteTest {
     void noMatch(String version) {
         rewriteRun(
           spec -> spec.recipe(new HasJavaVersion(version, false)),
-          version(
-            java(
-              """
-                class Test {
-                }
-                """
-            ),
-            17
+          java(
+            """
+              class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(17))
           )
         );
     }
@@ -79,6 +75,24 @@ class HasJavaVersionTest implements RewriteTest {
                  toText: 2
             """, "org.openrewrite.PreconditionTest"),
           text("1")
+        );
+    }
+
+    @Test
+    void declarativePreconditionMatch() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.PreconditionTest
+            preconditions:
+              - org.openrewrite.java.search.HasJavaVersion:
+                  version: 11
+            recipeList:
+              - org.openrewrite.text.ChangeText:
+                 toText: 2
+            """, "org.openrewrite.PreconditionTest"),
+          text("1", "2", spec -> spec.markers(javaVersion(11)))
         );
     }
 


### PR DESCRIPTION
## What's changed?
Let `HasJavaVersion` return a `TreeVisitor` instead of a `JavaIsoVisitor`

## What's your motivation?
Set a property for use of virtual threads if on Java 21, with a non-scanning recipe.
- https://github.com/openrewrite/rewrite-spring/pull/446

Necessary for proper functioning of this recipe & tests:
- https://github.com/openrewrite/rewrite-spring/pull/460

## Any additional context
We add the Java version marker to all source files in
https://github.com/openrewrite/rewrite-maven-plugin/blob/1d205eac8f43a17395ed317b8e8984aa25990a59/src/main/java/org/openrewrite/maven/MavenMojoProjectParser.java#L296