### PR TITLE
Fix `StackOverflowError` in `MavenPomDownloader`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -208,7 +208,9 @@ public class MavenPomDownloader {
                 .resolve("..")
                 .resolve(Paths.get(relativePath))
                 .normalize();
-        return projectPoms.get(parentPath);
+        Pom parentPom = projectPoms.get(parentPath);
+        return parentPom != null && parentPom.getGav().getGroupId().equals(parent.getGav().getGroupId()) &&
+               parentPom.getGav().getArtifactId().equals(parent.getGav().getArtifactId()) ? parentPom : null;
     }
 
     public MavenMetadata downloadMetadata(GroupArtifact groupArtifact, @Nullable ResolvedPom containingPom, List<MavenRepository> repositories) throws MavenDownloadingException {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -1027,6 +1027,44 @@ class MavenParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void nestedParentWithDownloadedParent() {
+        rewriteRun(
+          mavenProject("root",
+            pomXml(
+              """
+                    <project>
+                        <parent>
+                            <groupId>org.apache</groupId>
+                            <artifactId>apache</artifactId>
+                            <version>16</version>
+                            <relativePath/>
+                        </parent>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>0.1.0-SNAPSHOT</version>
+                    </project>
+                """,
+              spec -> spec.path("parent/pom.xml")
+            ),
+            pomXml(
+              """
+                    <project>
+                        <parent>
+                            <groupId>org.openrewrite.maven</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>0.1.0-SNAPSHOT</version>
+                            <relativePath>parent/pom.xml</relativePath>
+                        </parent>
+                        <artifactId>root</artifactId>
+                    </project>
+                """,
+              spec -> spec.path("pom.xml")
+            )
+          )
+        );
+    }
+
     // a depends on d without specifying version number. a's parent is b
     // b imports c into its dependencyManagement section
     // c's dependencyManagement specifies the version of d to use


### PR DESCRIPTION
When building gridgain/gridgain@main there is a `StackOverflowError` because the root project references `parent/pom.xml` as its parent and the latter contains `<relativePath/>`. But that actually means that Maven should *not* look for the parent in the current project.

It seems difficult to get this 100% correct right now, as we with our current model we deserialize using Jackson into `RawPom.Parent` can't tell the difference between an absent `<relativePath>` element and a present but empty `<relativePath>` element, even though that is significant in Maven.

As a shortcut we can check if the parent (in the file system) has a matching GA or not.