### PR TITLE
Improve diagnostics on RawPom parse failures

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -121,7 +121,7 @@ public class MavenParser implements Parser {
                         null);
                 parsed.add(docToPom.getKey().withMarkers(docToPom.getKey().getMarkers().add(parseExceptionResult)));
                 ctx.getOnError().accept(e);
-            } catch (MavenDownloadingException e) {
+            } catch (MavenDownloadingException | UncheckedIOException e) {
                 parsed.add(docToPom.getKey().withMarkers(docToPom.getKey().getMarkers().add(ParseExceptionResult.build(this, e))));
                 ctx.getOnError().accept(e);
             }


### PR DESCRIPTION
## What's changed?
- Catch the UncheckedIOException thrown in RawPom parser
https://github.com/openrewrite/rewrite/blob/e1d09d09f1467531f1d72388658ca7306ccc7ea6/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java#L105-L115  

## What's your motivation?
Ensure we're able to troubleshoot and/or continue in the face of parse failures, to get away from stack traces like:
```java
Caused by: com.ctc.wstx.exc.WstxUnexpectedCharException: Unexpected character 's' (code 115) expected '='
 at [row,col {unknown-source}]: [9,27]
    at com.ctc.wstx.sr.StreamScanner.throwUnexpectedChar (StreamScanner.java:666)
    at com.ctc.wstx.sr.BasicStreamReader.handleNonNsAttrs (BasicStreamReader.java:3213)
    at com.ctc.wstx.sr.BasicStreamReader.handleStartElem (BasicStreamReader.java:3055)
    at com.ctc.wstx.sr.BasicStreamReader.nextFromTree (BasicStreamReader.java:2928)
    at com.ctc.wstx.sr.BasicStreamReader.next (BasicStreamReader.java:1122)
    at com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream._skipAndCollectTextUntilTag (XmlTokenStream.java:602)
    at com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream._next (XmlTokenStream.java:521)
    at com.fasterxml.jackson.dataformat.xml.deser.XmlTokenStream.next (XmlTokenStream.java:306)
    at com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser._nextToken (FromXmlParser.java:1412)
    at com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser.nextToken (FromXmlParser.java:716)
    at com.fasterxml.jackson.databind.util.TokenBuffer._copyBufferContents (TokenBuffer.java:1203)
    at com.fasterxml.jackson.databind.util.TokenBuffer.copyCurrentStructure (TokenBuffer.java:1185)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased (BeanDeserializer.java:517)
    at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault (BeanDeserializerBase.java:1409)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject (BeanDeserializer.java:352)
    at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize (BeanDeserializer.java:185)
    at com.fasterxml.jackson.dataformat.xml.deser.XmlDeserializationContext.readRootValue (XmlDeserializationContext.java:91)
    at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose (ObjectMapper.java:4825)
    at com.fasterxml.jackson.databind.ObjectMapper.readValue (ObjectMapper.java:3809)
    at org.openrewrite.maven.internal.RawPom.parse (RawPom.java:107)
```
The above stack trace bubbles up all the way to the plugin, but does not include which file failed to parse, and hard breaks project parse.

## Have you considered any alternatives or workarounds?
We could have changed the exception thrown from RawPom, or caught this elsewhere. This seemed to make the most sense.

## Any additional context
Reported by email. 