### PR TITLE
Handle XML escapes in tag values

### DIFF
--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     implementation("org.antlr:antlr4:4.11.1")
     implementation("io.micrometer:micrometer-core:1.9.+")
+    implementation("org.apache.commons:commons-text:1.11.+")
 
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-maven"))

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -17,6 +17,7 @@ package org.openrewrite.xml.tree;
 
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import org.apache.commons.text.StringEscapeUtils;
 import org.intellij.lang.annotations.Language;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
@@ -358,11 +359,14 @@ public interface Xml extends Tree {
             if (content == null) {
                 return Optional.empty();
             }
-            if (content.size() != 1) {
-                return Optional.empty();
-            }
-            if (content.get(0) instanceof Xml.CharData) {
+            if (content.size() == 1 && content.get(0) instanceof Xml.CharData) {
                 return Optional.ofNullable(((CharData) content.get(0)).getText());
+            }
+            if (content.stream().allMatch(c -> c instanceof Xml.CharData)) {
+                return Optional.of(content.stream()
+                        .map(c -> ((CharData) c).getText())
+                        .map(StringEscapeUtils::unescapeXml)
+                        .collect(Collectors.joining()));
             }
             return Optional.empty();
         }


### PR DESCRIPTION
## What's changed?
Added test that replicates issue with escaped value in tag, which results in a List of Xml.CharData.
When encountered, tag the text from each CharData, unescape that for use in download URLs, and concatenate.

## What's your motivation?
This broke whenever we wanted to use an escaped value; we'd end up with no value at all.

Fixes #3811

## Anything in particular you'd like reviewers to focus on?
Ok to use Streams and commons-text `StringEscapeUtils` in the uncommon case of more than one child value?

## Have you considered any alternatives or workarounds?
Not escaping still lead to download errors when composing depedency URLs.

## Any additional context
- #3811