### PR TITLE
switch around mkdirs exists to avoid race condition

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParserExecutionContextView.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParserExecutionContextView.java
@@ -45,7 +45,7 @@ public class JavaParserExecutionContextView extends DelegatingExecutionContext {
         File target = getMessage(PARSER_CLASSPATH_DOWNLOAD_LOCATION);
         if (target == null) {
             File defaultTarget = new File(System.getProperty("user.home") + "/.rewrite/classpath");
-            if (!defaultTarget.exists() && !defaultTarget.mkdirs()) {
+            if (!defaultTarget.mkdirs() && !defaultTarget.exists()) {
                 throw new UncheckedIOException(new IOException("Failed to create directory " + defaultTarget.getAbsolutePath()));
             }
             return defaultTarget;


### PR DESCRIPTION
## What's changed?
Switched mkdirs and exists when creating a directory in home directory

## What's your motivation?
This can potentially be a race condition where the directory does not exists and we fail to create it because some other thread has created in between.
Fixes: https://github.com/moderneinc/customer-requests/issues/191

## Anyone you would like to review specifically?
@timtebeek @knutwannheden 


## Have you considered any alternatives or workarounds?
We could use `Files::createDirectories` since it does not fail if the directories already exists.


## Any additional context
Similar fix done here: https://github.com/moderneinc/moderne-cli/pull/1002

