### PR TITLE
Add new `SourceFileService`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/service/ParseErrorSourceFileService.java
+++ b/rewrite-core/src/main/java/org/openrewrite/service/ParseErrorSourceFileService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.service;
+
+import org.openrewrite.ParseErrorVisitor;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.function.BiConsumer;
+
+public class ParseErrorSourceFileService extends SourceFileService {
+    @Override
+    public <P> TreeVisitor<?, P> newVisitor(BiConsumer<Tree, P> consumer) {
+        return new ParseErrorVisitor<P>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, P p) {
+                consumer.accept(tree, p);
+                return super.visit(tree, p);
+            }
+        };
+    }
+
+}

--- a/rewrite-core/src/main/java/org/openrewrite/service/SourceFileService.java
+++ b/rewrite-core/src/main/java/org/openrewrite/service/SourceFileService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.service;
+
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+public class SourceFileService {
+    public long computeWeight(SourceFile sourceFile, Predicate<Object> uniqueIdentity) {
+        AtomicInteger n = new AtomicInteger();
+        this.<AtomicInteger>newVisitor((tree, atomicInteger) -> {
+            if (tree != null) {
+                atomicInteger.incrementAndGet();
+            }
+        }).visit(sourceFile, n);
+        return n.get();
+    }
+
+    public <P> TreeVisitor<?, P> newVisitor(BiConsumer<Tree, P> consumer) {
+        return new TreeVisitor<Tree, P>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, P p) {
+                consumer.accept(tree, p);
+                return super.visit(tree, p);
+            }
+        };
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/service/package-info.java
+++ b/rewrite-core/src/main/java/org/openrewrite/service/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.openrewrite.service;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/JavaSourceFileService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/JavaSourceFileService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.service;
+
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaTypeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.service.SourceFileService;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+public class JavaSourceFileService extends SourceFileService {
+    @Override
+    public long computeWeight(SourceFile sourceFile, Predicate<Object> uniqueIdentity) {
+        AtomicInteger n = new AtomicInteger();
+        new JavaVisitor<AtomicInteger>() {
+            final JavaTypeVisitor<AtomicInteger> typeVisitor = new JavaTypeVisitor<AtomicInteger>() {
+                @Override
+                public JavaType visit(@Nullable JavaType javaType, AtomicInteger n) {
+                    if (javaType != null && uniqueIdentity.test(javaType)) {
+                        n.incrementAndGet();
+                        return super.visit(javaType, n);
+                    }
+                    //noinspection ConstantConditions
+                    return javaType;
+                }
+            };
+
+            final JavadocVisitor<AtomicInteger> javadocVisitor = new JavadocVisitor<AtomicInteger>(this) {
+                @Override
+                public @Nullable Javadoc visit(@Nullable Tree tree, AtomicInteger n) {
+                    if (tree != null) {
+                        n.incrementAndGet();
+                    }
+                    return super.visit(tree, n);
+                }
+            };
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, AtomicInteger n) {
+                if (tree != null) {
+                    n.incrementAndGet();
+                }
+                return super.visit(tree, n);
+            }
+
+            @Override
+            public JavaType visitType(@Nullable JavaType javaType, AtomicInteger n) {
+                return typeVisitor.visit(javaType, n);
+            }
+
+            @Override
+            protected JavadocVisitor<AtomicInteger> getJavadocVisitor() {
+                return javadocVisitor;
+            }
+        }.visit(sourceFile, n);
+        return n.get();
+    }
+
+    @Override
+    public <P> TreeVisitor<?, P> newVisitor(BiConsumer<Tree, P> consumer) {
+        return new JavaVisitor<P>() {
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, P p) {
+                consumer.accept(tree, p);
+                return super.visit(tree, p);
+            }
+        };
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -27,9 +27,7 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaPrinter;
-import org.openrewrite.java.JavaTypeVisitor;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.JavadocVisitor;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.marker.Markers;
@@ -41,9 +39,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -1463,54 +1459,6 @@ public interface J extends Tree {
         @With
         @Getter
         Space eof;
-
-        @Transient
-        @Override
-        public long getWeight(Predicate<Object> uniqueIdentity) {
-            AtomicInteger n = new AtomicInteger();
-            new JavaVisitor<AtomicInteger>() {
-                final JavaTypeVisitor<AtomicInteger> typeVisitor = new JavaTypeVisitor<AtomicInteger>() {
-                    @Override
-                    public JavaType visit(@Nullable JavaType javaType, AtomicInteger n) {
-                        if (javaType != null && uniqueIdentity.test(javaType)) {
-                            n.incrementAndGet();
-                            return super.visit(javaType, n);
-                        }
-                        //noinspection ConstantConditions
-                        return javaType;
-                    }
-                };
-
-                final JavadocVisitor<AtomicInteger> javadocVisitor = new JavadocVisitor<AtomicInteger>(this) {
-                    @Override
-                    public @Nullable Javadoc visit(@Nullable Tree tree, AtomicInteger n) {
-                        if (tree != null) {
-                            n.incrementAndGet();
-                        }
-                        return super.visit(tree, n);
-                    }
-                };
-
-                @Override
-                public @Nullable J visit(@Nullable Tree tree, AtomicInteger n) {
-                    if (tree != null) {
-                        n.incrementAndGet();
-                    }
-                    return super.visit(tree, n);
-                }
-
-                @Override
-                public JavaType visitType(@Nullable JavaType javaType, AtomicInteger n) {
-                    return typeVisitor.visit(javaType, n);
-                }
-
-                @Override
-                protected JavadocVisitor<AtomicInteger> getJavadocVisitor() {
-                    return javadocVisitor;
-                }
-            }.visit(this, n);
-            return n.get();
-        }
 
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {


### PR DESCRIPTION
The service implements the methods `computeWeight()` and `newVisitor()`. This is then in turn used by `SourceFile#getWeight()` with the idea that it will automatically use a visitor that doesn't need to be adapted using `TreeVisitorAdapter`, which behind the scenes generates a new class.
