### PR TITLE
Include Recipe class simple name in validation errors

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -299,12 +299,13 @@ public abstract class Recipe implements Cloneable {
      */
     public Validated<Object> validate() {
         Validated<Object> validated = Validated.none();
-        List<Field> requiredFields = NullUtils.findNonNullFields(this.getClass());
+        Class<? extends Recipe> clazz = this.getClass();
+        List<Field> requiredFields = NullUtils.findNonNullFields(clazz);
         for (Field field : requiredFields) {
             try {
-                validated = validated.and(Validated.required(field.getName(), field.get(this)));
+                validated = validated.and(Validated.required(clazz.getSimpleName() + '.' + field.getName(), field.get(this)));
             } catch (IllegalAccessException e) {
-                logger.warn("Unable to validate the field [{}] on the class [{}]", field.getName(), this.getClass().getName());
+                logger.warn("Unable to validate the field [{}] on the class [{}]", field.getName(), clazz.getName());
             }
         }
         for (Recipe recipe : getRecipeList()) {


### PR DESCRIPTION
## What's changed?
When creating a Validated.required include the Recipe class simple name.

## What's your motivation?
Fixes #3587

## Anyone you would like to review specifically?
@Bananeweizen 

## Have you considered any alternatives or workarounds?
This seemed the have the least impact by not changing the Recipe class signature.
I figured `Class.getSimpleName` would be enough to pin down the cause in most cases.

## Any additional context
-  #3587