### PR TITLE
Maven POM downloader optimizations

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/InMemoryMavenPomCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/InMemoryMavenPomCache.java
@@ -64,15 +64,11 @@ public class InMemoryMavenPomCache implements MavenPomCache {
                                  Cache<MetadataKey, Optional<MavenMetadata>> mavenMetadataCache,
                                  Cache<MavenRepository, Optional<MavenRepository>> repositoryCache,
                                  Cache<ResolvedGroupArtifactVersion, ResolvedPom> dependencyCache) {
-        this.pomCache = pomCache;
-        this.mavenMetadataCache = mavenMetadataCache;
-        this.repositoryCache = repositoryCache;
-        this.dependencyCache = dependencyCache;
 
-        CaffeineCacheMetrics.monitor(Metrics.globalRegistry, pomCache, "Maven POMs - " + cacheNickname);
-        CaffeineCacheMetrics.monitor(Metrics.globalRegistry, mavenMetadataCache, "Maven metadata - " + cacheNickname);
-        CaffeineCacheMetrics.monitor(Metrics.globalRegistry, repositoryCache, "Maven repositories - " + cacheNickname);
-        CaffeineCacheMetrics.monitor(Metrics.globalRegistry, dependencyCache, "Resolved dependency POMs - " + cacheNickname);
+        this.pomCache = CaffeineCacheMetrics.monitor(Metrics.globalRegistry, pomCache, "Maven POMs - " + cacheNickname);
+        this.mavenMetadataCache = CaffeineCacheMetrics.monitor(Metrics.globalRegistry, mavenMetadataCache, "Maven metadata - " + cacheNickname);
+        this.repositoryCache = CaffeineCacheMetrics.monitor(Metrics.globalRegistry, repositoryCache, "Maven repositories - " + cacheNickname);
+        this.dependencyCache = CaffeineCacheMetrics.monitor(Metrics.globalRegistry, dependencyCache, "Resolved dependency POMs - " + cacheNickname);
     }
 
     public InMemoryMavenPomCache(Cache<ResolvedGroupArtifactVersion, Optional<Pom>> pomCache,

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -65,6 +65,7 @@ public class MavenRepository implements Serializable {
 
     @EqualsAndHashCode.Include
     @With
+    @NonFinal
     boolean knownToExist;
 
     // Prevent user credentials from being inadvertently serialized

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -63,6 +63,8 @@ public class MavenRepository implements Serializable {
     @Nullable
     String snapshots;
 
+    @EqualsAndHashCode.Include
+    @With
     @NonFinal
     boolean knownToExist;
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -65,7 +65,6 @@ public class MavenRepository implements Serializable {
 
     @EqualsAndHashCode.Include
     @With
-    @NonFinal
     boolean knownToExist;
 
     // Prevent user credentials from being inadvertently serialized

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
@@ -104,7 +104,7 @@ public class MavenRepositoryMirror {
     }
 
     public MavenRepository apply(MavenRepository repo) {
-        if (repo.getUri().equals(url) && Objects.equals(id, repo.getId()) || !matches(repo)) {
+        if (Objects.equals(id, repo.getId()) && (repo.getUri().equals(url) || repo.isKnownToExist()) || !matches(repo)) {
             return repo;
         } else {
             MavenRepository repoWithMirror = repo.withUri(url)

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -407,9 +407,12 @@ class MavenPomDownloaderTest {
     @Test
     void deriveMetaDataFromFileRepository(@TempDir Path repoPath) throws IOException, MavenDownloadingException {
         Path fred = repoPath.resolve("fred/fred");
-        Files.createDirectories(fred.resolve("1.0.0"));
-        Files.createDirectories(fred.resolve("1.1.0"));
-        Files.createDirectories(fred.resolve("2.0.0"));
+
+        for (String version : Arrays.asList("1.0.0", "1.1.0", "2.0.0")) {
+            Path versionPath = fred.resolve(version);
+            Files.createDirectories(versionPath);
+            Files.writeString(versionPath.resolve("fred-" + version + ".pom"), "");
+        }
 
         MavenRepository repository = MavenRepository.builder()
           .id("file-based")


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR introduces two small optimizations to `MavenPomDownloader`:
1. Add a trailing '/' to Maven repository URL checks to avoid HTTP 302 redirects on slow Artifactory instances. Also tag the repository URL as known, if able to connect to it.
2. When deriving metadata for artifacts present on the local maven repository, consider only successfully downloaded artifacts.

This PR also fixes the counting of `deriveMetadata` successful calls.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Increased latency when working on network restricted environments with slow Artifactory proxies.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
No.

## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No workarounds for environment issues

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
