### PR TITLE
filePattern on FindSourceFiles is now nullable, and matches all files…

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/FindSourceFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindSourceFiles.java
@@ -17,6 +17,7 @@ package org.openrewrite;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.table.SourcesFiles;
@@ -30,8 +31,10 @@ public class FindSourceFiles extends Recipe {
     transient SourcesFiles results = new SourcesFiles(this);
 
     @Option(displayName = "File pattern",
-            description = "A glob expression representing a file path to search for (relative to the project root).",
+            description = "A glob expression representing a file path to search for (relative to the project root). Blank/null matches all.",
+            required = false,
             example = ".github/workflows/*.yml")
+    @Nullable
     String filePattern;
 
     @Override
@@ -53,7 +56,7 @@ public class FindSourceFiles extends Recipe {
                 if (tree instanceof SourceFile) {
                     SourceFile sourceFile = (SourceFile) tree;
                     Path sourcePath = sourceFile.getSourcePath();
-                    if (PathUtils.matchesGlob(sourcePath, normalize(filePattern))) {
+                    if (StringUtils.isBlank(filePattern) || PathUtils.matchesGlob(sourcePath, normalize(filePattern))) {
                         results.insertRow(ctx, new SourcesFiles.Row(sourcePath.toString(),
                                 tree.getClass().getSimpleName()));
                         return SearchResult.found(sourceFile);

--- a/rewrite-test/src/test/java/org/openrewrite/FindSourceFilesTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/FindSourceFilesTest.java
@@ -18,6 +18,7 @@ package org.openrewrite;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -76,7 +77,8 @@ class FindSourceFilesTest implements RewriteTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"hello.txt", "/hello.txt", "\\hello.txt", "./hello.txt", ".\\hello.txt"})
+    @ValueSource(strings = {"hello.txt", "/hello.txt", "\\hello.txt", "./hello.txt", ".\\hello.txt", ""})
+    @NullSource
     void findRoot(String filePattern) {
         rewriteRun(
           spec -> spec.recipe(new FindSourceFiles(filePattern)),

--- a/rewrite-test/src/test/java/org/openrewrite/FindSourceFilesTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/FindSourceFilesTest.java
@@ -77,8 +77,7 @@ class FindSourceFilesTest implements RewriteTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"hello.txt", "/hello.txt", "\\hello.txt", "./hello.txt", ".\\hello.txt", ""})
-    @NullSource
+    @ValueSource(strings = {"hello.txt", "/hello.txt", "\\hello.txt", "./hello.txt", ".\\hello.txt"})
     void findRoot(String filePattern) {
         rewriteRun(
           spec -> spec.recipe(new FindSourceFiles(filePattern)),
@@ -90,6 +89,39 @@ class FindSourceFilesTest implements RewriteTest {
           text(
             "hello world!",
             spec -> spec.path("a/hello.txt")
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    @NullSource
+    void blankMatchesEverything(String filePattern) {
+        rewriteRun(
+          spec -> spec.recipe(new FindSourceFiles(filePattern)),
+          text(
+            "hello world!",
+            "~~>hello world!",
+            spec -> spec.path("hello.txt")
+          ),
+          text(
+            "hello world!",
+            "~~>hello world!",
+            spec -> spec.path("a/hello.txt")
+          ),
+          text(
+            """
+              name: hello-world
+              """,
+            """
+              ~~>name: hello-world
+              """,
+            spec -> spec.path(".github/workflows/hello.yml")
+          ),
+          text(
+            "hello world!",
+            "~~>hello world!",
+            spec -> spec.path("C:\\Windows\\hello.txt")
           )
         );
     }

--- a/rewrite-test/src/test/java/org/openrewrite/FindSourceFilesTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/FindSourceFilesTest.java
@@ -110,12 +110,8 @@ class FindSourceFilesTest implements RewriteTest {
             spec -> spec.path("a/hello.txt")
           ),
           text(
-            """
-              name: hello-world
-              """,
-            """
-              ~~>name: hello-world
-              """,
+            "name: hello-world",
+            "~~>name: hello-world",
             spec -> spec.path(".github/workflows/hello.yml")
           ),
           text(

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
@@ -48,7 +48,7 @@ public class RemoveXmlTag extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(fileMatcher != null ? new FindSourceFiles(fileMatcher) : new FindSourceFiles("**"), new XmlIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new FindSourceFiles(fileMatcher), new XmlIsoVisitor<ExecutionContext>() {
             private final XPathMatcher xPathMatcher = new XPathMatcher(xPath);
 
             @Override


### PR DESCRIPTION
… on blank input, to make it a little more convenient to use in place of HasSourcePath

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->


## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Brief discussion over here https://github.com/openrewrite/rewrite/issues/3807#issuecomment-1850976790


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
