### PR TITLE
`SemanticallyEqual`: Fix bug in `visitFieldAccess()`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -406,6 +406,28 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
     }
 
     @Test
+    void differentFieldAccesses() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  Object f = null;
+                  class B extends A {
+                      boolean m(Object o) {
+                          B other = (B) o;
+                          if (this.f == null || other.f == null) {
+                              return true;
+                          }
+                          return false;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void preserveComments() {
         rewriteRun(
           java(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -34,7 +34,7 @@ public class SemanticallyEqualTest {
     private final JavaParser javaParser = JavaParser.fromJavaVersion().build();
 
     @Test
-    void compareAbstractMethods() {
+    void abstractMethods() {
         assertEqualToSelf(
           """
             abstract class A {
@@ -45,7 +45,7 @@ public class SemanticallyEqualTest {
     }
 
     @Test
-    void compareClassModifierLists() {
+    void classModifierLists() {
         assertEqual(
           """
             public abstract class A {
@@ -59,7 +59,7 @@ public class SemanticallyEqualTest {
     }
 
     @Test
-    void compareLiterals() {
+    void literals() {
         assertEqual(
           """
             class A {
@@ -75,7 +75,7 @@ public class SemanticallyEqualTest {
     }
 
     @Test
-    void compareClassLiterals() {
+    void classLiterals() {
         assertExpressionsEqual(
           """
             import java.util.UUID;
@@ -98,7 +98,7 @@ public class SemanticallyEqualTest {
     }
 
     @CartesianTest
-    void staticFieldAccess(@CartesianTest.Values(strings = {
+    void staticFieldAccesses(@CartesianTest.Values(strings = {
       "java.util.regex.Pattern.CASE_INSENSITIVE",
       "Pattern.CASE_INSENSITIVE",
       "CASE_INSENSITIVE",
@@ -113,7 +113,7 @@ public class SemanticallyEqualTest {
     }
 
     @CartesianTest
-    void staticMethodAccess(@CartesianTest.Values(strings = {
+    void staticMethodAccesses(@CartesianTest.Values(strings = {
       "java.util.regex.Pattern.compile",
       "Pattern.compile",
       "compile",
@@ -128,7 +128,7 @@ public class SemanticallyEqualTest {
     }
 
     @Test
-    void compareTypeCasts() {
+    void typeCasts() {
         assertExpressionsEqual(
           """
             class T {
@@ -168,7 +168,7 @@ public class SemanticallyEqualTest {
     }
 
     @Test
-    void compareFieldAccess() {
+    void fieldAccesses() {
         assertExpressionsEqual(
           """
             class T {
@@ -193,6 +193,17 @@ public class SemanticallyEqualTest {
                 int n = 1;
                 int a = T.this.n;
                 int b = n;
+            }
+            """
+        );
+        assertExpressionsNotEqual(
+          """
+            class T {
+                int n = 1;
+                void m(int n) {
+                    int a = T.this.n;
+                    int b = n;
+                }
             }
             """
         );

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -76,19 +76,28 @@ public class SemanticallyEqualTest {
     void compareFieldAccess() {
         assertExpressionsEqual(
           """
-            class A {
+            class T {
                 int n = 1;
-                int a = A.this.n;
-                int b = A.this.n;
+                int a = T.this.n;
+                int b = T.this.n;
             }
             """
         );
         assertExpressionsEqual(
           """
-            class A {
+            class T {
                 int n = 1;
-                int a = A.this.n;
+                int a = T.this.n;
                 int b = this.n;
+            }
+            """
+        );
+        assertExpressionsEqual(
+          """
+            class T {
+                int n = 1;
+                int a = T.this.n;
+                int b = n;
             }
             """
         );

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -19,7 +19,6 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
 import java.util.HashMap;
@@ -75,20 +74,24 @@ public class SemanticallyEqualTest {
 
     @Test
     void compareFieldAccess() {
-        assertExpressionsEqual("""
-          class A {
-              int n = 1;
-              int a = A.this.n;
-              int b = A.this.n;
-          }
-          """);
-        assertExpressionsEqual("""
-          class A {
-              int n = 1;
-              int a = A.this.n;
-              int b = this.n;
-          }
-          """);
+        assertExpressionsEqual(
+          """
+            class A {
+                int n = 1;
+                int a = A.this.n;
+                int b = A.this.n;
+            }
+            """
+        );
+        assertExpressionsEqual(
+          """
+            class A {
+                int n = 1;
+                int a = A.this.n;
+                int b = this.n;
+            }
+            """
+        );
     }
 
     private void assertEqualToSelf(@Language("java") String a) {
@@ -116,11 +119,11 @@ public class SemanticallyEqualTest {
             }
         };
 
-        Map<String, J.VariableDeclarations.NamedVariable> result = new HashMap<>();
-        visitor.visit(cu, result);
-        Expression ea = result.get("a").getInitializer();
-        Expression eb = result.get("b").getInitializer();
-        assertEqual(Objects.requireNonNull(ea), Objects.requireNonNull(eb));
+        Map<String, J.VariableDeclarations.NamedVariable> result = visitor.reduce(cu, new HashMap<>());
+        assertEqual(
+          Objects.requireNonNull(result.get("a").getInitializer()),
+          Objects.requireNonNull(result.get("b").getInitializer())
+        );
     }
 
     private void assertEqual(J a, J b) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -587,6 +587,12 @@ public class SemanticallyEqual {
                     isEqual.set(false);
                     return fieldAccess;
                 }
+
+                if (nullMissMatch(fieldAccess.getTarget(), compareTo.getTarget())) {
+                    isEqual.set(false);
+                    return fieldAccess;
+                }
+                visit(fieldAccess.getTarget(), compareTo.getTarget());
             }
             return fieldAccess;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -575,23 +575,26 @@ public class SemanticallyEqual {
         public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, J j) {
             if (isEqual.get()) {
                 if (!(j instanceof J.FieldAccess)) {
-                    if (!(j instanceof J.Identifier) || !TypeUtils.isOfType(fieldAccess.getName().getFieldType(), ((J.Identifier) j).getFieldType())) {
+                    if (!(j instanceof J.Identifier) ||
+                        !TypeUtils.isOfType(fieldAccess.getName().getFieldType(), ((J.Identifier) j).getFieldType()) ||
+                        !fieldAccess.getSimpleName().equals(((J.Identifier) j).getSimpleName())) {
                         isEqual.set(false);
                     }
                     return fieldAccess;
                 }
 
                 J.FieldAccess compareTo = (J.FieldAccess) j;
-                if (!TypeUtils.isOfType(fieldAccess.getType(), compareTo.getType())
-                    || !TypeUtils.isOfType(fieldAccess.getName().getFieldType(), compareTo.getName().getFieldType())) {
+                if (fieldAccess.getType() instanceof JavaType.Unknown && compareTo.getType() instanceof JavaType.Unknown) {
+                    if (!fieldAccess.getSimpleName().equals(compareTo.getSimpleName())) {
+                        isEqual.set(false);
+                        return fieldAccess;
+                    }
+                } else if (!TypeUtils.isOfType(fieldAccess.getType(), compareTo.getType())
+                           || !TypeUtils.isOfType(fieldAccess.getName().getFieldType(), compareTo.getName().getFieldType())) {
                     isEqual.set(false);
                     return fieldAccess;
                 }
 
-                if (nullMissMatch(fieldAccess.getTarget(), compareTo.getTarget())) {
-                    isEqual.set(false);
-                    return fieldAccess;
-                }
                 visit(fieldAccess.getTarget(), compareTo.getTarget());
             }
             return fieldAccess;


### PR DESCRIPTION
When comparing `J.FieldAccess` instances, the targets also needs to be compared.
