### PR TITLE
Add GoToLine Recipe + Utility Methods

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/GoToLineTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/GoToLineTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class GoToLineTest implements RewriteTest {
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    private static class GoToLineRecipe extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Go to line";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Finds a line in a file. Will add LST markers to all AST nodes on the line (and column if specified).";
+        }
+
+        @Option(
+          displayName = "Line number",
+          description = "The line number to go to. 1-based.",
+          example = "1"
+        )
+        Integer lineNumber;
+
+        @Option(
+          displayName = "Column number",
+          description = "The column number to go to. 1-based.\nIf not specified, all AST nodes on the line will be selected.",
+          example = "1",
+          required = false
+        )
+        @Nullable
+        Integer columnNumber;
+
+        @Override
+        public Validated<Object> validate() {
+            Validated<Object> validated = super.validate();
+            //noinspection ConstantValue
+            if (lineNumber != null && lineNumber < 1) {
+                validated = validated.and(Validated.invalid("lineNumber", lineNumber, "lineNumber must be greater than 0"));
+            }
+            if (columnNumber != null && columnNumber < 1) {
+                validated = validated.and(Validated.invalid("columnNumber", columnNumber, "columnNumber must be greater than 0"));
+            }
+            return validated;
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                    Collection<J> found;
+                    if (columnNumber != null) {
+                        found = GoToLine.findLineColumn(cu, lineNumber, columnNumber);
+                    } else {
+                        found = GoToLine.findLine(cu, lineNumber);
+                    }
+                    if (found.isEmpty()) {
+                        return cu;
+                    }
+                    Set<J> foundSet = Collections.newSetFromMap(new IdentityHashMap<>());
+                    foundSet.addAll(found);
+
+                    //noinspection DataFlowIssue
+                    return (J.CompilationUnit) cu.accept(new JavaIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public @Nullable J preVisit(J tree, ExecutionContext executionContext) {
+                            J t = tree;
+                            if (foundSet.remove(t)) {
+                                t = SearchResult.found(t, getSimpleNameWithParent(tree.getClass()));
+                            }
+                            if (foundSet.isEmpty()) {
+                                stopAfterPreVisit();
+                            }
+                            return t;
+                        }
+                    }, executionContext);
+                }
+            };
+        }
+
+        private static String getSimpleNameWithParent(Class<?> clazz) {
+            if (clazz.getEnclosingClass() != null) {
+                return getSimpleNameWithParent(clazz.getEnclosingClass()) + "." + clazz.getSimpleName();
+            }
+            return clazz.getSimpleName();
+        }
+    }
+
+    private static Recipe locateLine(int line) {
+        return new GoToLineRecipe(line, null);
+    }
+
+    private static Recipe locateLineColumn(int line, int column) {
+        return new GoToLineRecipe(line, column);
+    }
+
+    @Test
+    void findLineColumnPassedString() {
+        rewriteRun(
+          spec -> spec.recipe(locateLineColumn(3, 28)),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      System.out.println(/*~~(J.Literal)~~>*/"Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findFindLineColumnMethodInvocation() {
+        rewriteRun(
+          spec -> spec.recipe(locateLineColumn(3, 20)),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      System.out./*~~(J.Identifier)~~>*/println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findLineColumnStaticImportMethodInvocation() {
+        rewriteRun(
+          spec -> spec.recipe(locateLineColumn(4, 9)),
+          java(
+            """
+              import static java.lang.Thread.sleep;
+              class Test {
+                  void test() {
+                      sleep(1000);
+                  }
+              }
+              """,
+            """
+              import static java.lang.Thread.sleep;
+              class Test {
+                  void test() {
+                      /*~~(J.MethodInvocation)~~>*//*~~(J.Identifier)~~>*/sleep(1000);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findLineColumnStaticImportMethodInvocationWithComment() {
+        rewriteRun(
+          spec -> spec.recipe(locateLineColumn(5, 9)),
+          java(
+            """
+              import static java.lang.Thread.sleep;
+              class Test {
+                  void test() {
+                      // comment
+                      sleep(1000);
+                  }
+              }
+              """,
+            """
+              import static java.lang.Thread.sleep;
+              class Test {
+                  void test() {
+                      // comment
+                      /*~~(J.MethodInvocation)~~>*//*~~(J.Identifier)~~>*/sleep(1000);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void findMethodCallLineNumber() {
+        rewriteRun(
+          spec -> spec.recipe(locateLine(3)),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      /*~~(J.MethodInvocation)~~>*//*~~(J.FieldAccess)~~>*//*~~(J.Identifier)~~>*/System./*~~(J.Identifier)~~>*/out./*~~(J.Identifier)~~>*/println(/*~~(J.Literal)~~>*/"Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderLine() {
+        rewriteRun(
+          spec -> spec.recipe(locateLine(1)),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /*~~(J.ClassDeclaration)~~>*/class /*~~(J.Identifier)~~>*/Test /*~~(J.Block)~~>*/{
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderWithMultilneCommentLine() {
+        rewriteRun(
+          spec -> spec.recipe(locateLine(1)),
+          java(
+            """
+              class Test /*
+              */ {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /*~~(J.ClassDeclaration)~~>*/class /*~~(J.Identifier)~~>*/Test /*
+              */ {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderWithSingleLineCommentLine() {
+        rewriteRun(
+          spec -> spec.recipe(locateLine(1)),
+          java(
+            """
+              class Test // comment
+              {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /*~~(J.ClassDeclaration)~~>*/class /*~~(J.Identifier)~~>*/Test // comment
+              {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderWithJavadocLine() {
+        rewriteRun(
+          spec -> spec.recipe(locateLine(4)),
+          java(
+            """
+              /**
+               * Javadoc
+               */
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /**
+               * Javadoc
+               */
+              /*~~(J.ClassDeclaration)~~>*/class /*~~(J.Identifier)~~>*/Test /*~~(J.Block)~~>*/{
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findClassHeaderWithJavadocLineAndMultilineComment() {
+        rewriteRun(
+          spec -> spec.recipe(locateLine(5)),
+          java(
+            """
+              /**
+               * Javadoc
+               */
+              /* comment */
+              class Test {
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """,
+            """
+              /**
+               * Javadoc
+               */
+              /* comment */
+              /*~~(J.ClassDeclaration)~~>*/class /*~~(J.Identifier)~~>*/Test /*~~(J.Block)~~>*/{
+                  void test() {
+                      System.out.println("Hello World!");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/GoToLine.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/GoToLine.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import lombok.*;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaPrinter;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.*;
+
+@Incubating(since = "8.12.1")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class GoToLine {
+    /**
+     * Set to true to print the file as it is being searched. Useful for debugging.
+     * The JIT will completely remove code flagged behind this when set to false because it is unreachable,
+     * and this is a constant.
+     */
+    private static final boolean debug = false;
+
+    /**
+     * Find all elements in the LST at the given line.
+     * <p>
+     * <strong>NOTE:</strong> line number is 1-based, which matches the behavior of most editors.
+     * </p>
+     *
+     * @param sourceFile The source file to search.
+     * @param line       The line number to search. 1-based.
+     * @return The elements found at the given line, or an empty collection if no elements were found.
+     */
+    public static Collection<J> findLine(JavaSourceFile sourceFile, int line) {
+        if (line < 1) {
+            throw new IllegalArgumentException("Line numbers must be 1-based");
+        }
+        Set<J> found = Collections.newSetFromMap(new IdentityHashMap<>());
+        LineColumnLocatorVisitor<Integer> locatorVisitor = new LineColumnLocatorVisitor<>(line, null, found);
+        locatorVisitor.visit(
+                sourceFile,
+                locatorVisitor.new LineColumnLocatorPrinter(0), new Cursor(null, "root")
+        );
+        return Collections.unmodifiableSet(found);
+    }
+
+    /**
+     * Find all element in the LST at the given line and column.
+     * <p>
+     * <strong>NOTE:</strong> line and column numbers are 1-based, which matches the behavior of most editors.
+     * </p>
+     *
+     * @param sourceFile The source file to search.
+     * @param line       The line number to search. 1-based.
+     * @param column     The column number to search. 1-based.
+     * @return The elements found at the given line and column, or an empty collection if no elements were found.
+     */
+    public static Collection<J> findLineColumn(JavaSourceFile sourceFile, int line, int column) {
+        if (line < 1 || column < 1) {
+            throw new IllegalArgumentException("Line and column numbers must be 1-based");
+        }
+        Set<J> found = Collections.newSetFromMap(new IdentityHashMap<>());
+        LineColumnLocatorVisitor<Integer> locatorVisitor = new LineColumnLocatorVisitor<>(line, column, found);
+        locatorVisitor.visit(
+                sourceFile,
+                locatorVisitor.new LineColumnLocatorPrinter(0), new Cursor(null, "root")
+        );
+        return Collections.unmodifiableSet(found);
+    }
+
+
+    @RequiredArgsConstructor
+    private static class LineColumnLocatorVisitor<P> extends JavaPrinter<P> {
+        private final int line;
+        @Nullable
+        private final Integer column;
+        private final Set<J> found;
+        private int foundLineNumber = 1;
+        private int foundColumnNumber = 1;
+
+        private boolean foundLine() {
+            return foundLineNumber == line;
+        }
+
+        private boolean beyondLine() {
+            return foundLineNumber > line;
+        }
+
+        private boolean foundColumn() {
+            return column == null || foundColumnNumber == column;
+        }
+
+        private boolean foundLineColumn() {
+            return foundLine() && foundColumn();
+        }
+
+        @Override
+        public Space visitSpace(Space space, Space.Location loc, PrintOutputCapture<P> p) {
+            Space s = super.visitSpace(space, loc, p);
+            if (foundLineColumn() && loc.isPrefix()) {
+                found.add(getCursor().getValue());
+                return s;
+            }
+            if (beyondLine()) {
+                // Optimization to avoid visiting the rest of the file once we've found the element(s)
+                stopAfterPreVisit();
+            }
+            return s;
+        }
+
+        class LineColumnLocatorPrinter extends PrintOutputCapture<P> {
+
+            public LineColumnLocatorPrinter(P p) {
+                super(p);
+            }
+
+            @Override
+            public PrintOutputCapture<P> append(@Nullable String text) {
+                if (text == null) {
+                    return this;
+                }
+                for (int i = 0; i < text.length(); i++) {
+                    append(text.charAt(i));
+                }
+                return this;
+            }
+
+            @Override
+            public PrintOutputCapture<P> append(char c) {
+                if (isNewLine(c)) {
+                    foundColumnNumber = 1;
+                    foundLineNumber++;
+                } else if (foundLine()) {
+                    foundColumnNumber++;
+                }
+                // Actually appending isn't necessary
+                return debug ? super.append(c) : this;
+            }
+        }
+    }
+
+    private static boolean isNewLine(int c) {
+        return c == '\n';
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.tree;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
+import org.openrewrite.Incubating;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Markers;
 
@@ -446,7 +447,17 @@ public class Space {
         WHILE_PREFIX,
         WILDCARD_BOUND,
         WILDCARD_PREFIX,
-        YIELD_PREFIX,
+        YIELD_PREFIX;
+
+        @Incubating(since = "8.12.1")
+        public boolean isPrefix() {
+            return this.toString().endsWith("_PREFIX");
+        }
+
+        @Incubating(since = "8.12.1")
+        public boolean isSuffix() {
+            return this.toString().endsWith("_SUFFIX");
+        }
     }
 
     static void rangeCheck(int arrayLength, int fromIndex, int toIndex) {


### PR DESCRIPTION
Adds a recipe that will find the LST nodes in the tree at a given
line/column.

This is useful for matching the OpenRewrite LST against outputs from
other scanners, for example security scanners that generate SARIF files.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Added a `GoToLine` recipe.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Being able to find LST nodes by their line/column coordinates can be helpful when matcing up the LST against scanners.

## Anything in particular you'd like reviewers to focus on?

Are there any unit tests that I'm missing that I should really make sure I include?

This strategy, unfortunately, doesn't inherintly support other languages. Is there any strategy that would make this multi-language?

## Anyone you would like to review specifically?
<!-- @mention them here -->


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
