### PR TITLE
Fixed prefix on key after folder scalars.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -208,6 +208,7 @@ public class YamlParser implements org.openrewrite.Parser {
                             case PLAIN:
                                 scalarValue = reader.readStringFromBuffer(valueStart, event.getEndMark().getIndex() - 1);
                                 break;
+                            case FOLDED:
                             case LITERAL:
                                 scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 1);
                                 if (scalarValue.endsWith("\n")) {
@@ -215,7 +216,6 @@ public class YamlParser implements org.openrewrite.Parser {
                                     scalarValue = scalarValue.substring(0, scalarValue.length() - 1);
                                 }
                                 break;
-                            case FOLDED:
                             default:
                                 scalarValue = reader.readStringFromBuffer(valueStart + 1, event.getEndMark().getIndex() - 1);
                                 break;

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/format/IndentsTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/format/IndentsTest.java
@@ -36,6 +36,21 @@ class IndentsTest implements RewriteTest {
         ));
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3531")
+    void multilineString() {
+        rewriteRun(
+          yaml("""
+            foo:
+              bar: >
+                A multiline string.
+              baz:
+                quz: Another string.
+            """
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void indentSequence() {


### PR DESCRIPTION
Changes:

- The new line at the end of folded scalars is appropriately set on the prefix of the next key.

fixes #3531