### PR TITLE
Feat:token length estimator

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ClassDefinitionLength.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ClassDefinitionLength.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.DeclaresMethod;
+import org.openrewrite.java.table.TokenCount;
+import org.openrewrite.java.tree.J;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ClassDefinitionLength extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Calculate token length of classes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Locates class definitions and predicts the number of token in each.";
+    }
+
+    transient TokenCount tokens = new TokenCount(this);
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration clazz, ExecutionContext ctx) {
+                J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                if(cd == null) {
+                    return cd;
+                }
+                int numberOfTokens = (int) ( cd.printTrimmed(getCursor()).length() / 3.5);
+                tokens.insertRow(ctx, new TokenCount.Row( cd.printTrimmed(getCursor()), numberOfTokens));
+                return cd;
+            }
+        };
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/ClassDefinitionLength.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ClassDefinitionLength.java
@@ -49,7 +49,7 @@ public class ClassDefinitionLength extends Recipe {
                     return cd;
                 }
                 int numberOfTokens = (int) ( cd.printTrimmed(getCursor()).length() / 3.5);
-                tokens.insertRow(ctx, new TokenCount.Row( cd.printTrimmed(getCursor()), numberOfTokens));
+                tokens.insertRow(ctx, new TokenCount.Row( cd.getSimpleName(), numberOfTokens));
                 return cd;
             }
         };

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodDefinitionLength.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodDefinitionLength.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.search.DeclaresMethod;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.table.TokenCount;
+
+import static java.util.Objects.requireNonNull;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class MethodDefinitionLength extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Calculate token length of method definitions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Locates method definitions and predicts the number of token in each.";
+    }
+
+    transient TokenCount tokens = new TokenCount(this);
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
+                J.ClassDeclaration cd = getCursor().firstEnclosing(J.ClassDeclaration.class);
+                if(cd == null) {
+                    return md;
+                }
+                int numberOfTokens = (int) ( md.printTrimmed(getCursor()).length() / 3.5);
+                tokens.insertRow(ctx, new TokenCount.Row( md.printTrimmed(getCursor()), numberOfTokens));
+                return md;
+            }
+        };
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodDefinitionLength.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodDefinitionLength.java
@@ -50,7 +50,7 @@ public class MethodDefinitionLength extends Recipe {
                     return md;
                 }
                 int numberOfTokens = (int) ( md.printTrimmed(getCursor()).length() / 3.5);
-                tokens.insertRow(ctx, new TokenCount.Row( md.printTrimmed(getCursor()), numberOfTokens));
+                tokens.insertRow(ctx, new TokenCount.Row( md.getSimpleName(), numberOfTokens));
                 return md;
             }
         };

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/TokenCount.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/TokenCount.java
@@ -33,8 +33,8 @@ public class TokenCount extends DataTable<TokenCount.Row> {
     @Value
     public static class Row {
 
-        @Column(displayName = "Code snippet",
-                description = "The text of code snippet.")
+        @Column(displayName = "Name of Class or Method",
+                description = "The name of the class or method.")
         String codeSnippet;
 
         @Column(displayName = "Tokens",

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/TokenCount.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/TokenCount.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class TokenCount extends DataTable<TokenCount.Row> {
+
+    public TokenCount(Recipe recipe) {
+        super(recipe,
+                "Token count",
+                "The number of tokens from a code snippet");
+    }
+
+    @Value
+    public static class Row {
+
+        @Column(displayName = "Code snippet",
+                description = "The text of code snippet.")
+        String codeSnippet;
+
+        @Column(displayName = "Tokens",
+                description = "The number of tokens estimated in the code snippet.")
+        int tokens;
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/ClassDefinitionLengthTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ClassDefinitionLengthTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ClassDefinitionLengthTest implements RewriteTest {
+    @Test
+    void declares() {
+        rewriteRun( spec -> spec.recipe(new ClassDefinitionLength()),
+          java("""
+                public class Foo {
+                    public void hello(){
+                        System.out.println("hello");
+                    }
+                }
+                """)
+        );
+    }
+
+
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/MethodDefinitionLengthTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/MethodDefinitionLengthTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MethodDefinitionLengthTest implements RewriteTest {
+
+    @Test
+    void declares() {
+        rewriteRun( spec -> spec.recipe(new MethodDefinitionLength()),
+          java("""
+                public class Foo {
+                    public void hello(){
+                        System.out.println("hello");
+                    }
+                }
+                """)
+        );
+    }
+
+
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
Adding two recipes which estimates the number of token for class definitions and method definitions, and inputs those estimates into datatables. 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
This is to estimate latency for the ai agent recommender.
