### PR TITLE
New `AnnotationService`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/service/AnnotationServiceTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/service/AnnotationServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.service;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+
+public class AnnotationServiceTest implements RewriteTest {
+
+    @Test
+    void classAnnotations() {
+        rewriteRun(
+          java(
+            """
+              import javax.annotation.processing.Generated;
+              
+              @SuppressWarnings("all")
+              public @Generated("foo") class T {}
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AnnotationService service = cu.service(AnnotationService.class);
+                assertThat(service.getAllAnnotations(cu)).isEmpty();
+                assertThat(service.getAllAnnotations(cu.getClasses().get(0))).satisfiesExactly(
+                  ann0 -> assertThat(ann0.getSimpleName()).isEqualTo("SuppressWarnings"),
+                  ann1 -> assertThat(ann1.getSimpleName()).isEqualTo("Generated")
+                );
+            })
+          )
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -137,7 +137,12 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
 
     @Incubating(since = "8.2.0")
     public <S> S service(Class<S> service) {
-        return getCursor().firstEnclosingOrThrow(JavaSourceFile.class).service(service);
+        for (Cursor c = getCursor(); c.getParent() != null; c = c.getParent()) {
+            if (c.getValue() instanceof JavaSourceFile) {
+                return ((JavaSourceFile) c.getValue()).service(service);
+            }
+        }
+        throw new IllegalArgumentException("No JavaSourceFile parent found");
     }
 
     public void maybeRemoveImport(@Nullable JavaType.FullyQualified clazz) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedClasses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedClasses.java
@@ -19,8 +19,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.TypeMatcher;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.NameTree;
@@ -28,11 +30,13 @@ import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
 
 import java.util.Iterator;
-import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class FindDeprecatedClasses extends Recipe {
+
+    private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");
+
     @Option(displayName = "Type pattern",
             description = "A type pattern that is used to find matching classes.",
             example = "org.springframework..*",
@@ -94,12 +98,10 @@ public class FindDeprecatedClasses extends Recipe {
                                     Iterator<Object> cursorPath = getCursor().getPath();
                                     while (cursorPath.hasNext()) {
                                         Object ancestor = cursorPath.next();
-                                        if (ancestor instanceof J.MethodDeclaration &&
-                                            isDeprecated(((J.MethodDeclaration) ancestor).getAllAnnotations())) {
+                                        if (ancestor instanceof J.MethodDeclaration && isDeprecated((J) ancestor)) {
                                             return nameTree;
                                         }
-                                        if (ancestor instanceof J.ClassDeclaration &&
-                                            isDeprecated(((J.ClassDeclaration) ancestor).getAllAnnotations())) {
+                                        if (ancestor instanceof J.ClassDeclaration && isDeprecated((J) ancestor)) {
                                             return nameTree;
                                         }
                                     }
@@ -114,13 +116,8 @@ public class FindDeprecatedClasses extends Recipe {
                 return nameTree;
             }
 
-            private boolean isDeprecated(List<J.Annotation> annotations) {
-                for (J.Annotation annotation : annotations) {
-                    if (TypeUtils.isOfClassType(annotation.getType(), "java.lang.Deprecated")) {
-                        return true;
-                    }
-                }
-                return false;
+            private boolean isDeprecated(J j) {
+                return service(AnnotationService.class).matches(j, DEPRECATED_MATCHER);
             }
         });
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedFields.java
@@ -19,8 +19,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.TypeMatcher;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
@@ -28,13 +30,15 @@ import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
 
 import java.util.Iterator;
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class FindDeprecatedFields extends Recipe {
+
+    private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");
+
     @Option(displayName = "Type pattern",
             description = "A type pattern that is used to find matching field uses.",
             example = "org.springframework..*",
@@ -98,12 +102,10 @@ public class FindDeprecatedFields extends Recipe {
                                 Iterator<Object> cursorPath = getCursor().getPath();
                                 while (cursorPath.hasNext()) {
                                     Object ancestor = cursorPath.next();
-                                    if (ancestor instanceof J.MethodDeclaration &&
-                                        isDeprecated(((J.MethodDeclaration) ancestor).getAllAnnotations())) {
+                                    if (ancestor instanceof J.MethodDeclaration && isDeprecated((J) ancestor)) {
                                         return i;
                                     }
-                                    if (ancestor instanceof J.ClassDeclaration &&
-                                        isDeprecated(((J.ClassDeclaration) ancestor).getAllAnnotations())) {
+                                    if (ancestor instanceof J.ClassDeclaration && isDeprecated((J) ancestor)) {
                                         return i;
                                     }
                                 }
@@ -117,13 +119,8 @@ public class FindDeprecatedFields extends Recipe {
                 return i;
             }
 
-            private boolean isDeprecated(List<J.Annotation> annotations) {
-                for (J.Annotation annotation : annotations) {
-                    if (TypeUtils.isOfClassType(annotation.getType(), "java.lang.Deprecated")) {
-                        return true;
-                    }
-                }
-                return false;
+            private boolean isDeprecated(J j) {
+                return service(AnnotationService.class).matches(j, DEPRECATED_MATCHER);
             }
         });
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -36,7 +36,8 @@ import static java.util.Objects.requireNonNull;
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class FindDeprecatedMethods extends Recipe {
-    public static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");
+    private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");
+
     @Option(displayName = "Method pattern",
             description = "A method pattern that is used to find matching method invocations.",
             example = "java.util.List add(..)",

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.service;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.java.tree.J;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+@Incubating(since = "8.12.0")
+public class AnnotationService {
+    public List<J .Annotation> getAllAnnotations(J j) {
+        if (j instanceof J.VariableDeclarations) {
+            return ((J.VariableDeclarations) j).getAllAnnotations();
+        } else if (j instanceof J.AnnotatedType) {
+            return ((J.AnnotatedType) j).getAllAnnotations();
+        } else if (j instanceof J.MethodDeclaration) {
+            return ((J.MethodDeclaration) j).getAllAnnotations();
+        } else if (j instanceof J.ClassDeclaration) {
+            return ((J.ClassDeclaration) j).getAllAnnotations();
+        } else if (j instanceof J.TypeParameter) {
+            return ((J.TypeParameter) j).getAnnotations();
+        } else if (j instanceof J.TypeParameters) {
+            return ((J.TypeParameters) j).getAnnotations();
+        } else if (j instanceof J.Package) {
+            return ((J.Package) j).getAnnotations();
+        }
+        return emptyList();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.service;
 
 import org.openrewrite.Incubating;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.tree.J;
 
 import java.util.List;
@@ -24,7 +25,17 @@ import static java.util.Collections.emptyList;
 
 @Incubating(since = "8.12.0")
 public class AnnotationService {
-    public List<J .Annotation> getAllAnnotations(J j) {
+
+    public boolean matches(J j, AnnotationMatcher matcher) {
+        for (J.Annotation annotation : getAllAnnotations(j)) {
+            if (matcher.matches(annotation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<J.Annotation> getAllAnnotations(J j) {
         if (j instanceof J.VariableDeclarations) {
             return ((J.VariableDeclarations) j).getAllAnnotations();
         } else if (j instanceof J.AnnotatedType) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
@@ -35,6 +35,7 @@ public class AnnotationService {
         return false;
     }
 
+    @SuppressWarnings("deprecation")
     public List<J.Annotation> getAllAnnotations(J j) {
         if (j instanceof J.VariableDeclarations) {
             return ((J.VariableDeclarations) j).getAllAnnotations();

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3646,6 +3646,9 @@ public interface J extends Tree {
             if (typeParameters != null) {
                 allAnnotations.addAll(typeParameters.getAnnotations());
             }
+            if (returnTypeExpression instanceof AnnotatedType) {
+                allAnnotations.addAll(((AnnotatedType) returnTypeExpression).getAnnotations());
+            }
             allAnnotations.addAll(name.getAnnotations());
             return allAnnotations;
         }
@@ -5765,6 +5768,9 @@ public interface J extends Tree {
             List<Annotation> allAnnotations = new ArrayList<>(leadingAnnotations);
             for (J.Modifier modifier : modifiers) {
                 allAnnotations.addAll(modifier.getAnnotations());
+            }
+            if (typeExpression != null && typeExpression instanceof J.AnnotatedType) {
+                allAnnotations.addAll(((J.AnnotatedType) typeExpression).getAnnotations());
             }
             return allAnnotations;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -134,6 +134,9 @@ public interface J extends Tree {
             return withTypeExpression(typeExpression.withType(type));
         }
 
+        /**
+         * @deprecated Use {@link org.openrewrite.java.service.AnnotationService#getAllAnnotations(J)} instead.
+         */
         @Deprecated
         public List<Annotation> getAllAnnotations() {
             List<J.Annotation> allAnnotations = annotations;
@@ -1240,6 +1243,9 @@ public interface J extends Tree {
             return v.visitClassDeclaration(this, p);
         }
 
+        /**
+         * @deprecated Use {@link org.openrewrite.java.service.AnnotationService#getAllAnnotations(J)} instead.
+         */
         @Deprecated
         // gather annotations from everywhere they may occur
         public List<J.Annotation> getAllAnnotations() {
@@ -3639,6 +3645,9 @@ public interface J extends Tree {
             return new CoordinateBuilder.MethodDeclaration(this);
         }
 
+        /**
+         * @deprecated Use {@link org.openrewrite.java.service.AnnotationService#getAllAnnotations(J)} instead.
+         */
         @Deprecated
         // gather annotations from everywhere they may occur
         public List<J.Annotation> getAllAnnotations() {
@@ -5766,6 +5775,9 @@ public interface J extends Tree {
             return new CoordinateBuilder.VariableDeclarations(this);
         }
 
+        /**
+         * @deprecated Use {@link org.openrewrite.java.service.AnnotationService#getAllAnnotations(J)} instead.
+         */
         @Deprecated
         // gather annotations from everywhere they may occur
         public List<J.Annotation> getAllAnnotations() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -134,6 +134,7 @@ public interface J extends Tree {
             return withTypeExpression(typeExpression.withType(type));
         }
 
+        @Deprecated
         public List<Annotation> getAllAnnotations() {
             List<J.Annotation> allAnnotations = annotations;
             List<J.Annotation> moreAnnotations;
@@ -1239,6 +1240,7 @@ public interface J extends Tree {
             return v.visitClassDeclaration(this, p);
         }
 
+        @Deprecated
         // gather annotations from everywhere they may occur
         public List<J.Annotation> getAllAnnotations() {
             List<Annotation> allAnnotations = new ArrayList<>(leadingAnnotations);
@@ -3637,6 +3639,7 @@ public interface J extends Tree {
             return new CoordinateBuilder.MethodDeclaration(this);
         }
 
+        @Deprecated
         // gather annotations from everywhere they may occur
         public List<J.Annotation> getAllAnnotations() {
             List<Annotation> allAnnotations = new ArrayList<>(leadingAnnotations);
@@ -5763,6 +5766,7 @@ public interface J extends Tree {
             return new CoordinateBuilder.VariableDeclarations(this);
         }
 
+        @Deprecated
         // gather annotations from everywhere they may occur
         public List<J.Annotation> getAllAnnotations() {
             List<Annotation> allAnnotations = new ArrayList<>(leadingAnnotations);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -19,6 +19,7 @@ import org.openrewrite.Incubating;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.service.ImportService;
 
@@ -62,6 +63,8 @@ public interface JavaSourceFile extends J {
             if (ImportService.class.getName().equals(service.getName())) {
                 return service.getConstructor().newInstance();
             } else if (AutoFormatService.class.getName().equals(service.getName())) {
+                return service.getConstructor().newInstance();
+            } else if (AnnotationService.class.getName().equals(service.getName())) {
                 return service.getConstructor().newInstance();
             } else {
                 throw new UnsupportedOperationException("Service " + service + " not supported");


### PR DESCRIPTION
Instead of calling the `getAllAnnotations()` and `getAnnotations()` methods directly, recipes and visitors should be using the `AnnotationService`. This will allow `rewrite-kotlin` to properly support multi annotations and annotations with use-site targets.