### PR TITLE
Revert "The `managedReference` fields are no longer required"

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -365,7 +365,6 @@ public interface JavaType {
         @With
         @Nullable
         @NonFinal
-        @JsonIgnore
         Integer managedReference;
 
         @With(AccessLevel.NONE)
@@ -639,7 +638,6 @@ public interface JavaType {
         @With
         @Nullable
         @NonFinal
-        @JsonIgnore
         Integer managedReference;
 
         @With
@@ -781,7 +779,6 @@ public interface JavaType {
         @Getter
         @Nullable
         @NonFinal
-        @JsonIgnore
         Integer managedReference;
 
         @With
@@ -877,7 +874,6 @@ public interface JavaType {
         @Getter
         @Nullable
         @NonFinal
-        @JsonIgnore
         Integer managedReference;
 
         @NonFinal
@@ -1069,7 +1065,6 @@ public interface JavaType {
         @With
         @Nullable
         @NonFinal
-        @JsonIgnore
         Integer managedReference;
 
         @With(AccessLevel.PRIVATE)
@@ -1349,7 +1344,6 @@ public interface JavaType {
         @With
         @Nullable
         @NonFinal
-        @JsonIgnore
         Integer managedReference;
 
         @With(AccessLevel.PRIVATE)


### PR DESCRIPTION
This reverts commit 006a99bf321e7f652c7acd52a4d54d37c0bc7036.

As discussed this caused downstream failures.