### PR TITLE
Fix the plugin default groupId

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -198,7 +198,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
 
     private boolean hasPluginGroupId(String groupId) {
         Xml.Tag tag = getCursor().getValue();
-        boolean isGroupIdFound = matchesGlob(tag.getChildValue("groupId").orElse(getResolutionResult().getPom().getGroupId()), groupId);
+        boolean isGroupIdFound = matchesGlob(tag.getChildValue("groupId").orElse("org.apache.maven.plugins"), groupId);
         if (!isGroupIdFound && getResolutionResult().getPom().getProperties() != null) {
             if (tag.getChildValue("groupId").isPresent() && tag.getChildValue("groupId").get().trim().startsWith("${")) {
                 String propertyKey = tag.getChildValue("groupId").get().trim();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
@@ -244,12 +244,12 @@ class UpgradePluginVersionTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                      
+
                 <packaging>pom</packaging>
                 <groupId>org.openrewrite.example</groupId>
                 <artifactId>my-app-bom</artifactId>
                 <version>1</version>
-                      
+
                 <build>
                   <pluginManagement>
                     <plugins>
@@ -660,6 +660,52 @@ class UpgradePluginVersionTest implements RewriteTest {
                         <source>1.8</source>
                         <target>1.8</target>
                       </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void defaultPluginGroupId() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion(
+            "org.apache.maven.plugins",
+            "maven-compiler-plugin",
+            "3.11.0",
+            null,
+            null,
+            false
+          )),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.10.0</version>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.11.0</version>
                     </plugin>
                   </plugins>
                 </build>


### PR DESCRIPTION
The default groupId for Maven plugins is not the one from the current pom but `org.apache.maven.plugins`.

## What's changed?

The default groupId for Maven plugins was the one from the currently resolved POM, while it should be `org.apache.maven.plugins`.

## What's your motivation?

Correctness :).
See https://stackoverflow.com/questions/65527291/is-groupid-required-for-plugins-in-maven-pom-xml for the details.

## Anyone you would like to review specifically?

@timtebeek hey, found this while working on the update recipes for Quarkus 3.7. I can work around it for now but I think it's worth a fix upstream. Thanks!

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files -> I use Eclipse but I was careful about not changing the formatting.
