### PR TITLE
Replace resilience4j with failsafe

### DIFF
--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -16,8 +16,7 @@ dependencies {
     implementation("com.github.ben-manes.caffeine:caffeine:2.+")
 
     implementation("org.antlr:antlr4:4.11.1")
-    // Use 1.7.0 due https://github.com/resilience4j/resilience4j/issues/1472, it has been resolved in Resilience4j 2.x, but that requires Java 17
-    implementation("io.github.resilience4j:resilience4j-retry:1.7.0")
+    implementation("dev.failsafe:failsafe:latest.release")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
     implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -147,10 +147,7 @@ public class MavenPomDownloader {
                 }
             });
         } catch (FailsafeException failsafeException) {
-            if (failsafeException.getCause() != null) {
-                throw failsafeException.getCause();
-            }
-            throw failsafeException;
+            throw failsafeException.getCause() == null ? failsafeException : failsafeException.getCause();
         } finally {
             this.ctx.recordResolutionTime(Duration.ofNanos(System.nanoTime() - start));
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -15,13 +15,11 @@
  */
 package org.openrewrite.maven.internal;
 
-import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.retry.RetryConfig;
-import io.github.resilience4j.retry.RetryRegistry;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
-import io.vavr.CheckedFunction1;
 import lombok.Getter;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.HttpSenderExecutionContextView;
@@ -59,15 +57,12 @@ import static java.util.stream.Collectors.toList;
 
 @SuppressWarnings("OptionalAssignedToNull")
 public class MavenPomDownloader {
-    private static final RetryConfig retryConfig = RetryConfig.custom()
-            .retryOnException(throwable -> throwable instanceof SocketTimeoutException ||
-                                           throwable instanceof TimeoutException)
-            .maxAttempts(5)
+    private static final RetryPolicy<Object> retryPolicy = RetryPolicy.builder()
+            .handle(SocketTimeoutException.class, TimeoutException.class)
+            .withDelay(Duration.ofMillis(500))
+            .withJitter(0.1)
+            .withMaxRetries(5)
             .build();
-
-    private static final RetryRegistry retryRegistry = RetryRegistry.of(retryConfig);
-
-    private static final Retry mavenDownloaderRetry = retryRegistry.retry("MavenDownloader");
 
     private static final Pattern SNAPSHOT_TIMESTAMP = Pattern.compile("^(.*-)?([0-9]{8}\\.[0-9]{6}-[0-9]+)$");
 
@@ -85,8 +80,6 @@ public class MavenPomDownloader {
 
     @Nullable
     private List<String> activeProfiles;
-
-    private final CheckedFunction1<HttpSender.Request, byte[]> sendRequest;
 
     private boolean addDefaultRepositories = true;
 
@@ -140,24 +133,32 @@ public class MavenPomDownloader {
         this.projectPomsByGav = projectPomsByGav(projectPoms);
         this.httpSender = httpSender;
         this.ctx = MavenExecutionContextView.view(ctx);
-        this.sendRequest = Retry.decorateCheckedFunction(
-                mavenDownloaderRetry,
-                request -> {
-                    int responseCode;
-                    long start = System.nanoTime();
-                    try (HttpSender.Response response = httpSender.send(request)) {
-                        if (response.isSuccessful()) {
-                            return response.getBodyAsBytes();
-                        }
-                        responseCode = response.getCode();
-                    } catch (Throwable t) {
-                        throw new HttpSenderResponseException(t, null);
-                    } finally {
-                        this.ctx.recordResolutionTime(Duration.ofNanos(System.nanoTime() - start));
-                    }
-                    throw new HttpSenderResponseException(null, responseCode);
-                });
         this.mavenCache = this.ctx.getPomCache();
+    }
+
+    private byte[] sendRequest(HttpSender.Request request) throws HttpSenderResponseException {
+        try {
+            return Failsafe.with(retryPolicy).get(() -> {
+                int responseCode;
+                long start = System.nanoTime();
+                try (HttpSender.Response response = httpSender.send(request)) {
+                    if (response.isSuccessful()) {
+                        return response.getBodyAsBytes();
+                    }
+                    responseCode = response.getCode();
+                } catch (Throwable t) {
+                    throw new HttpSenderResponseException(t, null);
+                } finally {
+                    this.ctx.recordResolutionTime(Duration.ofNanos(System.nanoTime() - start));
+                }
+                throw new HttpSenderResponseException(null, responseCode);
+            });
+        } catch (Throwable t) {
+            if (t.getCause() != null && t.getCause() instanceof HttpSenderResponseException) {
+                throw (HttpSenderResponseException) t.getCause();
+            }
+            throw t;
+        }
     }
 
     private Map<GroupArtifactVersion, Pom> projectPomsByGav(Map<Path, Pom> projectPoms) {
@@ -731,7 +732,7 @@ public class MavenPomDownloader {
                 HttpSender.Request.Builder request = applyAuthenticationToRequest(repository, httpSender.get(httpsUri));
                 MavenRepository normalized = null;
                 try {
-                    sendRequest.apply(request.build());
+                    sendRequest(request.build());
                     normalized = repository.withUri(httpsUri).withKnownToExist(true);
                 } catch (Throwable t) {
                     if (t instanceof HttpSenderResponseException) {
@@ -744,7 +745,7 @@ public class MavenPomDownloader {
                     if (normalized == null) {
                         if (!httpsUri.equals(originalUrl)) {
                             try {
-                                sendRequest.apply(request.url(originalUrl).build());
+                                sendRequest(request.url(originalUrl).build());
                                 normalized = new MavenRepository(
                                         repository.getId(),
                                         originalUrl,
@@ -798,7 +799,7 @@ public class MavenPomDownloader {
      */
     private byte[] requestAsAuthenticatedOrAnonymous(MavenRepository repo, String uriString) throws HttpSenderResponseException {
         try {
-            return sendRequest.apply(applyAuthenticationToRequest(repo, httpSender.get(uriString)).build());
+            return sendRequest(applyAuthenticationToRequest(repo, httpSender.get(uriString)).build());
         } catch (HttpSenderResponseException e) {
             if (hasCredentials(repo) && e.isClientSideException()) {
                 return retryRequestAnonymously(uriString, e);
@@ -812,7 +813,7 @@ public class MavenPomDownloader {
 
     private byte[] retryRequestAnonymously(String uriString, HttpSenderResponseException originalException) throws HttpSenderResponseException {
         try {
-            return sendRequest.apply(httpSender.get(uriString).build());
+            return sendRequest(httpSender.get(uriString).build());
         } catch (HttpSenderResponseException retryException) {
             if (retryException.isAccessDenied()) {
                 throw originalException;
@@ -835,9 +836,9 @@ public class MavenPomDownloader {
      * Returns a request builder with Authorization header set if the provided repository specifies credentials
      */
     private HttpSender.Request.Builder applyAuthenticationToRequest(MavenRepository repository, HttpSender.Request.Builder request) {
-        if(ctx.getSettings() != null && ctx.getSettings().getServers() != null) {
+        if (ctx.getSettings() != null && ctx.getSettings().getServers() != null) {
             for (MavenSettings.Server server : ctx.getSettings().getServers().getServers()) {
-                if(server.getId().equals(repository.getId()) && server.getConfiguration() != null && server.getConfiguration().getHttpHeaders() != null) {
+                if (server.getId().equals(repository.getId()) && server.getConfiguration() != null && server.getConfiguration().getHttpHeaders() != null) {
                     for (MavenSettings.HttpHeader header : server.getConfiguration().getHttpHeaders()) {
                         request.withHeader(header.getName(), header.getValue());
                     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -28,6 +28,7 @@ import org.openrewrite.maven.tree.ResolvedDependency;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -47,6 +48,7 @@ import static org.openrewrite.internal.StreamUtils.readAllBytes;
 public class MavenArtifactDownloader {
     private static final RetryPolicy<Object> retryPolicy = RetryPolicy.builder()
             .handle(SocketTimeoutException.class, TimeoutException.class)
+            .handleIf(throwable -> throwable instanceof UncheckedIOException && throwable.getCause() instanceof SocketTimeoutException)
             .withDelay(Duration.ofMillis(500))
             .withJitter(0.1)
             .withMaxRetries(5)

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -16,6 +16,7 @@
 package org.openrewrite.maven.utilities;
 
 import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.ipc.http.HttpSender;
@@ -118,7 +119,8 @@ public class MavenArtifactDownloader {
                     }
                     bodyStream = new ByteArrayInputStream(readAllBytes(body));
                 } catch (Throwable t) {
-                    throw new MavenDownloadingException("Unable to download dependency", t,
+                    Throwable cause = t instanceof FailsafeException && t.getCause() != null ? t.getCause() : t;
+                    throw new MavenDownloadingException("Unable to download dependency", cause,
                             dependency.getRequested().getGav());
                 }
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -68,7 +68,7 @@ class MavenPomDownloaderTest {
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    return new MockResponse().setResponseCode(responseCode).setBody("body");
+                    return new MockResponse().setResponseCode(responseCode).setBody("");
                 }
             });
             mockRepo.start();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -129,6 +129,7 @@ class MavenPomDownloaderTest {
             String body = new String(downloader.sendRequest(new HttpSender.Request(server.url("/test").url(), "request".getBytes(), HttpSender.Method.GET, Map.of())));
             assertThat(body).isEqualTo("body");
             assertThat(server.getRequestCount()).isEqualTo(2);
+            server.shutdown();
         }
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -64,22 +64,11 @@ class MavenPomDownloaderTest {
       .setHttpSender(new HttpUrlConnectionSender(Duration.ofMillis(100), Duration.ofMillis(100)));
 
     private void mockServer(Integer responseCode, Consumer<MockWebServer> block) {
-        mockServer(List.of(responseCode), block);
-    }
-
-    private void mockServer(List<Integer> responseCodes, Consumer<MockWebServer> block) {
-        List<Integer> responseCodeList = new ArrayList<>(responseCodes);
         try (MockWebServer mockRepo = new MockWebServer()) {
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    int code;
-                    if (responseCodeList.size() == 1) {
-                        code = responseCodeList.get(0);
-                    } else {
-                        code = responseCodeList.remove(0);
-                    }
-                    return new MockResponse().setResponseCode(code).setBody("body");
+                    return new MockResponse().setResponseCode(responseCode).setBody("body");
                 }
             });
             mockRepo.start();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -15,10 +15,9 @@
  */
 package org.openrewrite.maven.internal;
 
-import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import okhttp3.mockwebserver.*;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +29,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.HttpSenderExecutionContextView;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.MavenExecutionContextView;
@@ -40,32 +40,46 @@ import org.openrewrite.maven.tree.MavenMetadata;
 import org.openrewrite.maven.tree.MavenRepository;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"NullableProblems", "HttpUrlsUsage"})
+@SuppressWarnings({"HttpUrlsUsage"})
 class MavenPomDownloaderTest {
     private final ExecutionContext ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
       .setHttpSender(new HttpUrlConnectionSender(Duration.ofMillis(100), Duration.ofMillis(100)));
 
     private void mockServer(Integer responseCode, Consumer<MockWebServer> block) {
+        mockServer(List.of(responseCode), block);
+    }
+
+    private void mockServer(List<Integer> responseCodes, Consumer<MockWebServer> block) {
+        List<Integer> responseCodeList = new ArrayList<>(responseCodes);
         try (MockWebServer mockRepo = new MockWebServer()) {
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    return new MockResponse().setResponseCode(responseCode).setBody("");
+                    int code;
+                    if (responseCodeList.size() == 1) {
+                        code = responseCodeList.get(0);
+                    } else {
+                        code = responseCodeList.remove(0);
+                    }
+                    return new MockResponse().setResponseCode(code).setBody("body");
                 }
             });
             mockRepo.start();
@@ -73,6 +87,7 @@ class MavenPomDownloaderTest {
             assertThat(mockRepo.getRequestCount())
               .as("The mock repository received no requests. The test is not using it.")
               .isGreaterThan(0);
+            mockRepo.shutdown();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -114,6 +129,18 @@ class MavenPomDownloaderTest {
             var normalizedRepo = downloader.normalizeRepository(originalRepo, null);
             assertThat(normalizedRepo).isEqualTo(originalRepo);
         });
+    }
+
+    @Test
+    void retryConnectException() throws IOException, MavenPomDownloader.HttpSenderResponseException {
+        var downloader = new MavenPomDownloader(emptyMap(), ctx);
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+            server.enqueue(new MockResponse().setResponseCode(200).setBody("body"));
+            String body = new String(downloader.sendRequest(new HttpSender.Request(server.url("/test").url(), "request".getBytes(), HttpSender.Method.GET, Map.of())));
+            assertThat(body).isEqualTo("body");
+            assertThat(server.getRequestCount()).isEqualTo(2);
+        }
     }
 
     @Test

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -121,7 +121,7 @@ class MavenPomDownloaderTest {
     }
 
     @Test
-    void retryConnectException() throws IOException, MavenPomDownloader.HttpSenderResponseException {
+    void retryConnectException() throws Throwable {
         var downloader = new MavenPomDownloader(emptyMap(), ctx);
         try (MockWebServer server = new MockWebServer()) {
             server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));


### PR DESCRIPTION
## What's changed?
`resilience4j-retry` replaced with `dev.failsafe`

## What's your motivation?
`resilience4j-retry` has a lot of transitive dependencies and the latest version depends on java 17. Having to pin this to 1.7.0 can cause issues with consumers.

[FailSafe](https://github.com/failsafe-lib/failsafe) is a "lightweight, zero-dependency library for handling failures in Java 8+" which can handle the retries in stead

## Anything in particular you'd like reviewers to focus on?
I need to look into metrics. If the old retries had them and if we want them on the new.

## Have you considered any alternatives or workarounds?
Implement an internal retrier.