### PR TITLE
Preserve whitespace in escaped names.

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeTreeTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeTreeTest.java
@@ -16,8 +16,11 @@
 package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.marker.Quoted;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TypeTreeTest {
 
@@ -54,5 +57,15 @@ class TypeTreeTest {
 
         assertEquals("a.A.*", name.toString());
         assertEquals("*", name.getSimpleName());
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3845")
+    @Test
+    void buildEscapedName() {
+        J.FieldAccess name = TypeTree.build("foo.bar.`some escaped name`", '`');
+
+        assertTrue(name.getName().getMarkers().findFirst(Quoted.class).isPresent());
+        assertEquals("foo.bar.some escaped name", name.toString());
+        assertEquals("some escaped name", name.getSimpleName());
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeTree.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeTree.java
@@ -47,9 +47,14 @@ public interface TypeTree extends NameTree {
             StringBuilder whitespaceBeforeNext = new StringBuilder();
 
             String segment = scanner.next();
+            boolean inEscape = false;
             for (int j = 0; j < segment.length(); j++) {
                 char c = segment.charAt(j);
-                if (!Character.isWhitespace(c)) {
+                if (escape != null && c == escape) {
+                    inEscape = !inEscape;
+                }
+
+                if (!Character.isWhitespace(c) || inEscape) {
                     if (partBuilder == null) {
                         partBuilder = new StringBuilder();
                     }


### PR DESCRIPTION
Changes:

- TypeTree#build will preserve whitespace in escaped names.

fixes #3845