### PR TITLE
Added ArrayTypeTree and support for annotated dimensions of array types.

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2127,6 +2127,14 @@ public class GroovyParserVisitor {
 
     private <T extends TypeTree & Expression> T typeTree(@Nullable ClassNode classNode) {
         Space prefix = whitespace();
+        if (classNode != null && classNode.isArray()) {
+            //noinspection unchecked
+            return (T) new J.ArrayType(randomId(), prefix, Markers.EMPTY,
+                    typeTree(classNode.getComponentType()),
+                    null,
+                    padLeft(sourceBefore("["), sourceBefore("]")),
+                    typeMapping.type(classNode));
+        }
         String maybeFullyQualified = name();
         String[] parts = maybeFullyQualified.split("\\.");
 
@@ -2165,20 +2173,9 @@ public class GroovyParserVisitor {
         if (classNode != null) {
             if (classNode.isUsingGenerics() && !classNode.isGenericsPlaceHolder()) {
                 expr = new J.ParameterizedType(randomId(), EMPTY, Markers.EMPTY, (NameTree) expr, visitTypeParameterizations(classNode.getGenericsTypes()), typeMapping.type(classNode));
-            } else if (classNode.isArray()) {
-                expr = new J.ArrayType(randomId(), EMPTY, Markers.EMPTY, (TypeTree) expr, arrayDimensionsFrom(classNode));
             }
         }
         return expr.withPrefix(prefix);
-    }
-
-    private List<JRightPadded<Space>> arrayDimensionsFrom(ClassNode classNode) {
-        List<JRightPadded<Space>> result = new ArrayList<>();
-        while (classNode != null && classNode.isArray()) {
-            classNode = classNode.getComponentType();
-            result.add(JRightPadded.build(sourceBefore("[")).withAfter(sourceBefore("]")));
-        }
-        return result;
     }
 
     private Space sourceBefore(String untilDelim) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -42,6 +42,9 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.internal.StringUtils.indexOfNextNonWhitespace;
+import static org.openrewrite.java.tree.Space.EMPTY;
+import static org.openrewrite.java.tree.Space.format;
 
 public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
     private final Attr attr;
@@ -1146,26 +1149,17 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
 
         @Override
         public J visitArrayType(ArrayTypeTree node, Space fmt) {
-            com.sun.source.tree.Tree typeIdent = node.getType();
-            int dimCount = 1;
+            TypeTree elemType = (TypeTree) scan(node.getType(), Space.EMPTY);
 
-            while (typeIdent instanceof ArrayTypeTree) {
-                dimCount++;
-                typeIdent = ((ArrayTypeTree) typeIdent).getType();
-            }
-
-            TypeTree elemType = (TypeTree) scan(typeIdent, Space.EMPTY);
-
-            List<JRightPadded<Space>> dimensions = emptyList();
-            if (dimCount > 0) {
-                dimensions = new ArrayList<>(dimCount);
-                for (int n = 0; n < dimCount; n++) {
-                    if (!source.substring(cursor).startsWith("...")) {
-                        dimensions.add(padRight(
-                                Space.build(sourceBeforeAsString("["), emptyList()),
-                                Space.build(sourceBeforeAsString("]"), emptyList())));
-                    }
-                }
+            int saveCursor = cursor;
+            Space before = whitespace();
+            JLeftPadded<Space> dimension;
+            if (source.startsWith("[", cursor)) {
+                cursor++;
+                dimension = JLeftPadded.build(Space.build(sourceBeforeAsString("]"), emptyList())).withBefore(before);
+            } else {
+                cursor = saveCursor;
+                return elemType;
             }
 
             return new J.ArrayType(
@@ -1173,12 +1167,20 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     fmt,
                     Markers.EMPTY,
                     elemType,
-                    dimensions
+                    null,
+                    dimension,
+                    typeMapping.type(node)
             );
         }
 
-        private <T> JRightPadded<T> padRight(T tree, Space right) {
-            return new JRightPadded<>(tree, right, Markers.EMPTY);
+        private Space whitespace() {
+            int nextNonWhitespace = indexOfNextNonWhitespace(cursor, source);
+            if (nextNonWhitespace == cursor) {
+                return EMPTY;
+            }
+            Space space = format(source, cursor, nextNonWhitespace);
+            cursor = nextNonWhitespace;
+            return space;
         }
 
         @Override

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -119,7 +119,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         NameTree name = convert(node.getAnnotationType());
 
         JContainer<Expression> args = null;
-        if (node.getArguments().size() > 0) {
+        if (!node.getArguments().isEmpty()) {
             Space argsPrefix = sourceBefore("(");
             List<JRightPadded<Expression>> expressions;
             if (node.getArguments().size() == 1) {
@@ -171,31 +171,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitArrayType(ArrayTypeTree node, Space fmt) {
-        Tree typeIdent = node.getType();
-        int dimCount = 1;
-
-        while (typeIdent instanceof ArrayTypeTree) {
-            dimCount++;
-            typeIdent = ((ArrayTypeTree) typeIdent).getType();
-        }
-
-        TypeTree elemType = convert(typeIdent);
-
-        List<JRightPadded<Space>> dimensions = emptyList();
-        if (dimCount > 0) {
-            dimensions = new ArrayList<>(dimCount);
-            for (int n = 0; n < dimCount; n++) {
-                dimensions.add(padRight(sourceBefore("["), sourceBefore("]")));
-            }
-        }
-
-        return new J.ArrayType(
-                randomId(),
-                fmt,
-                Markers.EMPTY,
-                elemType,
-                dimensions
-        );
+        return arrayTypeTree((JCArrayTypeTree) node, new HashMap<>()).withPrefix(fmt);
     }
 
     @Override
@@ -376,12 +352,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitClass(ClassTree node, Space fmt) {
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getModifiers().getAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
-
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava11ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         List<J.Annotation> kindAnnotations = collectAnnotations(annotationPosTable);
@@ -496,11 +468,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         endPosTable = cu.endPositions;
         docCommentTable = cu.docComments;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getPackageAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getPackageAnnotations(),
+                new HashMap<>(node.getPackageAnnotations().size()));
         List<J.Annotation> packageAnnotations = collectAnnotations(annotationPosTable);
 
         J.Package packageDecl = null;
@@ -910,11 +879,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     public J visitMethod(MethodTree node, Space fmt) {
         JCMethodDecl jcMethod = (JCMethodDecl) node;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getModifiers().getAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava11ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         J.TypeParameters typeParams;
@@ -1239,13 +1205,25 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     }
     @Override
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getAnnotations()) {
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
+                new HashMap<>(node.getAnnotations().size()));
+        List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
+        if (!annotationPosTable.isEmpty()) {
+            if (node.getUnderlyingType() instanceof JCFieldAccess) {
+                return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, annotatedTypeTree(node.getUnderlyingType(), annotationPosTable));
+            } else if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+                return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, arrayTypeTree((JCArrayTypeTree) node.getUnderlyingType(), annotationPosTable));
+            }
+        }
+        return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, convert(node.getUnderlyingType()));
+    }
+
+    private Map<Integer, JCAnnotation> mapAnnotations(List<? extends AnnotationTree> annotations, Map<Integer, JCAnnotation> annotationPosTable) {
+        for (AnnotationTree annotationNode : annotations) {
             JCAnnotation annotation = (JCAnnotation) annotationNode;
             annotationPosTable.put(annotation.pos, annotation);
         }
-        return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations(annotationPosTable),
-                annotationPosTable.isEmpty() ? convert(node.getUnderlyingType()) : annotatedTypeTree(node.getUnderlyingType(), annotationPosTable));
+        return annotationPosTable;
     }
 
     private List<J.Annotation> leadingAnnotations(Map<Integer, JCAnnotation> annotationPosTable) {
@@ -1266,8 +1244,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     }
 
     private TypeTree annotatedTypeTree(Tree node, Map<Integer, JCAnnotation> annotationPosTable) {
-        Space prefix = whitespace();
         if (node instanceof JCFieldAccess) {
+            Space prefix = whitespace();
             JCFieldAccess fieldAccess = (JCFieldAccess) node;
             JavaType type = typeMapping.type(node);
             Expression select = (Expression) annotatedTypeTree(fieldAccess.selected, annotationPosTable);
@@ -1280,8 +1258,45 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                             annotations, fieldAccess.name.toString(), type, typeMapping.variableType(fieldAccess.sym))),
                     type
             );
+        } else if (node instanceof JCAnnotatedType) {
+            JCAnnotatedType annotatedType = (JCAnnotatedType) node;
+            if (annotatedType.getUnderlyingType() instanceof JCArrayTypeTree) {
+                return arrayTypeTree((JCArrayTypeTree) annotatedType.getUnderlyingType(),
+                        mapAnnotations(annotatedType.getAnnotations(), annotationPosTable));
+            }
         }
         return convert(node);
+    }
+
+    private TypeTree arrayTypeTree(JCArrayTypeTree arrayTypeTree, Map<Integer, JCAnnotation> annotationPosTable) {
+        Space prefix = whitespace();
+        Tree typeIdent = arrayTypeTree.getType();
+        while (!annotationPosTable.isEmpty() && typeIdent instanceof ArrayTypeTree) {
+            typeIdent = ((ArrayTypeTree) typeIdent).getType();
+        }
+
+        TypeTree elemType = annotatedTypeTree(typeIdent, annotationPosTable);
+        List<J.Annotation> annotations = leadingAnnotations(annotationPosTable);
+        int saveCursor = cursor;
+        Space before = whitespace();
+        JLeftPadded<Space> dimension;
+        if (source.startsWith("[", cursor)) {
+            skip("[");
+            dimension = padLeft(before, sourceBefore("]"));
+        } else {
+            cursor = saveCursor;
+            return elemType;
+        }
+
+        return new J.ArrayType(
+                randomId(),
+                prefix,
+                Markers.EMPTY,
+                elemType,
+                annotations.isEmpty() ? null : annotations,
+                dimension,
+                typeMapping.type(arrayTypeTree)
+        );
     }
 
     @Override
@@ -1408,10 +1423,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
         JCExpression vartype = node.vartype;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (JCAnnotation annotationNode : node.getModifiers().getAnnotations()) {
-            annotationPosTable.put(annotationNode.pos, annotationNode);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava11ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
@@ -1428,12 +1441,19 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
             }
         } else if (vartype instanceof JCArrayTypeTree) {
-            // we'll capture the array dimensions in a bit, just convert the element type
-            JCExpression elementType = ((JCArrayTypeTree) vartype).elemtype;
-            while (elementType instanceof JCArrayTypeTree) {
-                elementType = ((JCArrayTypeTree) elementType).elemtype;
+            JCExpression elementType = vartype;
+            while (elementType instanceof JCArrayTypeTree || elementType instanceof JCAnnotatedType) {
+                if (elementType instanceof JCAnnotatedType) {
+                    elementType = ((JCAnnotatedType) elementType).underlyingType;
+                }
+                if (elementType instanceof JCArrayTypeTree) {
+                    elementType = ((JCArrayTypeTree) elementType).elemtype;
+                }
             }
-            typeExpr = convert(elementType);
+            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
+            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+                    // we'll capture the array dimensions in a bit, just convert the element type
+                    convert(elementType);
         } else {
             typeExpr = convert(vartype);
         }
@@ -1442,18 +1462,14 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             typeExpr = new J.AnnotatedType(randomId(), Space.EMPTY, Markers.EMPTY, typeExprAnnotations, typeExpr);
         }
 
-        List<JLeftPadded<Space>> beforeDimensions = arrayDimensions();
+        List<JLeftPadded<Space>> beforeDimensions = emptyList();
 
         Space varargs = null;
-        if (typeExpr == null || typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
-            String vartypeString = typeExpr == null ? "" : source.substring(vartype.getStartPosition(), endPos(vartype));
-            Matcher varargMatcher = Pattern.compile("(\\s*)\\.{3}").matcher(vartypeString);
-            if (varargMatcher.find()) {
-                Matcher matcher = Pattern.compile("\\G(\\s*)\\.{3}").matcher(source);
-                if (matcher.find(cursor)) {
-                    cursor(matcher.end());
-                }
-                varargs = format(varargMatcher.group(1));
+        if (typeExpr != null && typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
+            int varargStart = indexOfNextNonWhitespace(cursor, source);
+            if (source.startsWith("...", varargStart)) {
+                varargs = format(source, cursor, varargStart);
+                cursor = varargStart + 3;
             }
         }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -45,6 +45,9 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.internal.StringUtils.indexOfNextNonWhitespace;
+import static org.openrewrite.java.tree.Space.EMPTY;
+import static org.openrewrite.java.tree.Space.format;
 
 public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
     private final Attr attr;
@@ -638,7 +641,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     for (int i = 0; i < paramTypes.size(); i++) {
                         JCTree param = paramTypes.get(i);
                         Expression paramExpr = (Expression) javaVisitor.scan(param, Space.build(whitespaceBeforeAsString(), emptyList()));
-                        Space rightFmt = Space.format(i == paramTypes.size() - 1 ?
+                        Space rightFmt = format(i == paramTypes.size() - 1 ?
                                 sourceBeforeAsString(")") : sourceBeforeAsString(","));
                         parameters.add(new JRightPadded<>(paramExpr, rightFmt, Markers.EMPTY));
                     }
@@ -1151,26 +1154,17 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
 
         @Override
         public J visitArrayType(ArrayTypeTree node, Space fmt) {
-            com.sun.source.tree.Tree typeIdent = node.getType();
-            int dimCount = 1;
+            TypeTree elemType = (TypeTree) scan(node.getType(), Space.EMPTY);
 
-            while (typeIdent instanceof ArrayTypeTree) {
-                dimCount++;
-                typeIdent = ((ArrayTypeTree) typeIdent).getType();
-            }
-
-            TypeTree elemType = (TypeTree) scan(typeIdent, Space.EMPTY);
-
-            List<JRightPadded<Space>> dimensions = emptyList();
-            if (dimCount > 0) {
-                dimensions = new ArrayList<>(dimCount);
-                for (int n = 0; n < dimCount; n++) {
-                    if (!source.substring(cursor).startsWith("...")) {
-                        dimensions.add(padRight(
-                                Space.build(sourceBeforeAsString("["), emptyList()),
-                                Space.build(sourceBeforeAsString("]"), emptyList())));
-                    }
-                }
+            int saveCursor = cursor;
+            Space before = whitespace();
+            JLeftPadded<Space> dimension;
+            if (source.startsWith("[", cursor)) {
+                cursor++;
+                dimension = JLeftPadded.build(Space.build(sourceBeforeAsString("]"), emptyList())).withBefore(before);
+            } else {
+                cursor = saveCursor;
+                return elemType;
             }
 
             return new J.ArrayType(
@@ -1178,12 +1172,20 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     fmt,
                     Markers.EMPTY,
                     elemType,
-                    dimensions
+                    null,
+                    dimension,
+                    typeMapping.type(node)
             );
         }
 
-        private <T> JRightPadded<T> padRight(T tree, Space right) {
-            return new JRightPadded<>(tree, right, Markers.EMPTY);
+        private Space whitespace() {
+            int nextNonWhitespace = indexOfNextNonWhitespace(cursor, source);
+            if (nextNonWhitespace == cursor) {
+                return EMPTY;
+            }
+            Space space = format(source, cursor, nextNonWhitespace);
+            cursor = nextNonWhitespace;
+            return space;
         }
 
         @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -55,8 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.Math.max;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.openrewrite.Tree.randomId;
@@ -123,7 +122,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         NameTree name = convert(node.getAnnotationType());
 
         JContainer<Expression> args = null;
-        if (node.getArguments().size() > 0) {
+        if (!node.getArguments().isEmpty()) {
             Space argsPrefix = sourceBefore("(");
             List<JRightPadded<Expression>> expressions;
             if (node.getArguments().size() == 1) {
@@ -175,31 +174,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitArrayType(ArrayTypeTree node, Space fmt) {
-        Tree typeIdent = node.getType();
-        int dimCount = 1;
-
-        while (typeIdent instanceof ArrayTypeTree) {
-            dimCount++;
-            typeIdent = ((ArrayTypeTree) typeIdent).getType();
-        }
-
-        TypeTree elemType = convert(typeIdent);
-
-        List<JRightPadded<Space>> dimensions = emptyList();
-        if (dimCount > 0) {
-            dimensions = new ArrayList<>(dimCount);
-            for (int n = 0; n < dimCount; n++) {
-                dimensions.add(padRight(sourceBefore("["), sourceBefore("]")));
-            }
-        }
-
-        return new J.ArrayType(
-                randomId(),
-                fmt,
-                Markers.EMPTY,
-                elemType,
-                dimensions
-        );
+        return arrayTypeTree((JCArrayTypeTree) node, new HashMap<>()).withPrefix(fmt);
     }
 
     @Override
@@ -398,11 +373,8 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitClass(ClassTree node, Space fmt) {
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getModifiers().getAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
 
         ReloadableJava17ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
@@ -553,11 +525,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         endPosTable = cu.endPositions;
         docCommentTable = cu.docComments;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getPackageAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getPackageAnnotations(),
+                new HashMap<>(node.getPackageAnnotations().size()));
+
         List<J.Annotation> packageAnnotations = collectAnnotations(annotationPosTable);
 
         J.Package packageDecl = null;
@@ -968,11 +938,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     public J visitMethod(MethodTree node, Space fmt) {
         JCMethodDecl jcMethod = (JCMethodDecl) node;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getModifiers().getAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
+
         ReloadableJava17ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         J.TypeParameters typeParams;
@@ -1315,13 +1283,25 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getAnnotations()) {
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
+                new HashMap<>(node.getAnnotations().size()));
+        List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
+        if (!annotationPosTable.isEmpty()) {
+            if (node.getUnderlyingType() instanceof JCFieldAccess) {
+                return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, annotatedTypeTree(node.getUnderlyingType(), annotationPosTable));
+            } else if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+                return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, arrayTypeTree((JCArrayTypeTree) node.getUnderlyingType(), annotationPosTable));
+            }
+        }
+        return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, convert(node.getUnderlyingType()));
+    }
+
+    private Map<Integer, JCAnnotation> mapAnnotations(List<? extends AnnotationTree> annotations, Map<Integer, JCAnnotation> annotationPosTable) {
+        for (AnnotationTree annotationNode : annotations) {
             JCAnnotation annotation = (JCAnnotation) annotationNode;
             annotationPosTable.put(annotation.pos, annotation);
         }
-        return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations(annotationPosTable),
-                annotationPosTable.isEmpty() ? convert(node.getUnderlyingType()) : annotatedTypeTree(node.getUnderlyingType(), annotationPosTable));
+        return annotationPosTable;
     }
 
     private List<J.Annotation> leadingAnnotations(Map<Integer, JCAnnotation> annotationPosTable) {
@@ -1342,8 +1322,8 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     }
 
     private TypeTree annotatedTypeTree(Tree node, Map<Integer, JCAnnotation> annotationPosTable) {
-        Space prefix = whitespace();
         if (node instanceof JCFieldAccess) {
+            Space prefix = whitespace();
             JCFieldAccess fieldAccess = (JCFieldAccess) node;
             JavaType type = typeMapping.type(node);
             Expression select = (Expression) annotatedTypeTree(fieldAccess.selected, annotationPosTable);
@@ -1356,8 +1336,45 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                             annotations, fieldAccess.name.toString(), type, typeMapping.variableType(fieldAccess.sym))),
                     type
             );
+        } else if (node instanceof JCAnnotatedType) {
+            JCAnnotatedType annotatedType = (JCAnnotatedType) node;
+            if (annotatedType.getUnderlyingType() instanceof JCArrayTypeTree) {
+                return arrayTypeTree((JCArrayTypeTree) annotatedType.getUnderlyingType(),
+                        mapAnnotations(annotatedType.getAnnotations(), annotationPosTable));
+            }
         }
         return convert(node);
+    }
+
+    private TypeTree arrayTypeTree(JCArrayTypeTree arrayTypeTree, Map<Integer, JCAnnotation> annotationPosTable) {
+        Space prefix = whitespace();
+        Tree typeIdent = arrayTypeTree.getType();
+        while (!annotationPosTable.isEmpty() && typeIdent instanceof ArrayTypeTree) {
+            typeIdent = ((ArrayTypeTree) typeIdent).getType();
+        }
+
+        TypeTree elemType = annotatedTypeTree(typeIdent, annotationPosTable);
+        List<J.Annotation> annotations = leadingAnnotations(annotationPosTable);
+        int saveCursor = cursor;
+        Space before = whitespace();
+        JLeftPadded<Space> dimension;
+        if (source.startsWith("[", cursor)) {
+            skip("[");
+            dimension = padLeft(before, sourceBefore("]"));
+        } else {
+            cursor = saveCursor;
+            return elemType;
+        }
+
+        return new J.ArrayType(
+                randomId(),
+                prefix,
+                Markers.EMPTY,
+                elemType,
+                annotations.isEmpty() ? null : annotations,
+                dimension,
+                typeMapping.type(arrayTypeTree)
+        );
     }
 
     @Override
@@ -1484,10 +1501,8 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
         JCExpression vartype = node.vartype;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (JCAnnotation annotationNode : node.getModifiers().getAnnotations()) {
-            annotationPosTable.put(annotationNode.pos, annotationNode);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava17ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
@@ -1504,12 +1519,19 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
             }
         } else if (vartype instanceof JCArrayTypeTree) {
-            // we'll capture the array dimensions in a bit, just convert the element type
-            JCExpression elementType = ((JCArrayTypeTree) vartype).elemtype;
-            while (elementType instanceof JCArrayTypeTree) {
-                elementType = ((JCArrayTypeTree) elementType).elemtype;
+            JCExpression elementType = vartype;
+            while (elementType instanceof JCArrayTypeTree || elementType instanceof JCAnnotatedType) {
+                if (elementType instanceof JCAnnotatedType) {
+                    elementType = ((JCAnnotatedType) elementType).underlyingType;
+                }
+                if (elementType instanceof JCArrayTypeTree) {
+                    elementType = ((JCArrayTypeTree) elementType).elemtype;
+                }
             }
-            typeExpr = convert(elementType);
+            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
+            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+                    // we'll capture the array dimensions in a bit, just convert the element type
+                    convert(elementType);
         } else {
             typeExpr = convert(vartype);
         }
@@ -1518,11 +1540,11 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             typeExpr = new J.AnnotatedType(randomId(), Space.EMPTY, Markers.EMPTY, typeExprAnnotations, typeExpr);
         }
 
-        List<JLeftPadded<Space>> beforeDimensions = arrayDimensions();
+        List<JLeftPadded<Space>> beforeDimensions = emptyList();
 
         Space varargs = null;
         if (typeExpr != null && typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
-            int varargStart = indexOfNextNonWhitespace(vartype.getStartPosition(), source);
+            int varargStart = indexOfNextNonWhitespace(cursor, source);
             if (source.startsWith("...", varargStart)) {
                 varargs = format(source, cursor, varargStart);
                 cursor = varargStart + 3;

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -45,6 +45,9 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.internal.StringUtils.indexOfNextNonWhitespace;
+import static org.openrewrite.java.tree.Space.EMPTY;
+import static org.openrewrite.java.tree.Space.format;
 
 public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
     private final Attr attr;
@@ -1150,26 +1153,17 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
 
         @Override
         public J visitArrayType(ArrayTypeTree node, Space fmt) {
-            com.sun.source.tree.Tree typeIdent = node.getType();
-            int dimCount = 1;
+            TypeTree elemType = (TypeTree) scan(node.getType(), Space.EMPTY);
 
-            while (typeIdent instanceof ArrayTypeTree) {
-                dimCount++;
-                typeIdent = ((ArrayTypeTree) typeIdent).getType();
-            }
-
-            TypeTree elemType = (TypeTree) scan(typeIdent, Space.EMPTY);
-
-            List<JRightPadded<Space>> dimensions = emptyList();
-            if (dimCount > 0) {
-                dimensions = new ArrayList<>(dimCount);
-                for (int n = 0; n < dimCount; n++) {
-                    if (!source.substring(cursor).startsWith("...")) {
-                        dimensions.add(padRight(
-                                Space.build(sourceBeforeAsString("["), emptyList()),
-                                Space.build(sourceBeforeAsString("]"), emptyList())));
-                    }
-                }
+            int saveCursor = cursor;
+            Space before = whitespace();
+            JLeftPadded<Space> dimension;
+            if (source.startsWith("[", cursor)) {
+                cursor++;
+                dimension = JLeftPadded.build(Space.build(sourceBeforeAsString("]"), emptyList())).withBefore(before);
+            } else {
+                cursor = saveCursor;
+                return elemType;
             }
 
             return new J.ArrayType(
@@ -1177,12 +1171,20 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                     fmt,
                     Markers.EMPTY,
                     elemType,
-                    dimensions
+                    null,
+                    dimension,
+                    typeMapping.type(node)
             );
         }
 
-        private <T> JRightPadded<T> padRight(T tree, Space right) {
-            return new JRightPadded<>(tree, right, Markers.EMPTY);
+        private Space whitespace() {
+            int nextNonWhitespace = indexOfNextNonWhitespace(cursor, source);
+            if (nextNonWhitespace == cursor) {
+                return EMPTY;
+            }
+            Space space = format(source, cursor, nextNonWhitespace);
+            cursor = nextNonWhitespace;
+            return space;
         }
 
         @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -123,7 +123,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         NameTree name = convert(node.getAnnotationType());
 
         JContainer<Expression> args = null;
-        if (node.getArguments().size() > 0) {
+        if (!node.getArguments().isEmpty()) {
             Space argsPrefix = sourceBefore("(");
             List<JRightPadded<Expression>> expressions;
             if (node.getArguments().size() == 1) {
@@ -175,31 +175,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitArrayType(ArrayTypeTree node, Space fmt) {
-        Tree typeIdent = node.getType();
-        int dimCount = 1;
-
-        while (typeIdent instanceof ArrayTypeTree) {
-            dimCount++;
-            typeIdent = ((ArrayTypeTree) typeIdent).getType();
-        }
-
-        TypeTree elemType = convert(typeIdent);
-
-        List<JRightPadded<Space>> dimensions = emptyList();
-        if (dimCount > 0) {
-            dimensions = new ArrayList<>(dimCount);
-            for (int n = 0; n < dimCount; n++) {
-                dimensions.add(padRight(sourceBefore("["), sourceBefore("]")));
-            }
-        }
-
-        return new J.ArrayType(
-                randomId(),
-                fmt,
-                Markers.EMPTY,
-                elemType,
-                dimensions
-        );
+        return arrayTypeTree((JCArrayTypeTree) node, new HashMap<>()).withPrefix(fmt);
     }
 
     @Override
@@ -398,12 +374,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
 
     @Override
     public J visitClass(ClassTree node, Space fmt) {
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getModifiers().getAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
-
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava21ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         List<J.Annotation> kindAnnotations = collectAnnotations(annotationPosTable);
@@ -553,11 +525,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         endPosTable = cu.endPositions;
         docCommentTable = cu.docComments;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getPackageAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getPackageAnnotations(),
+                new HashMap<>(node.getPackageAnnotations().size()));
         List<J.Annotation> packageAnnotations = collectAnnotations(annotationPosTable);
 
         J.Package packageDecl = null;
@@ -968,11 +937,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     public J visitMethod(MethodTree node, Space fmt) {
         JCMethodDecl jcMethod = (JCMethodDecl) node;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getModifiers().getAnnotations()) {
-            JCAnnotation annotation = (JCAnnotation) annotationNode;
-            annotationPosTable.put(annotation.pos, annotation);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava21ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         J.TypeParameters typeParams;
@@ -1314,13 +1280,26 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     }
 
     @Override
-    public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (AnnotationTree annotationNode : node.getAnnotations()) {
+    public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
+                new HashMap<>(node.getAnnotations().size()));
+        List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
+        if (!annotationPosTable.isEmpty()) {
+            if (node.getUnderlyingType() instanceof JCFieldAccess) {
+                return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, annotatedTypeTree(node.getUnderlyingType(), annotationPosTable));
+            } else if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+                return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, arrayTypeTree((JCArrayTypeTree) node.getUnderlyingType(), annotationPosTable));
+            }
+        }
+        return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations, convert(node.getUnderlyingType()));
+    }
+
+    private Map<Integer, JCAnnotation> mapAnnotations(List<? extends AnnotationTree> annotations, Map<Integer, JCAnnotation> annotationPosTable) {
+        for (AnnotationTree annotationNode : annotations) {
             JCAnnotation annotation = (JCAnnotation) annotationNode;
             annotationPosTable.put(annotation.pos, annotation);
         }
-        return new J.AnnotatedType(randomId(), fmt, Markers.EMPTY, leadingAnnotations(annotationPosTable),
-                annotationPosTable.isEmpty() ? convert(node.getUnderlyingType()) : annotatedTypeTree(node.getUnderlyingType(), annotationPosTable));
+        return annotationPosTable;
     }
 
     private List<J.Annotation> leadingAnnotations(Map<Integer, JCAnnotation> annotationPosTable) {
@@ -1341,8 +1320,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     }
 
     private TypeTree annotatedTypeTree(Tree node, Map<Integer, JCAnnotation> annotationPosTable) {
-        Space prefix = whitespace();
         if (node instanceof JCFieldAccess) {
+            Space prefix = whitespace();
             JCFieldAccess fieldAccess = (JCFieldAccess) node;
             JavaType type = typeMapping.type(node);
             Expression select = (Expression) annotatedTypeTree(fieldAccess.selected, annotationPosTable);
@@ -1355,8 +1334,45 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                             annotations, fieldAccess.name.toString(), type, typeMapping.variableType(fieldAccess.sym))),
                     type
             );
+        } else if (node instanceof JCAnnotatedType) {
+            JCAnnotatedType annotatedType = (JCAnnotatedType) node;
+            if (annotatedType.getUnderlyingType() instanceof JCArrayTypeTree) {
+                return arrayTypeTree((JCArrayTypeTree) annotatedType.getUnderlyingType(),
+                        mapAnnotations(annotatedType.getAnnotations(), annotationPosTable));
+            }
         }
         return convert(node);
+    }
+
+    private TypeTree arrayTypeTree(JCArrayTypeTree arrayTypeTree, Map<Integer, JCAnnotation> annotationPosTable) {
+        Space prefix = whitespace();
+        Tree typeIdent = arrayTypeTree.getType();
+        while (!annotationPosTable.isEmpty() && typeIdent instanceof ArrayTypeTree) {
+            typeIdent = ((ArrayTypeTree) typeIdent).getType();
+        }
+
+        TypeTree elemType = annotatedTypeTree(typeIdent, annotationPosTable);
+        List<J.Annotation> annotations = leadingAnnotations(annotationPosTable);
+        int saveCursor = cursor;
+        Space before = whitespace();
+        JLeftPadded<Space> dimension;
+        if (source.startsWith("[", cursor)) {
+            skip("[");
+            dimension = padLeft(before, sourceBefore("]"));
+        } else {
+            cursor = saveCursor;
+            return elemType;
+        }
+
+        return new J.ArrayType(
+                randomId(),
+                prefix,
+                Markers.EMPTY,
+                elemType,
+                annotations.isEmpty() ? null : annotations,
+                dimension,
+                typeMapping.type(arrayTypeTree)
+        );
     }
 
     @Override
@@ -1483,10 +1499,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
 
         JCExpression vartype = node.vartype;
 
-        Map<Integer, JCAnnotation> annotationPosTable = new HashMap<>();
-        for (JCAnnotation annotationNode : node.getModifiers().getAnnotations()) {
-            annotationPosTable.put(annotationNode.pos, annotationNode);
-        }
+        Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getModifiers().getAnnotations(),
+                new HashMap<>(node.getModifiers().getAnnotations().size()));
         ReloadableJava21ModifierResults modifierResults = sortedModifiersAndAnnotations(node.getModifiers(), annotationPosTable);
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
@@ -1503,12 +1517,19 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
             }
         } else if (vartype instanceof JCArrayTypeTree) {
-            // we'll capture the array dimensions in a bit, just convert the element type
-            JCExpression elementType = ((JCArrayTypeTree) vartype).elemtype;
-            while (elementType instanceof JCArrayTypeTree) {
-                elementType = ((JCArrayTypeTree) elementType).elemtype;
+            JCExpression elementType = vartype;
+            while (elementType instanceof JCArrayTypeTree || elementType instanceof JCAnnotatedType) {
+                if (elementType instanceof JCAnnotatedType) {
+                    elementType = ((JCAnnotatedType) elementType).underlyingType;
+                }
+                if (elementType instanceof JCArrayTypeTree) {
+                    elementType = ((JCArrayTypeTree) elementType).elemtype;
+                }
             }
-            typeExpr = convert(elementType);
+            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
+            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+                    // we'll capture the array dimensions in a bit, just convert the element type
+                    convert(elementType);
         } else {
             typeExpr = convert(vartype);
         }
@@ -1517,11 +1538,11 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             typeExpr = new J.AnnotatedType(randomId(), Space.EMPTY, Markers.EMPTY, typeExprAnnotations, typeExpr);
         }
 
-        List<JLeftPadded<Space>> beforeDimensions = arrayDimensions();
+        List<JLeftPadded<Space>> beforeDimensions = emptyList();
 
         Space varargs = null;
         if (typeExpr != null && typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
-            int varargStart = indexOfNextNonWhitespace(vartype.getStartPosition(), source);
+            int varargStart = indexOfNextNonWhitespace(cursor, source);
             if (source.startsWith("...", varargStart)) {
                 varargs = format(source, cursor, varargStart);
                 cursor = varargStart + 3;

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -42,6 +42,9 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.internal.StringUtils.indexOfNextNonWhitespace;
+import static org.openrewrite.java.tree.Space.EMPTY;
+import static org.openrewrite.java.tree.Space.format;
 
 public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
     private final Attr attr;
@@ -1067,26 +1070,17 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
 
         @Override
         public J visitArrayType(ArrayTypeTree node, Space fmt) {
-            com.sun.source.tree.Tree typeIdent = node.getType();
-            int dimCount = 1;
+            TypeTree elemType = (TypeTree) scan(node.getType(), Space.EMPTY);
 
-            while (typeIdent instanceof ArrayTypeTree) {
-                dimCount++;
-                typeIdent = ((ArrayTypeTree) typeIdent).getType();
-            }
-
-            TypeTree elemType = (TypeTree) scan(typeIdent, Space.EMPTY);
-
-            List<JRightPadded<Space>> dimensions = emptyList();
-            if (dimCount > 0) {
-                dimensions = new ArrayList<>(dimCount);
-                for (int n = 0; n < dimCount; n++) {
-                    if (!source.substring(cursor).startsWith("...")) {
-                        dimensions.add(padRight(
-                                Space.build(sourceBeforeAsString("["), emptyList()),
-                                Space.build(sourceBeforeAsString("]"), emptyList())));
-                    }
-                }
+            int saveCursor = cursor;
+            Space before = whitespace();
+            JLeftPadded<Space> dimension;
+            if (source.startsWith("[", cursor)) {
+                cursor++;
+                dimension = JLeftPadded.build(Space.build(sourceBeforeAsString("]"), emptyList())).withBefore(before);
+            } else {
+                cursor = saveCursor;
+                return elemType;
             }
 
             return new J.ArrayType(
@@ -1094,12 +1088,20 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                     fmt,
                     Markers.EMPTY,
                     elemType,
-                    dimensions
+                    null,
+                    dimension,
+                    typeMapping.type(node)
             );
         }
 
-        private <T> JRightPadded<T> padRight(T tree, Space right) {
-            return new JRightPadded<>(tree, right, Markers.EMPTY);
+        private Space whitespace() {
+            int nextNonWhitespace = indexOfNextNonWhitespace(cursor, source);
+            if (nextNonWhitespace == cursor) {
+                return EMPTY;
+            }
+            Space space = format(source, cursor, nextNonWhitespace);
+            cursor = nextNonWhitespace;
+            return space;
         }
 
         @Override

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ArrayTypeTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ArrayTypeTest.java
@@ -16,21 +16,113 @@
 package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class ArrayTypeTest implements RewriteTest {
 
-    @Test
-    void arrayType() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "String [] [ ] s;",
+      """
+      String [] [ ] method() {
+          return null;
+      }
+      """
+    })
+    void arrayType(String input) {
         rewriteRun(
+          java(
+            String.format("""
+              class Test {
+                %s
+              }
+              """, input), spec -> spec.afterRecipe(cu -> {
+                AtomicBoolean firstDimension = new AtomicBoolean(false);
+                AtomicBoolean secondDimension = new AtomicBoolean(false);
+                new JavaIsoVisitor<>() {
+                    @Override
+                    public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
+                        if (arrayType.getElementType() instanceof J.ArrayType) {
+                            assertThat(arrayType.toString()).isEqualTo("String [] [ ]");
+                            secondDimension.set(true);
+                        } else {
+                            assertThat(arrayType.toString()).isEqualTo("String []");
+                            firstDimension.set(true);
+                        }
+                        return super.visitArrayType(arrayType, o);
+                    }
+                }.visit(cu, 0);
+                assertThat(firstDimension.get()).isTrue();
+                assertThat(secondDimension.get()).isTrue();
+            })
+          )
+        );
+    }
+
+    @Test
+    void javaTypesFromJsonCreatorConstructor() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.ArrayType visitArrayType(J.ArrayType arrayType, ExecutionContext executionContext) {
+                  if (arrayType.getElementType() instanceof J.ArrayType) {
+                      assert arrayType.getType() != null && "java.lang.Integer[][]".equals(arrayType.getType().toString());
+                      // Construct a new J.ArrayType from an old LST model.
+                      //noinspection deprecation
+                      return new J.ArrayType(
+                          Tree.randomId(),
+                          Space.EMPTY,
+                          Markers.EMPTY,
+                          ((J.ArrayType) arrayType.getElementType()).getElementType().withType(arrayType.getType()),
+                          Arrays.asList(JRightPadded.build(Space.EMPTY).withAfter(Space.build("", emptyList())), JRightPadded.build(Space.EMPTY).withAfter(Space.build(" ", emptyList()))),
+                          null,
+                          null,
+                          null
+                      );
+                  }
+                  return super.visitArrayType(arrayType, executionContext);
+              }
+          })),
           java(
             """
               class Test {
-                String [] [ ] s;
+                  Integer[][ ] n = new Integer[0][0];
               }
-              """
+              """,
+            """
+              class Test {
+                  Integer[][ ] n = new Integer[0][0];
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
+                    assert arrayType.getType() != null;
+                    if (arrayType.getElementType() instanceof J.ArrayType) {
+                        assertThat(arrayType.getType().toString()).isEqualTo("java.lang.Integer[][]");
+                        assertThat(arrayType.getDimension().getElement().getWhitespace()).isEqualTo(" ");
+                    } else {
+                        assertThat(arrayType.getType().toString()).isEqualTo("java.lang.Integer[]");
+                        assert arrayType.getElementType().getType() != null;
+                        assertThat(arrayType.getElementType().getType().toString()).isEqualTo("java.lang.Integer");
+                    }
+                    return super.visitArrayType(arrayType, o);
+                }
+            }.visit(cu, 0))
           )
         );
     }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodInvocationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodInvocationTest.java
@@ -90,7 +90,15 @@ class MethodInvocationTest implements RewriteTest {
                             
                   public <TTTT> TTTT generic(TTTT n, TTTT... ns) { return n; }
               }
-              """
+              """, spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Object o) {
+                    if ("ns".equals(variable.getSimpleName())) {
+                        assertThat(variable.getPrefix().getWhitespace()).isEqualTo(" ");
+                    }
+                    return super.visitVariable(variable, o);
+                }
+            })
           )
         );
     }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -177,6 +177,34 @@ class TypeUtilsTest implements RewriteTest {
     }
 
     @Test
+    void arrayIsFullyQualifiedOfType() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  Integer[][] integer1;
+                  Integer[] integer2;
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, Object o) {
+                    assertThat(multiVariable.getTypeExpression().getType()).isInstanceOf(JavaType.Array.class);
+                    assertThat(TypeUtils.isOfClassType(multiVariable.getTypeExpression().getType(), "java.lang.Integer")).isTrue();
+                    return super.visitVariableDeclarations(multiVariable, o);
+                }
+
+                @Override
+                public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Object o) {
+                    assertThat(variable.getVariableType().getType()).isInstanceOf(JavaType.Array.class);
+                    return super.visitVariable(variable, o);
+                }
+            }.visit(cu, new InMemoryExecutionContext()))
+          )
+        );
+    }
+
+    @Test
     void isFullyQualifiedOfType() {
         rewriteRun(
           java(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
@@ -125,6 +125,27 @@ class FindTypesTest implements RewriteTest {
     }
 
     @Test
+    void multiDimensionalArray() {
+        rewriteRun(
+          java(
+            """
+              import a.A1;
+              public class B {
+                 A1[][] a = new A1[0][0];
+              }
+              """,
+            """
+              import a.A1;
+              public class B {
+                 /*~~>*/A1[][] a = new /*~~>*/A1[0][0];
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
     void classDecl() {
         rewriteRun(
           spec -> spec.recipes(

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -172,7 +172,11 @@ public class ChangeType extends Recipe {
         @Override
         public @Nullable J postVisit(J tree, ExecutionContext ctx) {
             J j = super.postVisit(tree, ctx);
-            if (j instanceof J.MethodDeclaration) {
+            if (j instanceof J.ArrayType) {
+                J.ArrayType arrayType = (J.ArrayType) j;
+                JavaType type = updateType(arrayType.getType());
+                j = arrayType.withType(type);
+            } else if (j instanceof J.MethodDeclaration) {
                 J.MethodDeclaration method = (J.MethodDeclaration) j;
                 JavaType.Method mt = updateType(method.getMethodType());
                 j = method.withMethodType(mt)

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -176,12 +176,11 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
     public J visitArrayType(ArrayType arrayType, PrintOutputCapture<P> p) {
         beforeSyntax(arrayType, Space.Location.ARRAY_TYPE_PREFIX, p);
         visit(arrayType.getElementType(), p);
-        for (JRightPadded<Space> d : arrayType.getDimensions()) {
-            visitSpace(d.getElement(), Space.Location.DIMENSION, p);
-            p.append('[');
-            visitSpace(d.getAfter(), Space.Location.DIMENSION_SUFFIX, p);
-            p.append(']');
-        }
+        visit(arrayType.getAnnotations(), p);
+        visitSpace(arrayType.getDimension().getBefore(), Space.Location.DIMENSION_PREFIX, p);
+        p.append('[');
+        visitSpace(arrayType.getDimension().getElement(), Space.Location.DIMENSION, p);
+        p.append(']');
         afterSyntax(arrayType, p);
         return arrayType;
     }
@@ -800,6 +799,7 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
             visitModifier(m, p);
         }
         visit(multiVariable.getTypeExpression(), p);
+        // For backwards compatibility.
         for (JLeftPadded<Space> dim : multiVariable.getDimensionsBeforeName()) {
             visitSpace(dim.getBefore(), Space.Location.DIMENSION_PREFIX, p);
             p.append('[');

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -297,13 +297,11 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
         a = a.withElementType(visitAndCast(a.getElementType(), p));
         a = a.withElementType(visitTypeName(a.getElementType(), p));
-        a = a.withDimensions(
-                ListUtils.map(a.getDimensions(), dim ->
-                        visitRightPadded(dim.withElement(
-                                visitSpace(dim.getElement(), Space.Location.DIMENSION, p)
-                        ), JRightPadded.Location.DIMENSION, p)
-                )
-        );
+        a = a.withAnnotations(ListUtils.map(a.getAnnotations(), ann -> visitAndCast(ann, p)));
+        a = a.withDimension(a.getDimension()
+                .withBefore(visitSpace(a.getDimension().getBefore(), Space.Location.DIMENSION_PREFIX, p))
+                .withElement(visitSpace(a.getDimension().getElement(), Space.Location.DIMENSION, p)));
+        a = a.withType(visitType(a.getType(), p));
         return a;
     }
 
@@ -954,6 +952,8 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         m = m.withVarargs(m.getVarargs() == null ?
                 null :
                 visitSpace(m.getVarargs(), Space.Location.VARARGS, p));
+        // For backwards compatibility.
+        //noinspection deprecation
         m = m.withDimensionsBeforeName(ListUtils.map(m.getDimensionsBeforeName(), dim ->
                 dim.withBefore(visitSpace(dim.getBefore(), Space.Location.DIMENSION_PREFIX, p))
                         .withElement(visitSpace(dim.getElement(), Space.Location.DIMENSION, p))

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
@@ -408,12 +408,11 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
         public J visitArrayType(J.ArrayType arrayType, PrintOutputCapture<P> p) {
             beforeSyntax(arrayType, Space.Location.ARRAY_TYPE_PREFIX, p);
             visit(arrayType.getElementType(), p);
-            for (JRightPadded<Space> d : arrayType.getDimensions()) {
-                visitSpace(d.getElement(), Space.Location.DIMENSION, p);
-                p.append('[');
-                visitSpace(d.getAfter(), Space.Location.DIMENSION_SUFFIX, p);
-                p.append(']');
-            }
+            visit(arrayType.getAnnotations(), p);
+            visitSpace(arrayType.getDimension().getBefore(), Space.Location.DIMENSION_PREFIX, p);
+            p.append('[');
+            visitSpace(arrayType.getDimension().getElement(), Space.Location.DIMENSION, p);
+            p.append(']');
             afterSyntax(arrayType, p);
             return arrayType;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -82,10 +82,12 @@ public class NoWhitespaceAfter extends Recipe {
             return m;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
             J.VariableDeclarations vd = super.visitVariableDeclarations(multiVariable, ctx);
             if (Boolean.TRUE.equals(noWhitespaceAfterStyle.getArrayDeclarator())) {
+                // For backwards compatibility.
                 if (vd.getDimensionsBeforeName().stream().anyMatch(d -> d.getBefore().getWhitespace().contains(" "))) {
                     vd = vd.withDimensionsBeforeName(ListUtils.map(vd.getDimensionsBeforeName(), d -> {
                         d = d.withBefore(d.getBefore().withWhitespace(""));
@@ -111,11 +113,8 @@ public class NoWhitespaceAfter extends Recipe {
         public J.ArrayType visitArrayType(J.ArrayType arrayType, ExecutionContext ctx) {
             J.ArrayType a = super.visitArrayType(arrayType, ctx);
             if (Boolean.TRUE.equals(noWhitespaceAfterStyle.getArrayDeclarator())) {
-                if (a.getDimensions().stream().anyMatch(d -> d.getElement().getWhitespace().contains(" "))) {
-                    a = a.withDimensions(ListUtils.map(a.getDimensions(), d -> {
-                        d = d.withElement(d.getElement().withWhitespace(""));
-                        return d;
-                    }));
+                if (a.getDimension().getBefore().getWhitespace().contains(" ")) {
+                    a = a.withDimension(a.getDimension().withBefore(a.getDimension().getBefore().withWhitespace("")));
                 }
             }
             return a;

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -66,9 +66,10 @@ public class FindTypes extends Recipe {
             @Override
             public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
                 if (ident.getType() != null &&
-                    getCursor().firstEnclosing(J.Import.class) == null &&
-                    getCursor().firstEnclosing(J.FieldAccess.class) == null &&
-                    !(getCursor().getParentOrThrow().getValue() instanceof J.ParameterizedType)) {
+                        getCursor().firstEnclosing(J.Import.class) == null &&
+                        getCursor().firstEnclosing(J.FieldAccess.class) == null &&
+                        !(getCursor().getParentOrThrow().getValue() instanceof J.ParameterizedType) &&
+                        !(getCursor().getParentOrThrow().getValue() instanceof J.ArrayType)) {
                     JavaType.FullyQualified type = TypeUtils.asFullyQualified(ident.getType());
                     if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
                         ident.getSimpleName().equals(type.getClassName())) {
@@ -83,7 +84,7 @@ public class FindTypes extends Recipe {
                 N n = super.visitTypeName(name, ctx);
                 JavaType.FullyQualified type = TypeUtils.asFullyQualified(n.getType());
                 if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
-                    getCursor().firstEnclosing(J.Import.class) == null) {
+                        getCursor().firstEnclosing(J.Import.class) == null) {
                     return SearchResult.found(n);
                 }
                 return n;

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
@@ -20,6 +20,7 @@ import org.openrewrite.Incubating;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.tree.J;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -41,8 +42,6 @@ public class AnnotationService {
         J j = cursor.getValue();
         if (j instanceof J.VariableDeclarations) {
             return ((J.VariableDeclarations) j).getAllAnnotations();
-        } else if (j instanceof J.AnnotatedType) {
-            return ((J.AnnotatedType) j).getAllAnnotations();
         } else if (j instanceof J.MethodDeclaration) {
             return ((J.MethodDeclaration) j).getAllAnnotations();
         } else if (j instanceof J.ClassDeclaration) {
@@ -53,7 +52,51 @@ public class AnnotationService {
             return ((J.TypeParameters) j).getAnnotations();
         } else if (j instanceof J.Package) {
             return ((J.Package) j).getAnnotations();
+        } else if (j instanceof J.AnnotatedType) {
+            return getAllAnnotations((J.AnnotatedType) j);
+        } else if (j instanceof J.ArrayType) {
+            return getAllAnnotations((J.ArrayType) j);
+        } else if (j instanceof J.FieldAccess) {
+            return getAllAnnotations((J.FieldAccess) j);
+        } else if (j instanceof J.Identifier) {
+            return getAllAnnotations((J.Identifier) j);
         }
         return emptyList();
+    }
+
+    private List<J.Annotation> getAllAnnotations(J j) {
+        if (j instanceof J.AnnotatedType) {
+            return getAllAnnotations((J.AnnotatedType) j);
+        } else if (j instanceof J.ArrayType) {
+            return getAllAnnotations((J.ArrayType) j);
+        } else if (j instanceof J.Identifier) {
+            return getAllAnnotations((J.Identifier) j);
+        } else if (j instanceof J.FieldAccess) {
+            return getAllAnnotations((J.FieldAccess) j);
+        }
+        return emptyList();
+    }
+
+    private List<J.Annotation> getAllAnnotations(J.AnnotatedType annotatedType) {
+        List<J.Annotation> annotations = new ArrayList<>(annotatedType.getAnnotations().size());
+        annotations.addAll(annotatedType.getAnnotations());
+        annotations.addAll(getAllAnnotations(annotatedType.getTypeExpression()));
+        return annotations;
+    }
+
+    private List<J.Annotation> getAllAnnotations(J.ArrayType arrayType) {
+        List<J.Annotation> annotations = new ArrayList<>(arrayType.getAnnotations() == null ? 0 : arrayType.getAnnotations().size());
+        if (arrayType.getAnnotations() != null) {
+            annotations.addAll(arrayType.getAnnotations());
+        }
+        return annotations;
+    }
+
+    private List<J.Annotation> getAllAnnotations(J.FieldAccess fieldAccess) {
+        return getAllAnnotations(fieldAccess.getName());
+    }
+
+    private List<J.Annotation> getAllAnnotations(J.Identifier identifier) {
+        return identifier.getAnnotations() == null ? emptyList() : identifier.getAnnotations();
     }
 }


### PR DESCRIPTION
Changes:

- Updated J.ArrayType to preserve annotations on dimensions.
- Removed `J.ArrayType#dimensions` field and added a constructor to transform old LSTs into the new model.
- Deprecated `J.VariableDeclarations#dimensionsBeforeName`
- `...` is preserved in the `J.VariableDeclarations#varargs` field instead of the prefix of the variable name.
- Updated `GroovyParserVisitor` with the new `J.ArrayType`.
- Applied optimizations from Java 17 and 21 parsers to Java 11 and 8 parsers.

fixes #2911
fixes #3440
fixes #3453
