### PR TITLE
Fix `ClassCastException` on J.Ternary visitor

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -1150,13 +1150,13 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         J.Ternary t = ternary;
         t = t.withPrefix(visitSpace(t.getPrefix(), Space.Location.TERNARY_PREFIX, p));
         t = t.withMarkers(visitMarkers(t.getMarkers(), p));
-        Expression temp = (Expression) visitExpression(t, p);
+        J temp = visitExpression(t, p);
         if (!(temp instanceof J.Ternary)) {
             return temp;
         } else {
             t = (J.Ternary) temp;
         }
-        Statement tempStat = (Statement) visitStatement(t, p);
+        J tempStat = visitStatement(t, p);
         if (!(tempStat instanceof J.Ternary)) {
             return tempStat;
         } else {


### PR DESCRIPTION
## What's changed?
Changed `JavaVisitor#visitTernary` to allow simplification of ternary expressions.

## What's your motivation?
I tried to implement [this issue](https://github.com/openrewrite/rewrite-static-analysis/issues/203) to explore `rewrite-templating`, and used the following implementation:

```java
import com.google.errorprone.refaster.annotation.AfterTemplate;
import com.google.errorprone.refaster.annotation.BeforeTemplate;
import org.openrewrite.java.template.RecipeDescriptor;

public class SimplifyTernary {

    @RecipeDescriptor(
            name = "Simplify ternaries",
            description = "Simplify `expr ? true : false` to `expr`."
    )
    public static class SimplifyTernaryTrueFalse {

        @BeforeTemplate
        boolean before(boolean expr) {
            return expr ? true : false;
        }

        @AfterTemplate
        boolean after(boolean expr) {
            return expr;
        }
    }
}
```
With the following test case:
```java
@Test
void simplifyTrueFalse() {
    rewriteRun(
      spec -> spec.recipe(new SimplifyTernaryRecipes()),
      java(
        """
          class Test {
              boolean trueCondition = true ? true : false;
          }
          """,
        """
          class Test {
              boolean trueCondition = true;
          }
          """
      )
    );
}
```

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Test passes, but the change might break something else.

## Anyone you would like to review specifically?
<!-- @mention them here -->
No one.

## Have you considered any alternatives or workarounds?
Implement the rule as a regular visitor, instead of a Refaster template.

## Any additional context
Here's the exception trace for the test:
```
Caused by: org.openrewrite.internal.RecipeRunException: java.lang.ClassCastException: class org.openrewrite.java.tree.J$Literal cannot be cast to class org.openrewrite.java.tree.Statement (org.openrewrite.java.tree.J$Literal and org.openrewrite.java.tree.Statement are in unnamed module of loader 'app')
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:329)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:184)
    at org.openrewrite.java.JavaTemplate.apply(JavaTemplate.java:67)
    at org.openrewrite.java.migrate.lang.SimplifyTernaryRecipes$SimplifyTernaryTrueFalseRecipe$1.visitExpression(SimplifyTernaryRecipes.java:81)
    at org.openrewrite.java.migrate.lang.SimplifyTernaryRecipes$SimplifyTernaryTrueFalseRecipe$1.visitExpression(SimplifyTernaryRecipes.java:72)
    at org.openrewrite.java.JavaVisitor.visitTernary(JavaVisitor.java:1153)
    at org.openrewrite.java.tree.J$Ternary.acceptJava(J.java:5181)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    at org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:361)
    at org.openrewrite.java.JavaVisitor.visitLeftPadded(JavaVisitor.java:1401)
    at org.openrewrite.java.JavaVisitor.visitVariable(JavaVisitor.java:1301)
    at org.openrewrite.java.tree.J$VariableDeclarations$NamedVariable.acceptJava(J.java:5932)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    at org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:361)
    at org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1373)
    at org.openrewrite.java.JavaVisitor.lambda$visitVariableDeclarations$29(JavaVisitor.java:961)
    at org.openrewrite.internal.ListUtils.map(ListUtils.java:176)
    at org.openrewrite.java.JavaVisitor.visitVariableDeclarations(JavaVisitor.java:961)
    at org.openrewrite.java.tree.J$VariableDeclarations.acceptJava(J.java:5818)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    at org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:361)
    at org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1373)
    at org.openrewrite.java.JavaVisitor.lambda$visitBlock$4(JavaVisitor.java:399)
    at org.openrewrite.internal.ListUtils.map(ListUtils.java:176)
    at org.openrewrite.java.JavaVisitor.visitBlock(JavaVisitor.java:398)
    at org.openrewrite.java.tree.J$Block.acceptJava(J.java:834)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    at org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:361)
    at org.openrewrite.java.JavaVisitor.visitClassDeclaration(JavaVisitor.java:486)
    at org.openrewrite.java.tree.J$ClassDeclaration.acceptJava(J.java:1286)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    at org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:361)
    at org.openrewrite.java.JavaVisitor.lambda$visitCompilationUnit$10(JavaVisitor.java:499)
    at org.openrewrite.internal.ListUtils.map(ListUtils.java:176)
    at org.openrewrite.java.JavaVisitor.visitCompilationUnit(JavaVisitor.java:499)
    at org.openrewrite.java.tree.J$CompilationUnit.acceptJava(J.java:1588)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:184)
    at org.openrewrite.scheduling.RecipeRunCycle.lambda$editSources$5(RecipeRunCycle.java:164)
    at io.micrometer.core.instrument.AbstractTimer.recordCallable(AbstractTimer.java:147)
    at org.openrewrite.table.RecipeRunStats.recordEdit(RecipeRunStats.java:68)
    at org.openrewrite.scheduling.RecipeRunCycle.lambda$editSources$6(RecipeRunCycle.java:161)
    ... 15 more
Caused by: java.lang.ClassCastException: class org.openrewrite.java.tree.J$Literal cannot be cast to class org.openrewrite.java.tree.Statement (org.openrewrite.java.tree.J$Literal and org.openrewrite.java.tree.Statement are in unnamed module of loader 'app')
    at org.openrewrite.java.JavaVisitor.visitTernary(JavaVisitor.java:1159)
    at org.openrewrite.java.tree.J$Ternary.acceptJava(J.java:5181)
    at org.openrewrite.java.tree.J.accept(J.java:59)
    at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:278)
    ... 62 more
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
