### PR TITLE
Correctly deduplicate managed dependencies using classifier

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -54,7 +54,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     @Override
     public boolean isAcceptable(SourceFile sourceFile, P p) {
         return super.isAcceptable(sourceFile, p) &&
-                sourceFile.getMarkers().findFirst(MavenResolutionResult.class).isPresent();
+               sourceFile.getMarkers().findFirst(MavenResolutionResult.class).isPresent();
     }
 
     protected MavenResolutionResult getResolutionResult() {
@@ -80,7 +80,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     /**
      * Is a tag a dependency that matches the group and artifact?
      *
-     * @param groupId The group ID glob expression to compare the tag against.
+     * @param groupId    The group ID glob expression to compare the tag against.
      * @param artifactId The artifact ID glob expression to compare the tag against.
      * @return true if the tag matches.
      */
@@ -109,9 +109,9 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                         }
                         Dependency req = resolvedDependency.getRequested();
                         String reqGroup = req.getGroupId();
-                        if  ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                                req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                                scope == tagScope) {
+                        if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
+                            req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                            scope == tagScope) {
                             return true;
                         }
                     }
@@ -127,7 +127,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         }
         Xml.Tag tag = getCursor().getValue();
         return matchesGlob(tag.getChildValue("groupId").orElse(null), groupId) &&
-                matchesGlob(tag.getChildValue("artifactId").orElse(null), artifactId);
+               matchesGlob(tag.getChildValue("artifactId").orElse(null), artifactId);
     }
 
     public boolean isManagedDependencyTag() {
@@ -137,7 +137,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     /**
      * Is a tag a managed dependency that matches the group and artifact?
      *
-     * @param groupId The group ID glob expression to compare the tag against.
+     * @param groupId    The group ID glob expression to compare the tag against.
      * @param artifactId The artifact ID glob expression to compare the tag against.
      * @return true if the tag matches.
      */
@@ -151,8 +151,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 ManagedDependency req = dm.getRequested();
                 String reqGroup = req.getGroupId();
                 if (reqGroup.equals(tag.getChildValue("groupId").orElse(null)) &&
-                        req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                        dm.getScope() == tag.getChildValue("scope").map(Scope::fromName).orElse(null)) {
+                    req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                    dm.getScope() == tag.getChildValue("scope").map(Scope::fromName).orElse(null)) {
                     return true;
                 }
             }
@@ -160,8 +160,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 if (matchesGlob(dm.getBomGav().getGroupId(), groupId) && matchesGlob(dm.getBomGav().getArtifactId(), artifactId)) {
                     ManagedDependency requestedBom = dm.getRequestedBom();
                     //noinspection ConstantConditions
-                    if  (requestedBom.getGroupId().equals(tag.getChildValue("groupId").orElse(null)) &&
-                            requestedBom.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null))) {
+                    if (requestedBom.getGroupId().equals(tag.getChildValue("groupId").orElse(null)) &&
+                        requestedBom.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null))) {
                         return true;
                     }
                 }
@@ -176,12 +176,12 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         }
         Xml.Tag tag = getCursor().getValue();
         return tag.getChildValue("type").map("pom"::equalsIgnoreCase).orElse(false)
-                && tag.getChildValue("scope").map("import"::equalsIgnoreCase).orElse(false);
+               && tag.getChildValue("scope").map("import"::equalsIgnoreCase).orElse(false);
     }
 
     public void maybeUpdateModel() {
         for (TreeVisitor<?, P> afterVisit : getAfterVisit()) {
-            if(afterVisit instanceof UpdateMavenModel) {
+            if (afterVisit instanceof UpdateMavenModel) {
                 return;
             }
         }
@@ -239,9 +239,9 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 String reqGroup = req.getGroupId();
                 String reqVersion = req.getVersion();
                 if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                        req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                        (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null))) &&
-                        (req.getClassifier() == null || req.getClassifier().equals(tag.getChildValue("classifier").orElse(null)))) {
+                    req.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                    (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null))) &&
+                    (req.getClassifier() == null || req.getClassifier().equals(tag.getChildValue("classifier").orElse(null)))) {
                     return resolvedDependency;
                 }
             }
@@ -253,16 +253,24 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     public ResolvedManagedDependency findManagedDependency(Xml.Tag tag) {
         String groupId = getResolutionResult().getPom().getValue(tag.getChildValue("groupId").orElse(getResolutionResult().getPom().getGroupId()));
         String artifactId = getResolutionResult().getPom().getValue(tag.getChildValue("artifactId").orElse(""));
+        String classifier = getResolutionResult().getPom().getValue(tag.getChildValue("classifier").orElse(null));
         if (groupId != null && artifactId != null) {
-            return findManagedDependency(groupId, artifactId);
+            return findManagedDependency(groupId, artifactId, classifier);
         }
         return null;
     }
 
     @Nullable
     public ResolvedManagedDependency findManagedDependency(String groupId, String artifactId) {
+        return findManagedDependency(groupId, artifactId, null);
+    }
+
+    @Nullable
+    private ResolvedManagedDependency findManagedDependency(String groupId, String artifactId, @Nullable String classifier) {
         for (ResolvedManagedDependency d : getResolutionResult().getPom().getDependencyManagement()) {
-            if (groupId.equals(d.getGroupId()) && artifactId.equals(d.getArtifactId())) {
+            if (groupId.equals(d.getGroupId()) &&
+                artifactId.equals(d.getArtifactId()) &&
+                (classifier == null || classifier.equals(d.getClassifier()))) {
                 return d;
             }
         }
@@ -288,7 +296,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
             if (inClasspathOf == null || scope.getKey() == inClasspathOf || scope.getKey().isInClasspathOf(inClasspathOf)) {
                 for (ResolvedDependency d : scope.getValue()) {
                     if (tag.getChildValue("groupId").orElse(getResolutionResult().getPom().getGroupId()).equals(d.getGroupId()) &&
-                            tag.getChildValue("artifactId").orElse(getResolutionResult().getPom().getArtifactId()).equals(d.getArtifactId())) {
+                        tag.getChildValue("artifactId").orElse(getResolutionResult().getPom().getArtifactId()).equals(d.getArtifactId())) {
                         return d;
                     }
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -18,13 +18,13 @@ package org.openrewrite.maven;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RemoveDuplicateDependenciesTest implements RewriteTest {
-
     @Override
     public void defaults(RecipeSpec spec) {
         spec.expectedCyclesThatMakeChanges(1).recipe(new RemoveDuplicateDependencies());
@@ -429,4 +429,45 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3832")
+    void retainDuplicateManagedDependenciesWithDifferentClassifier() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(0),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <properties>
+                  <version.chromedriver>94.0.4606.61</version.chromedriver>
+                </properties>
+                
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>selenium-tools</groupId>
+                      <artifactId>chromedriver</artifactId>
+                      <classifier>w64</classifier>
+                      <version>${version.chromedriver}</version>
+                      <type>tar.gz</type>
+                    </dependency>
+                    <dependency>
+                      <groupId>selenium-tools</groupId>
+                      <artifactId>chromedriver</artifactId>
+                      <classifier>x64</classifier>
+                      <version>${version.chromedriver}</version>
+                      <type>tar.gz</type>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Also take `classifier` into account when resolving managed dependencies.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/3832
