### PR TITLE
#3856 fileMatcher added back to MergeYaml

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -37,6 +37,14 @@ public class MergeYaml extends Recipe {
     @Language("yml")
     String yaml;
 
+    @Incubating(since = "7.11.0")
+    @Option(displayName = "Optional file matcher",
+            description = "Matching files will be modified. This is a glob expression.",
+            required = false,
+            example = "**/application-*.yml")
+    @Nullable
+    String fileMatcher;
+
     @Option(displayName = "Accept theirs",
             description = "When the YAML snippet to insert conflicts with an existing key value pair and an existing key has a different value, prefer the original value.",
             required = false)
@@ -85,6 +93,14 @@ public class MergeYaml extends Recipe {
                 .orElseThrow(() -> new IllegalArgumentException("Could not parse as YAML"))
                 .getDocuments().get(0).getBlock();
 
+        if(fileMatcher!=null && !fileMatcher.isEmpty()) {
+            return Preconditions.check(new FindSourceFiles(fileMatcher),
+                    getExecutionContextTreeVisitor(matcher, incoming));
+        }
+        return getExecutionContextTreeVisitor(matcher, incoming);
+    }
+
+    private TreeVisitor<?, ExecutionContext> getExecutionContextTreeVisitor(JsonPathMatcher matcher, Yaml incoming) {
         return new YamlIsoVisitor<ExecutionContext>() {
             @Override
             public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CopyValueTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CopyValueTest.java
@@ -68,7 +68,7 @@ class CopyValueTest implements RewriteTest {
     void insertCopyValueAndRemoveSource() {
         rewriteRun(
           spec -> spec.recipes(
-            new MergeYaml("$", "destination: TEMP", true, null),
+            new MergeYaml("$", "destination: TEMP", null, true, null),
             new CopyValue(".source", ".destination"),
             new DeleteKey(".source")
           ),

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -36,6 +36,7 @@ class MergeYamlTest implements RewriteTest {
               schedule:
                   - cron: "0 18 * * *"
               """,
+            null,
             true,
             null
           )),
@@ -61,6 +62,7 @@ class MergeYamlTest implements RewriteTest {
                   name: update
                   description: a description
               """,
+            null,
             false,
             null
           )),
@@ -89,6 +91,7 @@ class MergeYamlTest implements RewriteTest {
                   name: update
                   description: a description
               """,
+            null,
             false,
             null
           )),
@@ -122,6 +125,7 @@ class MergeYamlTest implements RewriteTest {
                     condition:
                         age: 7
               """,
+            null,
             false,
             null
           )),
@@ -159,7 +163,7 @@ class MergeYamlTest implements RewriteTest {
                   list:
                     - item 2
                 """,
-              false, null
+              null, false, null
             )),
           yaml(
             """
@@ -190,6 +194,7 @@ class MergeYamlTest implements RewriteTest {
                   list:
                     - item 2
                 """,
+              null,
               true, null
             )
           ),
@@ -212,6 +217,7 @@ class MergeYamlTest implements RewriteTest {
             """
               bucketPolicyOnly: true
               """,
+            null,
             false,
             null
           )),
@@ -248,6 +254,7 @@ class MergeYamlTest implements RewriteTest {
                       condition:
                           age: 7
                 """,
+              null,
               false,
               null
             )),
@@ -280,6 +287,7 @@ class MergeYamlTest implements RewriteTest {
             "$",
             //language=yaml
             "spec: 0",
+            null,
             true,
             null
           )),
@@ -303,6 +311,7 @@ class MergeYamlTest implements RewriteTest {
           spec -> spec.recipe(new MergeYaml(
             "$.spec.containers",
             "imagePullPolicy: Always",
+            null,
             true,
             null
           )),
@@ -332,6 +341,7 @@ class MergeYamlTest implements RewriteTest {
             "$.spec.containers[?(@.name == 'pod-0')]",
             //language=yaml
             "imagePullPolicy: Always",
+            null,
             true,
             null
           )),
@@ -365,6 +375,7 @@ class MergeYamlTest implements RewriteTest {
               securityContext:
                 privileged: false
               """,
+            null,
             true,
             null
           )),
@@ -400,6 +411,7 @@ class MergeYamlTest implements RewriteTest {
               securityContext:
                 privileged: false
               """,
+            null,
             true,
             null
           )),
@@ -432,6 +444,7 @@ class MergeYamlTest implements RewriteTest {
               with:
                 cache: 'gradle'
               """,
+            null,
             false,
             null
           )),
@@ -473,6 +486,7 @@ class MergeYamlTest implements RewriteTest {
                       - Woodpecker
                       - Mangrove
               """,
+            null,
             true,
             null
           )),
@@ -515,6 +529,7 @@ class MergeYamlTest implements RewriteTest {
                       - 1
                       - 2
               """,
+            null,
             true,
             null
           )),
@@ -551,6 +566,7 @@ class MergeYamlTest implements RewriteTest {
                   - nnmap1: v111
                     nnmap2: v222
               """,
+            null,
             true,
             null
           )),
@@ -594,6 +610,7 @@ class MergeYamlTest implements RewriteTest {
                   - name: jdk_version
                     value: 18
                 """,
+              null,
               false,
               "name"
             )),
@@ -630,6 +647,7 @@ class MergeYamlTest implements RewriteTest {
                   - name: jdk_version
                     value: 18
                 """,
+              null,
               false,
               "name"
             )),
@@ -662,6 +680,7 @@ class MergeYamlTest implements RewriteTest {
                   - name: jdk_version
                     value: 18
               """,
+            null,
             false,
             null
           )),
@@ -694,6 +713,7 @@ class MergeYamlTest implements RewriteTest {
                   - name: build_tool
                     row2key2: maven
                 """,
+              null,
               false,
               "name"
             )),
@@ -730,6 +750,7 @@ class MergeYamlTest implements RewriteTest {
                   - name: jdk_version
                     value: 17
                 """,
+              null,
               false,
               "name"
             )),
@@ -767,6 +788,7 @@ class MergeYamlTest implements RewriteTest {
                       kind: Postgres
                       name: customer-profile-database-02
                 """,
+              null,
               false,
               "name"
             )),
@@ -815,6 +837,7 @@ class MergeYamlTest implements RewriteTest {
                       kind: MySQL
                       name: relation-profile-database
                 """,
+              null,
               false,
               "name"
             )),
@@ -841,4 +864,90 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3856")
+    @Test
+    void mergeYamlAppliedWhenFileMatchesGivenPattern() {
+        rewriteRun(
+          spec -> spec
+            .expectedCyclesThatMakeChanges(1)
+            .recipe(new MergeYaml(
+              "$",
+              //language=yaml
+              """
+              node: java  
+              """,
+              "**/jules.yml",
+              false,
+              "value"
+            )),
+          yaml(
+            """
+            service: db
+            host: localhost
+            """,
+            """
+            service: db
+            host: localhost
+            node: java
+            """,
+            spec -> spec.path("src/main/resources/jules.yml")
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3856")
+    @Test
+    void mergeYamlNotAppliedWhenFileDoesnotMatchGivenPattern() {
+        rewriteRun(
+          spec -> spec
+            .expectedCyclesThatMakeChanges(0)
+            .recipe(new MergeYaml(
+              "$",
+              //language=yaml
+              """
+              node: java  
+              """,
+              "**/jules.yml",
+              false,
+              "value"
+            )),
+          yaml(
+            """
+            service: db
+            host: localhost
+            """,
+            spec -> spec.path("src/main/resources/application.yml")
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3856")
+    @Test
+    void mergeYamlAppliedOnAllFilesWhenFileMatcherPatternNotProvided() {
+        rewriteRun(
+          spec -> spec
+            .expectedCyclesThatMakeChanges(1)
+            .recipe(new MergeYaml(
+              "$",
+              //language=yaml
+              """
+              node: java  
+              """,
+              null,
+              false,
+              "value"
+            )),
+          yaml(
+            """
+            service: db
+            host: localhost
+            """,
+            """
+            service: db
+            host: localhost
+            node: java
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
fileMatcher option which is removed has been added back

## What's your motivation?
as the preconditions are not working in declarative approach for the issue #3856 
we have to scan the files and apply recipe only on the files which matches the regular expression.

## Anything in particular you'd like reviewers to focus on?
Added testcases which shows files which matches regular expression are only touched with this approach, 
there is one breaking change, users who are using MergeYaml in Java custom recipe now should pass one more extra parameter in the constructor.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
There are no alternatives for this issue. 


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
