### PR TITLE
Allow `JavaTemplate` to deal with expressions that are also statements

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -221,7 +221,9 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitExpression(Expression expression, Integer p) {
-                if (loc.equals(EXPRESSION_PREFIX) && expression.isScope(insertionPoint)) {
+                if ((loc.equals(EXPRESSION_PREFIX) ||
+                     loc.equals(STATEMENT_PREFIX) && expression instanceof Statement) &&
+                    expression.isScope(insertionPoint)) {
                     return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,


### PR DESCRIPTION
For Groovy support the `J.Ternary` was extended to also implement the `Statement` interface. As a consequence its coordinate is now a `CoordinateBuilder.Statement` coordinate. Allow `JavaTemplate` to replace it in its `visitExpression()` method in `JavaTemplateJavaExtension`.

Issue: openrewrite/rewrite-static-analysis#203
