### PR TITLE
Preserve space and comments after import in RemoveImport

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveImportTest.java
@@ -331,6 +331,162 @@ class RemoveImportTest implements RewriteTest {
         );
     }
 
+    @Test
+    void preservesWhitespaceAfterRemovedImportForWindowsWhitespace() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("java.util.List")),
+          java(
+              "package com.example.foo;\r\n" +
+              "\r\n" +
+              "import java.util.Collection;\r\n" +
+              "import java.util.List;\r\n" +
+              "\r\n" +
+              "import java.util.ArrayList;\r\n" +
+              "\r\n" +
+              "public class A {\r\n" +
+              "}\r\n",
+              "package com.example.foo;\r\n" +
+              "\r\n" +
+              "import java.util.Collection;\r\n" +
+              "\r\n" +
+              "import java.util.ArrayList;\r\n" +
+              "\r\n" +
+              "public class A {\r\n" +
+              "}\r\n"
+          )
+        );
+    }
+
+    @Test
+    void preservesWhitespaceAfterRemovedImportForMixedWhitespaceBefore() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("java.util.List")),
+          java(
+              "package com.example.foo;\n" +
+              "\n" +
+              "import java.util.Collection;\r\n" +
+              "import java.util.List;\n" +
+              "import java.util.ArrayList;\n" +
+              "\n" +
+              "public class A {\n" +
+              "}\n",
+              "package com.example.foo;\n" +
+              "\n" +
+              "import java.util.Collection;\n" +
+              "import java.util.ArrayList;\n" +
+              "\n" +
+              "public class A {\n" +
+              "}\n"
+          )
+        );
+    }
+
+    @Test
+    void preservesWhitespaceAfterRemovedImportForMixedWhitespaceAfter() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("java.util.List")),
+          java(
+              "package com.example.foo;\n" +
+              "\n" +
+              "import java.util.Collection;\n" +
+              "\n" +
+              "import java.util.List;\r\n" +
+              "import java.util.ArrayList;\n" +
+              "\n" +
+              "public class A {\n" +
+              "}\n",
+              "package com.example.foo;\n" +
+              "\n" +
+              "import java.util.Collection;\n" +
+              "\n" +
+              "import java.util.ArrayList;\n" +
+              "\n" +
+              "public class A {\n" +
+              "}\n"
+          )
+        );
+    }
+
+    @Test
+    void doNotLeaveLeaveInitialBlankLine() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("java.util.Collection")),
+          java(
+            """
+              import static java.util.Collection.*;
+              import static java.util.List.*;
+                            
+              public class A {
+              }
+              """,
+            """
+              import static java.util.List.*;
+                            
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesCommentAfterRemovedImport() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("java.util.List")),
+          java(
+            """
+              package com.example.foo;
+                            
+              import java.util.List;
+              // import java.util.UUID
+              import java.util.ArrayList;
+                            
+              public class A {
+              }
+              """,
+            """
+              package com.example.foo;
+                            
+              // import java.util.UUID
+              import java.util.ArrayList;
+                            
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesWhitespaceAfterRemovedStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(removeImport("java.util.Collections.singletonList")),
+          java(
+            """
+              package com.example.foo;
+
+              import static java.util.Collections.emptySet;
+              import static java.util.Collections.singletonList;
+                            
+              import java.util.UUID;
+                            
+              public class A {
+              }
+              """,
+            """
+              package com.example.foo;
+                            
+              import static java.util.Collections.emptySet;
+
+              import java.util.UUID;
+                            
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/701")
     @Test
     void preservesWhitespaceAfterPackageDeclarationNoImportsRemain() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImport.java
@@ -116,7 +116,12 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
             AtomicReference<Space> spaceForNextImport = new AtomicReference<>();
             c = c.withImports(ListUtils.flatMap(c.getImports(), import_ -> {
                 if (spaceForNextImport.get() != null) {
-                    import_ = import_.withPrefix(spaceForNextImport.get());
+                    Space removedPrefix = spaceForNextImport.get();
+                    Space currentPrefix = import_.getPrefix();
+                    if (removedPrefix.getLastWhitespace().isEmpty() ||
+                        (countTrailingLinebreaks(removedPrefix) > countTrailingLinebreaks(currentPrefix))) {
+                        import_ = import_.withPrefix(currentPrefix.withWhitespace(removedPrefix.getLastWhitespace()));
+                    }
                     spaceForNextImport.set(null);
                 }
 
@@ -143,9 +148,7 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
                         return null;
                     }
                 } else if (!keepImport && TypeUtils.fullyQualifiedNamesAreEqual(typeName, type)) {
-                    if (import_.getPrefix().isEmpty() || import_.getPrefix().getLastWhitespace().chars().filter(s -> s == '\n').count() > 1) {
-                        spaceForNextImport.set(import_.getPrefix());
-                    }
+                    spaceForNextImport.set(import_.getPrefix());
                     return null;
                 } else if (!keepImport && import_.getPackageName().equals(owner) &&
                         "*".equals(import_.getClassName()) &&
@@ -170,6 +173,10 @@ public class RemoveImport<P> extends JavaIsoVisitor<P> {
         }
 
         return j;
+    }
+
+    private long countTrailingLinebreaks(Space space) {
+        return space.getLastWhitespace().chars().filter(s -> s == '\n').count();
     }
 
     private Object unfoldStarImport(J.Import starImport, Set<String> otherImportsUsed) {


### PR DESCRIPTION
If the removed import was a static import and was followed by a separating blank line, that blank line would be collapsed. Also if the removed import was followed by a comment, that comment would be lost.

This commit addresses these two issues by:
- not overwriting the prefix spacing if it'd remove whitespace
- only copy whitespace from removed import, don't overwrite comments

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
