### PR TITLE
Check "var" keyword when varType is null or JCErroneous

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1430,14 +1430,16 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
         TypeTree typeExpr = null;
-        if (vartype == null || vartype instanceof JCErroneous) {
+        if (vartype == null) {
+            typeExpr = null;
+        } else if (vartype instanceof JCErroneous) {
             try {
-                if (source.substring(node.startPos, node.pos).contains("var")) {
+                if (source.substring(node.startPos, node.pos).startsWith("var")) {
                     // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
                     typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
                     typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
                 }
-            } catch (StringIndexOutOfBoundsException e) {
+            } catch (Exception e) {
                 typeExpr = null;
             }
         } else if (endPos(vartype) < 0) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1429,9 +1429,17 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
-        TypeTree typeExpr;
+        TypeTree typeExpr = null;
         if (vartype == null || vartype instanceof JCErroneous) {
-            typeExpr = null;
+            try {
+                if (source.substring(node.startPos, node.pos).contains("var")) {
+                    // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
+                    typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
+                    typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
+                }
+            } catch (StringIndexOutOfBoundsException e) {
+                typeExpr = null;
+            }
         } else if (endPos(vartype) < 0) {
             if ((node.sym.flags() & Flags.PARAMETER) > 0) {
                 // this is a lambda parameter with an inferred type expression

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1429,19 +1429,9 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
-        TypeTree typeExpr = null;
+        TypeTree typeExpr;
         if (vartype == null) {
             typeExpr = null;
-        } else if (vartype instanceof JCErroneous) {
-            try {
-                if (source.substring(node.startPos, node.pos).startsWith("var")) {
-                    // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
-                    typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
-                    typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
-                }
-            } catch (Exception e) {
-                typeExpr = null;
-            }
         } else if (endPos(vartype) < 0) {
             if ((node.sym.flags() & Flags.PARAMETER) > 0) {
                 // this is a lambda parameter with an inferred type expression

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1508,14 +1508,16 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
         TypeTree typeExpr = null;
-        if (vartype == null || vartype instanceof JCErroneous) {
+        if (vartype == null) {
+            typeExpr = null;
+        } else if (vartype instanceof JCErroneous) {
             try {
-                if (source.substring(node.startPos, node.pos).contains("var")) {
+                if (source.substring(node.startPos, node.pos).startsWith("var")) {
                     // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
                     typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
                     typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
                 }
-            } catch (StringIndexOutOfBoundsException e) {
+            } catch (Exception e) {
                 typeExpr = null;
             }
         } else if (endPos(vartype) < 0) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1565,7 +1565,6 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         for (int i = 0; i < nodes.size(); i++) {
             JCVariableDecl n = (JCVariableDecl) nodes.get(i);
 
-            // how to capture var ?
             Space namedVarPrefix = sourceBefore(n.getName().toString());
 
             JavaType type = typeMapping.type(n);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1507,19 +1507,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
-        TypeTree typeExpr = null;
+        TypeTree typeExpr;
         if (vartype == null) {
             typeExpr = null;
-        } else if (vartype instanceof JCErroneous) {
-            try {
-                if (source.substring(node.startPos, node.pos).startsWith("var")) {
-                    // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
-                    typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
-                    typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
-                }
-            } catch (Exception e) {
-                typeExpr = null;
-            }
         } else if (endPos(vartype) < 0) {
             if ((node.sym.flags() & Flags.PARAMETER) > 0) {
                 // this is a lambda parameter with an inferred type expression

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1505,19 +1505,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
 
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
-        TypeTree typeExpr = null;
+        TypeTree typeExpr;
         if (vartype == null) {
             typeExpr = null;
-        } else if (vartype instanceof JCErroneous) {
-            try {
-                if (source.substring(node.startPos, node.pos).startsWith("var")) {
-                    // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
-                    typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
-                    typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
-                }
-            } catch (Exception e) {
-                typeExpr = null;
-            }
         } else if (endPos(vartype) < 0) {
             if ((node.sym.flags() & Flags.PARAMETER) > 0) {
                 // this is a lambda parameter with an inferred type expression

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1506,14 +1506,16 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> typeExprAnnotations = collectAnnotations(annotationPosTable);
 
         TypeTree typeExpr = null;
-        if (vartype == null || vartype instanceof JCErroneous) {
+        if (vartype == null) {
+            typeExpr = null;
+        } else if (vartype instanceof JCErroneous) {
             try {
-                if (source.substring(node.startPos, node.pos).contains("var")) {
+                if (source.substring(node.startPos, node.pos).startsWith("var")) {
                     // "var x = unknownType" can be translated into "(ERROR) var x = unknownType"
                     typeExpr = new J.Identifier(randomId(), sourceBefore("var"), Markers.EMPTY, emptyList(), "var", typeMapping.type(vartype), null);
                     typeExpr = typeExpr.withMarkers(typeExpr.getMarkers().add(JavaVarKeyword.build()));
                 }
-            } catch (StringIndexOutOfBoundsException e) {
+            } catch (Exception e) {
                 typeExpr = null;
             }
         } else if (endPos(vartype) < 0) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/VariableDeclarationsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/VariableDeclarationsTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MinimumJava11;
 import org.openrewrite.java.MinimumJava17;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -263,4 +264,22 @@ class VariableDeclarationsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @MinimumJava11
+    void unknownVar() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              class Test {
+                  void test(Unknown b) {
+                      final var a = b;
+                  }
+              }
+              """
+          )
+        );
+    }
 }
+

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
@@ -63,7 +63,7 @@ class FinalizeLocalVariablesTest implements RewriteTest {
                         var a = b;
                     }
                 }
-                  """,
+                """,
               """
                 import foo.Unknown;
                 class Bar {
@@ -71,7 +71,7 @@ class FinalizeLocalVariablesTest implements RewriteTest {
                         final var a = b;
                     }
                 }
-                  """
+                """
             ), javaVersion
           )
         );
@@ -92,21 +92,20 @@ class FinalizeLocalVariablesTest implements RewriteTest {
                         var a = b;
                     }
                 }
-                  """,
+                """,
               """
                 class Bar {
                     void test(String b) {
                         final var a = b;
                     }
                 }
-                  """
+                """
             ), javaVersion
           )
         );
     }
 
     public static class FinalizeLocalVariables extends Recipe {
-
         @Override
         public String getDisplayName() {
             return "Finalize local variables";

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java;
 
 import static org.openrewrite.java.Assertions.java;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
@@ -40,14 +41,14 @@ import org.openrewrite.test.TypeValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
-public class FinalizeLocalVariablesTest implements RewriteTest {
+class FinalizeLocalVariablesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FinalizeLocalVariables());
     }
 
     @ParameterizedTest
-    @CsvSource(value = { "11", "17", "21" })
+    @ValueSource(ints = { 11, 17, 21 })
     @Issue("https://github.com/openrewrite/rewrite/issues/3744")
     void missingTypePlusVarNotMissingSpace(int javaVersion) {
         rewriteRun(
@@ -77,7 +78,7 @@ public class FinalizeLocalVariablesTest implements RewriteTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = { "11", "17", "21" })
+    @ValueSource(ints = { 11, 17, 21 })
     @Issue("https://github.com/openrewrite/rewrite/issues/3744")
     void explicitTypePlusVarNotMissingSpace(int javaVersion) {
         rewriteRun(
@@ -118,8 +119,7 @@ public class FinalizeLocalVariablesTest implements RewriteTest {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaIsoVisitor<ExecutionContext>() {
-
+            return new JavaIsoVisitor<>() {
                 @Override
                 public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
                                                                         ExecutionContext ctx) {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
@@ -1,0 +1,231 @@
+package org.openrewrite.java;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+public class FinalizeLocalVariablesTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new FinalizeLocalVariables());
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = { "11", "17", "21" })
+    @Issue("https://github.com/openrewrite/rewrite/issues/3744")
+    void missingTypePlusVarNotMissingSpace(int javaVersion) {
+        rewriteRun(
+          s -> s.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          version(
+            java(
+              """
+                import foo.Unknown;
+                class Bar {
+                    void test(Unknown b) {
+                        var a = b;
+                    }
+                }
+                  """,
+              """
+                import foo.Unknown;
+                class Bar {
+                    void test(Unknown b) {
+                        final var a = b;
+                    }
+                }
+                  """
+            ), javaVersion
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = { "11", "17", "21" })
+    @Issue("https://github.com/openrewrite/rewrite/issues/3744")
+    void explicitTypePlusVarNotMissingSpace(int javaVersion) {
+        rewriteRun(
+          s -> s.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          version(
+            java(
+              """
+                class Bar {
+                    void test(String b) {
+                        var a = b;
+                    }
+                }
+                  """,
+              """
+                class Bar {
+                    void test(String b) {
+                        final var a = b;
+                    }
+                }
+                  """
+            ), javaVersion
+          )
+        );
+    }
+
+    public static class FinalizeLocalVariables extends Recipe {
+
+        @Override
+        public String getDisplayName() {
+            return "Finalize local variables";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Adds the `final` modifier keyword to local variables which are not reassigned.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaIsoVisitor<ExecutionContext>() {
+
+                @Override
+                public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
+                                                                        ExecutionContext ctx) {
+                    J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
+
+                    // if this already has "final", we don't need to bother going any further; we're done
+                    if (mv.hasModifier(J.Modifier.Type.Final)) {
+                        return mv;
+                    }
+
+                    // consider uninitialized local variables non-final
+                    if (mv.getVariables().stream().anyMatch(nv -> nv.getInitializer() == null)) {
+                        return mv;
+                    }
+
+                    if (isDeclaredInForLoopControl(getCursor())) {
+                        return mv;
+                    }
+
+                    // ignore fields (aka "instance variable" or "class variable")
+                    if (mv.getVariables().stream().anyMatch(v -> v.isField(getCursor()))) {
+                        return mv;
+                    }
+
+                    // ignores anonymous class fields, contributed code for issue #t
+                    if (this.getCursorToParentScope(this.getCursor()).getValue() instanceof J.NewClass) {
+                        return mv;
+                    }
+
+                    if (mv.getVariables().stream()
+                          .noneMatch(v -> {
+                              Cursor declaringCursor = v.getDeclaringScope(getCursor());
+                              return FindAssignmentReferencesToVariable.find(declaringCursor.getValue(), v)
+                                                                       .get();
+                          })) {
+                        mv = autoFormat(
+                          mv.withModifiers(
+                            ListUtils.concat(mv.getModifiers(),
+                                             new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null,
+                                                            J.Modifier.Type.Final, Collections.emptyList()))
+                          ), ctx);
+                    }
+
+                    return mv;
+                }
+
+                private Cursor getCursorToParentScope(final Cursor cursor) {
+                    return cursor.dropParentUntil(
+                      is -> is instanceof J.NewClass || is instanceof J.ClassDeclaration);
+                }
+            };
+        }
+
+        private boolean isDeclaredInForLoopControl(Cursor cursor) {
+            return cursor.getParentTreeCursor()
+                         .getValue() instanceof J.ForLoop.Control;
+        }
+
+        @Value
+        @EqualsAndHashCode(callSuper = true)
+        private static class FindAssignmentReferencesToVariable extends JavaIsoVisitor<AtomicBoolean> {
+
+            J.VariableDeclarations.NamedVariable variable;
+
+            /**
+             * @param j        The subtree to search.
+             * @param variable A {@link J.VariableDeclarations.NamedVariable} to check for any reassignment calls.
+             * @return An {@link AtomicBoolean} that is true if the variable has been reassigned and false otherwise.
+             */
+            static AtomicBoolean find(J j, J.VariableDeclarations.NamedVariable variable) {
+                return new FindAssignmentReferencesToVariable(variable)
+                  .reduce(j, new AtomicBoolean());
+            }
+
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean hasAssignment) {
+                if (hasAssignment.get()) {
+                    return assignment;
+                }
+                J.Assignment a = super.visitAssignment(assignment, hasAssignment);
+                if (a.getVariable() instanceof J.Identifier) {
+                    J.Identifier i = (J.Identifier) a.getVariable();
+                    if (i.getSimpleName().equals(variable.getSimpleName())) {
+                        hasAssignment.set(true);
+                    }
+                }
+                return a;
+            }
+
+            @Override
+            public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp,
+                                                                  AtomicBoolean hasAssignment) {
+                if (hasAssignment.get()) {
+                    return assignOp;
+                }
+
+                J.AssignmentOperation a = super.visitAssignmentOperation(assignOp, hasAssignment);
+                if (a.getVariable() instanceof J.Identifier) {
+                    J.Identifier i = (J.Identifier) a.getVariable();
+                    if (i.getSimpleName().equals(variable.getSimpleName())) {
+                        hasAssignment.set(true);
+                    }
+                }
+                return a;
+            }
+
+            @Override
+            public J.Unary visitUnary(J.Unary unary, AtomicBoolean hasAssignment) {
+                if (hasAssignment.get()) {
+                    return unary;
+                }
+
+                J.Unary u = super.visitUnary(unary, hasAssignment);
+                if (u.getOperator().isModifying() && u.getExpression() instanceof J.Identifier) {
+                    J.Identifier i = (J.Identifier) u.getExpression();
+                    if (i.getSimpleName().equals(variable.getSimpleName())) {
+                        hasAssignment.set(true);
+                    }
+                }
+                return u;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
When `var` is used with unknown type, rewrite consider `var` as `Space`. We need to add additional logic to identifyt `var` keyword. 

## What's your motivation?
[Issue link](https://github.com/openrewrite/rewrite/issues/3744)

Below test code doesn't work. It rewrites `var a = b` into `finalvar a = b` (should have space between final and var) 
```java
@Test
@Issue("https://github.com/openrewrite/rewrite/issues/3744")
void missingTypePlusVarNotMissingSpace() {
    rewriteRun(
      s -> s.typeValidationOptions(TypeValidation.none()),
      //language=java
      java(
        """
          import foo.Unknown;
          class Bar {
              void test(Unknown b) {
                  var a = b;
              }
          }
            """,
        """
          import foo.Unknown;
          class Bar {
              void test(Unknown b) {
                  final var a = b;
              } 
          }
            """
      )
    );
}
```

## Anything in particular you'd like reviewers to focus on?
- Whether it's ok to put the checking logic into
  - `ReloadableJava11ParserVisitor`
  - `ReloadableJava17ParserVisitor`
  - `ReloadableJava21ParserVisitor`

## Anyone you would like to review specifically?
N/A 

## Have you considered any alternatives or workarounds?
N/A 

## Any additional context
AS-IS 
![image](https://github.com/openrewrite/rewrite/assets/69591622/a0350dea-a4ea-4b5b-bfa7-c542b10b0c05)

TO-BE 
![image](https://github.com/openrewrite/rewrite/assets/69591622/bc982f70-c147-4e7b-a263-a0a6e509fd09)


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
