### PR TITLE
Fixed formatting of annotated fully qualified type references in ShorenFullyQualifiedTypeReferences.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
@@ -538,4 +538,34 @@ public class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void annotatedFieldAccess() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              
+              class Test {
+                  java.util. @Anno List<String> l;
+              }
+              @Target(ElementType.TYPE_USE)
+              @interface Anno {}
+              """,
+            """
+                  import java.lang.annotation.ElementType;
+                  import java.lang.annotation.Target;
+                  import java.util.List;
+                  
+                  class Test {
+                      @Anno List<String> l;
+                  }
+                  @Target(ElementType.TYPE_USE)
+                  @interface Anno {}
+                  """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferences.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferences.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java;
 
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.DefaultJavaTypeSignatureBuilder;
@@ -176,6 +177,14 @@ public class ShortenFullyQualifiedTypeReferences extends Recipe {
                         if (!fullyQualifiedName.startsWith("java.lang.")) {
                             maybeAddImport(fullyQualifiedName);
                             usedTypes.put(simpleName, type);
+                            if (!fieldAccess.getName().getAnnotations().isEmpty()) {
+                                return fieldAccess.getName().withAnnotations(ListUtils.map(fieldAccess.getName().getAnnotations(), (i, a) -> {
+                                    if (i == 0) {
+                                        return a.withPrefix(fieldAccess.getPrefix());
+                                    }
+                                    return a;
+                                }));
+                            }
                             return fieldAccess.getName().withPrefix(fieldAccess.getPrefix());
                         }
                     }


### PR DESCRIPTION
Changes:

- Annotated fully qualified type references will be formatted correctly by ShortenFullyQualifiedTypeReferences.

fixes #3870