### PR TITLE
Fixed formatting of annotated arrays in NoWhitespaceAfter.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/NoWhitespaceAfterTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/NoWhitespaceAfterTest.java
@@ -424,65 +424,41 @@ class NoWhitespaceAfterTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2911")
-    @Disabled
     @Test
     void dontWronglyHandleArray() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().styles(noWhitespaceAfterStyle())),
           java(
             """
-            package sample;
-            
-            import org.jetbrains.annotations.NotNull;
-            
-            public class ArrayNotNull {
-            
-                byte[] bytes = new byte[0];
-            
-                public byte @NotNull [] getBytes() {
-                    return bytes;
-                }
-            
-                int[] ints = new int[0];
-            
-                public int @NotNull [] getInts() {
-                    return ints;
-                }
-            
-                Object[] objects = new Object[0];
-            
-                public Object @NotNull [] getObjects() {
-                    return objects;
-                }
-            
-            }
-              """,
-            """
-            package sample;
-            
-            import org.jetbrains.annotations.NotNull;
-            
-            public class ArrayNotNull {
-            
-                byte[] bytes = new byte[0];
-            
-                public byte @NotNull [] getBytes() {
-                    return bytes;
-                }
-            
-                int[] ints = new int[0];
-            
-                public int @NotNull [] getInts() {
-                    return ints;
-                }
-            
-                Object[] objects = new Object[0];
-            
-                public Object @NotNull [] getObjects() {
-                    return objects;
-                }
-            
-            }
+              package sample;
+              
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+              
+              public class ArrayNotNull {
+              
+                  byte[] bytes = new byte[0];
+              
+                  public byte @NotNull [] getBytes() {
+                      return bytes;
+                  }
+              
+                  int[] ints = new int[0];
+              
+                  public int @NotNull [] getInts() {
+                      return ints;
+                  }
+              
+                  Object[] objects = new Object[0];
+              
+                  public Object @NotNull [] getObjects() {
+                      return objects;
+                  }
+              
+              }
+              
+              @Target(ElementType.TYPE_USE)
+              @interface NotNull {}
               """,
             autoFormatIsIdempotent()
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -114,7 +114,9 @@ public class NoWhitespaceAfter extends Recipe {
             J.ArrayType a = super.visitArrayType(arrayType, ctx);
             if (Boolean.TRUE.equals(noWhitespaceAfterStyle.getArrayDeclarator())) {
                 if (a.getDimension() != null && a.getDimension().getBefore().getWhitespace().contains(" ")) {
-                    a = a.withDimension(a.getDimension().withBefore(a.getDimension().getBefore().withWhitespace("")));
+                    if (a.getAnnotations() == null || a.getAnnotations().isEmpty()) {
+                        a = a.withDimension(a.getDimension().withBefore(a.getDimension().getBefore().withWhitespace("")));
+                    }
                 }
             }
             return a;


### PR DESCRIPTION
Changes:

- Annotated arrays will be appropriately formatted by NoWhiteSpaceAfter.

fixes #3869
fixes #2911