### PR TITLE
Missing type tag in AddDependencyVisitor

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependencyVisitor.java
@@ -169,6 +169,8 @@ public class AddDependencyVisitor extends MavenIsoVisitor<ExecutionContext> {
                                 "<version>" + versionToUse + "</version>\n") +
                         (classifier == null ? "" :
                                 "<classifier>" + classifier + "</classifier>\n") +
+                        (type == null || "jar".equals(type) ? "" :
+                                "<type>" + type + "</type>\n") +
                         (scope == null || "compile".equals(scope) ? "" :
                                 "<scope>" + scope + "</scope>\n") +
                         (Boolean.TRUE.equals(optional) ? "<optional>true</optional>\n" : "") +

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -122,6 +122,43 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void pomType() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new AddDependency("com.google.guava","guava", "29.0-jre",null, null, null, null, "pom", null, null, null, null)),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            pomXml(
+              """
+                    <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                    </project>
+                """,
+              """
+                    <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.google.guava</groupId>
+                                <artifactId>guava</artifactId>
+                                <version>29.0-jre</version>
+                                <type>pom</type>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                """
+            )
+          )
+        );
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})
     void onlyIfUsingTestScope(String onlyIfUsing) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -126,33 +126,33 @@ class AddDependencyTest implements RewriteTest {
     void pomType() {
         rewriteRun(
           spec -> spec
-            .recipe(new AddDependency("com.google.guava","guava", "29.0-jre",null, null, null, null, "pom", null, null, null, null)),
+            .recipe(new AddDependency("com.google.guava", "guava", "29.0-jre", null, null, null, null, "pom", null, null, null, null)),
           mavenProject("project",
             srcMainJava(
               java(usingGuavaIntMath)
             ),
             pomXml(
               """
-                    <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
-                    </project>
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                </project>
                 """,
               """
-                    <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>com.google.guava</groupId>
-                                <artifactId>guava</artifactId>
-                                <version>29.0-jre</version>
-                                <type>pom</type>
-                            </dependency>
-                        </dependencies>
-                    </project>
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>29.0-jre</version>
+                            <type>pom</type>
+                        </dependency>
+                    </dependencies>
+                </project>
                 """
             )
           )


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
AddDependencyVisitor should add \<type\> tag during XML generation

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
I've noticed that the AddDependencyVisitor does not generate \<type\>, which prevents us from adding dependencies of the pom type. I believe this is not intentional, as the AddManagedDependencyVisitor is capable of generating \<type\>.
