### PR TITLE
Supporting changing name of implicit `value` attributes in ChangeAnnotationAttributeName

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeAnnotationAttributeName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeAnnotationAttributeName.java
@@ -21,11 +21,17 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.marker.Markers;
+
+import static java.util.Collections.emptyList;
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.java.tree.Space.EMPTY;
+import static org.openrewrite.java.tree.Space.SINGLE_SPACE;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class ChangeAnnotationAttributeName extends Recipe {
-
 
     @Option(displayName = "Annotation Type",
             description = "The fully qualified name of the annotation.",
@@ -73,11 +79,16 @@ public class ChangeAnnotationAttributeName extends Recipe {
                 }
                 return a.withArguments(ListUtils.map(a.getArguments(), arg -> {
                     if (arg instanceof J.Assignment) {
-                        J.Assignment assignment = (J.Assignment) arg;
-                        J.Identifier variable = (J.Identifier) assignment.getVariable();
-                        if (oldAttributeName.equals(variable.getSimpleName())) {
-                            return assignment.withVariable(variable.withSimpleName(newAttributeName));
+                        if (!oldAttributeName.equals(newAttributeName)) {
+                            J.Assignment assignment = (J.Assignment) arg;
+                            J.Identifier variable = (J.Identifier) assignment.getVariable();
+                            if (oldAttributeName.equals(variable.getSimpleName())) {
+                                return assignment.withVariable(variable.withSimpleName(newAttributeName));
+                            }
                         }
+                    } else if (oldAttributeName.equals("value")) {
+                        J.Identifier name = new J.Identifier(randomId(), arg.getPrefix(), Markers.EMPTY, emptyList(), newAttributeName, arg.getType(), null);
+                        return new J.Assignment(randomId(), EMPTY, arg.getMarkers(), name, new JLeftPadded<>(SINGLE_SPACE, arg.withPrefix(SINGLE_SPACE), Markers.EMPTY), arg.getType());
                     }
                     return arg;
                 }));

--- a/rewrite-java/src/test/java/org/openrewrite/java/ChangeAnnotationAttributeNameTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ChangeAnnotationAttributeNameTest.java
@@ -38,4 +38,104 @@ class ChangeAnnotationAttributeNameTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void doNotChangeIdenticalAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeAnnotationAttributeName("java.lang.SuppressWarnings", "value", "value")),
+          java(
+            """
+              @SuppressWarnings(value = {"foo", "bar"})
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void renameValueAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeAnnotationAttributeName("org.example.Foo", "value", "bar")),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String value() default "";
+                  String bar() default "";
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.Foo;
+                            
+              @Foo(/* some comment */ "1.0")
+              class A {}
+              """,
+            """
+              import org.example.Foo;
+                            
+              @Foo(/* some comment */ bar = "1.0")
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void expandImplicitValueAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeAnnotationAttributeName("java.lang.SuppressWarnings", "value", "value")),
+          java(
+            """
+              @SuppressWarnings({"foo", "bar"})
+              class A {}
+              """,
+            """
+              @SuppressWarnings(value = {"foo", "bar"})
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void rewriteEnumValue() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeAnnotationAttributeName("org.example.Foo", "value", "bar")),
+          java(
+            """
+              package org.example;
+                            
+              public enum E { A, B }
+              """
+          ),
+          java(
+            """
+              package org.example;
+
+              public @interface Foo {
+                  E value() default E.A;
+                  E bar() default E.A;
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.E;
+              import org.example.Foo;
+                            
+              @Foo(E.B)
+              class A {}
+              """,
+            """
+              import org.example.E;
+              import org.example.Foo;
+                            
+              @Foo(bar = E.B)
+              class A {}
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
The `ChangeAnnotationAttributeName` recipe supports renaming annotation attributes (like `@Foo(x = "y")`). If the attribute name is `value` it's possible to not write an assignment and just write the value (like `Bar("z")`), and this case was not handled previously.

## What's changed?
This change adds the following (validated by new tests):
- support for renaming implicit value attributes (`Bar("z")` to `Bar(foo = "z")`)
- support for expanding implicit value attributes (`Bar("z")` to `Bar(value = "z")`)
- ensures the tree is unchanged for an identical rename (`@Foo(x = "y")` to `@Foo(x = "y")`)

## What's your motivation?
Noticed this comment: https://github.com/openrewrite/rewrite-openapi/issues/1#issuecomment-1877633407

## Anything in particular you'd like reviewers to focus on?
How I created the `J.Assignment`, I hacked it to get what I wanted, but there might be a better way. Should there be an auto-format in case the padding of the `=` is different in the current code style?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
