### PR TITLE
Add `RemoveAnnotationAttribute` recipe

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class RemoveAnnotationAttribute extends Recipe {
-
 
     @Option(displayName = "Annotation Type",
             description = "The fully qualified name of the annotation.",

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationAttribute.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class RemoveAnnotationAttribute extends Recipe {
+
+
+    @Option(displayName = "Annotation Type",
+            description = "The fully qualified name of the annotation.",
+            example = "org.junit.Test")
+    String annotationType;
+
+    @Option(displayName = "Attribute name",
+            description = "The name of attribute to remove.",
+            example = "timeout")
+    String attributeName;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove annotation attribute";
+    }
+
+    @Override
+    public String getInstanceNameSuffix() {
+        String shortType = annotationType.substring(annotationType.lastIndexOf('.') + 1);
+        return String.format("`@%s(%s)`", shortType, attributeName);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Some annotations accept arguments. This recipe removes an existing attribute.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>(annotationType, false), new JavaIsoVisitor<ExecutionContext>() {
+            private final AnnotationMatcher annotationMatcher = new AnnotationMatcher(annotationType);
+
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                J.Annotation a = super.visitAnnotation(annotation, ctx);
+                if (!annotationMatcher.matches(a)) {
+                    return a;
+                }
+                return a.withArguments(ListUtils.map(a.getArguments(), arg -> {
+                    if (arg instanceof J.Assignment) {
+                        J.Assignment assignment = (J.Assignment) arg;
+                        J.Identifier variable = (J.Identifier) assignment.getVariable();
+                        if (attributeName.equals(variable.getSimpleName())) {
+                            return null;
+                        }
+                    } else if (attributeName.equals("value")) {
+                        return null;
+                    }
+                    return arg;
+                }));
+            }
+        });
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveAnnotationAttributeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveAnnotationAttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveAnnotationAttributeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveAnnotationAttributeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveAnnotationAttributeTest implements RewriteTest {
+    @Test
+    void removeNamedAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotationAttribute("java.lang.Deprecated", "since")),
+          java(
+            """
+              @Deprecated(since = "1.0", forRemoval = true)
+              class A {}
+              """,
+            """
+              @Deprecated(forRemoval = true)
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeLastAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotationAttribute("java.lang.Deprecated", "since")),
+          java(
+            """
+              @Deprecated(since = "1.0")
+              class A {}
+              """,
+            """
+              @Deprecated
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeIfNameDoesNotMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotationAttribute("java.lang.Deprecated", "forRemoval")),
+          java(
+            """
+              @Deprecated(since = "1.0")
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeValueAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveAnnotationAttribute("java.lang.SuppressWarnings", "value")),
+          java(
+            """
+              @SuppressWarnings({"foo", "bar"})
+              class A {}
+              """,
+            """
+              @SuppressWarnings
+              class A {}
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
New recipe for removing annotation attributes by name

## What's your motivation?
This is needed for https://github.com/openrewrite/rewrite-openapi/issues/1

## Anything in particular you'd like reviewers to focus on?
How to format attributes to avoid unwanted whitespace.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Opted for not changing `ChangeAnnotationAttributeName` since a dedicated recipe is more discoverable.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
