### PR TITLE
Validate that Change(Managed)DependencyGroupIdAndArtifactId updates GAV

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -29,6 +29,9 @@ import org.openrewrite.xml.tree.Xml;
 
 import java.util.*;
 
+import static org.openrewrite.Validated.test;
+import static org.openrewrite.internal.StringUtils.isBlank;
+
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
@@ -100,6 +103,17 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }
+        validated =
+            validated.and(test(
+                "coordinates",
+                "newGroupId OR newArtifactId must be different from before",
+                this,
+                r -> {
+                    boolean sameGroupId = isBlank(r.newGroupId) || Objects.equals(r.oldGroupId, r.newGroupId);
+                    boolean sameArtifactId = isBlank(r.newArtifactId) || Objects.equals(r.oldArtifactId, r.newArtifactId);
+                    return !(sameGroupId && sameArtifactId);
+                }
+            ));
         return validated;
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -96,6 +97,40 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/55")
+    void requireNewGroupIdOrNewArtifactId() {
+        assertThatExceptionOfType(AssertionError.class)
+          .isThrownBy(() -> rewriteRun(
+            spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+              "javax.activation",
+              "javax.activation-api",
+              null,
+              null,
+              null,
+              null,
+              null
+            ))
+          )).withMessageContaining("newGroupId OR newArtifactId must be different from before");
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/55")
+    void requireNewGroupIdOrNewArtifactIdToBeDifferentFromBefore() {
+        assertThatExceptionOfType(AssertionError.class)
+          .isThrownBy(() -> rewriteRun(
+            spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+              "javax.activation",
+              "javax.activation-api",
+              "javax.activation",
+              null,
+              null,
+              null,
+              null
+            ))
+          )).withMessageContaining("newGroupId OR newArtifactId must be different from before");
     }
 
     @Test

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
@@ -17,9 +17,11 @@ package org.openrewrite.maven;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
@@ -72,6 +74,21 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/55")
+    void requireNewGroupIdOrNewArtifactIdToBeDifferentFromBefore() {
+        assertThatExceptionOfType(AssertionError.class)
+          .isThrownBy(() -> rewriteRun(
+            spec -> spec.recipe(new ChangeManagedDependencyGroupIdAndArtifactId(
+              "javax.activation",
+              "javax.activation-api",
+              "javax.activation",
+              "javax.activation-api",
+              null
+            ))
+          )).withMessageContaining("newGroupId OR newArtifactId must be different from before");
     }
 
     @Test


### PR DESCRIPTION
## What's changed?
ChangeDependencyGroupIdAndArtifactId and ChangeManagedDependencyGroupIdAndArtifactId are intended to be set up to *change* maven coordinates. If the pre- and post-coordinates are the same, it's likely that the UpgradeDependencyVersion recipe was intended. This change adds validation of the newGroupId/newArtifactId options.

## What's your motivation?
See https://github.com/openrewrite/rewrite-java-dependencies/issues/55

## Anything in particular you'd like reviewers to focus on?
That the use of `Validated` is correct.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
