### PR TITLE
Do not simplify two identical method calls

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -463,6 +463,24 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doubleMethodInvocationNotSimplified() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  void foo() {
+                      boolean a = !(booleanExpression() && booleanExpression());
+                  }
+                  boolean booleanExpression() {
+                    return true;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @ParameterizedTest
     @Issue("https://github.com/openrewrite/rewrite-templating/issues/28")
     // Mimic what would be inserted by a Refaster template using two nullable parameters, with the second one a literal

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -470,7 +470,10 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
             """
               public class A {
                   void foo() {
-                      boolean a = !(booleanExpression() && booleanExpression());
+                      boolean a = booleanExpression() || booleanExpression();
+                      boolean b = !(booleanExpression() && booleanExpression());
+                      boolean c = booleanExpression() == booleanExpression();
+                      boolean d = booleanExpression() != booleanExpression();
                   }
                   boolean booleanExpression() {
                     return true;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -56,7 +56,8 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 j = asBinary.getRight();
             } else if (isLiteralFalse(asBinary.getRight())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
-            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
+            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight()) &&
+                       !(asBinary.getLeft() instanceof MethodCall)) {
                 j = asBinary.getLeft();
             }
         } else if (asBinary.getOperator() == J.Binary.Type.Equal) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.MethodCall;
 
 import java.util.Collections;
 
@@ -42,7 +43,8 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 j = asBinary.getRight();
             } else if (isLiteralTrue(asBinary.getRight())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
-            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
+            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight()) &&
+                       !(asBinary.getLeft() instanceof MethodCall)) {
                 j = asBinary.getLeft();
             }
         } else if (asBinary.getOperator() == J.Binary.Type.Or) {
@@ -163,8 +165,8 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         J.MethodInvocation asMethod = (J.MethodInvocation) j;
         Expression select = asMethod.getSelect();
         if (isEmpty.matches(asMethod)
-                && select instanceof J.Literal
-                && select.getType() == JavaType.Primitive.String) {
+            && select instanceof J.Literal
+            && select.getType() == JavaType.Primitive.String) {
             return booleanLiteral(method, J.Literal.isLiteralValue(select, ""));
         }
         return j;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -43,8 +43,8 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 j = asBinary.getRight();
             } else if (isLiteralTrue(asBinary.getRight())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
-            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight()) &&
-                       !(asBinary.getLeft() instanceof MethodCall)) {
+            } else if (!(asBinary.getLeft() instanceof MethodCall) &&
+                       SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
                 j = asBinary.getLeft();
             }
         } else if (asBinary.getOperator() == J.Binary.Type.Or) {
@@ -56,8 +56,8 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                 j = asBinary.getRight();
             } else if (isLiteralFalse(asBinary.getRight())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
-            } else if (SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight()) &&
-                       !(asBinary.getLeft() instanceof MethodCall)) {
+            } else if (!(asBinary.getLeft() instanceof MethodCall) &&
+                       SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
                 j = asBinary.getLeft();
             }
         } else if (asBinary.getOperator() == J.Binary.Type.Equal) {


### PR DESCRIPTION
As discovered on 
- https://github.com/openrewrite/rewrite-static-analysis/pull/231

```diff
SimplifyTernaryTest > test() FAILED
    org.opentest4j.AssertionFailedError: [Unexpected result in "Test.java":
    diff --git a/Test.java b/Test.java
    index acd7493..f59a06e 100644
    --- a/Test.java
    +++ b/Test.java
    @@ -16,8 +16,8 @@
         boolean unchanged1 = booleanExpression() ? booleanExpression() : !booleanExpression();
         boolean unchanged2 = booleanExpression() ? true : !booleanExpression();
         boolean unchanged3 = booleanExpression() ? booleanExpression() : false;
    -    boolean unchanged4 = booleanExpression() && booleanExpression() ? true : false;
    -    boolean unchanged5 = booleanExpression() && booleanExpression() ? false : true;
    +    boolean unchanged4 = booleanExpression();
    +    boolean unchanged5 = !booleanExpression();
 
         boolean booleanExpression() {
           return true;
    ] 
```

I'd briefly considered changing `SemanticallyEqual.areEqual`, but glancing at how that is used elsewhere it seemed this exception should be specific to this visitor.