### PR TITLE
Do not unwrap parentheses around negated ternary

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesTest.java
@@ -966,6 +966,21 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void negatedTernaryNotUnwrapped() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  void foo(String s, String other) {
+                      boolean a = !(s == null ? other == null : s.equalsIgnoreCase(other));
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/3883")
     @Test
     void unwrapNotMethodInvocation() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/UnwrapParentheses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UnwrapParentheses.java
@@ -58,7 +58,7 @@ public class UnwrapParentheses<P> extends JavaVisitor<P> {
             return !(parensScope.getValue() == ((J.DoWhileLoop) parent).getWhileCondition());
         } else if (parent instanceof J.Unary) {
             J innerJ = ((J.Parentheses<?>) parensScope.getValue()).getTree();
-            return !(innerJ instanceof J.Binary);
+            return !(innerJ instanceof J.Binary) && !(innerJ instanceof J.Ternary);
         }
         return true;
     }


### PR DESCRIPTION
As spotted in failure on `main` of rewrite-migrate-java in
- https://github.com/openrewrite/rewrite-migrate-java/pull/387