### PR TITLE
Added a new unit test to check the use of variables in the plugins section in a Gradle file

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindPluginsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindPluginsTest.java
@@ -55,4 +55,36 @@ class FindPluginsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void findPluginWithVariable() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'com.jfrog.bintray'
+                  id 'com.jfrog.bintray' version "${jfrogBintrayVersion}"
+              }
+              """,
+            """
+              plugins {
+                  /*~~>*/id 'com.jfrog.bintray'
+                  /*~~>*/id 'com.jfrog.bintray' version "${jfrogBintrayVersion}"
+              }
+              """,
+            spec -> spec.beforeRecipe(cu -> assertThat(FindPlugins.find(cu, "com.jfrog.bintray"))
+              .isNotEmpty()
+              .anySatisfy(p -> {
+                  assertThat(p.getPluginId()).isEqualTo("com.jfrog.bintray");
+                  assertThat(p.getVersion()).isEqualTo("1.8.5");
+              }))
+          ),
+          properties(
+            """
+              jfrogBintrayVersion=1.8.5
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Added a new unit test to check the use of variables in the plugins section in a Gradle file. There was an error when using variables in this section, and that was what led to the creation of the new test.

## Have you considered any alternatives or workarounds?
Yes, if the variables are removed from the plugins section everything works, however, this is not a good approach as it requires changing the Gradle file.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
