### PR TITLE
Constructor call type attribution should include generics

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -48,7 +48,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -656,7 +655,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
-        JavaType type = typeMapping.type(node);
+        // no `JavaType.Method` attribution for `super()` and `this()`
+        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 
@@ -1046,7 +1046,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1047,7 +1047,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
         JCNewClass jcNewClass = (JCNewClass) node;
         JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
-        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized() && node.getClassBody() == null) {
             constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
         }
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -656,7 +656,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
 
         JCIdent ident = (JCIdent) node;
         // no `JavaType.Method` attribution for `super()` and `this()`
-        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
+        JavaType type = ident.sym != null && ident.sym.isConstructor() ? null : typeMapping.type(ident);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1046,7 +1046,10 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+            constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
+        }
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -432,7 +432,7 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
             }
 
             resolvedOwner = type instanceof Type.MethodType ?
-                    methodInvocationType(type, sym) :
+                    methodDeclarationType(sym, (JavaType.FullyQualified) type(sym.owner.type)) :
                     type(type);
             assert resolvedOwner != null;
         }
@@ -530,12 +530,13 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType =
+                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert returnType != null;
+        assert methodSymbol.isConstructor() || returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -530,13 +530,12 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType =
-                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert methodSymbol.isConstructor() || returnType != null;
+        assert returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -238,14 +238,13 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=";
-            s += selectType instanceof Type.MethodType ? s : signature(selectType);
+            s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + signature(selectType.getReturnType());
+                 ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
+        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
@@ -262,7 +261,7 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + returnType;
+                 ",return=" + returnType;
         }
 
         return s + ",parameters=" + methodArgumentSignature(symbol) + '}';

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeSignatureBuilder.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.java.isolated;
 
-import com.sun.tools.javac.code.*;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaTypeSignatureBuilder;
@@ -23,7 +25,10 @@ import org.openrewrite.java.tree.JavaType;
 
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeMirror;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
 
 class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
@@ -233,13 +238,14 @@ class ReloadableJava11TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=" + s;
+            s += "{name=<constructor>,return=";
+            s += selectType instanceof Type.MethodType ? s : signature(selectType);
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
                     ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
+        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1115,7 +1115,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
         JCNewClass jcNewClass = (JCNewClass) node;
         JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
-        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized() && node.getClassBody() == null) {
             constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
         }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -55,7 +55,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.Math.max;
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.openrewrite.Tree.randomId;
@@ -1113,7 +1114,10 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+            constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
+        }
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -714,7 +714,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
-        JavaType type = typeMapping.type(node);
+        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 
@@ -1112,7 +1112,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -715,7 +715,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
         JCIdent ident = (JCIdent) node;
         // no `JavaType.Method` attribution for `super()` and `this()`
-        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
+        JavaType type = ident.sym != null && ident.sym.isConstructor() ? null : typeMapping.type(ident);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -714,6 +714,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
+        // no `JavaType.Method` attribution for `super()` and `this()`
         JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -537,9 +537,7 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             return null;
         }
 
-        if (!methodSymbol.isConstructor()) {
-            assert returnType != null;
-        }
+        assert methodSymbol.isConstructor() || returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -431,7 +431,7 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             }
 
             resolvedOwner = type instanceof Type.MethodType ?
-                    methodInvocationType(type, sym) :
+                    methodDeclarationType(sym, (JavaType.FullyQualified) type(sym.owner.type)) :
                     type(type);
             assert resolvedOwner != null;
         }
@@ -531,12 +531,15 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType =
+                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert returnType != null;
+        if (!methodSymbol.isConstructor()) {
+            assert returnType != null;
+        }
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -47,7 +47,7 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
 
     public JavaType type(@Nullable com.sun.tools.javac.code.Type type) {
         if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || type instanceof Type.UnknownType ||
-                type instanceof NullType) {
+            type instanceof NullType) {
             return JavaType.Class.Unknown.getInstance();
         }
 
@@ -267,8 +267,8 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             if (sym.members_field != null) {
                 for (Symbol elem : sym.members_field.getSymbols()) {
                     if (elem instanceof Symbol.VarSymbol &&
-                            (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL |
-                                    Flags.GENERATEDCONSTR | Flags.ANONCONSTR)) == 0) {
+                        (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL |
+                                             Flags.GENERATEDCONSTR | Flags.ANONCONSTR)) == 0) {
                         if (fqn.equals("java.lang.String") && elem.name.toString().equals("serialPersistentFields")) {
                             // there is a "serialPersistentFields" member within the String class which is used in normal Java
                             // serialization to customize how the String field is serialized. This field is tripping up Jackson
@@ -281,7 +281,7 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                         }
                         fields.add(variableType(elem, clazz));
                     } else if (elem instanceof Symbol.MethodSymbol &&
-                            (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL | Flags.ANONCONSTR)) == 0) {
+                               (elem.flags_field & (Flags.SYNTHETIC | Flags.BRIDGE | Flags.HYPOTHETICAL | Flags.ANONCONSTR)) == 0) {
                         if (methods == null) {
                             methods = new ArrayList<>();
                         }
@@ -531,13 +531,12 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType =
-                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert methodSymbol.isConstructor() || returnType != null;
+        assert returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,
@@ -575,8 +574,8 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                 }
             }
             List<String> defaultValues = null;
-            if(methodSymbol.getDefaultValue() != null) {
-                if(methodSymbol.getDefaultValue() instanceof Attribute.Array) {
+            if (methodSymbol.getDefaultValue() != null) {
+                if (methodSymbol.getDefaultValue() instanceof Attribute.Array) {
                     defaultValues = ((Attribute.Array) methodSymbol.getDefaultValue()).getValue().stream()
                             .map(attr -> attr.getValue().toString())
                             .collect(Collectors.toList());

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.java.isolated;
 
-import com.sun.tools.javac.code.*;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaTypeSignatureBuilder;
@@ -23,7 +25,10 @@ import org.openrewrite.java.tree.JavaType;
 
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeMirror;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
 
 class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
@@ -233,14 +238,13 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=";
-            s += selectType instanceof Type.MethodType ? s : signature(selectType);
+            s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + signature(selectType.getReturnType());
+                 ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
+        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
@@ -257,7 +261,7 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + returnType;
+                 ",return=" + returnType;
         }
 
         return s + ",parameters=" + methodArgumentSignature(symbol) + '}';

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeSignatureBuilder.java
@@ -233,13 +233,14 @@ class ReloadableJava17TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=" + s;
+            s += "{name=<constructor>,return=";
+            s += selectType instanceof Type.MethodType ? s : signature(selectType);
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
                     ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
+        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -713,7 +713,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
-        JavaType type = typeMapping.type(node);
+        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 
@@ -1110,7 +1110,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1111,7 +1111,10 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+            constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
+        }
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -713,7 +713,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
-        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
+        // no `JavaType.Method` attribution for `super()` and `this()`
+        JavaType type = ident.sym != null && ident.sym.isConstructor() ? null : typeMapping.type(ident);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1112,7 +1112,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
 
         JCNewClass jcNewClass = (JCNewClass) node;
         JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
-        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized() && node.getClassBody() == null) {
             constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
         }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -449,7 +449,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             }
 
             resolvedOwner = type instanceof Type.MethodType ?
-                    methodInvocationType(type, sym) :
+                    methodDeclarationType(sym, (JavaType.FullyQualified) type(sym.owner.type)) :
                     type(type);
             assert resolvedOwner != null;
         }
@@ -549,12 +549,13 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType =
+                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert returnType != null;
+        assert methodSymbol.isConstructor() || returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -549,13 +549,12 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType =
-                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert methodSymbol.isConstructor() || returnType != null;
+        assert returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
@@ -236,13 +236,14 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=" + s;
+            s += "{name=<constructor>,return=";
+            s += selectType instanceof Type.MethodType ? s : signature(selectType);
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
                     ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
+        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.java.isolated;
 
-import com.sun.tools.javac.code.*;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaTypeSignatureBuilder;
@@ -236,14 +238,13 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=";
-            s += selectType instanceof Type.MethodType ? s : signature(selectType);
+            s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + signature(selectType.getReturnType());
+                 ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
+        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
@@ -260,7 +261,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + returnType;
+                 ",return=" + returnType;
         }
 
         return s + ",parameters=" + methodArgumentSignature(symbol) + '}';

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -655,7 +655,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
-        JavaType type = typeMapping.type(node);
+        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 
@@ -1044,7 +1044,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1045,7 +1045,10 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.clazz.type, jcNewClass.constructor);
+        JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+            constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
+        }
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType);

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -655,7 +655,8 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         cursor += name.length();
 
         JCIdent ident = (JCIdent) node;
-        JavaType type = ((JCIdent) node).sym.isConstructor() ? null : typeMapping.type(node);
+        // no `JavaType.Method` attribution for `super()` and `this()`
+        JavaType type = ident.sym != null && ident.sym.isConstructor() ? null : typeMapping.type(ident);
         return new J.Identifier(randomId(), fmt, Markers.EMPTY, emptyList(), name, type, typeMapping.variableType(ident.sym));
     }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1046,7 +1046,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
 
         JCNewClass jcNewClass = (JCNewClass) node;
         JavaType.Method constructorType = typeMapping.methodInvocationType(jcNewClass.constructorType, jcNewClass.constructor);
-        if (constructorType != null && jcNewClass.clazz.type.isParameterized()) {
+        if (constructorType != null && jcNewClass.clazz.type.isParameterized() && node.getClassBody() == null) {
             constructorType = constructorType.withReturnType(typeMapping.type(jcNewClass.clazz.type));
         }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -432,7 +432,7 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
             }
 
             resolvedOwner = type instanceof Type.MethodType ?
-                    methodInvocationType(type, sym) :
+                    methodDeclarationType(sym, (JavaType.FullyQualified) type(sym.owner.type)) :
                     type(type);
             assert resolvedOwner != null;
         }
@@ -530,12 +530,13 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType =
+                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert returnType != null;
+        assert methodSymbol.isConstructor() || returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -530,13 +530,12 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
             returnType = JavaType.Unknown.getInstance();
         }
 
-        JavaType.FullyQualified resolvedDeclaringType =
-                TypeUtils.asFullyQualified(type(methodSymbol.isConstructor() ? selectType : methodSymbol.owner.type));
+        JavaType.FullyQualified resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
         if (resolvedDeclaringType == null) {
             return null;
         }
 
-        assert methodSymbol.isConstructor() || returnType != null;
+        assert returnType != null;
 
         method.unsafeSet(resolvedDeclaringType,
                 methodSymbol.isConstructor() ? resolvedDeclaringType : returnType,

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -237,14 +237,13 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=";
-            s += selectType instanceof Type.MethodType ? s : signature(selectType);
+            s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + signature(selectType.getReturnType());
+                 ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
+        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {
@@ -261,7 +260,7 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             s += "{name=<constructor>,return=" + s;
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
-                    ",return=" + returnType;
+                 ",return=" + returnType;
         }
 
         return s + ",parameters=" + methodArgumentSignature(symbol) + '}';

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeSignatureBuilder.java
@@ -15,15 +15,19 @@
  */
 package org.openrewrite.java;
 
-import com.sun.source.tree.Tree;
-import com.sun.tools.javac.code.*;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.tree.JavaType;
 
 import javax.lang.model.type.NullType;
 import javax.lang.model.type.TypeMirror;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
 
 class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
@@ -233,13 +237,14 @@ class ReloadableJava8TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     public String methodSignature(Type selectType, Symbol.MethodSymbol symbol) {
         String s = classSignature(symbol.owner.type);
         if (symbol.isConstructor()) {
-            s += "{name=<constructor>,return=" + s;
+            s += "{name=<constructor>,return=";
+            s += selectType instanceof Type.MethodType ? s : signature(selectType);
         } else {
             s += "{name=" + symbol.getSimpleName().toString() +
                     ",return=" + signature(selectType.getReturnType());
         }
 
-        return s + ",parameters=" + methodArgumentSignature(selectType) + '}';
+        return s + ",parameters=" + methodArgumentSignature(symbol) + '}';
     }
 
     public String methodSignature(Symbol.MethodSymbol symbol) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/NewClassTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/NewClassTest.java
@@ -75,6 +75,20 @@ class NewClassTest implements RewriteTest {
               class Test {
                   List<String> l = new ArrayList < > ();
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void typeAttribution() {
+        rewriteRun(
+          java(
+            """
+              import java.util.*;
+              class Test {
+                  List<String> l = new ArrayList < > ();
+              }
               """,
             spec -> spec.afterRecipe(cu -> {
                 J.VariableDeclarations.NamedVariable l =

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/NewClassTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/NewClassTest.java
@@ -81,6 +81,25 @@ class NewClassTest implements RewriteTest {
     }
 
     @Test
+    void delegate() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  private String name;
+                  A() {
+                    this("ABC");
+                  }
+                  A(String name) {
+                    this.name = name;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void typeAttribution() {
         rewriteRun(
           java(

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/NewClassTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/NewClassTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.MinimumJava11;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -124,6 +125,7 @@ class NewClassTest implements RewriteTest {
     }
 
     @Test
+    @MinimumJava11
     void anonymousTypeAttribution() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -4412,7 +4412,7 @@ public interface J extends Tree {
         @Nullable
         @Override
         public JavaType getType() {
-            return constructorType == null ? null : constructorType.getDeclaringType();
+            return constructorType == null ? null : constructorType.getReturnType();
         }
 
         /**


### PR DESCRIPTION
When the target type of a constructor call declares generic type variables, the `J.NewClass` type attribution should also include these details. So for example the type attribution for `new ArrayList<String>()` should be a `JavaType.Method` which as the declaring type has `java.util.ArrayList<String>` rather than just `java.util.ArrayList`.