### PR TITLE
Fix LOWER_CAMEL, UPPER_CAMEL to handle uppercase abbreviation better

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
@@ -56,6 +56,7 @@ public enum NameCaseConvention {
     UPPER_UNDERSCORE;
 
     private static final Pattern CAMEL_CASE_SPLIT = Pattern.compile("[\\s_-]");
+    private static final int uppercaseAbbreviationMinLength = 3;
 
     /**
      * Formats the input to the style of this {@link NameCaseConvention}.
@@ -149,18 +150,31 @@ public enum NameCaseConvention {
     private static String toCamelCase(String str, boolean lowerCaseFirstLetter) {
         boolean allUpperCase = true;
         final int strLength = str.length();
+
+        boolean uppercaseAbbreviationIncluded = false;
+        int uppercaseAbbreviationEndIndex = -1;
         for (int i = 0; i < strLength; i++) {
             final char c = str.charAt(i);
             if (Character.isLowerCase(c)) {
                 allUpperCase = false;
                 break;
             }
-        }
-        if (allUpperCase) {
-            str = str.toLowerCase();
+
+            if ((i + 1) >= uppercaseAbbreviationMinLength) {
+                uppercaseAbbreviationIncluded = true;
+                uppercaseAbbreviationEndIndex = i - 1;
+            }
         }
 
         StringBuilder sb = new StringBuilder(strLength);
+        if (allUpperCase) {
+            str = str.toLowerCase();
+        } else if (uppercaseAbbreviationIncluded) {
+            final String uppercaseAbbreviation = str.substring(0, uppercaseAbbreviationEndIndex + 1);
+            sb.append(StringUtils.capitalize(uppercaseAbbreviation.toLowerCase()));
+            str = str.substring(uppercaseAbbreviationEndIndex + 1);
+        }
+
         for (String s : CAMEL_CASE_SPLIT.split(str)) {
             String capitalize = StringUtils.capitalize(s);
             sb.append(capitalize);
@@ -201,7 +215,8 @@ public enum NameCaseConvention {
                         builder.append(lowerCaseChar);
                     } else if (Character.isUpperCase(last) || last == '.') {
                         builder.append(lowerCaseChar);
-                    } else if (Character.isDigit(last) && (Character.isUpperCase(secondLast) || secondLast == separatorChar)) {
+                    } else if (Character.isDigit(last) && (Character.isUpperCase(secondLast)
+                                                           || secondLast == separatorChar)) {
                         builder.append(lowerCaseChar);
                     } else {
                         builder.append(separatorChar).append(lowerCaseChar);

--- a/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/NameCaseConvention.java
@@ -153,26 +153,27 @@ public enum NameCaseConvention {
 
         boolean uppercaseAbbreviationIncluded = false;
         int uppercaseAbbreviationEndIndex = -1;
-        for (int i = 0; i < strLength; i++) {
+        int i = 0;
+        while (i < strLength) {
             final char c = str.charAt(i);
             if (Character.isLowerCase(c)) {
                 allUpperCase = false;
                 break;
             }
-
-            if ((i + 1) >= uppercaseAbbreviationMinLength) {
-                uppercaseAbbreviationIncluded = true;
-                uppercaseAbbreviationEndIndex = i - 1;
-            }
+            i++;
+        }
+        if (i > uppercaseAbbreviationMinLength) {
+            uppercaseAbbreviationIncluded = true;
+            uppercaseAbbreviationEndIndex = i - 1;
         }
 
         StringBuilder sb = new StringBuilder(strLength);
         if (allUpperCase) {
             str = str.toLowerCase();
         } else if (uppercaseAbbreviationIncluded) {
-            final String uppercaseAbbreviation = str.substring(0, uppercaseAbbreviationEndIndex + 1);
+            final String uppercaseAbbreviation = str.substring(0, uppercaseAbbreviationEndIndex);
             sb.append(StringUtils.capitalize(uppercaseAbbreviation.toLowerCase()));
-            str = str.substring(uppercaseAbbreviationEndIndex + 1);
+            str = str.substring(uppercaseAbbreviationEndIndex);
         }
 
         for (String s : CAMEL_CASE_SPLIT.split(str)) {
@@ -215,8 +216,7 @@ public enum NameCaseConvention {
                         builder.append(lowerCaseChar);
                     } else if (Character.isUpperCase(last) || last == '.') {
                         builder.append(lowerCaseChar);
-                    } else if (Character.isDigit(last) && (Character.isUpperCase(secondLast)
-                                                           || secondLast == separatorChar)) {
+                    } else if (Character.isDigit(last) && (Character.isUpperCase(secondLast) || secondLast == separatorChar)) {
                         builder.append(lowerCaseChar);
                     } else {
                         builder.append(separatorChar).append(lowerCaseChar);

--- a/rewrite-core/src/test/java/org/openrewrite/internal/NameCaseConventionTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/NameCaseConventionTest.java
@@ -81,6 +81,8 @@ class NameCaseConventionTest {
       "foo bar:fooBar",
       " foo  bar :fooBar",
       "FOO_BAR:fooBar",
+      "XMLParser:xmlParser",
+      "PDFViewModel:pdfViewModel",
     }, delimiter = ':')
     void lowerCamel(String input, String expected) {
         assertThat(NameCaseConvention.LOWER_CAMEL.format(input)).isEqualTo(expected);
@@ -95,6 +97,8 @@ class NameCaseConventionTest {
       "foo-bar:FooBar",
       "foo bar:FooBar",
       " foo  bar :FooBar",
+      "XMLParser:XmlParser",
+      "PDFViewModel:PdfViewModel",
     }, delimiter = ':')
     void upperCamel(String input, String expected) {
         assertThat(NameCaseConvention.UPPER_CAMEL.format(input)).isEqualTo(expected);


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
`LOWER_CAMEL` and `UPPER_CAMEL` can now handle uppercase abbreviation better 

AS-IS 
```
-      PdfDocumentViewModel PDFviewModel = new PdfDocumentViewModel(mockPDF);
+      PdfDocumentViewModel pDFviewModel = new PdfDocumentViewModel(mockPDF);
```

TO-BE(`LOWER_CAMEL`)  
```
-      PdfDocumentViewModel PDFviewModel = new PdfDocumentViewModel(mockPDF);
+      PdfDocumentViewModel pdfViewModel = new PdfDocumentViewModel(mockPdf);
```

## What's your motivation?
https://github.com/openrewrite/rewrite/issues/3333


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@koppor
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
[Issue](https://github.com/openrewrite/rewrite/issues/3333#issuecomment-1888128281)
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
