### PR TITLE
Allow regular expressions on `ChangeTagAttribute`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 public class UpgradePluginVersion extends Recipe {
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
@@ -88,7 +88,7 @@ public class ChangeTagAttribute extends Recipe {
                 }
 
                 String stringValue = attribute.getValueAsString();
-                if (oldValue != null && !stringValue.startsWith(oldValue)) {
+                if (oldValue != null) {
                     if (Boolean.TRUE.equals(regex) && !Pattern.matches(oldValue, stringValue)) {
                         return attribute;
                     } else if ((regex == null || Boolean.FALSE.equals(regex)) && !stringValue.startsWith(oldValue)) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
@@ -91,7 +91,8 @@ public class ChangeTagAttribute extends Recipe {
                 if (oldValue != null) {
                     if (Boolean.TRUE.equals(regex) && !Pattern.matches(oldValue, stringValue)) {
                         return attribute;
-                    } else if ((regex == null || Boolean.FALSE.equals(regex)) && !stringValue.startsWith(oldValue)) {
+                    }
+                    if ((regex == null || Boolean.FALSE.equals(regex)) && !stringValue.startsWith(oldValue)) {
                         return attribute;
                     }
                 }
@@ -101,7 +102,10 @@ public class ChangeTagAttribute extends Recipe {
                     return null;
                 }
 
-                String changedValue = (oldValue != null) ? stringValue.replaceAll(oldValue, newValue) : newValue;
+                String changedValue = oldValue != null
+                        ? (Boolean.TRUE.equals(regex) ? stringValue.replaceAll(oldValue, newValue) : stringValue.replace(oldValue, newValue))
+                        : newValue;
+
                 return attribute.withValue(
                         new Xml.Attribute.Value(attribute.getId(),
                                 "",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
@@ -25,6 +25,8 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.regex.Pattern;
+
 @Value
 @EqualsAndHashCode(callSuper = true)
 public class ChangeTagAttribute extends Recipe {
@@ -62,6 +64,12 @@ public class ChangeTagAttribute extends Recipe {
     @Nullable
     String oldValue;
 
+    @Option(displayName = "Regex",
+            description = "Default false. If true, `oldValue` will be interpreted as a Regular Expression, and capture group contents will be available in `newValue`.",
+            required = false)
+    @Nullable
+    Boolean regex;
+
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new XmlVisitor<ExecutionContext>() {
@@ -75,11 +83,17 @@ public class ChangeTagAttribute extends Recipe {
             }
 
             public Xml.Attribute visitChosenElementAttribute(Xml.Attribute attribute) {
-                if(!attribute.getKeyAsString().equals(attributeName)) {
+                if (!attribute.getKeyAsString().equals(attributeName)) {
                     return attribute;
                 }
-                if(oldValue != null && !attribute.getValueAsString().startsWith(oldValue)) {
-                    return attribute;
+
+                String stringValue = attribute.getValueAsString();
+                if (oldValue != null && !stringValue.startsWith(oldValue)) {
+                    if (Boolean.TRUE.equals(regex) && !Pattern.matches(oldValue, stringValue)) {
+                        return attribute;
+                    } else if ((regex == null || Boolean.FALSE.equals(regex)) && !stringValue.startsWith(oldValue)) {
+                        return attribute;
+                    }
                 }
 
                 if (newValue == null) {
@@ -87,13 +101,13 @@ public class ChangeTagAttribute extends Recipe {
                     return null;
                 }
 
-                String changedValue = (oldValue != null) ? attribute.getValueAsString().replace(oldValue, newValue): newValue;
+                String changedValue = (oldValue != null) ? stringValue.replaceAll(oldValue, newValue) : newValue;
                 return attribute.withValue(
-                    new Xml.Attribute.Value(attribute.getId(),
-                        "",
-                        attribute.getMarkers(),
-                        attribute.getValue().getQuote(),
-                        changedValue));
+                        new Xml.Attribute.Value(attribute.getId(),
+                                "",
+                                attribute.getMarkers(),
+                                attribute.getValue().getQuote(),
+                                changedValue));
             }
         };
     }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
@@ -27,7 +27,7 @@ class ChangeTagAttributeTest implements RewriteTest {
     @Test
     void alterAttributeWhenElementAndAttributeMatch() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", "myBean.subpackage")),
+          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", "myBean.subpackage", null)),
           xml(
             """
               <beans>
@@ -48,7 +48,7 @@ class ChangeTagAttributeTest implements RewriteTest {
     @Test
     void alterAttributeWithNullOldValue() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", null))
+          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", null, null))
             .expectedCyclesThatMakeChanges(1).cycles(1),
           xml(
             """
@@ -70,7 +70,7 @@ class ChangeTagAttributeTest implements RewriteTest {
     @Test
     void removeAttribute() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", null, "myBean.subpackage")),
+          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", null, "myBean.subpackage", null)),
           xml(
             """
               <beans>
@@ -91,11 +91,33 @@ class ChangeTagAttributeTest implements RewriteTest {
     @Test
     void attributeNotMatched() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", "not.matched")),
+          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", "not.matched", null)),
           xml(
             """
               <beans>
                   <bean id='myBean.subpackage.subpackage2'/>
+                  <other id='myBean.subpackage.subpackage2'/>
+              </beans>
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void alterAttributeWithRegex() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.$1", "myBean\\.(.*)", true)),
+          xml(
+            """
+              <beans>
+                  <bean id='myBean.subpackage.subpackage2'/>
+                  <other id='myBean.subpackage.subpackage2'/>
+              </beans>
+              """,
+            """
+              <beans>
+                  <bean id='myBean2.subpackage.subpackage2'/>
                   <other id='myBean.subpackage.subpackage2'/>
               </beans>
               """


### PR DESCRIPTION
## What's changed?
Allow the usage of regular expressions on `ChangeTagAttribute`

## What's your motivation?
Replace namespaces/namespaces URIs on `schemaLocation`.

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
No

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
