### PR TITLE
Gradle `AddDependencyVisitor` should not use default Maven repos

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
@@ -393,7 +393,7 @@ public class AddDependencyVisitor extends GroovyIsoVisitor<ExecutionContext> {
     }
 
     private static MavenMetadata downloadMetadata(String groupId, String artifactId, List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
-        return new MavenPomDownloader(emptyMap(), ctx, null, null)
+        return new MavenPomDownloader(ctx)
                 .downloadMetadata(new GroupArtifact(groupId, artifactId), null,
                         repositories);
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -235,7 +235,7 @@ public class UpgradeDependencyVersion extends Recipe {
                     return arg;
                 }));
                 Exception err = getCursor().pollMessage(UPDATE_VERSION_ERROR_KEY);
-                if(err != null) {
+                if (err != null) {
                     m = Markup.warn(m, err);
                 }
                 List<Expression> depArgs = m.getArguments();

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -96,6 +96,32 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void noRepos() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              dependencies {
+                compileOnly 'com.google.guava:guava:29.0-jre'
+              }
+              """,
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              dependencies {
+                /*~~(com.google.guava:guava failed. Unable to download metadata.)~~>*/compileOnly 'com.google.guava:guava:29.0-jre'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void updateVersionInVariable() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
When downloading Maven metadata the `AddDependencyVisitor` should not configure any default repos and must therefore use the `MavenPomDownloader(ExecutionContext)` constructor.
