### PR TITLE
Perform same newGroupId and newArtifactId validations for Gradle ChangeDependency recipe

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -16,7 +16,8 @@
 package org.openrewrite.gradle;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
@@ -37,6 +38,7 @@ import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 import org.openrewrite.semver.DependencyMatcher;
+import org.openrewrite.semver.Semver;
 
 import java.util.*;
 
@@ -127,7 +129,27 @@ public class ChangeDependency extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Change a Gradle dependency coordinates.";
+        return "Change a Gradle dependency coordinates. The `newGroupId` or `newArtifactId` **MUST** be different from before.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate();
+        if (newVersion != null) {
+            validated = validated.and(Semver.validate(newVersion, versionPattern));
+        }
+        validated = validated.and(Validated.required("newGroupId", newGroupId).or(Validated.required("newArtifactId", newArtifactId)));
+        validated = validated.and(Validated.test(
+                "coordinates",
+                "newGroupId OR newArtifactId must be different from before",
+                this,
+                r -> {
+                    boolean sameGroupId = StringUtils.isBlank(r.newGroupId) || Objects.equals(r.oldGroupId, r.newGroupId);
+                    boolean sameArtifactId = StringUtils.isBlank(r.newArtifactId) || Objects.equals(r.oldArtifactId, r.newArtifactId);
+                    return !(sameGroupId && sameArtifactId);
+                }
+        ));
+        return validated;
     }
 
     @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -110,14 +110,28 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
     }
 
     @Override
+    public String getDisplayName() {
+        return "Change Maven dependency";
+    }
+
+    @Override
+    public String getInstanceNameSuffix() {
+        return String.format("`%s:%s`", oldGroupId, oldArtifactId);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Change a Maven dependency coordinates. The `newGroupId` or `newArtifactId` **MUST** be different from before.";
+    }
+
+    @Override
     public Validated<Object> validate() {
         Validated<Object> validated = super.validate();
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }
         validated = validated.and(required("newGroupId", newGroupId).or(required("newArtifactId", newArtifactId)));
-        validated =
-            validated.and(test(
+        validated = validated.and(test(
                 "coordinates",
                 "newGroupId OR newArtifactId must be different from before",
                 this,
@@ -126,18 +140,8 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                     boolean sameArtifactId = isBlank(r.newArtifactId) || Objects.equals(r.oldArtifactId, r.newArtifactId);
                     return !(sameGroupId && sameArtifactId);
                 }
-            ));
+        ));
         return validated;
-    }
-
-    @Override
-    public String getDisplayName() {
-        return "Change Maven dependency groupId, artifactId and optionally the version";
-    }
-
-    @Override
-    public String getDescription() {
-        return "Change the groupId, artifactId and optionally the version of a specified Maven dependency.";
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
Added same validation for Gradle `ChangeDependency` as was done for the Maven equivalent via https://github.com/openrewrite/rewrite/pull/3889.

## Anything in particular you'd like reviewers to focus on?
I did go ahead and clean up the descriptions a little bit more, so now I think they overall are a bit clearer in terms of intent.

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
- https://github.com/openrewrite/rewrite/pull/3889
- https://github.com/openrewrite/rewrite/commit/82d57a4c24c5998a7db2e8e564ca038d7e214317

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
