### PR TITLE
Plugin configuration can be null

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Plugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Plugin.java
@@ -43,6 +43,7 @@ public class Plugin {
     @Nullable
     String inherited;
 
+    @Nullable
     JsonNode configuration;
 
     List<Dependency> dependencies;
@@ -66,6 +67,10 @@ public class Plugin {
 
     @Nullable
     public String getConfigurationStringValue(String path) {
+        if (configuration == null) {
+            return null;
+        }
+
         JsonNode current = configuration;
         if (!path.isEmpty()) {
             String[] elements = path.split("\\.");
@@ -81,6 +86,10 @@ public class Plugin {
 
     @Nullable
     public <T> T getConfiguration(String path, Class<T> configClass) {
+        if (configuration == null) {
+            return null;
+        }
+
         JsonNode current = configuration;
         if (!path.isEmpty()) {
             String[] elements = path.split("\\.");
@@ -102,6 +111,10 @@ public class Plugin {
     }
 
     public <T> List<T> getConfigurationList(String path, Class<T> elementClass) {
+        if (configuration == null) {
+            return Collections.emptyList();
+        }
+
         JsonNode current = configuration;
         if (!path.isEmpty()) {
             String[] elements = path.split("\\.");

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -2350,10 +2350,41 @@ class MavenParserTest implements RewriteTest {
                   </build>
               </project>
               """,
-            spec -> spec.afterRecipe(pomXml ->
-              assertThat(pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom().getPlugins()
-                .get(0).getArtifactId())
-                .isEqualTo("maven-compiler-plugin")
+            spec -> spec.afterRecipe(pomXml -> {
+                  Plugin plugin = pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom().getPlugins().get(0);
+                  assertThat(plugin.getArtifactId()).isEqualTo("maven-compiler-plugin");
+                  assertThat(plugin.getConfiguration()).isNotNull();
+              }
+            )
+          )
+        );
+    }
+
+    @Test
+    void pluginWithoutConfig() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>org.openrewrite.maven</groupId>
+                  <artifactId>a</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+              
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.11.0</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            spec -> spec.afterRecipe(pomXml -> {
+                  Plugin plugin = pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom().getPlugins().get(0);
+                  assertThat(plugin.getArtifactId()).isEqualTo("maven-compiler-plugin");
+                  assertThat(plugin.getConfiguration()).isNull();
+              }
             )
           )
         );


### PR DESCRIPTION
## What's changed?
Mark `JsonNode configuration` as `@Nullable`, and make cascading null safety changes.

## What's your motivation?
MavenParser leaves the field as null when not provided.