### PR TITLE
Adding support for plugin versions in gradle.properties file

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/IsBuildGradle.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/IsBuildGradle.java
@@ -16,9 +16,8 @@
 package org.openrewrite.gradle;
 
 import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
 
@@ -26,9 +25,9 @@ import java.nio.file.Path;
 
 import static java.util.Objects.requireNonNull;
 
-public class IsBuildGradle<P> extends JavaIsoVisitor<P> {
+public class IsBuildGradle<P> extends TreeVisitor<Tree, P> {
     @Override
-    public J visit(@Nullable Tree tree, P p) {
+    public Tree visit(@Nullable Tree tree, P p) {
         if (tree instanceof JavaSourceFile) {
             JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
             if (matches(cu.getSourcePath())) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/IsSettingsGradle.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/IsSettingsGradle.java
@@ -16,18 +16,16 @@
 package org.openrewrite.gradle;
 
 import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.SearchResult;
 
 import static java.util.Objects.requireNonNull;
 
-public class IsSettingsGradle<P> extends JavaIsoVisitor<P> {
-
+public class IsSettingsGradle<P> extends TreeVisitor<Tree, P> {
     @Override
-    public J visit(@Nullable Tree tree, P p) {
+    public Tree visit(@Nullable Tree tree, P p) {
         if (tree instanceof JavaSourceFile) {
             JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
             if (cu.getSourcePath().toString().endsWith("settings.gradle") ||

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -262,10 +262,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 gradleProject = acc.gradleProject != null ?
                                         acc.gradleProject :
                                         cu.getMarkers().findFirst(GradleProject.class)
-                                                .orElse(null);
-                                if(gradleProject == null) {
-                                    return cu;
-                                }
+                                                .orElseThrow(() -> new IllegalStateException("Unable to find Gradle project."));
                                 return super.visitCompilationUnit(cu, ctx);
                             }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -262,7 +262,10 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 gradleProject = acc.gradleProject != null ?
                                         acc.gradleProject :
                                         cu.getMarkers().findFirst(GradleProject.class)
-                                                .orElseThrow(() -> new IllegalStateException("Unable to find Gradle project."));
+                                                .orElse(null);
+                                if(gradleProject == null) {
+                                    return cu;
+                                }
                                 return super.visitCompilationUnit(cu, ctx);
                             }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -37,7 +37,10 @@ import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.Semver;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -223,7 +226,7 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                     cu.getMarkers().findFirst(GradleSettings.class);
 
                 if (!maybeGradleProject.isPresent() && !maybeGradleSettings.isPresent()) {
-                    return cu;
+                    throw new IllegalStateException("Unable to find a gradle project or gradle settings");
                 }
 
                 gradleProject = maybeGradleProject.orElse(null);
@@ -279,10 +282,7 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                 if (gradleSettings != null) {
                     return gradleSettings.getPluginRepositories();
                 }
-                if(gradleProject != null) {
-                    return gradleProject.getMavenPluginRepositories();
-                }
-                return new ArrayList<>();
+                return gradleProject.getMavenPluginRepositories();
             }
         };
         return Preconditions.or(propertiesVisitor, Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), groovyVisitor));

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -37,10 +37,7 @@ import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.Semver;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -226,7 +223,7 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                     cu.getMarkers().findFirst(GradleSettings.class);
 
                 if (!maybeGradleProject.isPresent() && !maybeGradleSettings.isPresent()) {
-                    throw new IllegalStateException("Unable to find a gradle project or gradle settings");
+                    return cu;
                 }
 
                 gradleProject = maybeGradleProject.orElse(null);
@@ -282,7 +279,10 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                 if (gradleSettings != null) {
                     return gradleSettings.getPluginRepositories();
                 }
-                return gradleProject.getMavenPluginRepositories();
+                if(gradleProject != null) {
+                    return gradleProject.getMavenPluginRepositories();
+                }
+                return new ArrayList<>();
             }
         };
         return Preconditions.or(propertiesVisitor, Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), groovyVisitor));

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -148,8 +148,15 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                 if (!(versionArgs.get(0) instanceof G.GString)) {
                     return m;
                 }
-                // TODO error handling here
-                String currentVersion = (String) ((G.GString.Value) ((G.GString) versionArgs.get(0)).getStrings().get(0)).getTree().toString();
+
+                G.GString gString = (G.GString) versionArgs.get(0);
+                if(gString == null || gString.getStrings().isEmpty() || !(gString.getStrings().get(0) instanceof G.GString.Value)) {
+                    return m;
+                }
+
+                G.GString.Value gStringValue = (G.GString.Value) gString.getStrings().get(0);
+                String currentVersion = (String) gStringValue.getTree().toString();
+
                 acc.pluginDependencies.put(currentVersion, pluginId);
                 return m;
             }
@@ -183,7 +190,6 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                     if (!StringUtils.isBlank(newVersion)) {
                         String resolvedVersion = null;
                         try {
-                            // TODO this is where we figure out what the new version should be
                             resolvedVersion = AddPluginVisitor.resolvePluginVersion(pluginId, currentVersion, newVersion, versionPattern, getRepositories(), ctx).orElse(null);
                         } catch (MavenDownloadingException e) {
                             return e.warn(entry);
@@ -273,6 +279,6 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                 return gradleProject.getMavenPluginRepositories();
             }
         };
-        return Preconditions.or(propertiesVisitor, groovyVisitor);
+        return Preconditions.or(propertiesVisitor, Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), groovyVisitor));
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -217,10 +217,16 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
 
             @Override
             public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
-                Optional<GradleProject> maybeGradleProject = cu.getMarkers().findFirst(GradleProject.class);
-                Optional<GradleSettings> maybeGradleSettings = cu.getMarkers().findFirst(GradleSettings.class);
+                Optional<GradleProject> maybeGradleProject =  acc.gradleProject != null ?
+                    Optional.of(acc.gradleProject) :
+                    cu.getMarkers().findFirst(GradleProject.class);
+
+                Optional<GradleSettings> maybeGradleSettings = acc.gradleSettings != null ?
+                    Optional.of(acc.gradleSettings) :
+                    cu.getMarkers().findFirst(GradleSettings.class);
+
                 if (!maybeGradleProject.isPresent() && !maybeGradleSettings.isPresent()) {
-                    return cu;
+                    throw new IllegalStateException("Unable to find a gradle project or gradle settings");
                 }
 
                 gradleProject = maybeGradleProject.orElse(null);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -33,15 +33,20 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.properties.PropertiesVisitor;
+import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.Semver;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public class UpgradePluginVersion extends Recipe {
+public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.DependencyVersionState> {
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
+    private static final String GRADLE_PROPERTIES_FILE_NAME = "gradle.properties";
 
     @Option(displayName = "Plugin id",
             description = "The `ID` part of `plugin { ID }`, as a glob expression.",
@@ -86,24 +91,39 @@ public class UpgradePluginVersion extends Recipe {
         return validated;
     }
 
+    public static class DependencyVersionState {
+        GradleProject gradleProject;
+        GradleSettings gradleSettings;
+        Map<String, String> pluginDependencies = new HashMap<>();
+    }
+
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
+    public UpgradePluginVersion.DependencyVersionState getInitialValue(ExecutionContext ctx) {
+        return new UpgradePluginVersion.DependencyVersionState();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(UpgradePluginVersion.DependencyVersionState acc) {
         MethodMatcher pluginMatcher = new MethodMatcher("PluginSpec id(..)", false);
         MethodMatcher versionMatcher = new MethodMatcher("Plugin version(..)", false);
         return Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), new GroovyVisitor<ExecutionContext>() {
-            private GradleProject gradleProject;
-            private GradleSettings gradleSettings;
 
             @Override
             public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
                 Optional<GradleProject> maybeGradleProject = cu.getMarkers().findFirst(GradleProject.class);
                 Optional<GradleSettings> maybeGradleSettings = cu.getMarkers().findFirst(GradleSettings.class);
+
+                if (acc.gradleProject == null) {
+                    acc.gradleProject = maybeGradleProject.orElse(null);
+                }
+                if (acc.gradleSettings == null) {
+                    acc.gradleSettings = maybeGradleSettings.orElse(null);
+                }
+
                 if (!maybeGradleProject.isPresent() && !maybeGradleSettings.isPresent()) {
                     return cu;
                 }
 
-                gradleProject = maybeGradleProject.orElse(null);
-                gradleSettings = maybeGradleSettings.orElse(null);
                 return super.visitCompilationUnit(cu, ctx);
             }
 
@@ -111,8 +131,8 @@ public class UpgradePluginVersion extends Recipe {
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (!(versionMatcher.matches(m) &&
-                      m.getSelect() instanceof J.MethodInvocation &&
-                      pluginMatcher.matches(m.getSelect()))) {
+                    m.getSelect() instanceof J.MethodInvocation &&
+                    pluginMatcher.matches(m.getSelect()))) {
                     return m;
                 }
                 List<Expression> pluginArgs = ((J.MethodInvocation) m.getSelect()).getArguments();
@@ -125,38 +145,134 @@ public class UpgradePluginVersion extends Recipe {
                 }
 
                 List<Expression> versionArgs = m.getArguments();
-                if (!(versionArgs.get(0) instanceof J.Literal)) {
+                if (!(versionArgs.get(0) instanceof G.GString)) {
                     return m;
                 }
-                String currentVersion = (String) ((J.Literal) versionArgs.get(0)).getValue();
-                if (currentVersion == null) {
-                    return m;
+                // TODO error handling here
+                String currentVersion = (String) ((G.GString.Value)((G.GString) versionArgs.get(0)).getStrings().get(0)).getTree().toString();
+                acc.pluginDependencies.put(currentVersion, pluginId);
+                return m;
+            }
+
+            private List<MavenRepository> getRepositories(DependencyVersionState acc) {
+                if (acc.gradleSettings != null) {
+                    return acc.gradleSettings.getPluginRepositories();
                 }
-                Optional<String> version;
-                try {
-                    version = AddPluginVisitor.resolvePluginVersion(pluginId, currentVersion, newVersion, versionPattern, getRepositories(), ctx);
-                    J.MethodInvocation finalM = m;
-                    m = version.map(upgradeVersion -> finalM.withArguments(ListUtils.map(versionArgs, v -> {
+                return acc.gradleProject.getMavenPluginRepositories();
+            }
+        });
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(DependencyVersionState acc) {
+        MethodMatcher pluginMatcher = new MethodMatcher("PluginSpec id(..)", false);
+        MethodMatcher versionMatcher = new MethodMatcher("Plugin version(..)", false);
+        return Preconditions.or(
+            new PropertiesVisitor<ExecutionContext>() {
+                @Override
+                public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                    return super.isAcceptable(sourceFile, ctx) && sourceFile.getSourcePath().endsWith(GRADLE_PROPERTIES_FILE_NAME);
+                }
+
+                @Override
+                public org.openrewrite.properties.tree.Properties visitEntry(Properties.Entry entry, ExecutionContext ctx) {
+
+                    if (acc.pluginDependencies.containsKey(entry.getKey())) {
+                        String currentVersion = entry.getValue().getText();
+                        String pluginId = acc.pluginDependencies.get(entry.getKey());
+                        if (!StringUtils.isBlank(newVersion)) {
+                            String resolvedVersion = null;
+                            try {
+                                // TODO this is where we figure out what the new version should be
+                                resolvedVersion = AddPluginVisitor.resolvePluginVersion(pluginId, currentVersion, newVersion, versionPattern, getRepositories(), ctx).orElse(null);
+                            } catch (MavenDownloadingException e) {
+                                return e.warn(entry);
+                            }
+                            if (resolvedVersion != null) {
+                                return entry.withValue(entry.getValue().withText(resolvedVersion));
+                            }
+                            return entry.withValue(entry.getValue().withText(newVersion));
+                        }
+                    }
+
+                    return entry;
+                }
+
+                private List<MavenRepository> getRepositories() {
+                    if (acc.gradleSettings != null) {
+                        return acc.gradleSettings.getPluginRepositories();
+                    }
+                    return acc.gradleProject.getMavenPluginRepositories();
+                }
+            },
+            Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new IsSettingsGradle<>()), new GroovyVisitor<ExecutionContext>() {
+                private GradleProject gradleProject;
+                private GradleSettings gradleSettings;
+
+                @Override
+                public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+                    Optional<GradleProject> maybeGradleProject = cu.getMarkers().findFirst(GradleProject.class);
+                    Optional<GradleSettings> maybeGradleSettings = cu.getMarkers().findFirst(GradleSettings.class);
+                    if (!maybeGradleProject.isPresent() && !maybeGradleSettings.isPresent()) {
+                        return cu;
+                    }
+
+                    gradleProject = maybeGradleProject.orElse(null);
+                    gradleSettings = maybeGradleSettings.orElse(null);
+                    return super.visitCompilationUnit(cu, ctx);
+                }
+
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                    if (!(versionMatcher.matches(m) &&
+                        m.getSelect() instanceof J.MethodInvocation &&
+                        pluginMatcher.matches(m.getSelect()))) {
+                        return m;
+                    }
+                    List<Expression> pluginArgs = ((J.MethodInvocation) m.getSelect()).getArguments();
+                    if (!(pluginArgs.get(0) instanceof J.Literal)) {
+                        return m;
+                    }
+                    String pluginId = (String) ((J.Literal) pluginArgs.get(0)).getValue();
+                    if (pluginId == null || !StringUtils.matchesGlob(pluginId, pluginIdPattern)) {
+                        return m;
+                    }
+
+                    List<Expression> versionArgs = m.getArguments();
+                    if (!(versionArgs.get(0) instanceof J.Literal)) {
+                        return m;
+                    }
+                    String currentVersion = (String) ((J.Literal) versionArgs.get(0)).getValue();
+                    if (currentVersion == null) {
+                        return m;
+                    }
+                    Optional<String> version;
+                    try {
+                        version = AddPluginVisitor.resolvePluginVersion(pluginId, currentVersion, newVersion, versionPattern, getRepositories(), ctx);
+                        J.MethodInvocation finalM = m;
+                        m = version.map(upgradeVersion -> finalM.withArguments(ListUtils.map(versionArgs, v -> {
                                 J.Literal versionLiteral = (J.Literal) v;
                                 assert versionLiteral.getValueSource() != null;
                                 return versionLiteral
-                                        .withValue(upgradeVersion)
-                                        .withValueSource(versionLiteral.getValueSource().replace(currentVersion, upgradeVersion));
+                                    .withValue(upgradeVersion)
+                                    .withValueSource(versionLiteral.getValueSource().replace(currentVersion, upgradeVersion));
                             })))
                             .orElse(m);
 
-                    return m;
-                } catch (MavenDownloadingException e) {
-                    return e.warn(m);
+                        return m;
+                    } catch (MavenDownloadingException e) {
+                        return e.warn(m);
+                    }
                 }
-            }
 
-            private List<MavenRepository> getRepositories() {
-                if (gradleSettings != null) {
-                    return gradleSettings.getPluginRepositories();
+                private List<MavenRepository> getRepositories() {
+                    if (gradleSettings != null) {
+                        return gradleSettings.getPluginRepositories();
+                    }
+                    return gradleProject.getMavenPluginRepositories();
                 }
-                return gradleProject.getMavenPluginRepositories();
-            }
-        });
+            })
+        );
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.*;
+import static org.openrewrite.properties.Assertions.properties;
 
 class UpgradePluginVersionTest implements RewriteTest {
     @Override
@@ -150,6 +151,31 @@ class UpgradePluginVersionTest implements RewriteTest {
             """
               plugins {
                   id 'io.spring.dependency-management' version '1.1.0'
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample("Upgrading a build plugin with version in gradle.properties")
+    @Test
+    void upgradePluginVersionInProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.40.7", null)),
+          properties(
+            """
+              rewriteVersion=5.40.0
+              """,
+            """
+              rewriteVersion=5.40.7
+              """,
+            spec -> spec.path("gradle.properties")
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'org.openrewrite.rewrite' version "$rewriteVersion"
+                  id 'com.github.johnrengelman.shadow' version '6.1.0'
               }
               """
           )

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -181,4 +181,30 @@ class UpgradePluginVersionTest implements RewriteTest {
           )
         );
     }
+
+    @DocumentExample("Don't touch gradle.properties if version is hardcoded in build.gradle")
+    @Test
+    void upgradePluginVersionInBuildGradleNotProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.40.7", null)),
+          properties(
+            """
+              org.openrewrite.rewrite=5.40.0
+              """,
+            spec -> spec.path("gradle.properties")
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'org.openrewrite.rewrite' version "5.40.0"
+              }
+              """,
+            """
+              plugins {
+                  id 'org.openrewrite.rewrite' version "5.40.7"
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Changing the `UpgradePluginVersion` recipe from a Recipe to a ScanningRecipe so that we can match plugin version variables with anything declared in a `gradle.properties` file

## Anyone you would like to review specifically?
@timtebeek @shanman190 who are aware of the context behind this and the similar improvements that were made to `UpgradeDependencyVersion`

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
