### PR TITLE
Recipe to comment imports

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/CommentImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/CommentImport.java
@@ -1,0 +1,81 @@
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
+
+import java.util.UUID;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class CommentImport extends Recipe {
+
+    @Option(displayName = "Fully-qualified type name",
+            description = "Fully-qualified class name of the type.",
+            example = "org.junit.Assume")
+    String fullyQualifiedTypeName;
+
+    @Option(displayName = "Comment text",
+            description = "The text to add as a comment.",
+            example = "This type was removed.")
+    String commentText;
+
+    @Option(displayName = "Multiline comment",
+            description = "Add the comment as a multiline comment. Defaults to `false`.",
+            required = false)
+    @Nullable
+    Boolean multiline;
+
+    @Override
+    public String getDisplayName() {
+        return "Comments an import statement";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Comments an import statement.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(fullyQualifiedTypeName, false),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitImport(J.Import import_, ExecutionContext ctx) {
+                        import_ = (J.Import) super.visitImport(import_, ctx);
+                        if (import_.getMarkers().findFirst(ImportAlreadyCommented.class).isPresent()) {
+                            return import_;
+                        }
+                        if (import_.getTypeName().equals(fullyQualifiedTypeName)) {
+                            boolean multilineComment = Boolean.TRUE.equals(multiline);
+                            String formattedComment = multilineComment ? "\n" + commentText + "\n" : commentText;
+                            Comment comment = new TextComment(multilineComment, formattedComment, import_.getPrefix().getWhitespace(), Markers.EMPTY);
+                            return import_.withComments(ListUtils.concat(import_.getComments(), comment))
+                                    .withMarkers(import_.getMarkers().add(new ImportAlreadyCommented(UUID.randomUUID())));
+                        }
+                        return import_;
+                    }
+                }
+        );
+    }
+
+    @Value
+    @With
+    static class ImportAlreadyCommented implements Marker {
+        UUID id;
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/CommentImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/CommentImport.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;

--- a/rewrite-java/src/test/java/org/openrewrite/java/CommentImportTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/CommentImportTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class CommentImportTest implements RewriteTest {
+
+    @Test
+    void singleLineComment() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentImport("java.util.UUID", "comment", null)),
+          //language=java
+          java("""
+            // An existing comment
+            import java.util.UUID;
+                      
+            class A {}
+            """, """
+            // An existing comment
+            //comment
+            //import java.util.UUID;
+                      
+            class A {}
+            """)
+        );
+    }
+
+    @Test
+    void multiLineComment() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentImport("java.util.UUID", "comment", true)),
+          //language=java
+          java("""
+            // An existing comment
+            import java.util.UUID;
+                      
+            class A {}
+            """, """
+            // An existing comment
+            /*
+            comment
+            import java.util.UUID;
+            */
+
+            class A {}
+            """)
+        );
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/CommentImportTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/CommentImportTest.java
@@ -63,4 +63,18 @@ public class CommentImportTest implements RewriteTest {
             """)
         );
     }
+
+    @Test
+    void noChanges() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentImport("java.util.Map", "comment", true)),
+          //language=java
+          java("""
+            // An existing comment
+            import java.util.UUID;
+                      
+            class A {}
+            """)
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Added a new recipe to comment imports

## What's your motivation?
Add a comment to types that were removed

## Anything in particular you'd like reviewers to focus on?
- The `import` statement is not included in the comment as expected
- The failing test output is not showing the diffs anymore

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
