### PR TITLE
Fix another bug in `LargeSourceSetCheckingExpectedCycles`

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -100,7 +100,7 @@ public class DeclarativeRecipeTest implements RewriteTest {
           text("1", "1+1")
         );
         rewriteRun(
-          spec -> spec.recipe(new RepeatedFindAndReplace(".+", "$0+1", 2)),
+          spec -> spec.recipe(new RepeatedFindAndReplace(".+", "$0+1", 2)).expectedCyclesThatMakeChanges(2),
           text("1", "1+1+1")
         );
     }
@@ -124,7 +124,7 @@ public class DeclarativeRecipeTest implements RewriteTest {
           )
         );
         rewriteRun(
-          spec -> spec.recipe(root).cycles(10).expectedCyclesThatMakeChanges(2),
+          spec -> spec.recipe(root).cycles(10).cycles(3).expectedCyclesThatMakeChanges(3),
           text("1", "1+1+1")
         );
         assertThat(cycleCount).hasValue(3);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -512,6 +512,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void preferExistingDistributionSource() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("8.0.x", null, null, null))
+            .expectedCyclesThatMakeChanges(2)
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
           properties(
             """
@@ -549,6 +550,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void customDistributionUri() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("8.0.x", null, null, "https://company.com/repo/gradle-${version}-${distribution}.zip"))
+            .expectedCyclesThatMakeChanges(2)
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
           properties(
             """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -268,7 +268,8 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Test
     void implicitValueToExplicitValue() {
-        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null)),
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null))
+            .expectedCyclesThatMakeChanges(2),
           java(
             """
               package org.junit;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -35,7 +35,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     @Test
     void replaceAnnotation() {
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+          spec -> spec.expectedCyclesThatMakeChanges(2)
+            .recipe(toRecipe(() -> new JavaVisitor<>() {
                   @Override
                   public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
                       return JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateContextFreeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateContextFreeTest.java
@@ -74,7 +74,7 @@ class JavaTemplateContextFreeTest implements RewriteTest {
                   }
                   return super.visitVariableDeclarations(vd, ctx);
               }
-          })),
+          }).withMaxCycles(1)),
           java(
             """
               class Test {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -464,7 +464,7 @@ class JavaTemplateTest implements RewriteTest {
     @Test
     void templatingWhileLoopCondition() {
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(toRecipe(() -> new JavaVisitor<>() {
               @Override
               public J visitBinary(J.Binary binary, ExecutionContext p) {
                   if (binary.getLeft() instanceof J.MethodInvocation) {
@@ -560,7 +560,7 @@ class JavaTemplateTest implements RewriteTest {
                       unary.getExpression()
                     );
               }
-          })),
+          }).withMaxCycles(1)),
           java(
             """
               class Test {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaVisitorTest.java
@@ -33,29 +33,31 @@ class JavaVisitorTest implements RewriteTest {
     @Test
     void javaVisitorHandlesPaddedWithNullElem() {
         rewriteRun(
-          spec -> spec.recipes(
-            toRecipe(() -> new JavaIsoVisitor<>() {
-                @Override
-                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext p) {
-                    var mi = super.visitMethodInvocation(method, p);
-                    if ("removeMethod".equals(mi.getSimpleName())) {
-                        //noinspection ConstantConditions
-                        return null;
-                    }
-                    return mi;
-                }
-            }),
-            toRecipe(() -> new JavaIsoVisitor<>() {
-                @Override
-                public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext p) {
-                    if (method.getSimpleName().equals("allTheThings")) {
-                        return JavaTemplate.builder("Exception").contextSensitive().build()
-                          .apply(getCursor(), method.getCoordinates().replaceThrows());
-                    }
-                    return method;
-                }
-            })
-          ),
+          spec -> spec
+            .expectedCyclesThatMakeChanges(2)
+            .recipes(
+              toRecipe(() -> new JavaIsoVisitor<>() {
+                  @Override
+                  public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext p) {
+                      var mi = super.visitMethodInvocation(method, p);
+                      if ("removeMethod".equals(mi.getSimpleName())) {
+                          //noinspection ConstantConditions
+                          return null;
+                      }
+                      return mi;
+                  }
+              }),
+              toRecipe(() -> new JavaIsoVisitor<>() {
+                  @Override
+                  public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext p) {
+                      if (method.getSimpleName().equals("allTheThings")) {
+                          return JavaTemplate.builder("Exception").contextSensitive().build()
+                            .apply(getCursor(), method.getCoordinates().replaceThrows());
+                      }
+                      return method;
+                  }
+              })
+            ),
           java(
             """
               class A {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1142,6 +1142,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
     @Test
     void doesNotRemoveWildCardImport() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               package com.Source.mine;
@@ -1403,6 +1404,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
     @Test
     void removeWildcardImportWithDirectImport() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               import java.util.*;
@@ -1469,6 +1471,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
     @Test
     void removeMultipleImportsWhileUnfoldingWildcard() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               import java.util.Set;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/MinimumViableSpacingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/MinimumViableSpacingTest.java
@@ -50,6 +50,7 @@ class MinimumViableSpacingTest implements RewriteTest {
     @Test
     void method() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               class A {
@@ -67,6 +68,7 @@ class MinimumViableSpacingTest implements RewriteTest {
     @Test
     void returnExpression() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               class A {
@@ -85,6 +87,7 @@ class MinimumViableSpacingTest implements RewriteTest {
     @Test
     void variableDeclarationsInClass() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               class A {
@@ -105,6 +108,7 @@ class MinimumViableSpacingTest implements RewriteTest {
     @Test
     void variableDeclarationsInMethod() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               class A {
@@ -127,6 +131,7 @@ class MinimumViableSpacingTest implements RewriteTest {
     @Test
     void variableDeclarationsInForLoops() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               class Test {
@@ -153,6 +158,7 @@ class MinimumViableSpacingTest implements RewriteTest {
     @Test
     void spacesBetweenModifiers() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               public final class A {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentationTest.java
@@ -35,6 +35,7 @@ class SourceSpecTextBlockIndentationTest implements RewriteTest {
     @Test
     void minimalIndentation() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               import org.openrewrite.test.RewriteTest;
@@ -87,6 +88,7 @@ class SourceSpecTextBlockIndentationTest implements RewriteTest {
     @Test
     void startsOnNewline() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               import org.openrewrite.test.RewriteTest;

--- a/rewrite-java/src/test/java/org/openrewrite/java/CreateEmptyJavaClassTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/CreateEmptyJavaClassTest.java
@@ -59,7 +59,7 @@ class CreateEmptyJavaClassTest implements RewriteTest {
             "ExampleClass",
             true,
             null
-          )),
+          )).cycles(1).expectedCyclesThatMakeChanges(1),
           java(
             """
               package org.openrewrite.example;
@@ -131,7 +131,7 @@ class CreateEmptyJavaClassTest implements RewriteTest {
             "ExampleClass2",
             true,
             null
-          )),
+          )).cycles(1).expectedCyclesThatMakeChanges(1),
           java(
             """
               package org.openrewrite.example;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
@@ -17,10 +17,7 @@ package org.openrewrite.maven;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.RemoveContentVisitor;
@@ -76,7 +73,6 @@ public class AddProfile extends Recipe {
     }
 
     private class AddProfileVisitor extends MavenIsoVisitor<ExecutionContext> {
-
 
         @Override
         public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
@@ -29,7 +29,7 @@ public class AddProfileTest implements RewriteTest {
     @Test
     void addProfileToPom() {
         rewriteRun(
-          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
             "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
           pomXml(
             """
@@ -69,7 +69,7 @@ public class AddProfileTest implements RewriteTest {
     @Test
     void preExistingOtherProfile() {
         rewriteRun(
-          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
             "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
           pomXml(
             """
@@ -122,7 +122,7 @@ public class AddProfileTest implements RewriteTest {
     @Test
     void preExistingMatchingProfile() {
         rewriteRun(
-          spec -> spec.recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
+          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(new AddProfile("myprofile", "<activation><foo>foo</foo></activation>",
             "<properties><bar>bar</bar></properties>", "<build><param>value</param></build>")),
           pomXml(
             """

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/CreatePropertiesFileTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/CreatePropertiesFileTest.java
@@ -54,7 +54,7 @@ class CreatePropertiesFileTest implements RewriteTest {
             "test/test.properties",
             "after=true",
             true
-          )),
+          )).cycles(1).expectedCyclesThatMakeChanges(1),
           properties(
             "test.property=test",
             "after=true",

--- a/rewrite-test/src/main/java/org/openrewrite/test/LargeSourceSetCheckingExpectedCycles.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/LargeSourceSetCheckingExpectedCycles.java
@@ -45,6 +45,7 @@ class LargeSourceSetCheckingExpectedCycles extends InMemoryLargeSourceSet {
     private LargeSourceSetCheckingExpectedCycles(LargeSourceSetCheckingExpectedCycles from, @Nullable Map<SourceFile, List<Recipe>> deletions, List<SourceFile> mapped) {
         super(from.getInitialState(), deletions, mapped);
         this.expectedCyclesThatMakeChanges = from.expectedCyclesThatMakeChanges;
+        this.cyclesThatResultedInChanges = from.cyclesThatResultedInChanges;
         this.lastCycleEdits = from.lastCycleEdits;
         this.lastCycleGenerated = from.lastCycleGenerated;
         this.lastCycleDeleted = from.lastCycleDeleted;

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeNamespaceValueTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeNamespaceValueTest.java
@@ -25,7 +25,8 @@ class ChangeNamespaceValueTest implements RewriteTest {
     @Test
     void replaceVersion24Test() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/j2ee", "2.4", false)),
+          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/j2ee", "2.4", false))
+            .expectedCyclesThatMakeChanges(2),
           xml(
             """
               <web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.4"
@@ -50,7 +51,8 @@ class ChangeNamespaceValueTest implements RewriteTest {
     @Test
     void replaceVersion25Test() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/java", "2.5,3.0", false)),
+          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/java", "2.5,3.0", false))
+            .expectedCyclesThatMakeChanges(2),
           xml(
             """
               <web-app xmlns="http://java.sun.com/xml/ns/j2ee" version="2.5"
@@ -75,7 +77,8 @@ class ChangeNamespaceValueTest implements RewriteTest {
     @Test
     void replaceVersion30Test() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/java", "2.5,3.0", false)),
+          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://java.sun.com/xml/ns/java", "2.5,3.0", false))
+            .expectedCyclesThatMakeChanges(2),
           xml(
             """
               <web-app xmlns="http://java.sun.com/xml/ns/j2ee" version="3.0"
@@ -100,7 +103,8 @@ class ChangeNamespaceValueTest implements RewriteTest {
     @Test
     void replaceVersion31Test() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://xmlns.jcp.org/xml/ns/javaee", "3.1+", false)),
+          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://xmlns.jcp.org/xml/ns/javaee", "3.1+", false))
+            .expectedCyclesThatMakeChanges(2),
           xml(
             """
               <web-app xmlns="http://java.sun.com/xml/ns/j2ee" version="3.1"
@@ -125,7 +129,8 @@ class ChangeNamespaceValueTest implements RewriteTest {
     @Test
     void replaceVersion32Test() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://xmlns.jcp.org/xml/ns/javaee", "3.1+", false)),
+          spec -> spec.recipe(new ChangeNamespaceValue("web-app", null, "http://xmlns.jcp.org/xml/ns/javaee", "3.1+", false))
+            .expectedCyclesThatMakeChanges(2),
           xml(
             """
               <web-app xmlns="http://java.sun.com/xml/ns/j2ee" version="3.2"

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
@@ -48,7 +48,8 @@ class ChangeTagAttributeTest implements RewriteTest {
     @Test
     void alterAttributeWithNullOldValue() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", null, null)),
+          spec -> spec.recipe(new ChangeTagAttribute("bean", "id", "myBean2.subpackage", null, null))
+            .expectedCyclesThatMakeChanges(2),
           xml(
             """
               <beans>

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/CreateXmlFileTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/CreateXmlFileTest.java
@@ -67,7 +67,7 @@ class CreateXmlFileTest implements RewriteTest {
             "test/test.xml",
             fileContents,
             true
-          )),
+          )).cycles(1).expectedCyclesThatMakeChanges(1),
           xml(
             """
               <?xml version="1.0" encoding="UTF-8"?>

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -237,6 +237,7 @@ class MergeYamlTest implements RewriteTest {
     void insertYaml() {
         rewriteRun(
           spec -> spec
+            .cycles(2)
             .recipe(new MergeYaml(
               "$.spec",
               //language=yaml
@@ -584,6 +585,7 @@ class MergeYamlTest implements RewriteTest {
     void mergeSequenceMapAddAdditionalObject() {
         rewriteRun(
           spec -> spec
+            .expectedCyclesThatMakeChanges(2)
             .recipe(new MergeYaml(
               "$.testing",
               //language=yaml
@@ -619,6 +621,7 @@ class MergeYamlTest implements RewriteTest {
     void mergeSequenceMapAddObject() {
         rewriteRun(
           spec -> spec
+            .expectedCyclesThatMakeChanges(2)
             .recipe(new MergeYaml(
               "$.testing",
               //language=yaml
@@ -680,6 +683,7 @@ class MergeYamlTest implements RewriteTest {
     void mergeSequenceMapWhenOneIdenticalObjectExistsTheSecondIsAdded() {
         rewriteRun(
           spec -> spec
+            .expectedCyclesThatMakeChanges(2)
             .recipe(new MergeYaml(
               "$.testing",
               //language=yaml
@@ -717,6 +721,7 @@ class MergeYamlTest implements RewriteTest {
     void mergeSequenceMapWhenOneDifferentObjectExistsValuesAreChanged() {
         rewriteRun(
           spec -> spec
+            .expectedCyclesThatMakeChanges(2)
             .recipe(new MergeYaml(
               "$.testing",
               //language=yaml
@@ -750,6 +755,7 @@ class MergeYamlTest implements RewriteTest {
     void mergeSequenceMapAddComplexMapping() {
         rewriteRun(
           spec -> spec
+            .expectedCyclesThatMakeChanges(2)
             .recipe(new MergeYaml(
               "$.spec",
               //language=yaml
@@ -797,6 +803,7 @@ class MergeYamlTest implements RewriteTest {
     void mergeSequenceMapChangeComplexMapping() {
         rewriteRun(
           spec -> spec
+            .expectedCyclesThatMakeChanges(2)
             .recipe(new MergeYaml(
               "$.spec",
               //language=yaml


### PR DESCRIPTION
There appear to be quite a few more recipes which make additional invisible changes in the second cycle. As a quick fix this commit adds `expectedCyclesThatMakeChanges(2)` to these tests so they pass.
