### PR TITLE
Upgrade plugin versions in gradle.properties

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -190,7 +190,6 @@ public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.De
                         if (resolvedVersion != null) {
                             return entry.withValue(entry.getValue().withText(resolvedVersion));
                         }
-                        return entry.withValue(entry.getValue().withText(newVersion));
                     }
                 }
                 return entry;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -182,6 +182,31 @@ class UpgradePluginVersionTest implements RewriteTest {
         );
     }
 
+    @DocumentExample("Upgrading a build plugin with version in gradle.properties when upgrading to 5.40.X")
+    @Test
+    void upgradePluginVersionInPropertiesWhenUsingGlobs() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.40.X", null)),
+          properties(
+            """
+              rewriteVersion=5.40.0
+              """,
+            """
+              rewriteVersion=5.40.6
+              """,
+            spec -> spec.path("gradle.properties")
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'org.openrewrite.rewrite' version "$rewriteVersion"
+                  id 'com.github.johnrengelman.shadow' version '6.1.0'
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample("Don't touch gradle.properties if version is hardcoded in build.gradle")
     @Test
     void upgradePluginVersionInBuildGradleNotProperties() {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Change the gradle plugin property resolver to ignore unresolved versions instead of setting them - this mirrors what the groovy resolver does. This solves a problem whereby glob versions like "5.40.X" were getting set incorrectly.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @shanman190 
