### PR TITLE
Find Committers on freshly cloned repositories

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -322,10 +322,11 @@ public class GitProvenance implements Marker {
         try (Git git = Git.open(repository.getDirectory())) {
             ObjectId head = repository.readOrigHead();
             if (head == null) {
-                head = repository.getRefDatabase().findRef("HEAD").getObjectId();
-                if (head == null) {
+                Ref headRef = repository.getRefDatabase().findRef("HEAD");
+                if (headRef == null) {
                     return emptyList();
                 }
+                head = headRef.getObjectId();
             }
 
             Map<String, Committer> committers = new TreeMap<>();

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -321,8 +321,11 @@ public class GitProvenance implements Marker {
     private static List<Committer> getCommitters(Repository repository) {
         try (Git git = Git.open(repository.getDirectory())) {
             ObjectId head = repository.readOrigHead();
-            if(head == null) {
-                return emptyList();
+            if (head == null) {
+                head = repository.getRefDatabase().findRef("HEAD").getObjectId();
+                if (head == null) {
+                    return emptyList();
+                }
             }
 
             Map<String, Committer> committers = new TreeMap<>();


### PR DESCRIPTION
When a repository is freshly cloned and no other actions have been taken (like pull) ORIG_HEAD is not available. Using HEAD as a fallback works to find the committers.