### PR TITLE
Add null check. A non null ref can point to a null objectId:

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -322,11 +322,15 @@ public class GitProvenance implements Marker {
         try (Git git = Git.open(repository.getDirectory())) {
             ObjectId head = repository.readOrigHead();
             if (head == null) {
-                Ref headRef = repository.getRefDatabase().findRef("HEAD");
-                if (headRef == null) {
+                try {
+                    Ref headRef = repository.getRefDatabase().findRef("HEAD");
+                    if (headRef == null || headRef.getObjectId() == null) {
+                        return emptyList();
+                    }
+                    head = headRef.getObjectId();
+                } catch (Exception ignored) {
                     return emptyList();
                 }
-                head = headRef.getObjectId();
             }
 
             Map<String, Committer> committers = new TreeMap<>();

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -322,15 +322,11 @@ public class GitProvenance implements Marker {
         try (Git git = Git.open(repository.getDirectory())) {
             ObjectId head = repository.readOrigHead();
             if (head == null) {
-                try {
-                    Ref headRef = repository.getRefDatabase().findRef("HEAD");
-                    if (headRef == null || headRef.getObjectId() == null) {
-                        return emptyList();
-                    }
-                    head = headRef.getObjectId();
-                } catch (Exception ignored) {
+                Ref headRef = repository.getRefDatabase().findRef("HEAD");
+                if (headRef == null || headRef.getObjectId() == null) {
                     return emptyList();
                 }
+                head = headRef.getObjectId();
             }
 
             Map<String, Committer> committers = new TreeMap<>();


### PR DESCRIPTION
## What's changed?
Add null check for objectId

## What's your motivation?
A non null ref can have a null objectId (if there are no commits):
SymbolicRef[HEAD -> refs/heads/main=0000000000000000000000000000000000000000(-1)]