### PR TITLE
`@PackageRecipeTags` annotation on `package-info.java`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/PackageRecipeTags.java
+++ b/rewrite-core/src/main/java/org/openrewrite/PackageRecipeTags.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.openrewrite.config.RecipeDescriptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A package-level annotation that can be used to tag all {@link Recipe} within a given package and children
+ * packages with a given tag.
+ * <p>
+ * This annotation is useful for tagging all recipes within a package with a given tag, without having to
+ * add it manually to each overridden {@link Recipe#getTags()} method.
+ * <p>
+ * The tag will not be accessible via {@link Recipe#getTags()}, but will be accessible via {@link RecipeDescriptor#getTags()}
+ * when the {@link RecipeDescriptor} is created via {@link Recipe#getDescriptor()}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE})
+public @interface PackageRecipeTags {
+    String[] value() default {};
+}

--- a/rewrite-core/src/test/java/org/openrewrite/tags/PackageRecipeTagsAnnotationTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/tags/PackageRecipeTagsAnnotationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.tags;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.tags.child.ChildRecipeWithNoTags;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PackageRecipeTagsAnnotationTest {
+
+    private static class RecipeWithNoTags extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Recipe with no tags";
+        }
+
+        @Override
+        public String getDescription() {
+            return "It's tag-less!";
+        }
+
+        @Override
+        public Set<String> getTags() {
+            // Look ma, no tags! 🤣
+            return Collections.emptySet();
+        }
+    }
+
+    @Test
+    void testRecipeWithNoTags() {
+        RecipeWithNoTags recipe = new RecipeWithNoTags();
+        RecipeDescriptor descriptor = recipe.getDescriptor();
+        assertThat(descriptor.getTags())
+          .withFailMessage("Expected tag to be pulled from package-info.java")
+          .contains("What a fun tag!");
+    }
+
+    @Test
+    void testChildRecipeWithNoTags() {
+        ChildRecipeWithNoTags recipe = new ChildRecipeWithNoTags();
+        RecipeDescriptor descriptor = recipe.getDescriptor();
+        assertThat(descriptor.getTags())
+          .withFailMessage("Expected tag to be pulled from parent package-info.java")
+          .contains("What a fun tag!");
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/tags/child/ChildRecipeWithNoTags.java
+++ b/rewrite-core/src/test/java/org/openrewrite/tags/child/ChildRecipeWithNoTags.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.tags.child;
+
+import org.openrewrite.Recipe;
+
+public class ChildRecipeWithNoTags extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Recipe with no tags";
+    }
+
+    @Override
+    public String getDescription() {
+        return "It's tag-less!";
+    }
+
+}

--- a/rewrite-core/src/test/java/org/openrewrite/tags/child/package-info.java
+++ b/rewrite-core/src/test/java/org/openrewrite/tags/child/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.openrewrite.tags.child;
+
+import io.micrometer.core.lang.NonNullApi;

--- a/rewrite-core/src/test/java/org/openrewrite/tags/package-info.java
+++ b/rewrite-core/src/test/java/org/openrewrite/tags/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@PackageRecipeTags({"What a fun tag!"})
+@NonNullApi
+package org.openrewrite.tags;
+
+import org.openrewrite.PackageRecipeTags;
+import org.openrewrite.internal.lang.NonNullApi;


### PR DESCRIPTION
Adds a package level annotation for adding tags to recipes at the
package-level scope.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

`Recipe#getDescriptor` now looks for Recipe tags on `package-info.java`, as well as parent `package-info.java`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

When writing recipes that all fall into a similar set of tags, for example `security` recipes, you likely want to
tag recipes at the package level, so you don't need to add the same exact tag to every single `Recipe`.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

Is the `PackageRecipeTags` annotation name fine?

## Anyone you would like to review specifically?
<!-- @mention them here -->

Anyone!

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

Could write an OpenRewrite-OpenRewrite recipe that modifies every recipe in a package to add a tag.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
