### PR TITLE
fix: prevent all referenced properties from updating to latest regardless of recipe

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -236,6 +236,9 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     public org.openrewrite.properties.tree.Properties visitEntry(Properties.Entry entry, ExecutionContext ctx) {
                         if (acc.buildDependencies.containsKey(entry.getKey()) && acc.gradleProject != null) {
                             GroupArtifact groupArtifact = acc.buildDependencies.get(entry.getKey());
+                            if(groupArtifact == null || !dependencyMatcher.matches(groupArtifact.getGroupId(), groupArtifact.getArtifactId())) {
+                                return entry;
+                            }
                             if (!StringUtils.isBlank(newVersion)) {
                                 String resolvedVersion;
                                 try {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -666,4 +666,38 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void globVersionsInPropertiesFileWithMultipleVersionsOnlyUpdatesCorrectProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.springframework.security", "*", "5.4.x", null)),
+          properties(
+            """
+              springBootVersion=3.0.0
+              springSecurityVersion=5.4.0
+              """,
+            """
+              springBootVersion=3.0.0
+              springSecurityVersion=5.4.11
+              """,
+            spec -> spec.path("gradle.properties")
+          ),
+          buildGradle(
+            """
+                plugins {
+                    id 'java'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencies {
+                    implementation("org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}")
+                    implementation("org.springframework.security:spring-security-oauth2-core:${springSecurityVersion}")
+                }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fixing a bug in the Properties visitor for the rewrite-gradle plugin which failed to check whether the property currently being visited is referenced by the GroupArtifact that the recipe refers to


## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek and @shanman190  have the context for this

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
