### PR TITLE
feat: add from date option to FindCommitters recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
@@ -38,7 +38,7 @@ public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Com
 
     @Option(displayName = "From date",
             required = false,
-            description = "Optional. Take into account only commits after this date. Default will be the entire history.",
+            description = "Optional. Take into account only commits since this date (inclusive). Default will be the entire history.",
             example = "2023-01-01")
     @Nullable
     String fromDate;

--- a/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
@@ -22,6 +22,7 @@ import org.openrewrite.marker.SearchResult;
 import org.openrewrite.table.CommitsByDay;
 import org.openrewrite.table.DistinctCommitters;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -30,6 +31,13 @@ import java.util.TreeMap;
 public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Committer>> {
     private transient final DistinctCommitters committers = new DistinctCommitters(this);
     private transient final CommitsByDay commitsByDay = new CommitsByDay(this);
+
+    @Option(displayName = "From date",
+            required = false,
+            description = "Optional. Take into account only commits after this date. Default will be the entire history.",
+            example = "2023-01-01")
+    @Nullable
+    String fromDate;
 
     @Override
     public String getDisplayName() {
@@ -48,6 +56,7 @@ public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Com
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Map<String, GitProvenance.Committer> acc) {
+        LocalDate from = this.fromDate == null ? null : LocalDate.parse(this.fromDate).minusDays(1);
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
@@ -56,7 +65,9 @@ public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Com
                     sourceFile.getMarkers().findFirst(GitProvenance.class).ifPresent(provenance -> {
                         if (provenance.getCommitters() != null) {
                             for (GitProvenance.Committer committer : provenance.getCommitters()) {
-                                acc.put(committer.getEmail(), committer);
+                                if (from == null || committer.getCommitsByDay().keySet().stream().anyMatch(day -> day.isAfter(from))) {
+                                    acc.put(committer.getEmail(), committer);
+                                }
                             }
                         }
                     });

--- a/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.search;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.GitProvenance;
@@ -28,6 +30,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Committer>> {
     private transient final DistinctCommitters committers = new DistinctCommitters(this);
     private transient final CommitsByDay commitsByDay = new CommitsByDay(this);

--- a/rewrite-core/src/test/java/org/openrewrite/search/FindCommittersTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/search/FindCommittersTest.java
@@ -21,7 +21,6 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -60,13 +59,13 @@ public class FindCommittersTest implements RewriteTest {
         GitProvenance git = new GitProvenance(
           randomId(), "github.com", "main", "123", null, null,
           List.of(new GitProvenance.Committer("Jon", "jkschneider@gmail.com",
-            new TreeMap<>() {{
-                put(LocalDate.of(2023,1,9), 5);
-                put(LocalDate.of(2023,1,1), 5);
-            }}),
+              new TreeMap<>() {{
+                  put(LocalDate.of(2023, 1, 9), 5);
+                  put(LocalDate.of(2023, 1, 1), 5);
+              }}),
             new GitProvenance.Committer("Peter", "p.streef@gmail.com",
               new TreeMap<>() {{
-                  put(LocalDate.of(2023,1,10), 5);
+                  put(LocalDate.of(2023, 1, 10), 5);
               }}))
         );
 


### PR DESCRIPTION
## What's changed?
An option added to the FindCommitters recipe to only list committers since a specific date

## What's your motivation?
I want to filter on committers from the last N days

## Anything in particular you'd like reviewers to focus on?
no

## Anyone you would like to review specifically?
no

## Have you considered any alternatives or workarounds?
Yes, doing this on the consumer side, but this is more useful for everyone.

## Any additional context
no

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
