### PR TITLE
Make DependencyUseStringNotation compatible with G.GString

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
@@ -29,10 +29,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.openrewrite.Tree.randomId;
 
@@ -153,6 +150,21 @@ public class DependencyUseStringNotation extends Recipe {
                     return (String) ((J.Literal) expression).getValue();
                 } else if (expression instanceof J.Identifier) {
                     return "$" + ((J.Identifier) expression).getSimpleName();
+                } else if (expression instanceof G.GString) {
+                    List<J> str = ((G.GString) expression).getStrings();
+                    StringBuilder sb = new StringBuilder();
+                    for (J valuePart : str) {
+                        if (valuePart instanceof Expression) {
+                            sb.append(coerceToStringNotation((Expression) valuePart));
+                        } else if (valuePart instanceof G.GString.Value) {
+                            J tree = ((G.GString.Value) valuePart).getTree();
+                            if (tree instanceof Expression) {
+                                sb.append(coerceToStringNotation((Expression) tree));
+                            }
+                            //Can it be something else? If so, what?
+                        }
+                    }
+                    return sb.toString();
                 }
                 return null;
             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
@@ -29,7 +29,11 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.openrewrite.Tree.randomId;
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -115,6 +115,36 @@ class DependencyUseStringNotationTest implements RewriteTest {
     }
 
     @Test
+    void withGStringLiteral() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              def version = "latest.release"
+              dependencies {
+                  api(group: 'org.openrewrite', name: 'rewrite-core', version: "$version")
+                  implementation group: 'group', name: 'artifact', version: "$version"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              def version = "latest.release"
+              dependencies {
+                  api("org.openrewrite:rewrite-core:$version")
+                  implementation "group:artifact:$version"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void withoutVersion() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
## What's changed?
Added support in the `DependencyUseStringNotation.coerceToStringNotation` method for GString to String

## What's your motivation?
closes #3959 

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
As currently the variable is just not in output, it think, although perhaps not completely mapping all kinds of GString's, this is still better as it supports something more. 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [] I've used the IntelliJ IDEA auto-formatter on affected files
