### PR TITLE
Also update Maven managed dependency by default in `ChangeDependencyGroupIdAndArtifactId`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -88,18 +88,18 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
     @Nullable
     Boolean overrideManagedVersion;
 
+    @Option(displayName = "Update dependency management",
+            description = "Also update the dependency management section. The default for this flag is `true`.",
+            required = false)
+    @Nullable
+    Boolean changeManagedDependency;
+
     public ChangeDependencyGroupIdAndArtifactId(String oldGroupId, String oldArtifactId, @Nullable String newGroupId, @Nullable String newArtifactId, @Nullable String newVersion, @Nullable String versionPattern) {
-        this.oldGroupId = oldGroupId;
-        this.oldArtifactId = oldArtifactId;
-        this.newGroupId = newGroupId;
-        this.newArtifactId = newArtifactId;
-        this.newVersion = newVersion;
-        this.versionPattern = versionPattern;
-        this.overrideManagedVersion = false;
+        this(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, false, true);
     }
 
     @JsonCreator
-    public ChangeDependencyGroupIdAndArtifactId(String oldGroupId, String oldArtifactId, @Nullable String newGroupId, @Nullable String newArtifactId, @Nullable String newVersion, @Nullable String versionPattern, @Nullable Boolean overrideManagedVersion) {
+    public ChangeDependencyGroupIdAndArtifactId(String oldGroupId, String oldArtifactId, @Nullable String newGroupId, @Nullable String newArtifactId, @Nullable String newVersion, @Nullable String versionPattern, @Nullable Boolean overrideManagedVersion, @Nullable Boolean changeManagedDependency) {
         this.oldGroupId = oldGroupId;
         this.oldArtifactId = oldArtifactId;
         this.newGroupId = newGroupId;
@@ -107,6 +107,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
         this.newVersion = newVersion;
         this.versionPattern = versionPattern;
         this.overrideManagedVersion = overrideManagedVersion;
+        this.changeManagedDependency = changeManagedDependency;
     }
 
     @Override
@@ -146,7 +147,6 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-
         return new MavenVisitor<ExecutionContext>() {
             @Nullable
             final VersionComparator versionComparator = newVersion != null ? Semver.validate(newVersion, versionPattern).getValue() : null;
@@ -154,10 +154,21 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
             private Collection<String> availableVersions;
 
             @Override
+            public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
+                // Any managed dependency change is unlikely to use the same version, so only update selectively.
+                if ((changeManagedDependency == null || changeManagedDependency) && newVersion != null || versionPattern != null) {
+                    doAfterVisit(new ChangeManagedDependencyGroupIdAndArtifactId(
+                            oldGroupId, oldArtifactId,
+                            Optional.ofNullable(newGroupId).orElse(oldGroupId),
+                            Optional.ofNullable(newArtifactId).orElse(oldArtifactId),
+                            newVersion, versionPattern).getVisitor());
+                }
+                return super.visitDocument(document, ctx);
+            }
+
+            @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
-
                 Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
-
                 if (isDependencyTag(oldGroupId, oldArtifactId)) {
                     String groupId = newGroupId;
                     if (groupId != null) {
@@ -177,21 +188,26 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                             Optional<Xml.Tag> scopeTag = t.getChild("scope");
                             Scope scope = scopeTag.map(xml -> Scope.fromName(xml.getValue().orElse("compile"))).orElse(Scope.Compile);
                             Optional<Xml.Tag> versionTag = t.getChild("version");
-                            if (!versionTag.isPresent() &&
-                                (Boolean.TRUE.equals(overrideManagedVersion) || !isDependencyManaged(scope, groupId, artifactId))) {
+
+                            boolean configuredToOverrideManageVersion = overrideManagedVersion != null && overrideManagedVersion; // False by default
+                            boolean configuredToChangeManagedDependency = changeManagedDependency == null || changeManagedDependency; // True by default
+
+                            boolean versionTagPresent = versionTag.isPresent();
+                            boolean oldDependencyManaged = isDependencyManaged(scope, oldGroupId, oldArtifactId);
+                            boolean newDependencyManaged = isDependencyManaged(scope, groupId, artifactId);
+                            if (versionTagPresent) {
+                                // If the previous dependency had a version but the new artifact is managed, removed the version tag.
+                                if (!configuredToOverrideManageVersion && newDependencyManaged || (oldDependencyManaged && configuredToChangeManagedDependency)) {
+                                    t = (Xml.Tag) new RemoveContentVisitor<>(versionTag.get(), false).visit(t, ctx);
+                                } else {
+                                    // Otherwise, change the version to the new value.
+                                    t = changeChildTagValue(t, "version", resolvedNewVersion, ctx);
+                                }
+                            } else if (configuredToOverrideManageVersion || !newDependencyManaged && !(oldDependencyManaged && configuredToChangeManagedDependency)) {
                                 //If the version is not present, add the version if we are explicitly overriding a managed version or if no managed version exists.
                                 Xml.Tag newVersionTag = Xml.Tag.build("<version>" + resolvedNewVersion + "</version>");
                                 //noinspection ConstantConditions
                                 t = (Xml.Tag) new AddToTagVisitor<ExecutionContext>(t, newVersionTag, new MavenTagInsertionComparator(t.getChildren())).visitNonNull(t, ctx, getCursor().getParent());
-                            } else if (versionTag.isPresent()) {
-                                if (isDependencyManaged(scope, groupId, artifactId) && !Boolean.TRUE.equals(overrideManagedVersion)) {
-                                    //If the previous dependency had a version but the new artifact is managed, removed the
-                                    //version tag.
-                                    t = (Xml.Tag) new RemoveContentVisitor<>(versionTag.get(), false).visit(t, ctx);
-                                } else {
-                                    //Otherwise, change the version to the new value.
-                                    t = changeChildTagValue(t, "version", resolvedNewVersion, ctx);
-                                }
                             }
                         } catch (MavenDownloadingException e) {
                             return e.warn(tag);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/RetainVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/RetainVersions.java
@@ -48,7 +48,7 @@ public class RetainVersions {
             // optimization for glob GAVs: more efficient to use one CDGIAAI recipe if they all will have the same version anyway
             if (requestedRetainedVersion != null && noneMatch(existingDependencies, it -> it.getChild("version").isPresent())) {
                 recipes.add(new ChangeDependencyGroupIdAndArtifactId(requestedRetainedGroupId, requestedRetainedArtifactId, null, null,
-                        requestedRetainedVersion, null, true));
+                        requestedRetainedVersion, null, true, true));
                 continue;
             }
 
@@ -72,7 +72,7 @@ public class RetainVersions {
                     }
                 }
                 recipes.add(new ChangeDependencyGroupIdAndArtifactId(retainedGroupId, retainedArtifactId, null, null,
-                        retainedVersion, null, true));
+                        retainedVersion, null, true, true));
             }
         }
         return recipes;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -25,7 +25,6 @@ import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
-
     @DocumentExample
     @Test
     void changeDependencyGroupIdAndArtifactId() {
@@ -100,6 +99,55 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
     }
 
     @Test
+    void changeManagedDependencyGroupIdAndArtifactId() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "1.2.x",
+            null)),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>javax.activation</groupId>
+                              <artifactId>javax.activation-api</artifactId>
+                              <version>1.2.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                              <version>1.2.2</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/55")
     void requireNewGroupIdOrNewArtifactId() {
         assertThatExceptionOfType(AssertionError.class)
@@ -107,7 +155,6 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
               "javax.activation",
               "javax.activation-api",
-              null,
               null,
               null,
               null,
@@ -127,7 +174,6 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
               "javax.activation",
               null,
               null,
-              null,
               null
             ))
           )).withMessageContaining("newGroupId OR newArtifactId must be different from before");
@@ -143,7 +189,8 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "jakarta.activation-api",
             "1.2.2",
             null,
-            true
+            true,
+            false
           )),
           pomXml(
             """
@@ -216,7 +263,70 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "jakarta.activation",
             "jakarta.activation-api",
             "1.2.2",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.activation</groupId>
+                          <artifactId>javax.activation-api</artifactId>
+                      </dependency>
+                  </dependencies>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>javax.activation</groupId>
+                              <artifactId>javax.activation-api</artifactId>
+                              <version>1.2.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.activation</groupId>
+                          <artifactId>jakarta.activation-api</artifactId>
+                      </dependency>
+                  </dependencies>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>jakarta.activation</groupId>
+                              <artifactId>jakarta.activation-api</artifactId>
+                              <version>1.2.2</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void managedToUnmanagedWithoutChangeManagedDependency() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "1.2.2",
             null,
+            false,
             false
           )),
           pomXml(
@@ -280,8 +390,7 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "jakarta.activation",
             "jakarta.activation-api",
             "1.2.2",
-            null,
-            false
+            null
           )),
           pomXml(
             """
@@ -345,7 +454,8 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "jakarta.activation-api",
             "1.2.2",
             null,
-            true
+            true,
+            null
           )),
           pomXml(
             """
@@ -409,7 +519,6 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
             "jakarta.activation",
             "jakarta.activation-api",
             "1.2.2",
-            null,
             null
           )),
           pomXml(


### PR DESCRIPTION
## What's changed?
Also update Maven managed dependencies by default in ChangeDependencyGroupIdAndArtifactId 

## What's your motivation?
By customer request to be less surprising by default: a change in the GAV should propagate to managed dependencies too by default, not require the same parameters passed into `ChangeManagedDependencyGroupIdAndArtifactId` a second time.

## Anything in particular you'd like reviewers to focus on?
There was a surprising bit of depth to this into how the various arguments work together, and what might be desired from a user's perspective; I hope the named variables in the decision logic help follow along and troubleshoot if there are any issues.

I've chosen to only update the managed dependency GAV is a version argument is already provided, as it's quite unlikely that a GAV change uses the same version, and we don't want to have failures to resolve the managed dependency. I specifically chose not to insert a version ourselves if none is provided; it is then better not to change the managed dependency at all.

## Have you considered any alternatives or workarounds?
This does what a user would expect by default: a changed GAV extends to managed dependencies unless explicitly disabled.