### PR TITLE
Changes packaging only if it matches provided packaging

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePackaging.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePackaging.java
@@ -29,6 +29,8 @@ import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.Optional;
+
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 import static org.openrewrite.xml.AddOrUpdateChild.addOrUpdateChild;
 import static org.openrewrite.xml.FilterTagChildrenVisitor.filterTagChildren;
@@ -54,6 +56,13 @@ public class ChangePackaging extends Recipe {
     @Nullable
     String packaging;
 
+    @Option(displayName = "Old Packaging",
+            description = "The old packaging type. If provided, will only change if the current packaging matches",
+            required = false,
+            example = "jar")
+    @Nullable
+    String oldPackaging;
+
     @Override
     public String getDisplayName() {
         return "Set Maven project packaging";
@@ -70,30 +79,36 @@ public class ChangePackaging extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new MavenVisitor<ExecutionContext>() {
+        return new MavenIsoVisitor<ExecutionContext>() {
             @Override
-            public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
                 ResolvedPom pom = getResolutionResult().getPom();
-                if (!(matchesGlob(pom.getGroupId(), groupId) && matchesGlob(pom.getArtifactId(), artifactId))) {
+                if (!matchesGlob(pom.getGroupId(), groupId) || !matchesGlob(pom.getArtifactId(), artifactId)) {
                     return document;
                 }
-                document = document.withMarkers(document.getMarkers().withMarkers(ListUtils.map(document.getMarkers().getMarkers(), m -> {
-                    if (m instanceof MavenResolutionResult) {
-                        return getResolutionResult().withPom(pom.withRequested(pom.getRequested().withPackaging(packaging)));
-                    }
-                    return m;
-                })));
-                return super.visitDocument(document, ctx);
+                Xml.Document xml = super.visitDocument(document, ctx);
+                if (xml != document) {
+                    return xml.withMarkers(xml.getMarkers().withMarkers(ListUtils.map(xml.getMarkers().getMarkers(), m -> {
+                        if (m instanceof MavenResolutionResult) {
+                            return getResolutionResult().withPom(pom.withRequested(pom.getRequested().withPackaging(packaging)));
+                        }
+                        return m;
+                    })));
+                }
+                return xml;
             }
 
             @Override
-            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
-                Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
                 if (PROJECT_MATCHER.matches(getCursor())) {
-                    if (packaging == null || "jar".equals(packaging)) {
-                        t = filterTagChildren(t, it -> !"packaging".equals(it.getName()));
-                    } else {
-                        t = addOrUpdateChild(t, Xml.Tag.build("\n<packaging>" + packaging + "</packaging>"), getCursor().getParentOrThrow());
+                    Optional<Xml.Tag> maybePackaging = t.getChild("packaging");
+                    if (!maybePackaging.isPresent() || oldPackaging == null || oldPackaging.equals(maybePackaging.get().getValue().orElse(null))) {
+                        if (packaging == null || "jar".equals(packaging)) {
+                            t = filterTagChildren(t, it -> !"packaging".equals(it.getName()));
+                        } else {
+                            t = addOrUpdateChild(t, Xml.Tag.build("\n<packaging>" + packaging + "</packaging>"), getCursor().getParentOrThrow());
+                        }
                     }
                 }
                 return t;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePackagingTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePackagingTest.java
@@ -27,9 +27,9 @@ class ChangePackagingTest implements RewriteTest {
     @Test
     void addPackaging() {
         rewriteRun(
-          spec -> spec.recipe(new ChangePackaging("*", "*", "pom")),
+          spec -> spec.recipe(new ChangePackaging("*", "*", "pom", null)),
           pomXml(
-"""
+            """
               <project>
                   <groupId>org.example</groupId>
                   <artifactId>foo</artifactId>
@@ -51,9 +51,9 @@ class ChangePackagingTest implements RewriteTest {
     @Test
     void removePackaging() {
         rewriteRun(
-          spec -> spec.recipe(new ChangePackaging("*", "*", null)),
+          spec -> spec.recipe(new ChangePackaging("*", "*", null, null)),
           pomXml(
-"""
+            """
               <project>
                   <groupId>org.example</groupId>
                   <artifactId>foo</artifactId>
@@ -75,9 +75,9 @@ class ChangePackagingTest implements RewriteTest {
     @Test
     void changePackaging() {
         rewriteRun(
-          spec -> spec.recipe(new ChangePackaging("*", "*", "pom")),
+          spec -> spec.recipe(new ChangePackaging("*", "*", "pom", null)),
           pomXml(
-"""
+            """
               <project>
                   <groupId>org.example</groupId>
                   <artifactId>foo</artifactId>
@@ -100,9 +100,50 @@ class ChangePackagingTest implements RewriteTest {
     @Test
     void changePackagingRemovingDefault() {
         rewriteRun(
-          spec -> spec.recipe(new ChangePackaging("*", "*", "jar")),
+          spec -> spec.recipe(new ChangePackaging("*", "*", "jar", null)),
           pomXml(
-"""
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+                  <packaging>war</packaging>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangesIfOldPackagingDoesNotMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackaging("*", "*", "jar", "bundle")),
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+                  <packaging>war</packaging>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void changePackageIfMatches() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackaging("*", "*", "jar", "war")),
+          pomXml(
+            """
               <project>
                   <groupId>org.example</groupId>
                   <artifactId>foo</artifactId>


### PR DESCRIPTION
## What's changed?
Added option to `ChangePackaging` to match the pom's packaging before changes

## What's your motivation?
Change only packaging of a specific type

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
No

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
