### PR TITLE
Less than 100 response status implies bad connection

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -737,7 +737,7 @@ public class MavenPomDownloader {
                     if (t instanceof HttpSenderResponseException) {
                         HttpSenderResponseException e = (HttpSenderResponseException) t;
                         // response was returned from the server, but it was not a 200 OK. The server therefore exists.
-                        if (e.getResponseCode() != null && e.getResponseCode() > 0) {
+                        if (e.isServerReached()) {
                             normalized = repository.withUri(httpsUri);
                         }
                         if (!"Directory listing forbidden".equals(e.getBody())) {
@@ -759,7 +759,7 @@ public class MavenPomDownloader {
                                         repository.getPassword());
                             } catch (HttpSenderResponseException e) {
                                 //Response was returned from the server, but it was not a 200 OK. The server therefore exists.
-                                if (e.getResponseCode() != null && e.getResponseCode() > 0) {
+                                if (e.isServerReached()) {
                                     normalized = new MavenRepository(
                                             repository.getId(),
                                             originalUrl,
@@ -892,6 +892,11 @@ public class MavenPomDownloader {
 
         public boolean isAccessDenied() {
             return responseCode != null && 400 < responseCode && responseCode <= 403;
+        }
+
+        // Any response code below 100 implies that no connection was made. Sometimes 0 or -1 is used for connection failures.
+        public boolean isServerReached() {
+            return responseCode != null && responseCode >= 100;
         }
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -737,7 +737,7 @@ public class MavenPomDownloader {
                     if (t instanceof HttpSenderResponseException) {
                         HttpSenderResponseException e = (HttpSenderResponseException) t;
                         // response was returned from the server, but it was not a 200 OK. The server therefore exists.
-                        if (e.getResponseCode() != null) {
+                        if (e.getResponseCode() != null && e.getResponseCode() > 0) {
                             normalized = repository.withUri(httpsUri);
                         }
                         if (!"Directory listing forbidden".equals(e.getBody())) {
@@ -759,7 +759,7 @@ public class MavenPomDownloader {
                                         repository.getPassword());
                             } catch (HttpSenderResponseException e) {
                                 //Response was returned from the server, but it was not a 200 OK. The server therefore exists.
-                                if (e.getResponseCode() != null) {
+                                if (e.getResponseCode() != null && e.getResponseCode() > 0) {
                                     normalized = new MavenRepository(
                                             repository.getId(),
                                             originalUrl,


### PR DESCRIPTION
## What's changed?
When deciding if a HttpSender response has reached a server, ignore  lower than 100 response codes

## What's your motivation?
Currently a -1 response code can be returned when the server was not reachable.