### PR TITLE
refactor: Use of `@EqualsAndHashCode` on `Recipe`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/DeleteSourceFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/DeleteSourceFiles.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DeleteSourceFiles extends Recipe {
 
     @Option(displayName = "File pattern",

--- a/rewrite-core/src/main/java/org/openrewrite/FindCollidingSourceFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindCollidingSourceFiles.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindCollidingSourceFiles extends ScanningRecipe<FindCollidingSourceFiles.Accumulator> {
 
     transient CollidingSourceFiles collidingSourceFiles = new CollidingSourceFiles(this);

--- a/rewrite-core/src/main/java/org/openrewrite/FindDeserializationErrors.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindDeserializationErrors.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 import static java.time.ZoneOffset.UTC;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindDeserializationErrors extends Recipe {
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/FindLstProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindLstProvenance.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import static java.time.ZoneOffset.UTC;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindLstProvenance extends ScanningRecipe<FindLstProvenance.Accumulator> {
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/FindParseFailures.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindParseFailures.java
@@ -24,7 +24,7 @@ import org.openrewrite.table.ParseFailures;
 import java.util.Objects;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindParseFailures extends Recipe {
 
     @Option(displayName = "Max snippet length",

--- a/rewrite-core/src/main/java/org/openrewrite/FindQuarks.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindQuarks.java
@@ -24,7 +24,7 @@ import org.openrewrite.quark.Quark;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindQuarks extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-core/src/main/java/org/openrewrite/FindSourceFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FindSourceFiles.java
@@ -26,7 +26,7 @@ import java.nio.file.Path;
 
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindSourceFiles extends Recipe {
     transient SourcesFiles results = new SourcesFiles(this);
 

--- a/rewrite-core/src/main/java/org/openrewrite/IsInRepository.java
+++ b/rewrite-core/src/main/java/org/openrewrite/IsInRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class IsInRepository extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-core/src/main/java/org/openrewrite/RenameFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RenameFile.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RenameFile extends Recipe {
     @Option(displayName = "File matcher",
             description = "Matching files will be renamed. This is a glob expression.",

--- a/rewrite-core/src/main/java/org/openrewrite/SetFilePermissions.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SetFilePermissions.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class SetFilePermissions extends Recipe {
     @Option(displayName = "File matcher",
             description = "Permissions will be applied to matching files. This is a glob expression.",

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -124,7 +124,7 @@ public class DeclarativeRecipe extends Recipe {
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     @RequiredArgsConstructor
     static class PreconditionBellwether extends Recipe {
 
@@ -162,7 +162,7 @@ public class DeclarativeRecipe extends Recipe {
         }
     }
 
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     @Value
     static class BellwetherDecoratedRecipe extends Recipe {
 
@@ -196,7 +196,7 @@ public class DeclarativeRecipe extends Recipe {
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     static class BellwetherDecoratedScanningRecipe<T>  extends ScanningRecipe<T> {
 
         DeclarativeRecipe.PreconditionBellwether bellwether;
@@ -318,7 +318,7 @@ public class DeclarativeRecipe extends Recipe {
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     private static class LazyLoadedRecipe extends Recipe {
         String recipeFqn;
 

--- a/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Committer>> {
     private transient final DistinctCommitters committers = new DistinctCommitters(this);
     private transient final CommitsByDay commitsByDay = new CommitsByDay(this);

--- a/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/AppendToTextFile.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AppendToTextFile extends ScanningRecipe<AtomicBoolean> {
     @Option(displayName = "Relative File Name",
             description = "File name, using a relative path. If a non-plaintext file already exists at this location, then this recipe will do nothing.",

--- a/rewrite-core/src/main/java/org/openrewrite/text/Find.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/Find.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class Find extends Recipe {
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindAndReplace extends Recipe {
 
     @Option(displayName = "Find",

--- a/rewrite-core/src/main/java/org/openrewrite/text/FindMultiselect.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindMultiselect.java
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toSet;
 
 @Incubating(since = "8.2.0")
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindMultiselect extends Recipe {
 
     @Override

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -84,7 +84,7 @@ class RecipeLifecycleTest implements RewriteTest {
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     static class DeleteFirst extends Recipe {
 
         @Override

--- a/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
@@ -128,7 +128,7 @@ class FindAndReplaceTest implements RewriteTest {
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     static class MultiFindAndReplace extends Recipe {
 
         @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -37,7 +37,7 @@ import java.util.*;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
 
     @EqualsAndHashCode.Exclude

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -45,7 +45,7 @@ import java.util.*;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeDependency extends Recipe {
     @Option(displayName = "Old groupId",
             description = "The old groupId to replace. The groupId is the first part of a dependency coordinate 'com.google.guava:guava:VERSION'. Supports glob expressions.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class ChangeDependencyArtifactId extends Recipe {
     @Option(displayName = "Group",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
@@ -36,7 +36,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeDependencyClassifier extends Recipe {
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyConfiguration.java
@@ -33,7 +33,7 @@ import java.time.Duration;
 import java.util.List;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeDependencyConfiguration extends Recipe {
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyExtension.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyExtension.java
@@ -36,7 +36,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeDependencyExtension extends Recipe {
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class ChangeDependencyGroupId extends Recipe {
     @Option(displayName = "Group",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeExtraProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeExtraProperty.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeExtraProperty extends Recipe {
 
     @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveDependency extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRepository.java
@@ -23,7 +23,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveRepository extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -49,7 +49,7 @@ import static org.openrewrite.internal.StringUtils.isBlank;
 
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.GradleWrapperState> {
 
     @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
@@ -35,7 +35,7 @@ import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpdateJavaCompatibility extends Recipe {
     @Option(displayName = "Java version",
             description = "The Java version to upgrade to.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -496,7 +496,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     private class UpdateVariable extends GroovyIsoVisitor<ExecutionContext> {
         Map<String, Map<GroupArtifact, Set<String>>> versionVariableNames;
         GradleProject gradleProject;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddBuildPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddBuildPlugin.java
@@ -28,7 +28,7 @@ import org.openrewrite.semver.Semver;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddBuildPlugin extends Recipe {
     @Option(displayName = "Plugin id",
             description = "The plugin id to apply.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -48,7 +48,7 @@ import static java.util.Collections.singletonList;
 import static org.openrewrite.gradle.plugins.AddPluginVisitor.resolvePluginVersion;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddDevelocityGradlePlugin extends Recipe {
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPlugin.java
@@ -29,7 +29,7 @@ import org.openrewrite.semver.Semver;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddSettingsPlugin extends Recipe {
     @Option(displayName = "Plugin id",
             description = "The plugin id to apply.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPluginRepository.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddSettingsPluginRepository extends Recipe {
 
     @Option(displayName = "Type",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePlugin.java
@@ -51,7 +51,7 @@ import static java.util.Objects.requireNonNull;
  * If you are using either of these plugin styles, you should ensure that the plugin's version is appropriately updated.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePlugin extends Recipe {
     @Option(displayName = "Plugin ID",
             description = "The current Gradle plugin id.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveBuildPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveBuildPlugin.java
@@ -21,7 +21,7 @@ import org.openrewrite.*;
 import org.openrewrite.gradle.IsBuildGradle;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveBuildPlugin extends Recipe {
     @Option(displayName = "Plugin id",
             description = "The plugin id to remove.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPlugin.java
@@ -21,7 +21,7 @@ import org.openrewrite.*;
 import org.openrewrite.gradle.IsSettingsGradle;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveSettingsPlugin extends Recipe {
     @Option(displayName = "Plugin id",
             description = "The plugin id to remove.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/UpgradePluginVersion.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpgradePluginVersion extends ScanningRecipe<UpgradePluginVersion.DependencyVersionState> {
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
     private static final String GRADLE_PROPERTIES_FILE_NAME = "gradle.properties";

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DependencyInsight extends Recipe {
     transient DependenciesInUse dependenciesInUse = new DependenciesInUse(this);
 
@@ -191,7 +191,7 @@ public class DependencyInsight extends Recipe {
         };
     }
 
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     @Value
     private static class MarkIndividualDependency extends JavaIsoVisitor<ExecutionContext> {
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
@@ -30,7 +30,7 @@ import org.openrewrite.marker.SearchResult;
 import java.util.List;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindDependency extends Recipe {
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindGradleWrapper.java
@@ -37,7 +37,7 @@ import static org.openrewrite.PathUtils.equalIgnoringSeparators;
 import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_PROPERTIES_LOCATION;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindGradleWrapper extends Recipe {
     transient GradleWrappersInUse wrappersInUse = new GradleWrappersInUse(this);
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindPlugins.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindPlugins.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindPlugins extends Recipe {
     @Option(displayName = "Plugin id",
             description = "The `ID` part of `plugin { ID }`.",

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindRepository.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindRepository.java
@@ -31,7 +31,7 @@ import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.SearchResult;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindRepository extends Recipe {
     @Option(displayName = "Type",
             description = "The type of the artifact repository",

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/FinalizeLocalVariablesTest.java
@@ -178,7 +178,7 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         }
 
         @Value
-        @EqualsAndHashCode(callSuper = true)
+        @EqualsAndHashCode(callSuper = false)
         private static class FindAssignmentReferencesToVariable extends JavaIsoVisitor<AtomicBoolean> {
 
             J.VariableDeclarations.NamedVariable variable;

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddLicenseHeader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddLicenseHeader.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddLicenseHeader extends Recipe {
     /**
      * A method pattern that is used to find matching method declarations/invocations.

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddOrUpdateAnnotationAttribute extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeAnnotationAttributeName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeAnnotationAttributeName.java
@@ -30,7 +30,7 @@ import static org.openrewrite.java.tree.Space.EMPTY;
 import static org.openrewrite.java.tree.Space.SINGLE_SPACE;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeAnnotationAttributeName extends Recipe {
 
     @Option(displayName = "Annotation Type",

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevel.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevel.java
@@ -23,7 +23,7 @@ import org.openrewrite.java.search.DeclaresMethod;
 import org.openrewrite.java.tree.J;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeMethodAccessLevel extends Recipe {
 
     @Option(displayName = "Method pattern",

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
@@ -24,7 +24,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.*;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeMethodName extends Recipe {
 
     @Option(displayName = "Method pattern",

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -31,7 +31,7 @@ import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeMethodTargetToStatic extends Recipe {
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToVariable.java
@@ -33,7 +33,7 @@ import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeMethodTargetToVariable extends Recipe {
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
  * is defined on the super class.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePackage extends Recipe {
     @Option(displayName = "Old package name",
             description = "The package name to replace.",

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
@@ -25,7 +25,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.search.UsesField;
 import org.openrewrite.java.tree.*;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class ChangeStaticFieldToMethod extends Recipe {
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeType extends Recipe {
 
     @Option(displayName = "Old fully-qualified type name",

--- a/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
@@ -33,7 +33,7 @@ import static org.openrewrite.Tree.randomId;
  * which argument is removed.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DeleteMethodArgument extends Recipe {
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/NoStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/NoStaticImport.java
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyList;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @Getter
 @RequiredArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class NoStaticImport extends Recipe {
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
@@ -44,7 +44,7 @@ import static java.util.Collections.emptyList;
  * imports that are not referenced within the compilation unit.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class OrderImports extends Recipe {
 
     @Option(displayName = "Remove unused",

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotation.java
@@ -20,7 +20,7 @@ import lombok.Value;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class RemoveAnnotation extends Recipe {
     @Option(displayName = "Annotation pattern",

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationAttribute.java
@@ -25,7 +25,7 @@ import org.openrewrite.java.tree.J;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveAnnotationAttribute extends Recipe {
 
     @Option(displayName = "Annotation Type",

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveImplements.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveImplements.java
@@ -29,7 +29,7 @@ import static java.util.stream.Collectors.toList;
 import static org.openrewrite.java.tree.TypeUtils.isOfClassType;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveImplements extends Recipe {
 
     private static final AnnotationMatcher OVERRIDE_MATCHER = new AnnotationMatcher("java.lang.Override");

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -42,7 +42,7 @@ import static org.openrewrite.java.tree.TypeUtils.toFullyQualifiedName;
  * drop below the configured values.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveUnusedImports extends Recipe {
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
  * array of parameter names.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ReorderMethodArguments extends Recipe {
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/SimplifyMethodChain.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class SimplifyMethodChain extends Recipe {
     @Option(displayName = "Method pattern chain",
             description = "A list of method patterns that are called in sequence",

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -29,7 +29,7 @@ import org.openrewrite.java.tree.Javadoc;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @Getter
 @RequiredArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UseStaticImport extends Recipe {
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/ai/ClassDefinitionLength.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ai/ClassDefinitionLength.java
@@ -27,7 +27,7 @@ import org.openrewrite.java.table.TokenCount;
 import org.openrewrite.java.tree.J;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ClassDefinitionLength extends Recipe {
     transient TokenCount tokens = new TokenCount(this);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/ai/MethodDefinitionLength.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ai/MethodDefinitionLength.java
@@ -25,7 +25,7 @@ import org.openrewrite.java.table.TokenCount;
 import org.openrewrite.java.tree.J;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class MethodDefinitionLength extends Recipe {
     transient TokenCount tokens = new TokenCount(this);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindAnnotations extends Recipe {
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindComments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindComments.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 import static org.openrewrite.Tree.randomId;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindComments extends Recipe {
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedClasses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedClasses.java
@@ -32,7 +32,7 @@ import org.openrewrite.marker.SearchResult;
 import java.util.Iterator;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindDeprecatedClasses extends Recipe {
 
     private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedFields.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindDeprecatedFields extends Recipe {
 
     private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindDeprecatedMethods extends Recipe {
     private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("java.lang.Deprecated");
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindEmptyMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindEmptyMethods.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindEmptyMethods extends Recipe {
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindFields.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindFields.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindFields extends Recipe {
     @Option(displayName = "Fully-qualified type name",
             description = "A fully-qualified Java type name, that is used to find matching fields.",

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindFieldsOfType.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * Finds fields that have a matching type.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindFieldsOfType extends Recipe {
 
     @Option(displayName = "Fully-qualified type name",

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethodDeclaration.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethodDeclaration.java
@@ -25,7 +25,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindMethodDeclaration extends Recipe {
 
     @Option(displayName = "Method pattern",

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 /**
  * Finds matching method invocations.
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindMethods extends Recipe {
     transient MethodCalls methodCalls = new MethodCalls(this);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypeMappings.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypeMappings.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static java.util.Collections.emptyList;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindTypeMappings extends ScanningRecipe<Map<FindTypeMappings.TypeAssociation, Integer>> {
     transient TypeMappings typeMappingsPerSource = new TypeMappings(this);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindTypes extends Recipe {
 
     @Option(displayName = "Fully-qualified type name",

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/ResultOfMethodCallIgnored.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/ResultOfMethodCallIgnored.java
@@ -28,7 +28,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ResultOfMethodCallIgnored extends Recipe {
     /**
      * A method pattern that is used to find matching method invocations.

--- a/rewrite-json/src/main/java/org/openrewrite/json/ChangeKey.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/ChangeKey.java
@@ -21,7 +21,7 @@ import org.openrewrite.*;
 import org.openrewrite.json.tree.Json;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeKey extends Recipe {
     @Option(displayName = "Old key path",
             description = "A JsonPath expression to locate a JSON entry.",

--- a/rewrite-json/src/main/java/org/openrewrite/json/ChangeValue.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/ChangeValue.java
@@ -27,7 +27,7 @@ import org.openrewrite.marker.Markers;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeValue extends Recipe {
     @Option(displayName = "Key path",
             description = "A JsonPath expression to locate a JSON entry.",

--- a/rewrite-json/src/main/java/org/openrewrite/json/DeleteKey.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/DeleteKey.java
@@ -25,7 +25,7 @@ import org.openrewrite.json.tree.Space;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DeleteKey extends Recipe {
     @Option(displayName = "Key path",
             description = "A JsonPath expression to locate a JSON entry.",

--- a/rewrite-json/src/main/java/org/openrewrite/json/search/FindKey.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/search/FindKey.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindKey extends Recipe {
     @Option(displayName = "Key path",
             description = "A JsonPath expression used to find matching keys.",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddCommentToMavenDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddCommentToMavenDependency.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddCommentToMavenDependency extends Recipe {
 
     @Option(displayName = "XPath",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
  * NOTE: IF PROVENANCE INFORMATION IS NOT PRESENT, THIS RECIPE WILL DO NOTHING.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
     @EqualsAndHashCode.Exclude
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMavenExtension.Accumulator> {
     private static final String GRADLE_ENTERPRISE_MAVEN_EXTENSION_ARTIFACT_ID = "gradle-enterprise-maven-extension";
     private static final String EXTENSIONS_XML_PATH = ".mvn/extensions.xml";

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 import static java.util.Objects.requireNonNull;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Scanned> {
     @EqualsAndHashCode.Exclude
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -33,7 +33,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddPlugin extends Recipe {
 
     private static final XPathMatcher BUILD_MATCHER = new XPathMatcher("/project/build");

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPluginDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPluginDependency.java
@@ -32,7 +32,7 @@ import static org.openrewrite.xml.MapTagChildrenVisitor.mapTagChildren;
 import static org.openrewrite.xml.SemanticallyEqual.areEqual;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddPluginDependency extends Recipe {
     private static final XPathMatcher PLUGINS_MATCHER = new XPathMatcher("/project/build/plugins");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
@@ -30,7 +30,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddProfile extends Recipe {
     private static final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProperty.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProperty.java
@@ -28,7 +28,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddProperty extends Recipe {
 
     @Option(displayName = "Key",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddRepository.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddRepository extends Recipe {
     private static final XPathMatcher REPOS_MATCHER = new XPathMatcher("/project/repositories");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyClassifier.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyClassifier.java
@@ -30,7 +30,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeDependencyClassifier extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyScope.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyScope.java
@@ -30,7 +30,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeDependencyScope extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -33,7 +33,7 @@ import static org.openrewrite.Validated.test;
 import static org.openrewrite.internal.StringUtils.isBlank;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
     @EqualsAndHashCode.Exclude
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePackaging.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePackaging.java
@@ -36,7 +36,7 @@ import static org.openrewrite.xml.AddOrUpdateChild.addOrUpdateChild;
 import static org.openrewrite.xml.FilterTagChildrenVisitor.filterTagChildren;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePackaging extends Recipe {
     private static final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -43,7 +43,7 @@ import static java.util.Collections.emptyList;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeParentPom extends Recipe {
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginConfiguration.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginConfiguration.java
@@ -32,7 +32,7 @@ import static org.openrewrite.xml.AddOrUpdateChild.addOrUpdateChild;
 import static org.openrewrite.xml.FilterTagChildrenVisitor.filterChildren;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePluginConfiguration extends Recipe {
     private static final XPathMatcher PLUGINS_MATCHER = new XPathMatcher("/project/build/plugins");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginDependencies.java
@@ -33,7 +33,7 @@ import static org.openrewrite.xml.AddOrUpdateChild.addOrUpdateChild;
 import static org.openrewrite.xml.FilterTagChildrenVisitor.filterChildren;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePluginDependencies extends Recipe {
     private static final XPathMatcher PLUGINS_MATCHER = new XPathMatcher("/project/build/plugins");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginExecutions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginExecutions.java
@@ -32,7 +32,7 @@ import static org.openrewrite.xml.AddOrUpdateChild.addOrUpdateChild;
 import static org.openrewrite.xml.FilterTagChildrenVisitor.filterChildren;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePluginExecutions extends Recipe {
     private static final XPathMatcher PLUGINS_MATCHER = new XPathMatcher("/project/build/plugins");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
@@ -29,7 +29,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePluginGroupIdAndArtifactId extends Recipe {
     @EqualsAndHashCode.Exclude
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeProjectVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeProjectVersion.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeProjectVersion extends Recipe {
     // there are several implicitly defined version properties that we should never attempt to update
     private static final Collection<String> implicitlyDefinedVersionProperties = Arrays.asList(

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyValue.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePropertyValue.java
@@ -24,7 +24,7 @@ import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePropertyValue extends Recipe {
 
     @Option(displayName = "Key",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ExcludeDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ExcludeDependency.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ExcludeDependency extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/IncrementProjectVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/IncrementProjectVersion.java
@@ -33,7 +33,7 @@ import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class IncrementProjectVersion extends ScanningRecipe<Map<GroupArtifact, String>> {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * version if none is provided).
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ManageDependencies extends ScanningRecipe<Map<GroupArtifactVersion, Collection<ResolvedDependency>>> {
     private static final XPathMatcher MANAGED_DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencyManagement/dependencies");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
@@ -25,7 +25,7 @@ import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveDependency extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
@@ -34,7 +34,7 @@ import java.time.Duration;
 import java.util.*;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveDuplicateDependencies extends Recipe {
 
     @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveExclusion extends Recipe {
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. Supports glob.",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
@@ -25,7 +25,7 @@ import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveManagedDependency extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePlugin.java
@@ -26,7 +26,7 @@ import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemovePlugin extends Recipe {
 
     @Option(displayName = "Group",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePluginDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePluginDependency.java
@@ -30,7 +30,7 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
 import static org.openrewrite.xml.FilterTagChildrenVisitor.filterTagChildren;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemovePluginDependency extends Recipe {
     private static final XPathMatcher PLUGINS_MATCHER = new XPathMatcher("/project/build/plugins");
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveProperty.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveProperty.java
@@ -24,7 +24,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveProperty extends Recipe {
 
     @Option(displayName = "Property name",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveRedundantDependencyVersions extends Recipe {
     @Option(displayName = "Group",
             description = "Group glob expression pattern used to match dependencies that should be managed." +

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRepository.java
@@ -27,7 +27,7 @@ import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveRepository extends Recipe {
     private static final XPathMatcher REPOS_MATCHER = new XPathMatcher("/project/repositories/repository");
     private static final XPathMatcher PLUGIN_REPOS_MATCHER = new XPathMatcher("/project/pluginRepositories/pluginRepository");

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RenamePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RenamePropertyKey.java
@@ -27,7 +27,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.Optional;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RenamePropertyKey extends Recipe {
 
     @Option(displayName = "Old key",

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenWrapper.java
@@ -55,7 +55,7 @@ import static org.openrewrite.maven.utilities.MavenWrapper.*;
  */
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenWrapperState> {
     private static final String DISTRIBUTION_URL_KEY = "distributionUrl";
     private static final String DISTRIBUTION_SHA_256_SUM_KEY = "distributionSha256Sum";

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -47,7 +47,7 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
  * <li>The default behavior for managed dependencies is to leave them unaltered unless the "overrideManagedVersion" is set to true.</li>
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpgradeDependencyVersion extends ScanningRecipe<Set<GroupArtifact>> {
     @EqualsAndHashCode.Exclude
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  * more precise control over version updates to patch or minor releases.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpgradePluginVersion extends Recipe {
     @EqualsAndHashCode.Exclude
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cleanup/ExplicitPluginGroupId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cleanup/ExplicitPluginGroupId.java
@@ -26,7 +26,7 @@ import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ExplicitPluginGroupId extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
@@ -39,7 +39,7 @@ import java.util.Optional;
  * either match or transitively include a dependency matching {@link #groupIdPattern} and
  * {@link #artifactIdPattern}.
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class DependencyInsight extends Recipe {
     transient DependenciesInUse dependenciesInUse = new DependenciesInUse(this);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DoesNotIncludeDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DoesNotIncludeDependency.java
@@ -23,7 +23,7 @@ import org.openrewrite.maven.tree.Scope;
 
 import static org.openrewrite.Validated.notBlank;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class DoesNotIncludeDependency extends Recipe {
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindDependency.java
@@ -25,7 +25,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.HashSet;
 import java.util.Set;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindDependency extends Recipe {
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindPlugin.java
@@ -25,7 +25,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.HashSet;
 import java.util.Set;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindPlugin extends Recipe {
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 
 import static org.openrewrite.Tree.randomId;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindProperties extends Recipe {
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -28,7 +28,7 @@ import org.openrewrite.xml.tree.Xml;
 
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class ParentPomInsight extends Recipe {
     transient ParentPomsInUse inUse = new ParentPomsInUse(this);

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/AddProperty.java
@@ -28,7 +28,7 @@ import org.openrewrite.properties.tree.Properties;
 import java.util.*;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddProperty extends Recipe {
 
     @Option(displayName = "Property key",

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyKey.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyKey.java
@@ -26,7 +26,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.properties.tree.Properties;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePropertyKey extends Recipe {
 
     @Option(displayName = "Old property key",

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyValue.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/ChangePropertyValue.java
@@ -26,7 +26,7 @@ import org.openrewrite.properties.tree.Properties;
 import java.util.regex.Pattern;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePropertyValue extends Recipe {
 
     @Option(displayName = "Property key",

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/DeleteProperty.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/DeleteProperty.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.openrewrite.internal.NameCaseConvention.LOWER_CAMEL;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DeleteProperty extends Recipe {
 
     @Override

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/search/FindProperties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/search/FindProperties.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindProperties extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-test/src/test/java/org/openrewrite/config/RecipeAcceptingParameters.java
+++ b/rewrite-test/src/test/java/org/openrewrite/config/RecipeAcceptingParameters.java
@@ -21,7 +21,7 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RecipeAcceptingParameters extends Recipe {
 
     @Option(displayName = "foo")

--- a/rewrite-test/src/test/java/org/openrewrite/config/RecipeNoParameters.java
+++ b/rewrite-test/src/test/java/org/openrewrite/config/RecipeNoParameters.java
@@ -20,7 +20,7 @@ import lombok.Value;
 import org.openrewrite.Recipe;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RecipeNoParameters extends Recipe {
     @Override
     public String getDisplayName() {

--- a/rewrite-test/src/test/java/org/openrewrite/test/RecipePrinterTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/RecipePrinterTest.java
@@ -77,7 +77,7 @@ class RecipePrinterTest implements RewriteTest {
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
+    @EqualsAndHashCode(callSuper = false)
     private static class TestRecipe extends Recipe {
 
         @Option(displayName = "An option",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddCommentToXmlTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddCommentToXmlTag.java
@@ -29,7 +29,7 @@ import static org.openrewrite.Tree.randomId;
 
 @Incubating(since = "7.24.0")
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddCommentToXmlTag extends Recipe {
 
     @Option(displayName = "XPath",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeNamespaceValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeNamespaceValue.java
@@ -23,7 +23,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeNamespaceValue extends Recipe {
     private static final String XMLNS_PREFIX = "xmlns";
     private static final String VERSION_PREFIX = "version";

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagAttribute.java
@@ -28,7 +28,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.regex.Pattern;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeTagAttribute extends Recipe {
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagName.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagName.java
@@ -24,7 +24,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeTagName extends Recipe {
     @Option(displayName = "Element name",
             description = "The name of the element whose attribute's value is to be changed. Interpreted as an XPath expression.",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
@@ -25,7 +25,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeTagValue extends Recipe {
 
     @Option(displayName = "Element name",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
@@ -22,7 +22,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.tree.Xml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveXmlTag extends Recipe {
 
     @Option(displayName = "XPath",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/search/FindTags.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/search/FindTags.java
@@ -27,7 +27,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.util.HashSet;
 import java.util.Set;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @Value
 public class FindTags extends Recipe {
     @Option(displayName = "XPath",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/AddOwaspDateBoundSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/AddOwaspDateBoundSuppressions.java
@@ -30,7 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AddOwaspDateBoundSuppressions extends Recipe {
 
     @Option(displayName = "Until date",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/RemoveOwaspSuppressions.java
@@ -32,7 +32,7 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class RemoveOwaspSuppressions extends Recipe {
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/security/UpdateOwaspSuppressionDate.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/security/UpdateOwaspSuppressionDate.java
@@ -30,7 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class UpdateOwaspSuppressionDate extends Recipe {
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/AppendToSequence.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/AppendToSequence.java
@@ -26,7 +26,7 @@ import org.openrewrite.internal.lang.Nullable;
 import java.util.List;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class AppendToSequence extends Recipe {
     @Option(displayName = "sequence path",
             description = "A [JsonPath](https://github.com/json-path/JsonPath) expression to locate a YAML sequence.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeKey.java
@@ -24,7 +24,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeKey extends Recipe {
     @Option(displayName = "Old key path",
             description = "A [JsonPath](https://github.com/json-path/JsonPath) expression to locate a YAML entry.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -43,7 +43,7 @@ import static org.openrewrite.Tree.randomId;
  * interprets application.yml files.
  */
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePropertyKey extends Recipe {
 
     @Option(displayName = "Old property key",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangePropertyValue extends Recipe {
     @Option(displayName = "Property key",
             description = "The key to look for. Supports glob patterns.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangeValue.java
@@ -27,7 +27,7 @@ import org.openrewrite.yaml.tree.Yaml;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class ChangeValue extends Recipe {
     @Option(displayName = "Key path",
             description = "A [JsonPath](https://github.com/json-path/JsonPath) expression to locate a YAML entry.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
@@ -30,7 +30,7 @@ import static java.util.stream.StreamSupport.stream;
 
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class CommentOutProperty extends Recipe {
     @Option(displayName = "Property key",
             description = "The key to be commented out.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
@@ -24,7 +24,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class CopyValue extends Recipe {
     @Option(displayName = "Old key path",
             description = "A [JsonPath](https://github.com/json-path/JsonPath) expression to locate a YAML key/value pair to copy.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
@@ -24,7 +24,7 @@ import org.openrewrite.yaml.tree.Yaml;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DeleteKey extends Recipe {
     @Option(displayName = "Key path",
             description = "A [JsonPath](https://github.com/json-path/JsonPath) expression to locate a YAML entry.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
@@ -36,7 +36,7 @@ import static java.util.stream.StreamSupport.stream;
 import static org.openrewrite.Tree.randomId;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class DeleteProperty extends Recipe {
     @Option(displayName = "Property key",
             description = "The key to be deleted.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -24,7 +24,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.yaml.tree.Yaml;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class MergeYaml extends Recipe {
     @Option(displayName = "Key path",
             description = "A [JsonPath](https://github.com/json-path/JsonPath) expression used to find matching keys.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindKey.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindKey extends Recipe {
     @Option(displayName = "Path",
             description = "A JsonPath expression used to find matching keys.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindProperty.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 @Value
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 public class FindProperty extends Recipe {
 
     @Option(displayName = "Property key",


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.recipes.RecipeEqualsAndHashCodeCallSuper?organizationId=T3BlblJld3JpdGU%3D

Following
- refactor: Use of @EqualsAndHashCode on Recipe https://github.com/openrewrite/rewrite/commit/eaa8871e33e9edb200feb7b7349bf13dbfe67410
- Revert "refactor: Use of @EqualsAndHashCode on Recipe"  https://github.com/openrewrite/rewrite/commit/516c70b89ebbb43803d2dd6e0bc2cf31307a80d3