### PR TITLE
Support negation in globmatcher in pathutils

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/PathUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/PathUtilsTest.java
@@ -111,6 +111,17 @@ class PathUtilsTest {
         assertThat(matchesGlob(path("test/bar"), "test/{foo,bar}")).isTrue();
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3847")
+    void negation() {
+        assertThat(matchesGlob(path("test.txt"), "test.!(txt)")).isFalse();
+        assertThat(matchesGlob(path("test.java"), "test.!(txt)")).isTrue();
+        assertThat(matchesGlob(path("test/foo"), "test/!(foo|bar)")).isFalse();
+        assertThat(matchesGlob(path("test/bar"), "test/!(foo|bar)")).isFalse();
+        assertThat(matchesGlob(path("test/quz"), "test/!(foo|bar)")).isTrue();
+        assertThat(matchesGlob(path("test/bar"), "test/!(f*|b*)")).isFalse();
+    }
+
     private static Path path(String path) {
         return Paths.get(path);
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
matchesGlob in PathUtils now supports negation with !()

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
I was writing a custom recipe where I wanted to apply the changes to source files whose filename ends with `*IT.java`, while excluding a few exceptions e.g. `CucumberLauncherIT.java`. However, when I used FindSourceFiles, I realized negation was not supported in the glob patterns.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@shanman190 @timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
#3847 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
