### PR TITLE
Skip dependency resolution option for `MavenParser` skips parent resolution as well

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -45,6 +45,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     private static final String MAVEN_POM_CACHE = "org.openrewrite.maven.pomCache";
     private static final String MAVEN_RESOLUTION_LISTENER = "org.openrewrite.maven.resolutionListener";
     private static final String MAVEN_RESOLUTION_TIME = "org.openrewrite.maven.resolutionTime";
+    private static final String MAVEN_SKIP_DEPENDENCY_RESOLUTION = "org.openrewrite.maven.skipDependencyResolution";
 
     public MavenExecutionContextView(ExecutionContext delegate) {
         super(delegate);
@@ -122,6 +123,15 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
         }
         credentials.addAll(getMessage(MAVEN_CREDENTIALS, emptyList()));
         return credentials;
+    }
+
+    public boolean getSkipDependencyResolution() {
+        return getMessage(MAVEN_SKIP_DEPENDENCY_RESOLUTION, false);
+    }
+
+    public MavenExecutionContextView setSkipDependencyResolution(boolean skipDependencyResolution) {
+        putMessage(MAVEN_SKIP_DEPENDENCY_RESOLUTION, skipDependencyResolution);
+        return this;
     }
 
     public MavenExecutionContextView setPomCache(MavenPomCache pomCache) {
@@ -212,7 +222,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     }
 
     private static List<String> mapActiveProfiles(MavenSettings settings, String... activeProfiles) {
-        if(settings.getActiveProfiles() == null) {
+        if (settings.getActiveProfiles() == null) {
             return Arrays.asList(activeProfiles);
         }
         return Stream.concat(

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -45,6 +45,8 @@ import static org.openrewrite.Tree.randomId;
 public class MavenParser implements Parser {
 
     private final Collection<String> activeProfiles;
+
+    @Deprecated
     private final boolean skipDependencyResolution;
 
     @Override
@@ -105,6 +107,12 @@ public class MavenParser implements Parser {
         MavenPomDownloader downloader = new MavenPomDownloader(projectPomsByPath, ctx);
 
         MavenExecutionContextView mavenCtx = MavenExecutionContextView.view(ctx);
+
+        // TODO scheduled for removal when users of MavenParser.Builder.skipDependencyResolution are migrated
+        if (skipDependencyResolution) {
+            mavenCtx.setSkipDependencyResolution(true);
+        }
+
         MavenSettings sanitizedSettings = mavenCtx.getSettings() == null ? null : mavenCtx.getSettings()
                 .withServers(null);
 
@@ -112,7 +120,7 @@ public class MavenParser implements Parser {
             try {
                 ResolvedPom resolvedPom = docToPom.getValue().resolve(activeProfiles, downloader, ctx);
                 MavenResolutionResult model = new MavenResolutionResult(randomId(), null, resolvedPom, emptyList(), null, emptyMap(), sanitizedSettings, mavenCtx.getActiveProfiles());
-                if (!skipDependencyResolution) {
+                if (!mavenCtx.getSkipDependencyResolution()) {
                     model = model.resolveDependencies(downloader, ctx);
                 }
                 parsed.add(docToPom.getKey().withMarkers(docToPom.getKey().getMarkers().compute(model, (old, n) -> n)));
@@ -134,7 +142,7 @@ public class MavenParser implements Parser {
         for (int i = 0; i < parsed.size(); i++) {
             SourceFile maven = parsed.get(i);
             Optional<MavenResolutionResult> maybeResolutionResult = maven.getMarkers().findFirst(MavenResolutionResult.class);
-            if(!maybeResolutionResult.isPresent()) {
+            if (!maybeResolutionResult.isPresent()) {
                 continue;
             }
             MavenResolutionResult resolutionResult = maybeResolutionResult.get();
@@ -144,7 +152,7 @@ public class MavenParser implements Parser {
                     continue;
                 }
                 Optional<MavenResolutionResult> maybeModuleResolutionResult = possibleModule.getMarkers().findFirst(MavenResolutionResult.class);
-                if(!maybeModuleResolutionResult.isPresent()) {
+                if (!maybeModuleResolutionResult.isPresent()) {
                     continue;
                 }
                 MavenResolutionResult moduleResolutionResult = maybeModuleResolutionResult.get();
@@ -177,12 +185,21 @@ public class MavenParser implements Parser {
 
     public static class Builder extends Parser.Builder {
         private final Collection<String> activeProfiles = new HashSet<>();
+
+        @Deprecated
         private boolean skipDependencyResolution;
 
         public Builder() {
             super(Xml.Document.class);
         }
 
+        /**
+         * @param skip Whether to skip dependency resolution
+         * @return This builder
+         * @deprecated Use {@link MavenExecutionContextView#setSkipDependencyResolution(boolean)}
+         * on the execution context passed into the parser instead.
+         */
+        @Deprecated
         public Builder skipDependencyResolution(boolean skip) {
             skipDependencyResolution = skip;
             return this;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -343,7 +343,9 @@ public class ResolvedPom {
         MavenPomDownloader downloader;
 
         public ResolvedPom resolve() throws MavenDownloadingException {
-            resolveParentsRecursively(requested);
+            if (!MavenExecutionContextView.view(ctx).getSkipDependencyResolution()) {
+                resolveParentsRecursively(requested);
+            }
             return ResolvedPom.this;
         }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -39,8 +39,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -55,7 +54,7 @@ class MavenParserTest implements RewriteTest {
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-              
+                            
                 <dependencies>
                   <dependency>
                     <groupId>junit</groupId>
@@ -72,14 +71,34 @@ class MavenParserTest implements RewriteTest {
     @Test
     void skipDependencyResolution() {
         rewriteRun(
-          spec -> spec.parser(MavenParser.builder().skipDependencyResolution(true)),
+          spec -> spec
+            .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
+              .setSkipDependencyResolution(true)
+              .setResolutionListener(new ResolutionEventListener() {
+                  @Override
+                  public void parent(Pom parent, Pom containing) {
+                      fail("Parent resolution should have been skipped");
+                  }
+
+                  @Override
+                  public void dependency(Scope scope, ResolvedDependency resolvedDependency, ResolvedPom containing) {
+                      fail("Dependency resolution should have been skipped");
+                  }
+              })),
           pomXml(
             """
               <project>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>3.2.2</version>
+                    <relativePath/> <!-- lookup parent from repository -->
+                </parent>
+                  
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-              
+                            
                 <dependencies>
                   <dependency>
                     <groupId>foo</groupId>
@@ -128,7 +147,7 @@ class MavenParserTest implements RewriteTest {
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-                
+                                
                   <dependencies>
                     <dependency>
                       <groupId>junit</groupId>
@@ -517,7 +536,7 @@ class MavenParserTest implements RewriteTest {
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
-              
+                            
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
@@ -527,7 +546,7 @@ class MavenParserTest implements RewriteTest {
                           <name>Trygve Laugst&oslash;l</name>
                       </developer>
                   </developers>
-              
+                            
                   <dependencies>
                     <dependency>
                       <groupId>org.junit.jupiter</groupId>
@@ -583,11 +602,11 @@ class MavenParserTest implements RewriteTest {
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
-              
+                            
                   <groupId>org.openrewrite.maven</groupId>
                   <artifactId>single-project</artifactId>
                   <version>0.1.0-SNAPSHOT</version>
-              
+                            
                   <dependencies>
                       <dependency>
                           <groupId>com.google.guava</groupId>
@@ -595,7 +614,7 @@ class MavenParserTest implements RewriteTest {
                           <version>29.0-jre</version>
                       </dependency>
                   </dependencies>
-              
+                            
                   <repositories>
                       <repository>
                           <id>jcenter</id>
@@ -617,15 +636,15 @@ class MavenParserTest implements RewriteTest {
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
-              
+                            
                   <groupId>org.openrewrite.maven</groupId>
                   <artifactId>single-project</artifactId>
                   <version>0.1.0-SNAPSHOT</version>
-              
+                            
                   <properties>
                       <dependency.scope>compile</dependency.scope>
                   </properties>
-              
+                            
                   <dependencies>
                       <dependency>
                           <groupId>com.google.guava</groupId>
@@ -677,7 +696,7 @@ class MavenParserTest implements RewriteTest {
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
-              
+                            
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
@@ -701,7 +720,7 @@ class MavenParserTest implements RewriteTest {
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
-              
+                            
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
@@ -893,11 +912,11 @@ class MavenParserTest implements RewriteTest {
                         resp.setBody("""
                           <project>
                             <modelVersion>4.0.0</modelVersion>
-                          
+                                                    
                             <groupId>com.foo</groupId>
                             <artifactId>bar</artifactId>
                             <version>1.0.0</version>
-                          
+                                                    
                           </project>
                           """
                         );
@@ -1812,11 +1831,11 @@ class MavenParserTest implements RewriteTest {
                 <artifactId>sample</artifactId>
                 <version>${revision}</version>
                 <packaging>pom</packaging>
-              
+                            
                 <modules>
                   <module>sample-rest</module>
                 </modules>
-              
+                            
               </project>
               """, spec -> spec.path("pom.xml")),
           pomXml(
@@ -1824,11 +1843,11 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-rest</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -1854,14 +1873,14 @@ class MavenParserTest implements RewriteTest {
                 <artifactId>sample</artifactId>
                 <version>${revision}</version>
                 <packaging>pom</packaging>
-              
+                            
                 <modules>
                   <module>sample-parent</module>
                   <module>sample-app</module>
                   <module>sample-rest</module>
                   <module>sample-web</module>
                 </modules>
-              
+                            
                 <properties>
                   <revision>0.0.0-SNAPSHOT</revision>
                 </properties>
@@ -1877,11 +1896,11 @@ class MavenParserTest implements RewriteTest {
                 <groupId>net.sample</groupId>
                 <version>${revision}</version>
                 <packaging>pom</packaging>
-              
+                            
                 <properties>
                   <revision>0.0.0-SNAPSHOT</revision>
                 </properties>
-              
+                            
                 <dependencyManagement>
                   <dependencies>
                     <dependency>
@@ -1903,24 +1922,24 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-app</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
                   <version>${revision}</version>
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
-              
+                            
                 <dependencies>
                   <dependency>
                     <groupId>net.sample</groupId>
                     <artifactId>sample-rest</artifactId>
                   </dependency>
-              
+                            
                   <dependency>
                     <groupId>net.sample</groupId>
                     <artifactId>sample-web</artifactId>
@@ -1933,11 +1952,11 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-rest</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
@@ -1951,11 +1970,11 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-web</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
@@ -1982,14 +2001,14 @@ class MavenParserTest implements RewriteTest {
                 <artifactId>sample</artifactId>
                 <version>${revision}</version>
                 <packaging>pom</packaging>
-              
+                            
                 <modules>
                   <module>sample-parent</module>
                   <module>sample-app</module>
                   <module>sample-rest</module>
                   <module>sample-web</module>
                 </modules>
-              
+                            
                 <properties>
                   <revision>0.0.0-SNAPSHOT</revision>
                 </properties>
@@ -2005,11 +2024,11 @@ class MavenParserTest implements RewriteTest {
                 <groupId>net.sample</groupId>
                 <version>${revision}</version>
                 <packaging>pom</packaging>
-              
+                            
                 <properties>
                   <revision>0.0.0-SNAPSHOT</revision>
                 </properties>
-              
+                            
                 <dependencyManagement>
                   <dependencies>
                     <dependency>
@@ -2031,24 +2050,24 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-app</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
                   <version>${revision}</version>
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
-              
+                            
                 <dependencies>
                   <dependency>
                     <groupId>net.sample</groupId>
                     <artifactId>sample-rest</artifactId>
                   </dependency>
-              
+                            
                   <dependency>
                     <groupId>net.sample</groupId>
                     <artifactId>sample-web</artifactId>
@@ -2065,24 +2084,24 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-app</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
                   <version>${revision}</version>
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
-              
+                            
                 <dependencies>
                   <dependency>
                     <groupId>net.sample</groupId>
                     <artifactId>sample-rest</artifactId>
                   </dependency>
-              
+                            
                   <dependency>
                     <groupId>net.sample</groupId>
                     <artifactId>sample-web</artifactId>
@@ -2101,11 +2120,11 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-rest</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
@@ -2119,11 +2138,11 @@ class MavenParserTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-              
+                            
                 <modelVersion>4.0.0</modelVersion>
                 <artifactId>sample-web</artifactId>
                 <packaging>jar</packaging>
-              
+                            
                 <parent>
                   <groupId>net.sample</groupId>
                   <artifactId>sample-parent</artifactId>
@@ -2360,7 +2379,7 @@ class MavenParserTest implements RewriteTest {
                   <groupId>org.openrewrite.maven</groupId>
                   <artifactId>a</artifactId>
                   <version>0.1.0-SNAPSHOT</version>
-              
+                            
                   <build>
                       <plugins>
                           <plugin>
@@ -2393,7 +2412,7 @@ class MavenParserTest implements RewriteTest {
                   <groupId>org.openrewrite.maven</groupId>
                   <artifactId>a</artifactId>
                   <version>0.1.0-SNAPSHOT</version>
-              
+                            
                   <build>
                       <plugins>
                           <plugin>
@@ -2474,7 +2493,7 @@ class MavenParserTest implements RewriteTest {
                   <groupId>org.openrewrite.maven</groupId>
                   <artifactId>a</artifactId>
                   <version>0.1.0-SNAPSHOT</version>
-  
+                
                   <build>
                     <pluginManagement>
                       <plugins>


### PR DESCRIPTION
Improves the skipping of dependency resolution on `MavenParser` by:

* Allowing to skip parent resolution as well
* Moving the skip option to `MavenExecutionContextView` which is already supplied to the parsing phase.