### PR TITLE
Allow non-period terminated Recipe descriptions

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -644,8 +644,14 @@ public interface RewriteTest extends SourceSpecs {
             }
         } else {
             assertThat(recipe.getDisplayName()).as("%s display name should not end with a period.", recipe.getName()).doesNotEndWith(".");
-            assertThat(recipe.getDescription()).as("%s description should not be null or empty", recipe.getName()).isNotEmpty();
-            assertThat(recipe.getDescription()).as("%s description should end with a period.", recipe.getName()).endsWith(".");
+            String description = recipe.getDescription();
+            assertThat(description).as("%s description should not be null or empty", recipe.getName()).isNotEmpty();
+            if (description.endsWith(")")) {
+                String lastLine = description.substring(description.lastIndexOf('\n') + 1).trim();
+                assertThat(lastLine).as("%s description not ending with a period should be because the description ends with a markdown list of pure links", recipe.getName()).startsWith("- [");
+            } else {
+                assertThat(description).as("%s description should end with a period.", recipe.getName()).endsWith(".");
+            }
         }
     }
 

--- a/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
@@ -38,6 +38,24 @@ class RewriteTestTest implements RewriteTest {
     }
 
     @Test
+    void acceptsRecipeWithDescriptionListOfLinks() {
+        validateRecipeNameAndDescription(new RecipeWithDescriptionListOfLinks());
+    }
+
+    @Test
+    void acceptsRecipeWithDescriptionListOfDescribedLinks() {
+        validateRecipeNameAndDescription(new RecipeWithDescriptionListOfDescribedLinks());
+    }
+
+    @Test
+    void rejectsRecipeWithDescriptionNotEndingWithPeriod() {
+        assertThrows(
+          AssertionError.class,
+          () -> validateRecipeNameAndDescription(new RecipeWithDescriptionNotEndingWithPeriod())
+        );
+    }
+
+    @Test
     void verifyAll() {
         assertThrows(AssertionError.class, this::assertRecipesConfigure);
     }
@@ -64,3 +82,52 @@ class RecipeWithNameOption extends Recipe {
         return "A fancy description.";
     }
 }
+
+@NonNullApi
+class RecipeWithDescriptionListOfLinks extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Recipe with name option";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A fancy description.\n" +
+                "For more information, see:\n" +
+                "  - [link 1](https://example.com/link1)\n" +
+                "  - [link 2](https://example.com/link2)";
+    }
+}
+
+@NonNullApi
+class RecipeWithDescriptionListOfDescribedLinks extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Recipe with name option";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A fancy description.\n" +
+               "For more information, see:\n" +
+               "  - First Resource [link 1](https://example.com/link1).\n" +
+               "  - Second Resource [link 2](https://example.com/link2).";
+    }
+}
+
+@NonNullApi
+class RecipeWithDescriptionNotEndingWithPeriod extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Recipe with name option";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A fancy description";
+    }
+}
+


### PR DESCRIPTION
In the cases where the description ends with a list of resources
the recipe should allow that the list not end with a period.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Modifies `RecipeTest#validateRecipeNameAndDescription` to support descriptions
that are not terminated in a `.` under certain conditions.

## What's your motivation?

I want to write a recipe that has a description that ends with a list of links.
The formatting is very weird if this list is required to end in a `.`

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

Are there other conditions that I should be testing for here?

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Recipe authors could manually override `validateRecipeNameAndDescription` to change the behaviour of the validation, but this seems like a better general solution.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
