### PR TITLE
Add other possible scopes for maven dependencies

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -78,7 +78,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
             description = "A scope to use when it is not what can be inferred from usage. Most of the time this will be left empty, but " +
                           "is used when adding a runtime, provided, or import dependency.",
             example = "runtime",
-            valid = {"import", "runtime", "provided"},
+            valid = {"compile", "import", "provided", "runtime", "system", "test"},
             required = false)
     @Nullable
     String scope;


### PR DESCRIPTION
## What's changed?
Added remaining possible scopes for Maven dependencies to valid values.

## What's your motivation?
Maven has 6 possible scopes for dependencies, however only 3 of them were allowed as valid ones.

## Anything in particular you'd like reviewers to focus on?


## Anyone you would like to review specifically?


## Have you considered any alternatives or workarounds?
No

## Any additional context
https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
