### PR TITLE
Add test for updating parent gradle.properties when dependency is in …

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -127,6 +127,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     @Value
     public static class DependencyVersionState {
         Map<String, GroupArtifact> versionPropNameToGA = new HashMap<>();
+        // The value is either a String representing the resolved version or a MavenDownloadingException representing an error during resolution.
         Map<GroupArtifact, Object> gaToNewVersion = new HashMap<>();
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -141,6 +141,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         return new GroovyVisitor<ExecutionContext>() {
             GradleProject gradleProject;
             final DependencyMatcher dependencyMatcher = new DependencyMatcher(groupId, artifactId, null);
+
             @Override
             public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext executionContext) {
                 gradleProject = cu.getMarkers().findFirst(GradleProject.class).orElse(null);
@@ -199,16 +200,16 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 version = valueValue;
                             }
                         }
-                        if(groupId == null || artifactId == null) {
+                        if (groupId == null || artifactId == null) {
                             return m;
                         }
 
-                        if(!dependencyMatcher.matches(groupId, artifactId)) {
+                        if (!dependencyMatcher.matches(groupId, artifactId)) {
                             return m;
                         }
                         String versionVariableName = version;
                         GroupArtifact ga = new GroupArtifact(groupId, artifactId);
-                        if(acc.gaToNewVersion.containsKey(ga)) {
+                        if (acc.gaToNewVersion.containsKey(ga)) {
                             return m;
                         }
                         try {
@@ -236,12 +237,12 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                     continue;
                                 }
                                 Dependency dep = DependencyStringNotationConverter.parse((String) groupArtifact.getValue());
-                                if(!dependencyMatcher.matches(dep.getGroupId(), dep.getArtifactId())) {
+                                if (!dependencyMatcher.matches(dep.getGroupId(), dep.getArtifactId())) {
                                     continue;
                                 }
                                 String versionVariableName = ((J.Identifier) versionValue.getTree()).getSimpleName();
                                 GroupArtifact ga = new GroupArtifact(dep.getGroupId(), dep.getArtifactId());
-                                if(acc.gaToNewVersion.containsKey(ga)) {
+                                if (acc.gaToNewVersion.containsKey(ga)) {
                                     continue;
                                 }
                                 try {
@@ -302,7 +303,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             @Override
                             public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
                                 gradleProject = cu.getMarkers().findFirst(GradleProject.class)
-                                                .orElseThrow(() -> new IllegalStateException("Unable to find GradleProject marker."));
+                                        .orElseThrow(() -> new IllegalStateException("Unable to find GradleProject marker."));
                                 return super.visitCompilationUnit(cu, ctx);
                             }
 
@@ -392,8 +393,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                             String version = dep.getVersion();
                                             try {
                                                 String newVersion = "classpath".equals(method.getSimpleName()) ?
-                                                            findNewerPluginVersion(dep.getGroupId(), dep.getArtifactId(), version, gradleProject, ctx) :
-                                                            findNewerProjectDependencyVersion(dep.getGroupId(), dep.getArtifactId(), version, gradleProject, ctx);
+                                                        findNewerPluginVersion(dep.getGroupId(), dep.getArtifactId(), version, gradleProject, ctx) :
+                                                        findNewerProjectDependencyVersion(dep.getGroupId(), dep.getArtifactId(), version, gradleProject, ctx);
                                                 if (newVersion == null || version.equals(newVersion)) {
                                                     return arg;
                                                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
@@ -91,7 +90,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
     }
 
     private static MavenMetadata downloadMetadata(String groupId, String artifactId, List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
-        return new MavenPomDownloader(emptyMap(), ctx, null, null)
+        return new MavenPomDownloader(ctx)
                 .downloadMetadata(new GroupArtifact(groupId, artifactId), null,
                         repositories);
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -576,6 +576,52 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
+
+    @Test
+    void versionInParentSubprojectDefinitionWithPropertiesFiles() {
+        rewriteRun(
+          properties(
+            """
+              guavaVersion=29.0-jre
+              """,
+            """
+              guavaVersion=30.1.1-jre
+              """,
+            spec -> spec.path("gradle.properties")
+          ),
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              repositories {
+                      mavenCentral()
+              }
+                  
+              subprojects {
+                  repositories {
+                      mavenCentral()
+                  }
+                  
+                  dependencies {
+                    implementation ("com.google.guava:guava:$guavaVersion")
+                  }
+              }
+              """,
+            spec -> spec.path("build.gradle")
+          ),
+          buildGradle(
+            """
+              dependencies {
+              }
+              """,
+            spec -> spec.path("moduleA/build.gradle")
+          )
+        );
+    }
+
+
     @Test
     void versionOnlyInMultiModuleChildPropertiesFiles() {
         rewriteRun(


### PR DESCRIPTION
…subprojects block

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Trying to get parents versions in `gradle.properties` to correctly update when the dependency is applied to subprojects

## Anyone you would like to review specifically?
<!-- @mention them here -->
@shanman190 


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
