### PR TITLE
Assorted UpdateMavenWrapper fixes

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenWrapper.java
@@ -389,7 +389,7 @@ public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenW
                 }
                 if (mavenWrapper.getWrapperDistributionType() == DistributionType.Bin) {
                     if ((sourceFile instanceof Quark || sourceFile instanceof Remote) && PathUtils.matchesGlob(sourceFile.getSourcePath(), "**/" + WRAPPER_JAR_LOCATION_RELATIVE_PATH)) {
-                        return mavenWrapper.wrapperJar().withId(sourceFile.getId()).withMarkers(sourceFile.getMarkers());
+                        return mavenWrapper.wrapperJar(sourceFile);
                     }
 
                     if (PathUtils.matchesGlob(sourceFile.getSourcePath(), "**/" + WRAPPER_DOWNLOADER_LOCATION_RELATIVE_PATH)) {
@@ -397,7 +397,7 @@ public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenW
                     }
                 } else if (mavenWrapper.getWrapperDistributionType() == DistributionType.Source) {
                     if ((sourceFile instanceof Quark || sourceFile instanceof Remote) && PathUtils.matchesGlob(sourceFile.getSourcePath(), "**/" + WRAPPER_DOWNLOADER_LOCATION_RELATIVE_PATH)) {
-                        return mavenWrapper.wrapperDownloader().withId(sourceFile.getId()).withMarkers(sourceFile.getMarkers());
+                        return mavenWrapper.wrapperDownloader(sourceFile);
                     }
 
                     if (PathUtils.matchesGlob(sourceFile.getSourcePath(), "**/" + WRAPPER_JAR_LOCATION_RELATIVE_PATH)) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenWrapper.java
@@ -208,13 +208,13 @@ public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenW
                         if ("distributionUrl".equals(entry.getKey())) {
                             // Typical example: https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.0/apache-maven-3.8.0-bin.zip
                             String currentDistributionUrl = entry.getValue().getText();
-                            if (!mavenWrapper.getPropertiesFormattedDistributionUrl().equals(currentDistributionUrl)) {
+                            if (!mavenWrapper.getDistributionUrl().equals(currentDistributionUrl)) {
                                 acc.needsWrapperUpdate = true;
                             }
                         } else if ("wrapperUrl".equals(entry.getKey())) {
                             // Typical example: https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
                             String currentWrapperUrl = entry.getValue().getText();
-                            if (!mavenWrapper.getPropertiesFormattedWrapperUrl().equals(currentWrapperUrl)) {
+                            if (!mavenWrapper.getWrapperUrl().equals(currentWrapperUrl)) {
                                 acc.needsWrapperUpdate = true;
                             }
                         }
@@ -289,11 +289,11 @@ public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenW
         if (acc.addMavenWrapperProperties) {
             @Language("properties")
             String mavenWrapperPropertiesText = ASF_LICENSE_HEADER +
-                                                DISTRIBUTION_URL_KEY + "=" + mavenWrapper.getPropertiesFormattedDistributionUrl() + "\n" +
+                                                DISTRIBUTION_URL_KEY + "=" + mavenWrapper.getDistributionUrl() + "\n" +
                                                 DISTRIBUTION_SHA_256_SUM_KEY + "=" + mavenWrapper.getDistributionChecksum().getHexValue();
             if (mavenWrapper.getWrapperDistributionType() != DistributionType.OnlyScript) {
                 mavenWrapperPropertiesText += "\n" +
-                                              WRAPPER_URL_KEY + "=" + mavenWrapper.getPropertiesFormattedWrapperUrl() + "\n" +
+                                              WRAPPER_URL_KEY + "=" + mavenWrapper.getWrapperUrl() + "\n" +
                                               WRAPPER_SHA_256_SUM_KEY + "=" + mavenWrapper.getWrapperChecksum().getHexValue();
             }
             //noinspection UnusedProperty
@@ -459,8 +459,8 @@ public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenW
         public Properties.Entry visitEntry(Properties.Entry entry, ExecutionContext ctx) {
             if (DISTRIBUTION_URL_KEY.equals(entry.getKey())) {
                 Properties.Value value = entry.getValue();
-                if (!mavenWrapper.getPropertiesFormattedDistributionUrl().equals(value.getText())) {
-                    return entry.withValue(value.withText(mavenWrapper.getPropertiesFormattedDistributionUrl()));
+                if (!mavenWrapper.getDistributionUrl().equals(value.getText())) {
+                    return entry.withValue(value.withText(mavenWrapper.getDistributionUrl()));
                 }
             } else if (DISTRIBUTION_SHA_256_SUM_KEY.equals(entry.getKey())) {
                 Properties.Value value = entry.getValue();
@@ -471,8 +471,8 @@ public class UpdateMavenWrapper extends ScanningRecipe<UpdateMavenWrapper.MavenW
             } else if (WRAPPER_URL_KEY.equals(entry.getKey())) {
                 if (mavenWrapper.getWrapperDistributionType() != DistributionType.OnlyScript) {
                     Properties.Value value = entry.getValue();
-                    if (!mavenWrapper.getPropertiesFormattedWrapperUrl().equals(value.getText())) {
-                        return entry.withValue(value.withText(mavenWrapper.getPropertiesFormattedWrapperUrl()));
+                    if (!mavenWrapper.getWrapperUrl().equals(value.getText())) {
+                        return entry.withValue(value.withText(mavenWrapper.getWrapperUrl()));
                     }
                 } else {
                     //noinspection ConstantConditions

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
@@ -156,12 +156,12 @@ public class MavenWrapper {
         }
     }
 
-    public String getPropertiesFormattedWrapperUrl() {
-        return wrapperUri.replaceAll("(?<!\\\\)://", "\\\\://");
+    public String getWrapperUrl() {
+        return wrapperUri;
     }
 
-    public String getPropertiesFormattedDistributionUrl() {
-        return distributionUri.replaceAll("(?<!\\\\)://", "\\\\://");
+    public String getDistributionUrl() {
+        return distributionUri;
     }
 
     public Remote wrapperJar() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
@@ -18,6 +18,7 @@ package org.openrewrite.maven.utilities;
 import lombok.Value;
 import org.openrewrite.Checksum;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.MavenDownloadingException;
@@ -170,9 +171,23 @@ public class MavenWrapper {
         ).build();
     }
 
+    public Remote wrapperJar(SourceFile previous) {
+        return Remote.builder(
+                previous,
+                URI.create(wrapperUri)
+        ).build();
+    }
+
     public Remote wrapperDownloader() {
         return Remote.builder(
                 WRAPPER_DOWNLOADER_LOCATION,
+                URI.create(wrapperDistributionUri)
+        ).build(".mvn/wrapper/MavenWrapperDownloader.java");
+    }
+
+    public Remote wrapperDownloader(SourceFile previous) {
+        return Remote.builder(
+                previous,
                 URI.create(wrapperDistributionUri)
         ).build(".mvn/wrapper/MavenWrapperDownloader.java");
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenWrapperTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenWrapperTest.java
@@ -98,9 +98,9 @@ class UpdateMavenWrapperTest implements RewriteTest {
           properties(
             null,
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
               wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
               """),
             spec -> spec.path(".mvn/wrapper/maven-wrapper.properties")
@@ -136,8 +136,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
               wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
               """),
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
               """),
@@ -180,8 +180,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
               wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
               """),
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
               """),
@@ -223,8 +223,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
               wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
               """),
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
               """),
@@ -265,7 +265,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
               distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.0/apache-maven-3.8.0-bin.zip
               """),
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               """),
             spec -> spec.path(".mvn/wrapper/maven-wrapper.properties")
@@ -301,8 +301,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
                 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
                 """),
               withLicenseHeader("""
-                distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-                wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+                distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+                wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
                 distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
                 wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
                 """),
@@ -319,8 +319,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
                 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
                 """),
               withLicenseHeader("""
-                distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-                wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+                distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+                wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
                 distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
                 wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
                 """),
@@ -372,8 +372,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
             }),
           properties(
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
               """),
@@ -422,8 +422,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
             }),
           properties(
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.0/apache-maven-3.8.0-bin.zip
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.0/apache-maven-3.8.0-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               wrapperSha256Sum=ff7f21f2ef81723377e3d42d06661c4e3af60cf4bdfb7579ac8f22051399942d
               """),
@@ -450,8 +450,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
                   assertThat(wrapperChecksum).isNotBlank();
 
                   return withLicenseHeader("""
-                    distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip
-                    wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/%s/maven-wrapper-%s.jar
+                    distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/%s/apache-maven-%s-bin.zip
+                    wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/%s/maven-wrapper-%s.jar
                     distributionSha256Sum=%s
                     wrapperSha256Sum=%s
                     """.formatted(mavenDistributionVersion, mavenDistributionVersion, wrapperVersion, wrapperVersion, distributionChecksum, wrapperChecksum));
@@ -508,8 +508,8 @@ class UpdateMavenWrapperTest implements RewriteTest {
               wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
               """),
             withLicenseHeader("""
-              distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
-              wrapperUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
               distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
               wrapperSha256Sum=e63a53cfb9c4d291ebe3c2b0edacb7622bbc480326beaa5a0456e412f52f066a
               """),

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenWrapperTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenWrapperTest.java
@@ -632,12 +632,12 @@ class UpdateMavenWrapperTest implements RewriteTest {
                       wrapperVersion: 3.2.0
                       distributionVersion: 3.8.8
                       addIfMissing: false
-                      checkMavenWrapperJarChecksum: true
+                      enforceWrapperChecksumVerification: true
                   - org.openrewrite.maven.UpdateMavenWrapper:
                       wrapperVersion: 3.1.1
                       distributionVersion: 3.6.0
                       addIfMissing: false
-                      checkMavenWrapperJarChecksum: true
+                      enforceWrapperChecksumVerification: true
                 """,
               "org.openrewrite.maven.MultipleWrapperUpdates"
             )

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenWrapperTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenWrapperTest.java
@@ -69,12 +69,48 @@ class UpdateMavenWrapperTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, null));
+        spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, null, Boolean.TRUE));
     }
 
     @Test
     @DocumentExample("Add a new Maven wrapper")
     void addMavenWrapper() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, null, null))
+            .afterRecipe(run -> {
+              assertThat(run.getChangeset().getAllResults()).hasSize(4);
+
+              var mvnw = result(run, PlainText.class, "mvnw");
+              assertThat(mvnw.getSourcePath()).isEqualTo(WRAPPER_SCRIPT_LOCATION);
+              assertThat(mvnw.getText()).isEqualTo(MVNW_TEXT);
+              assertThat(mvnw.getFileAttributes()).isNotNull();
+              assertThat(mvnw.getFileAttributes().isReadable()).isTrue();
+              assertThat(mvnw.getFileAttributes().isWritable()).isTrue();
+
+              var mvnwCmd = result(run, PlainText.class, "mvnw.cmd");
+              assertThat(mvnwCmd.getSourcePath()).isEqualTo(WRAPPER_BATCH_LOCATION);
+              assertThat(mvnwCmd.getText()).isEqualTo(MVNW_CMD_TEXT);
+
+              var mavenWrapperJar = result(run, Remote.class, "maven-wrapper.jar");
+              assertThat(mavenWrapperJar.getSourcePath()).isEqualTo(WRAPPER_JAR_LOCATION);
+              assertThat(mavenWrapperJar.getUri()).isEqualTo(URI.create("https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar"));
+              assertThat(isValidWrapperJar(mavenWrapperJar)).as("Wrapper jar is not valid").isTrue();
+          }),
+          properties(
+            null,
+            withLicenseHeader("""
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              """),
+            spec -> spec.path(".mvn/wrapper/maven-wrapper.properties")
+          )
+        );
+    }
+
+    @Test
+    @DocumentExample("Add a new Maven wrapper with wrapper jar checksum enabled")
+    void addMavenWrapperWithWrapperJarChecksumEnabled() {
         rewriteRun(
           spec -> spec.afterRecipe(run -> {
               assertThat(run.getChangeset().getAllResults()).hasSize(4);
@@ -111,6 +147,100 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     @DocumentExample("Update existing Maven wrapper")
     void updateWrapper() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
+            .afterRecipe(run -> {
+                var mvnw = result(run, PlainText.class, "mvnw");
+                assertThat(mvnw.getSourcePath()).isEqualTo(WRAPPER_SCRIPT_LOCATION);
+                assertThat(mvnw.getText()).isEqualTo(MVNW_TEXT);
+                assertThat(mvnw.getFileAttributes()).isNotNull();
+                assertThat(mvnw.getFileAttributes().isReadable()).isTrue();
+                assertThat(mvnw.getFileAttributes().isWritable()).isTrue();
+
+                var mvnwCmd = result(run, PlainText.class, "mvnw.cmd");
+                assertThat(mvnwCmd.getSourcePath()).isEqualTo(WRAPPER_BATCH_LOCATION);
+                assertThat(mvnwCmd.getText()).isEqualTo(MVNW_CMD_TEXT);
+
+                var mavenWrapperJar = result(run, Remote.class, "maven-wrapper.jar");
+                assertThat(mavenWrapperJar.getSourcePath()).isEqualTo(WRAPPER_JAR_LOCATION);
+                assertThat(mavenWrapperJar.getUri()).isEqualTo(URI.create("https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar"));
+                assertThat(isValidWrapperJar(mavenWrapperJar)).as("Wrapper jar is not valid").isTrue();
+            }),
+          properties(
+            withLicenseHeader("""
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.0/apache-maven-3.8.0-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+              """),
+            withLicenseHeader("""
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
+              """),
+            spec -> spec.path(".mvn/wrapper/maven-wrapper.properties")
+              .afterRecipe(mavenWrapperProperties ->
+                assertThat(mavenWrapperProperties.getMarkers().findFirst(BuildTool.class)).hasValueSatisfying(buildTool -> {
+                    assertThat(buildTool.getType()).isEqualTo(BuildTool.Type.Maven);
+                    assertThat(buildTool.getVersion()).isEqualTo("3.8.8");
+                }))
+          ),
+          mvnw,
+          mvnwCmd,
+          mvnWrapperJarQuark
+        );
+    }
+
+    @Test
+    @DocumentExample("Update existing Maven wrapper")
+    void updateWrapperWithWrapperJarChecksumDisabledButChecksumAlreadyThere() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, null, null))
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
+            .afterRecipe(run -> {
+                var mvnw = result(run, PlainText.class, "mvnw");
+                assertThat(mvnw.getSourcePath()).isEqualTo(WRAPPER_SCRIPT_LOCATION);
+                assertThat(mvnw.getText()).isEqualTo(MVNW_TEXT);
+                assertThat(mvnw.getFileAttributes()).isNotNull();
+                assertThat(mvnw.getFileAttributes().isReadable()).isTrue();
+                assertThat(mvnw.getFileAttributes().isWritable()).isTrue();
+
+                var mvnwCmd = result(run, PlainText.class, "mvnw.cmd");
+                assertThat(mvnwCmd.getSourcePath()).isEqualTo(WRAPPER_BATCH_LOCATION);
+                assertThat(mvnwCmd.getText()).isEqualTo(MVNW_CMD_TEXT);
+
+                var mavenWrapperJar = result(run, Remote.class, "maven-wrapper.jar");
+                assertThat(mavenWrapperJar.getSourcePath()).isEqualTo(WRAPPER_JAR_LOCATION);
+                assertThat(mavenWrapperJar.getUri()).isEqualTo(URI.create("https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar"));
+                assertThat(isValidWrapperJar(mavenWrapperJar)).as("Wrapper jar is not valid").isTrue();
+            }),
+          properties(
+            withLicenseHeader("""
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+              distributionSha256Sum=ba1517f73c5c22cf39afa0d570c998e6e024f37c75569f5c5524a69ff00a7f1b
+              wrapperSha256Sum=46b0acdfe3da08b3f40d25bd135858b6014ee62b92883768995c946a3b446bd6
+              """),
+            withLicenseHeader("""
+              distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+              wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+              distributionSha256Sum=2e181515ce8ae14b7a904c40bb4794831f5fd1d9641107a13b916af15af4001a
+              """),
+            spec -> spec.path(".mvn/wrapper/maven-wrapper.properties")
+              .afterRecipe(mavenWrapperProperties ->
+                assertThat(mavenWrapperProperties.getMarkers().findFirst(BuildTool.class)).hasValueSatisfying(buildTool -> {
+                    assertThat(buildTool.getType()).isEqualTo(BuildTool.Type.Maven);
+                    assertThat(buildTool.getVersion()).isEqualTo("3.8.8");
+                }))
+          ),
+          mvnw,
+          mvnwCmd,
+          mvnWrapperJarQuark
+        );
+    }
+
+    @Test
+    @DocumentExample("Update existing Maven wrapper with wrapper jar checksum enabled")
+    void updateWrapperWithWrapperJarChecksumEnabled() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
             .afterRecipe(run -> {
@@ -157,7 +287,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void updateVersionUsingSourceDistribution() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", "source", "3.8.x", null, null))
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", "source", "3.8.x", null, null, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
             .afterRecipe(run -> {
                 var mvnw = result(run, PlainText.class, "mvnw");
@@ -200,7 +330,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void updateVersionUsingScriptDistribution() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", "script", "3.8.x", null, null))
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", "script", "3.8.x", null, null, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
             .afterRecipe(run -> {
                 var mvnw = result(run, PlainText.class, "mvnw");
@@ -243,7 +373,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void updateVersionUsingOnlyScriptDistribution() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper(null, "only-script", "3.8.x", null, null))
+          spec -> spec.recipe(new UpdateMavenWrapper(null, "only-script", "3.8.x", null, null, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
             .afterRecipe(run -> {
                 var mvnw = result(run, PlainText.class, "mvnw");
@@ -283,7 +413,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void dontAddMissingWrapper() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, Boolean.FALSE))
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, Boolean.FALSE, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
             .afterRecipe(run -> assertThat(run.getChangeset().getAllResults()).isEmpty())
         );
@@ -292,7 +422,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void updateMultipleWrappers() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, Boolean.FALSE))
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", null, "3.8.x", null, Boolean.FALSE, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0"))),
           dir("example1",
             properties(
@@ -353,7 +483,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void allowUpdatingDistributionTypeWhenSameVersion() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", "script", "3.8.x", null, null))
+          spec -> spec.recipe(new UpdateMavenWrapper("3.1.x", "script", "3.8.x", null, null, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.8")))
             .afterRecipe(run -> {
                 var mvnw = result(run, PlainText.class, "mvnw");
@@ -397,7 +527,7 @@ class UpdateMavenWrapperTest implements RewriteTest {
     @Test
     void defaultsToLatestRelease() {
         rewriteRun(
-          spec -> spec.recipe(new UpdateMavenWrapper(null, null, null, null, null))
+          spec -> spec.recipe(new UpdateMavenWrapper(null, null, null, null, null, Boolean.TRUE))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.8.0")))
             .afterRecipe(run -> {
                 var mvnw = result(run, PlainText.class, "mvnw");
@@ -477,10 +607,12 @@ class UpdateMavenWrapperTest implements RewriteTest {
                     wrapperVersion: 3.2.0
                     distributionVersion: 3.8.8
                     addIfMissing: false
+                    checkMavenWrapperJarChecksum: true
                 - org.openrewrite.maven.UpdateMavenWrapper:
                     wrapperVersion: 3.1.1
                     distributionVersion: 3.6.0
                     addIfMissing: false
+                    checkMavenWrapperJarChecksum: true
               """,
             "org.openrewrite.maven.MultipleWrapperUpdates"
             )


### PR DESCRIPTION
## What's changed?

- Make sure the files are updated in place when updated
- Do not escape colons in the URLs injected in the .properties file. When using `mvn wrapper:wrapper` you don't get colons and they are actually causing issues at least for the `maven-wrapper.jar` as this property is not loaded from Java
- Avoid adding the `maven-wrapper.jar` checksum by default as it's causing issues on Windows due to https://issues.apache.org/jira/browse/MWRAPPER-103 -> this is probably something we need to discussed

## What's your motivation?

- https://github.com/openrewrite/rewrite/issues/3982
- Discussions in https://github.com/quarkusio/quarkus/issues/38569

## Anything in particular you'd like reviewers to focus on?

I didn't have the time to add tests for the first commit yet. I'll have a look at it in the next days as time permits if nobody beats me to it.

## Anyone you would like to review specifically?

@timtebeek @shanman190 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files

^ Is there a way to apply the formatter with a command line? I'm all for formatting rules but not using Intellij atm. I suppose I could try to use it if there are no other option.
