### PR TITLE
Add RewriteTestClassesShouldNotBePublic recipe for reviews

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/RewriteTestClassesShouldNotBePublic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/RewriteTestClassesShouldNotBePublic.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Not handled by org.openrewrite.java.testing.cleanup.TestsShouldNotBePublicTest for classes that @Override defaults()
+public class RewriteTestClassesShouldNotBePublic extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "RewriteTest classes should not be public";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove the public modifier from classes that implement RewriteTest.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>("org.openrewrite.test.RewriteTest", true),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                        J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                        if (TypeUtils.isAssignableTo("org.openrewrite.test.RewriteTest", cd.getType()) &&
+                            cd.getModifiers().stream().anyMatch(mod -> mod.getType() == J.Modifier.Type.Public)) {
+
+                            // Remove public modifier and move associated comment
+                            final List<Comment> modifierComments = new ArrayList<>();
+                            List<J.Modifier> modifiers = ListUtils.map(cd.getModifiers(), mod -> {
+                                if (mod.getType() == J.Modifier.Type.Public) {
+                                    modifierComments.addAll(mod.getComments());
+                                    return null;
+                                }
+                                // copy access level modifier comment to next modifier if it exists
+                                if (!modifierComments.isEmpty()) {
+                                    J.Modifier nextModifier = mod.withComments(ListUtils.concatAll(new ArrayList<>(modifierComments), mod.getComments()));
+                                    modifierComments.clear();
+                                    return nextModifier;
+                                }
+                                return mod;
+                            });
+                            // if no following modifier exists, add comments to method itself
+                            if (!modifierComments.isEmpty()) {
+                                cd = cd.withComments(ListUtils.concatAll(cd.getComments(), modifierComments));
+                            }
+                            cd = maybeAutoFormat(cd, cd.withModifiers(modifiers), cd.getName(), ctx, getCursor().getParentTreeCursor());
+                        }
+                        return cd;
+                    }
+                }
+        );
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/recipes/RewriteTestClassesShouldNotBePublicTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/recipes/RewriteTestClassesShouldNotBePublicTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RewriteTestClassesShouldNotBePublicTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+          .recipe(new RewriteTestClassesShouldNotBePublic());
+    }
+
+    @Test
+    void rewriteTestThatOverridesDefaults() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.test.RecipeSpec;
+              import org.openrewrite.test.RewriteTest;
+              
+              // org.openrewrite.java.testing.cleanup.TestsShouldNotBePublicTest skips classes that override defaults()
+              public class ATest implements RewriteTest {
+                  @Override
+                  public void defaults(RecipeSpec spec) {
+                  }
+              }
+              """,
+            """
+              import org.openrewrite.test.RecipeSpec;
+              import org.openrewrite.test.RewriteTest;
+
+              // org.openrewrite.java.testing.cleanup.TestsShouldNotBePublicTest skips classes that override defaults()
+              class ATest implements RewriteTest {
+                  @Override
+                  public void defaults(RecipeSpec spec) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void rewriteTestClassesNotPublic() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.test.RewriteTest;
+              
+              public class ATest implements RewriteTest {
+              }
+              """,
+            """
+              import org.openrewrite.test.RewriteTest;
+
+              class ATest implements RewriteTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeNotPublic() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.test.RewriteTest;
+
+              class ATest implements RewriteTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeNotRewriteTest() {
+        rewriteRun(
+          java(
+            """
+              public class ATest {
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's your motivation?
One less thing to keep an eye on in reviews; mostly lifted from the existing `TestsShouldNotBePublicTest` that does not match when there's overridden methods, and we can't safely change `TestsShouldNotBePublicTest` for other cases.