### PR TITLE
Convert `FindCommitters` to standard recipe

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
     api("com.fasterxml.jackson.module:jackson-module-parameter-names")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("net.java.dev.jna:jna-platform:latest.release")
 
     // Pinning okhttp while waiting on 5.0.0

--- a/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/FindCommitters.java
@@ -21,21 +21,19 @@ import org.openrewrite.*;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.GitProvenance;
-import org.openrewrite.marker.SearchResult;
 import org.openrewrite.table.CommitsByDay;
 import org.openrewrite.table.DistinctCommitters;
 
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Committer>> {
-    private transient final DistinctCommitters committers = new DistinctCommitters(this);
-    private transient final CommitsByDay commitsByDay = new CommitsByDay(this);
+public class FindCommitters extends Recipe {
+
+    transient AtomicBoolean process = new AtomicBoolean(true);
+    transient DistinctCommitters committers = new DistinctCommitters(this);
+    transient CommitsByDay commitsByDay = new CommitsByDay(this);
 
     @Option(displayName = "From date",
             required = false,
@@ -55,23 +53,31 @@ public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Com
     }
 
     @Override
-    public Map<String, GitProvenance.Committer> getInitialValue(ExecutionContext ctx) {
-        return new TreeMap<>();
-    }
-
-    @Override
-    public TreeVisitor<?, ExecutionContext> getScanner(Map<String, GitProvenance.Committer> acc) {
-        LocalDate from = StringUtils.isBlank(this.fromDate) ? null : LocalDate.parse(this.fromDate).minusDays(1);
-        return new TreeVisitor<Tree, ExecutionContext>() {
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(process.get(), new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof SourceFile) {
                     SourceFile sourceFile = (SourceFile) tree;
                     sourceFile.getMarkers().findFirst(GitProvenance.class).ifPresent(provenance -> {
+                        process.set(false);
                         if (provenance.getCommitters() != null) {
+                            LocalDate from = StringUtils.isBlank(fromDate) ? null : LocalDate.parse(fromDate).minusDays(1);
                             for (GitProvenance.Committer committer : provenance.getCommitters()) {
                                 if (from == null || committer.getCommitsByDay().keySet().stream().anyMatch(day -> day.isAfter(from))) {
-                                    acc.put(committer.getEmail(), committer);
+                                    committers.insertRow(ctx, new DistinctCommitters.Row(
+                                            committer.getName(),
+                                            committer.getEmail(),
+                                            committer.getCommitsByDay().lastKey(),
+                                            committer.getCommitsByDay().values().stream().mapToInt(Integer::intValue).sum()
+                                    ));
+
+                                    committer.getCommitsByDay().forEach((day, commits) -> commitsByDay.insertRow(ctx, new CommitsByDay.Row(
+                                            committer.getName(),
+                                            committer.getEmail(),
+                                            day,
+                                            commits
+                                    )));
                                 }
                             }
                         }
@@ -79,40 +85,6 @@ public class FindCommitters extends ScanningRecipe<Map<String, GitProvenance.Com
                 }
                 return tree;
             }
-        };
-    }
-
-    @Override
-    public Collection<? extends SourceFile> generate(Map<String, GitProvenance.Committer> acc, ExecutionContext ctx) {
-        for (GitProvenance.Committer committer : acc.values()) {
-            committers.insertRow(ctx, new DistinctCommitters.Row(
-                    committer.getName(),
-                    committer.getEmail(),
-                    committer.getCommitsByDay().lastKey(),
-                    committer.getCommitsByDay().values().stream().mapToInt(Integer::intValue).sum()
-            ));
-
-            committer.getCommitsByDay().forEach((day, commits) -> commitsByDay.insertRow(ctx, new CommitsByDay.Row(
-                    committer.getName(),
-                    committer.getEmail(),
-                    day,
-                    commits
-            )));
-        }
-        return Collections.emptyList();
-    }
-
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor(Map<String, GitProvenance.Committer> acc) {
-        return new TreeVisitor<Tree, ExecutionContext>() {
-            @Override
-            @Nullable
-            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                if (tree instanceof SourceFile) {
-                    return SearchResult.found(tree, String.join("\n", acc.keySet()));
-                }
-                return tree;
-            }
-        };
+        });
     }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RecipeSpec.java
@@ -225,7 +225,7 @@ public class RecipeSpec {
     }
 
     @Incubating(since = "7.35.0")
-    public <E, V> RecipeSpec dataTableAsCsv(Class<DataTable<?>> dataTableClass, String expect) {
+    public <E, V> RecipeSpec dataTableAsCsv(Class<? extends DataTable<?>> dataTableClass, String expect) {
         return dataTableAsCsv(dataTableClass.getName(), expect);
     }
 


### PR DESCRIPTION
As all source files in a repo contain the same (or identical) `GitProvenance` marker, there is no need for a scanning recipe. Instead, the data tables can be fully generated from the first source file which has a `GitProvenance` marker.

The recipe uses a transient field to remember if the data table has been generated already. An alternative would be to use a message in the `ExecutionContext`.
