### PR TITLE
Allow usage of additional file extensions per parser.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/PathUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/PathUtils.java
@@ -229,6 +229,12 @@ public class PathUtils {
         return excludedPatterns;
     }
 
+    public static String getExtension(Path path) {
+        String pathString = path.toString();
+        final int extensionIndex = pathString.lastIndexOf('.');
+        return extensionIndex < 0 ? "" : pathString.substring(extensionIndex);
+    }
+
     private static String[] tokenize(String path) {
         List<String> tokens = new ArrayList<>();
         int pathIdxStart = 0;

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclParser.java
@@ -46,7 +46,7 @@ public class HclParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(input -> {
+        return acceptedInputs(sourceFiles, ctx).map(input -> {
             try {
                 parsingListener.startedParsing(input);
                 EncodingDetectingInputStream is = input.getSource(ctx);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -188,7 +188,7 @@ public class ReloadableJava17Parser implements JavaParser {
         }
 
         LinkedHashMap<Input, JCTree.JCCompilationUnit> cus = new LinkedHashMap<>();
-        acceptedInputs(sourceFiles).forEach(input1 -> {
+        acceptedInputs(sourceFiles, ctx).forEach(input1 -> {
             try {
                 JCTree.JCCompilationUnit jcCompilationUnit = compiler.parse(new ReloadableJava17ParserInputFileObject(input1, ctx));
                 cus.put(input1, jcCompilationUnit);

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
@@ -188,7 +188,7 @@ public class ReloadableJava21Parser implements JavaParser {
         }
 
         LinkedHashMap<Input, JCTree.JCCompilationUnit> cus = new LinkedHashMap<>();
-        acceptedInputs(sourceFiles).forEach(input1 -> {
+        acceptedInputs(sourceFiles, ctx).forEach(input1 -> {
             try {
                 JCTree.JCCompilationUnit jcCompilationUnit = compiler.parse(new ReloadableJava21ParserInputFileObject(input1, ctx));
                 cus.put(input1, jcCompilationUnit);

--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
@@ -36,7 +36,7 @@ public class JsonParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(input -> {
+        return acceptedInputs(sourceFiles, ctx).map(input -> {
             parsingListener.startedParsing(input);
             try (InputStream sourceStream = input.getSource(ctx)) {
                 JSON5Parser parser = new JSON5Parser(new CommonTokenStream(new JSON5Lexer(

--- a/rewrite-properties/build.gradle.kts
+++ b/rewrite-properties/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
 
     testImplementation(project(":rewrite-test"))
+    testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")
 }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -41,7 +41,7 @@ public class PropertiesParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(input -> {
+        return acceptedInputs(sourceFiles, ctx).map(input -> {
             parsingListener.startedParsing(input);
             Path path = input.getRelativePath(relativeTo);
             try (EncodingDetectingInputStream is = input.getSource(ctx)) {

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
@@ -18,13 +18,16 @@ package org.openrewrite.properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.SetSystemProperty;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
+import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -229,6 +232,31 @@ class PropertiesParserTest implements RewriteTest {
             spec -> spec.afterRecipe(file -> {
                 assertThat(file).isInstanceOf(Properties.File.class);
             })
+          )
+        );
+    }
+
+    @Test
+    @SetSystemProperty(key = "org.openrewrite.properties.PropertiesParser.additionalExtensions", value = ".cfg")
+    void parseAnAdditionalExtensionFromSystemProperty() {
+        rewriteRun(
+          properties(
+            "key=value",
+            spec -> spec.path("file.cfg")
+          )
+        );
+    }
+
+    @Test
+    void parseAnAdditionalExtensionFromContext() {
+        ParsingExecutionContextView ctx = ParsingExecutionContextView.view(new InMemoryExecutionContext());
+        ctx.addAdditionalExtension(PropertiesParser.class, ".cfg");
+
+        rewriteRun(
+          spec -> spec.executionContext(ctx),
+          properties(
+            "key=value",
+            spec -> spec.path("file.cfg")
           )
         );
     }

--- a/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/ProtoParser.java
+++ b/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/ProtoParser.java
@@ -43,7 +43,7 @@ public class ProtoParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(input -> {
+        return acceptedInputs(sourceFiles, ctx).map(input -> {
                     parsingListener.startedParsing(input);
                     Path path = input.getRelativePath(relativeTo);
                     try {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -36,7 +36,7 @@ public class XmlParser implements Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles).map(input -> {
+        return acceptedInputs(sourceFiles, ctx).map(input -> {
             parsingListener.startedParsing(input);
             Path path = input.getRelativePath(relativeTo);
             try (EncodingDetectingInputStream is = input.getSource(ctx)) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -61,7 +61,7 @@ public class YamlParser implements org.openrewrite.Parser {
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
-        return acceptedInputs(sourceFiles)
+        return acceptedInputs(sourceFiles, ctx)
                 .map(input -> {
                     parsingListener.startedParsing(input);
                     Path path = input.getRelativePath(relativeTo);


### PR DESCRIPTION
## What's changed?
Allow parsers to parse additional file extensions.

## What's your motivation?
Parse Karaf's configuration files as properties.

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
No

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
