### PR TITLE
Use `TypedTree` for `J.ForEachLoop.Control#variable`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -464,7 +464,7 @@ public class GroovyParserVisitor {
             // Method name might be in quotes
             Space namePrefix = whitespace();
             String methodName;
-            if(source.startsWith(method.getName(), cursor)) {
+            if (source.startsWith(method.getName(), cursor)) {
                 methodName = method.getName();
             } else {
                 char openingQuote = source.charAt(cursor);
@@ -601,7 +601,7 @@ public class GroovyParserVisitor {
         private Expression insideParentheses(ASTNode node, Function<Space, Expression> parenthesizedTree) {
             Integer insideParenthesesLevel;
             Object rawIpl = node.getNodeMetaData("_INSIDE_PARENTHESES_LEVEL");
-            if(rawIpl instanceof AtomicInteger) {
+            if (rawIpl instanceof AtomicInteger) {
                 // On Java 11 and newer _INSIDE_PARENTHESES_LEVEL is an AtomicInteger
                 insideParenthesesLevel = ((AtomicInteger) rawIpl).get();
             } else {
@@ -697,8 +697,8 @@ public class GroovyParserVisitor {
                 }
             }
 
-            if(unparsedArgs.isEmpty()) {
-                args.add(JRightPadded.build((Expression)new J.Empty(randomId(), whitespace(), Markers.EMPTY))
+            if (unparsedArgs.isEmpty()) {
+                args.add(JRightPadded.build((Expression) new J.Empty(randomId(), whitespace(), Markers.EMPTY))
                         .withAfter(omitParentheses == null ? sourceBefore(")") : EMPTY));
             } else {
                 for (int i = 0; i < unparsedArgs.size(); i++) {
@@ -1304,7 +1304,7 @@ public class GroovyParserVisitor {
             queue.add(labeled(statement, () -> {
                 super.visitExpressionStatement(statement);
                 Object e = queue.poll();
-                if(e instanceof Statement) {
+                if (e instanceof Statement) {
                     return (Statement) e;
                 }
                 return new G.ExpressionStatement(randomId(), (Expression) e);
@@ -1362,7 +1362,7 @@ public class GroovyParserVisitor {
                         forEachMarkers = forEachMarkers.add(new InStyleForEachLoop(randomId()));
                     }
 
-                    JRightPadded<J.VariableDeclarations> variable = JRightPadded.build(new J.VariableDeclarations(randomId(), paramFmt,
+                    JRightPadded<TypedTree> variable = JRightPadded.<TypedTree>build(new J.VariableDeclarations(randomId(), paramFmt,
                             Markers.EMPTY, emptyList(), emptyList(), paramType, null, emptyList(),
                             singletonList(paramName))
                     ).withAfter(rightPad);

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DeleteStatementTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DeleteStatementTest.java
@@ -285,31 +285,6 @@ class DeleteStatementTest implements RewriteTest {
               @Override
               public J.ForEachLoop visitForEachLoop(J.ForEachLoop forLoop, ExecutionContext ctx) {
                   J.ForEachLoop f = super.visitForEachLoop(forLoop, ctx);
-                  doAfterVisit(new DeleteStatement<>(f.getControl().getVariable()));
-                  return f;
-              }
-          })),
-          java(
-            """
-              public class A {
-                  public void a() {
-                      for (int i : new int[]{ 1 }) {
-                          int j = 0;
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void dontDeleteForEachControl() {
-        rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-              @Override
-              public J.ForEachLoop visitForEachLoop(J.ForEachLoop forLoop, ExecutionContext ctx) {
-                  J.ForEachLoop f = super.visitForEachLoop(forLoop, ctx);
                   if (!((J.Block) f.getBody()).getStatements().isEmpty()) {
                       doAfterVisit(new DeleteStatement<>(f.getBody()));
                   }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2138,13 +2138,13 @@ public interface J extends Tree {
             @Getter
             Markers markers;
 
-            JRightPadded<VariableDeclarations> variable;
+            JRightPadded<TypedTree> variable; // not `J.VariableDeclarations` to allow Kotlin destructuring declarations
 
-            public VariableDeclarations getVariable() {
+            public TypedTree getVariable() {
                 return variable.getElement();
             }
 
-            public Control withVariable(VariableDeclarations variable) {
+            public Control withVariable(TypedTree variable) {
                 return getPadding().withVariable(this.variable.withElement(variable));
             }
 
@@ -2187,11 +2187,11 @@ public interface J extends Tree {
             public static class Padding {
                 private final Control t;
 
-                public JRightPadded<VariableDeclarations> getVariable() {
+                public JRightPadded<TypedTree> getVariable() {
                     return t.variable;
                 }
 
-                public Control withVariable(JRightPadded<VariableDeclarations> variable) {
+                public Control withVariable(JRightPadded<TypedTree> variable) {
                     return t.variable == variable ? t : new Control(t.id, t.prefix, t.markers, variable, t.iterable);
                 }
 


### PR DESCRIPTION
This allows Kotlin to use destructuring declarations as the loop variable.
