### PR TITLE
Show detail when recipes make referential changes incorrectly

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -16,16 +16,21 @@
 package org.openrewrite;
 
 import lombok.Getter;
-import org.eclipse.jgit.lib.*;
+import org.eclipse.jgit.lib.FileMode;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.internal.InMemoryDiffEntry;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.RecipesThatMadeChanges;
+import org.openrewrite.marker.SearchResult;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
 
 public class Result {
     /**
@@ -71,9 +76,63 @@ public class Result {
     public Result(@Nullable SourceFile before, SourceFile after) {
         this(before, after, after.getMarkers()
                 .findFirst(RecipesThatMadeChanges.class)
-                .orElseThrow(() -> new IllegalStateException("SourceFile changed but no recipe " +
-                                                             "reported making a change"))
+                .orElseThrow(() -> new IllegalStateException(
+                        String.format(
+                                "Source file changed but no recipe " +
+                                "reported making a change. %s",
+                                explainWhatChanged(before, after)
+                        )
+                ))
                 .getRecipes());
+    }
+
+    private static String explainWhatChanged(@Nullable SourceFile before, SourceFile after) {
+        if (before == null) {
+            return String.format("A new file %s was generated but no recipe reported generating it. This is likely a bug in OpenRewrite itself.",
+                    after.getSourcePath());
+        }
+        Map<UUID, Tree> beforeTrees = new HashMap<>();
+        new TreeVisitor<Tree, Integer>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, Integer integer) {
+                if (tree != null) {
+                    beforeTrees.put(tree.getId(), tree);
+                }
+                return super.visit(tree, integer);
+            }
+        }.visit(before, 0);
+
+        SourceFile changesMarked = (SourceFile) new TreeVisitor<Tree, Integer>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, Integer p) {
+                if (tree != null &&
+                    beforeTrees.get(tree.getId()) != tree &&
+                    !subtreeChanged(tree, beforeTrees)) {
+                    return SearchResult.found(tree);
+                }
+                return super.visit(tree, p);
+            }
+        }.visitNonNull(after, 0);
+
+        String diff = diff(before.printAllTrimmed(), changesMarked.printAllTrimmed(), after.getSourcePath());
+        return "The following diff highlights the places where unexpected changes were made:\n" +
+               Arrays.stream(requireNonNull(diff).split("\n"))
+                       .map(l -> "  " + l)
+                       .collect(Collectors.joining("\n"));
+    }
+
+    private static boolean subtreeChanged(Tree root, Map<UUID, Tree> beforeTrees) {
+        return new TreeVisitor<Tree, AtomicBoolean>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, AtomicBoolean changed) {
+                if (tree != null && tree != root) {
+                    if (beforeTrees.get(tree.getId()) != tree) {
+                        changed.set(true);
+                    }
+                }
+                return super.visit(tree, changed);
+            }
+        }.reduce(root, new AtomicBoolean(false)).get();
     }
 
     /**

--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     testRuntimeOnly("org.apache.commons:commons-lang3:latest.release")
     testRuntimeOnly(project(":rewrite-yaml"))
     testImplementation(project(":rewrite-maven"))
-    testRuntimeOnly("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
+    testImplementation("org.eclipse.jgit:org.eclipse.jgit:5.13.+")
 }
 
 tasks.withType<Javadoc> {

--- a/rewrite-java-test/src/test/java/org/openrewrite/ResultTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/ResultTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.openrewrite.java.Assertions.java;
+
+public class ResultTest implements RewriteTest {
+
+    @Test
+    void noChangesNewList() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println("Hello, world!");
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(before -> {
+                J.CompilationUnit after = (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.Block visitBlock(J.Block block, Integer p) {
+                        // intentional inappropriate creation of a new list
+                        List<Statement> statements = ListUtils.concat(block.getStatements(),
+                          new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY));
+                        return block
+                          .withStatements(statements)
+                          .withStatements(ListUtils.map(statements, (n, s) -> n == 0 ? s : null));
+                    }
+                }.visitNonNull(before, 0);
+
+                assertThat(
+                  assertThrows(IllegalStateException.class, () -> new Result(before, after))
+                    .getMessage()
+                ).contains("+class Test /*~~>*/{");
+            })
+          )
+        );
+    }
+}


### PR DESCRIPTION
Accidental changes to object references can propagate up to the top level `SourceFile` object and cause OpenRewrite to consider the file to have been changed, but when we go to create a diff for the change there is an empty patch.

The most common example of this bug is creating new lists but with the same contents.