### PR TITLE
ChangeParentPom now allows changing groupId/artifactId in the case wh…

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -185,18 +185,20 @@ public class ChangeParentPom extends Recipe {
                         (oldRelativePath == null || matchesGlob(resolvedPom.getValue(tag.getChildValue("relativePath").orElse(null)), oldRelativePath))) {
                         String oldVersion = resolvedPom.getValue(tag.getChildValue("version").orElse(null));
                         assert oldVersion != null;
-                        String targetGroupId = newGroupId == null ? tag.getChildValue("groupId").orElse(oldGroupId) : newGroupId;
-                        String targetArtifactId = newArtifactId == null ? tag.getChildValue("artifactId").orElse(oldArtifactId) : newArtifactId;
+                        String currentGroupId = tag.getChildValue("groupId").orElse(oldGroupId);
+                        String targetGroupId = newGroupId == null ? currentGroupId : newGroupId;
+                        String currentArtifactId = tag.getChildValue("artifactId").orElse(oldArtifactId);
+                        String targetArtifactId = newArtifactId == null ? currentArtifactId : newArtifactId;
                         String targetRelativePath = newRelativePath == null ? tag.getChildValue("relativePath").orElse(oldRelativePath) : newRelativePath;
                         try {
                             Optional<String> targetVersion = findAcceptableVersion(targetGroupId, targetArtifactId, oldVersion, ctx);
                             if (targetVersion.isPresent()) {
                                 List<XmlVisitor<ExecutionContext>> changeParentTagVisitors = new ArrayList<>();
-                                if (!oldGroupId.equals(targetGroupId)) {
+                                if (!currentGroupId.equals(targetGroupId)) {
                                     changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("groupId").get(), targetGroupId));
                                 }
 
-                                if (!oldArtifactId.equals(targetArtifactId)) {
+                                if (!currentArtifactId.equals(targetArtifactId)) {
                                     changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("artifactId").get(), targetArtifactId));
                                 }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -189,7 +189,7 @@ public class ChangeParentPom extends Recipe {
                         String targetArtifactId = newArtifactId == null ? tag.getChildValue("artifactId").orElse(oldArtifactId) : newArtifactId;
                         String targetRelativePath = newRelativePath == null ? tag.getChildValue("relativePath").orElse(oldRelativePath) : newRelativePath;
                         try {
-                            Optional<String> targetVersion = findNewerDependencyVersion(targetGroupId, targetArtifactId, oldVersion, ctx);
+                            Optional<String> targetVersion = findAcceptableVersion(targetGroupId, targetArtifactId, oldVersion, ctx);
                             if (targetVersion.isPresent()) {
                                 List<XmlVisitor<ExecutionContext>> changeParentTagVisitors = new ArrayList<>();
                                 if (!oldGroupId.equals(targetGroupId)) {
@@ -207,7 +207,7 @@ public class ChangeParentPom extends Recipe {
                                 // Update or add relativePath
                                 if (oldRelativePath != null && !oldRelativePath.equals(targetRelativePath)) {
                                     changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("relativePath").get(), targetRelativePath));
-                                } else if (tag.getChildValue("relativePath").orElse(null) == null && targetRelativePath != null) {
+                                } else if (mismatches(tag.getChild("relativePath").orElse(null), targetRelativePath)) {
                                     final Xml.Tag relativePathTag;
                                     if (StringUtils.isBlank(targetRelativePath)) {
                                         relativePathTag = Xml.Tag.build("<relativePath />");
@@ -218,7 +218,7 @@ public class ChangeParentPom extends Recipe {
                                     maybeUpdateModel();
                                 }
 
-                                if (changeParentTagVisitors.size() > 0) {
+                                if (!changeParentTagVisitors.isEmpty()) {
                                     retainVersions();
                                     doAfterVisit(new RemoveRedundantDependencyVersions(null, null, true, retainVersions).getVisitor());
                                     for (XmlVisitor<ExecutionContext> visitor : changeParentTagVisitors) {
@@ -236,6 +236,17 @@ public class ChangeParentPom extends Recipe {
                 return t;
             }
 
+            private boolean mismatches(@Nullable Xml.Tag relativePath, @Nullable String targetRelativePath) {
+                if (relativePath == null) {
+                    return targetRelativePath != null;
+                }
+                String relativePathValue = relativePath.getValue().orElse(null);
+                if (relativePathValue == null) {
+                    return !StringUtils.isBlank(targetRelativePath);
+                }
+                return !relativePathValue.equals(targetRelativePath);
+            }
+
             private void retainVersions() {
                 for (Recipe retainVersionRecipe : RetainVersions.plan(this, retainVersions == null ?
                         emptyList() : retainVersions)) {
@@ -243,7 +254,7 @@ public class ChangeParentPom extends Recipe {
                 }
             }
 
-            private Optional<String> findNewerDependencyVersion(String groupId, String artifactId, String currentVersion,
+            private Optional<String> findAcceptableVersion(String groupId, String artifactId, String currentVersion,
                                                                 ExecutionContext ctx) throws MavenDownloadingException {
                 String finalCurrentVersion = !Semver.isVersion(currentVersion) ? "0.0.0" : currentVersion;
 
@@ -251,10 +262,18 @@ public class ChangeParentPom extends Recipe {
                     MavenMetadata mavenMetadata = metadataFailures.insertRows(ctx, () -> downloadMetadata(groupId, artifactId, ctx));
                     availableVersions = mavenMetadata.getVersioning().getVersions().stream()
                             .filter(v -> versionComparator.isValid(finalCurrentVersion, v))
-                            .filter(v -> Boolean.TRUE.equals(allowVersionDowngrades) || versionComparator.compare(finalCurrentVersion, finalCurrentVersion, v) < 0)
+                            .filter(v -> Boolean.TRUE.equals(allowVersionDowngrades) || versionComparator.compare(finalCurrentVersion, finalCurrentVersion, v) <= 0)
                             .collect(Collectors.toList());
                 }
-                return Boolean.TRUE.equals(allowVersionDowngrades) ? availableVersions.stream().max((v1, v2) -> versionComparator.compare(finalCurrentVersion, v1, v2)) : versionComparator.upgrade(finalCurrentVersion, availableVersions);
+                if (Boolean.TRUE.equals(allowVersionDowngrades)) {
+                    return availableVersions.stream()
+                            .max((v1, v2) -> versionComparator.compare(finalCurrentVersion, v1, v2));
+                }
+                Optional<String> upgradedVersion = versionComparator.upgrade(finalCurrentVersion, availableVersions);
+                if (upgradedVersion.isPresent()) {
+                    return upgradedVersion;
+                }
+                return availableVersions.stream().filter(finalCurrentVersion::equals).findFirst();
             }
         });
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -1323,4 +1323,43 @@ class ChangeParentPomTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeParentToSameVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom("org.springframework.boot", null, "spring-boot-dependencies", "spring-boot-starter-parent", "latest.patch", null, null, null, null, null)),
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-dependencies</artifactId>
+                  <version>2.7.18</version>
+                </parent>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.7.18</version>
+                </parent>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
…ere old and new version match, without requiring the `allowVersionDowngrades` option (also added extra logic to preserve idempotency for `relativePath` changes)

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The new test case was previously failing, with the recipe making no changes. Adding the `allowVersionDowngrades` option as `true` would allow the expected changes, but it's not really a "downgrade", so that option doesn't feel like it should be required in that case.

...And once I made that change, one of the other tests started adding duplicative `<relativePath />` tags on subsequent cycles, hence the adjusted logic in that section.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
The new `return` logic in `findAcceptableVersion` is a bit cumbersome. I considered instead adjusting `VersionComparator::upgrade` to allow returning the current version -- it would certainly simplify this control flow -- but that seemed like a semantic change with implications for all other usages, and even adding an optional arg for that behavior felt excessive.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
