### PR TITLE
Allow declarative preconditions for scanning recipes

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -88,18 +88,37 @@ class DeclarativeRecipeTest implements RewriteTest {
                  toText: 2
               - org.openrewrite.text.ChangeText:
                  toText: 3
+            """, "org.openrewrite.PreconditionTest"),
+          text("1", "3"),
+          text("2")
+        );
+    }
+
+    @Test
+    void yamlPreconditionWithScanningRecipe() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.PreconditionTest
+            preconditions:
+              - org.openrewrite.text.Find:
+                  find: 1
+            recipeList:
               - org.openrewrite.text.CreateTextFile:
                  relativeFileName: test.txt
                  fileContents: "test"
             """, "org.openrewrite.PreconditionTest")
             .afterRecipe(run -> {
                 assertThat(run.getChangeset().getAllResults()).anySatisfy(
-                  s -> assertThat(s.getAfter().getSourcePath()).isEqualTo(Paths.get("test.txt"))
+                  s -> {
+                      assertThat(s.getAfter()).isNotNull();
+                      assertThat(s.getAfter().getSourcePath()).isEqualTo(Paths.get("test.txt"));
+                  }
                 );
-                System.out.println(run);
-            }),
-          text("1", "3"),
-          text("2")
+            })
+            .expectedCyclesThatMakeChanges(1),
+          text("1")
         );
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -30,6 +30,7 @@ import org.openrewrite.text.ChangeText;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -87,7 +88,16 @@ class DeclarativeRecipeTest implements RewriteTest {
                  toText: 2
               - org.openrewrite.text.ChangeText:
                  toText: 3
-            """, "org.openrewrite.PreconditionTest"),
+              - org.openrewrite.text.CreateTextFile:
+                 relativeFileName: test.txt
+                 fileContents: "test"
+            """, "org.openrewrite.PreconditionTest")
+            .afterRecipe(run -> {
+                assertThat(run.getChangeset().getAllResults()).anySatisfy(
+                  s -> assertThat(s.getAfter().getSourcePath()).isEqualTo(Paths.get("test.txt"))
+                );
+                System.out.println(run);
+            }),
           text("1", "3"),
           text("2")
         );


### PR DESCRIPTION
When a declarative recipe contains both preconditions and scanning recipes in its list, the scanning recipe's scanner is never executed because the bellwether precondition doesn't get initialized until the execute phase. Similarly, the generate phase won't be executed either, because `BellwetherDecoratedScanningRecipe` doesn't cater for this.

This PR changes this by always running the scanning and generate phase of any contained scanning recipes. This at least allows scanning recipes to function properly.

More fine grained control of how preconditions should apply to the scanning phase are the subject of #4005.