### PR TITLE
Enhance autoformat logic for Groovy files

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyVisitor.java
@@ -15,10 +15,7 @@
  */
 package org.openrewrite.groovy;
 
-import org.openrewrite.Cursor;
 import org.openrewrite.SourceFile;
-import org.openrewrite.groovy.format.MinimumViableSpacingVisitor;
-import org.openrewrite.groovy.format.OmitParenthesesForLastArgumentLambdaVisitor;
 import org.openrewrite.groovy.tree.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
@@ -172,17 +169,5 @@ public class GroovyVisitor<P> extends JavaVisitor<P> {
     public <J2 extends J> JContainer<J2> visitContainer(JContainer<J2> container,
                                                         GContainer.Location loc, P p) {
         return super.visitContainer(container, JContainer.Location.LANGUAGE_EXTENSION, p);
-    }
-
-    @Override
-    public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, P p, Cursor cursor) {
-        J after = super.autoFormat(j, stopAfter, p, cursor.fork());
-
-        after = new OmitParenthesesForLastArgumentLambdaVisitor<>(stopAfter).visitNonNull(after, p, cursor.fork());
-
-        after = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(after, p, cursor.fork());
-
-        //noinspection unchecked
-        return (J2) after;
     }
 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormat.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormat.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+public class AutoFormat extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Format Groovy code";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Format Groovy code using a standard comprehensive set of Groovy formatting recipes.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AutoFormatVisitor<>(null);
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.format.*;
+import org.openrewrite.java.style.*;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.style.GeneralFormatStyle;
+
+import java.util.Optional;
+
+import static org.openrewrite.java.format.AutodetectGeneralFormatStyle.autodetectGeneralFormatStyle;
+
+public class AutoFormatVisitor<P> extends GroovyIsoVisitor<P> {
+    @Nullable
+    private final Tree stopAfter;
+
+    @SuppressWarnings("unused")
+    public AutoFormatVisitor() {
+        this(null);
+    }
+
+    public AutoFormatVisitor(@Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public J visit(@Nullable Tree tree, P p, Cursor cursor) {
+        JavaSourceFile cu = (tree instanceof JavaSourceFile) ?
+                (JavaSourceFile) tree :
+                cursor.firstEnclosingOrThrow(JavaSourceFile.class);
+
+        J t = new MinimumViableSpacingVisitor<>(stopAfter).visit(tree, p, cursor.fork());
+
+        t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
+                .orElse(IntelliJ.blankLines()), stopAfter)
+                .visit(t, p, cursor.fork());
+
+        t = new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
+                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+                .visit(t, p, cursor.fork());
+
+        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
+                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+                .visit(t, p, cursor.fork());
+
+        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))
+                .orElse(autodetectGeneralFormatStyle(cu)), stopAfter)
+                .visit(t, p, cursor.fork());
+
+        t = new RemoveTrailingWhitespaceVisitor<>(stopAfter).visit(t, p, cursor.fork());
+
+        t = new OmitParenthesesForLastArgumentLambdaVisitor<>(stopAfter).visitNonNull(t, p, cursor.fork());
+
+        t = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(t, p, cursor.fork());
+
+        return t;
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
@@ -48,11 +48,22 @@ public class AutoFormatVisitor<P> extends GroovyIsoVisitor<P> {
                 (JavaSourceFile) tree :
                 cursor.firstEnclosingOrThrow(JavaSourceFile.class);
 
-        J t = new MinimumViableSpacingVisitor<>(stopAfter).visit(tree, p, cursor.fork());
+        J t = new NormalizeFormatVisitor<>(stopAfter).visit(tree, p, cursor.fork());
 
         t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
                 .orElse(IntelliJ.blankLines()), stopAfter)
                 .visit(t, p, cursor.fork());
+
+        t = new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
+                .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+                .visit(t, p, cursor.fork());
+
+        t = new SpacesVisitor<>(
+                Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces()),
+                cu.getStyle(EmptyForInitializerPadStyle.class),
+                cu.getStyle(EmptyForIteratorPadStyle.class),
+                stopAfter
+        ).visit(t, p, cursor.fork());
 
         t = new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
                 .orElse(IntelliJ.tabsAndIndents()), stopAfter)

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MinimumViableSpacingVisitor.java
@@ -15,19 +15,21 @@
  */
 package org.openrewrite.groovy.format;
 
-import lombok.RequiredArgsConstructor;
 import org.openrewrite.Tree;
-import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 
-@RequiredArgsConstructor
-public class MinimumViableSpacingVisitor<P> extends GroovyIsoVisitor<P> {
+public class MinimumViableSpacingVisitor<P> extends org.openrewrite.java.format.MinimumViableSpacingVisitor<P> {
     @Nullable
     private final Tree stopAfter;
+
+    public MinimumViableSpacingVisitor(@Nullable Tree stopAfter) {
+        super(stopAfter);
+        this.stopAfter = stopAfter;
+    }
 
     @Override
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/service/GroovyAutoFormatService.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/service/GroovyAutoFormatService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.service;
+
+import org.openrewrite.Tree;
+import org.openrewrite.groovy.format.AutoFormatVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.service.AutoFormatService;
+
+public class GroovyAutoFormatService extends AutoFormatService {
+    @Override
+    public <P> JavaVisitor<P> autoFormatVisitor(@Nullable Tree stopAfter) {
+        return new AutoFormatVisitor<>(stopAfter);
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -22,9 +22,11 @@ import org.openrewrite.*;
 import org.openrewrite.groovy.GroovyPrinter;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.groovy.internal.GroovyWhitespaceValidationService;
+import org.openrewrite.groovy.service.GroovyAutoFormatService;
 import org.openrewrite.internal.WhitespaceValidationService;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.internal.TypesInUse;
+import org.openrewrite.java.service.AutoFormatService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -141,10 +143,22 @@ public interface G extends J {
         @SuppressWarnings("unchecked")
         @Override
         public <S, T extends S> T service(Class<S> service) {
-            if(WhitespaceValidationService.class.getName().equals(service.getName())) {
-                return (T) new GroovyWhitespaceValidationService();
+            String serviceName = service.getName();
+            try {
+                Class<S> serviceClass;
+                if (GroovyAutoFormatService.class.getName().equals(serviceName)) {
+                    serviceClass = service;
+                } else if (AutoFormatService.class.getName().equals(serviceName)) {
+                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyAutoFormatService.class.getName());
+                } else if (WhitespaceValidationService.class.getName().equals(serviceName)) {
+                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyWhitespaceValidationService.class.getName());
+                } else {
+                    return JavaSourceFile.super.service(service);
+                }
+                return (T) serviceClass.getConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
-            return JavaSourceFile.super.service(service);
         }
 
         List<JRightPadded<Statement>> statements;
@@ -271,7 +285,19 @@ public interface G extends J {
                         .map(i -> (JRightPadded<Statement>) (Object) i)
                         .collect(Collectors.toList()));
 
-                return t.getPadding().getClasses() == classes ? t : new G.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof);
+                List<JRightPadded<ClassDeclaration>> originalClasses = t.getPadding().getClasses();
+                if (originalClasses.size() != classes.size()) {
+                    return new G.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof);
+                } else {
+                    boolean hasChanges = false;
+                    for (int i = 0; i < originalClasses.size(); i++) {
+                        if (originalClasses.get(i) != classes.get(i)) {
+                            hasChanges = true;
+                            break;
+                        }
+                    }
+                    return !hasChanges ? t : new G.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof);
+                }
             }
 
             @Transient
@@ -294,7 +320,19 @@ public interface G extends J {
                         .map(i -> (JRightPadded<Statement>) (Object) i)
                         .collect(Collectors.toList()));
 
-                return t.getPadding().getImports() == imports ? t : new G.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof);
+                List<JRightPadded<Import>> originalImports = t.getPadding().getImports();
+                if (originalImports.size() != imports.size()) {
+                    return new G.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof);
+                } else {
+                    boolean hasChanges = false;
+                    for (int i = 0; i < originalImports.size(); i++) {
+                        if (originalImports.get(i) != imports.get(i)) {
+                            hasChanges = true;
+                            break;
+                        }
+                    }
+                    return !hasChanges ? t : new G.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.packageDeclaration, statements, t.eof);
+                }
             }
 
             public List<JRightPadded<Statement>> getStatements() {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+class AutoFormatVisitorTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AutoFormat());
+    }
+
+    @DocumentExample
+    @Test
+    void keepMaximumBetweenHeaderAndPackage() {
+        rewriteRun(
+          groovy(
+            """
+              /*
+               * This is a sample file.
+               */
+
+
+
+
+              package com.intellij.samples
+
+              class Test {
+              }
+              """,
+            """
+              /*
+               * This is a sample file.
+               */
+
+
+              package com.intellij.samples
+
+              class Test {
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/NormalizeLineBreaksTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/NormalizeLineBreaksTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.format.NormalizeLineBreaksVisitor;
+import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.function.Consumer;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class NormalizeLineBreaksTest implements RewriteTest {
+    private static Consumer<RecipeSpec> normalizeLineBreaks(boolean useCRLF) {
+        return spec -> spec.recipe(toRecipe(() -> new NormalizeLineBreaksVisitor<>(new GeneralFormatStyle(useCRLF))));
+    }
+
+    @Language("groovy")
+    String windows = "" +
+                     "class Test {\r\n" +
+                     "    // some comment\r\n" +
+                     "    def test() {\r\n" +
+                     "        System.out.println()\r\n" +
+                     "    }\r\n" +
+                     "}";
+
+    @Language("groovy")
+    String linux = "" +
+                   "class Test {\n" +
+                   "    // some comment\n" +
+                   "    def test() {\n" +
+                   "        System.out.println()\n" +
+                   "    }\n" +
+                   "}";
+
+    @Language("groovy")
+    String windowsJavadoc = "" +
+                            "/**\r\n" +
+                            " *\r\n" +
+                            " */\r\n" +
+                            "class Test {\r\n" +
+                            "}";
+
+    @Language("groovy")
+    String linuxJavadoc = "" +
+                          "/**\n" +
+                          " *\n" +
+                          " */\n" +
+                          "class Test {\n" +
+                          "}";
+
+    @Test
+    void windowsToLinux() {
+        rewriteRun(
+          normalizeLineBreaks(false),
+          groovy(windows, linux)
+        );
+    }
+
+    @Test
+    void linuxToWindows() {
+        rewriteRun(
+          normalizeLineBreaks(true),
+          groovy(linux, windows)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/980")
+    @Test
+    void doNotChangeWindowsJavadoc() {
+        rewriteRun(
+          normalizeLineBreaks(true),
+          groovy(windowsJavadoc)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/980")
+    @Test
+    void doNotChangeLinuxJavadoc() {
+        rewriteRun(
+          normalizeLineBreaks(false),
+          groovy(linuxJavadoc)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/980")
+    @Test
+    void windowsToLinuxJavadoc() {
+        rewriteRun(
+          normalizeLineBreaks(false),
+          groovy(windowsJavadoc, linuxJavadoc)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/980")
+    @Test
+    void linuxToWindowsJavadoc() {
+        rewriteRun(
+          normalizeLineBreaks(true),
+          groovy(linuxJavadoc, windowsJavadoc)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-docs/issues/67")
+    @Test
+    void preservesExistingWindowsEndingsByDefault() {
+        rewriteRun(
+          normalizeLineBreaks(true),
+          groovy(windows)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-docs/issues/67")
+    @Test
+    void preservesExistingLinuxEndingsByDefault() {
+        rewriteRun(
+          normalizeLineBreaks(false),
+          groovy(linux)
+        );
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/NormalizeTabsOrSpacesTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/NormalizeTabsOrSpacesTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.Tree;
+import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.java.format.NormalizeTabsOrSpacesVisitor;
+import org.openrewrite.java.style.IntelliJ;
+import org.openrewrite.java.style.TabsAndIndentsStyle;
+import org.openrewrite.style.NamedStyles;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class NormalizeTabsOrSpacesTest implements RewriteTest {
+    private static Consumer<RecipeSpec> tabsAndIndents() {
+        return tabsAndIndents(style -> style);
+    }
+
+    private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with) {
+        return spec -> spec.recipe(toRecipe(() -> new NormalizeTabsOrSpacesVisitor<>(with.apply(IntelliJ.tabsAndIndents()))))
+          .parser(GroovyParser.builder().styles(singletonList(
+            new NamedStyles(
+              Tree.randomId(), "test", "test", "test", emptySet(),
+              singletonList(with.apply(IntelliJ.tabsAndIndents()))
+            )
+          )));
+    }
+
+    @DocumentExample
+    @Test
+    void mixedToTabs() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true)),
+          groovy(
+            """
+              class Test {
+                  def test() {
+                      var n = 1
+                  }
+              }
+              """,
+            """
+              class Test {
+              	def test() {
+              		var n = 1
+              	}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mixedToSpaces() {
+        rewriteRun(
+          tabsAndIndents(),
+          groovy(
+            """
+              class Test {
+                  def test() {
+              		val n = 1
+                  }
+              }
+              """,
+            """
+              class Test {
+                  def test() {
+                      val n = 1
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void tabsReplacedWithSpaces() {
+        rewriteRun(
+          tabsAndIndents(),
+          groovy(
+            """
+              class Test {
+              	var a = 1
+              	var b = 2
+              	var c = 3
+              	var d = 4
+              
+              	/*
+              	 *
+              	 *
+              	 *
+              	 *
+              	 */
+              
+              	/**
+              	 *
+              	 *
+              	 *
+              	 *
+              	 */
+              	def test() {
+              	}
+              }
+              """,
+            """
+              class Test {
+                  var a = 1
+                  var b = 2
+                  var c = 3
+                  var d = 4
+              
+                  /*
+                   *
+                   *
+                   *
+                   *
+                   */
+              
+                  /**
+                   *
+                   *
+                   *
+                   *
+                   */
+                  def test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/929")
+    @Test
+    void doNotReplaceSpacesBeforeAsterisks() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true)),
+          groovy(
+            """
+              /**
+               *
+               */
+              class Test {
+              	/*
+              	 * Preserve `*`'s on
+              	 * each new line.
+              	 */
+              	class Inner {
+              	}
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/928")
+    @Test
+    void normalizeJavaDocSuffix() {
+        rewriteRun(
+          tabsAndIndents(),
+          groovy(
+            """
+              class Test {
+              	/** Test
+              	 */
+              	class Inner {
+              	}
+              }
+              """,
+            """
+              class Test {
+                  /** Test
+                   */
+                  class Inner {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1237")
+    @Test
+    void normalizeLastWhitespace() {
+        rewriteRun(
+          tabsAndIndents(style -> style.withUseTabCharacter(true)),
+          groovy(
+            """
+              class Test {
+              	def test() {
+              		var n = 1
+               }
+              }
+              """,
+            """
+              class Test {
+              	def test() {
+              		var n = 1
+              	}
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.groovy.tree;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
@@ -43,6 +44,36 @@ class ConstructorTest implements RewriteTest {
               new Object() {
                   int one() {
                       return i
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Disabled("Fails to parse")
+    void implicitPublic() {
+        rewriteRun(
+          groovy(
+            """
+              class T {
+                  T(int a, int b, int c) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Disabled("Fails to parse")
+    void defaultConstructorArguments() {
+        rewriteRun(
+          groovy(
+            """
+              class T {
+                  T(int a = 1) {
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Bringing back some auto formatting rules to the `G` type. This focuses on tabs VS spaces, normalizing EOL characters, blank lines, and removing trailing whitespace.

## What's your motivation?
Historically, Groovy auto formatting was a bear and would pretty often result in files becoming invalid. As a result, it was disabled fully in the `org.openrewrite.java.format.AutoFormatVisitor`, so that the Java auto formatting rules would never be applied to any non-`J` type.

## Anything in particular you'd like reviewers to focus on?
While re-introducing auto format support, I found two bugs. One of which is found fixed within this PR, but the other has been noted with a pair of disabled tests.

* If a visitor used with `withClasses` or `withImports` on an instance of `G`, this would result in the `G.CompilationUnit` being recreated due to a bug in the logic. Specifically, getting the classes or imports will always return a new list which means that they will never have instance identity equality. So instead, we should verify that the elements themselves are unchanged, then take the appropriate actions.
* GroovyParser appears to be unable to parse the implicit-public constructor. This additionally may extend into constructors with default arguments, so there is a second test case to cover that specific case.

## Have you considered any alternatives or workarounds?
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
