### PR TITLE
Fixed regex in XPathMatcher to support dots

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  */
 public class XPathMatcher {
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']`
-    private static final Pattern PATTERN = Pattern.compile("([-\\w]+)\\[([-\\w]+)='([-\\w]+)']");
+    private static final Pattern PATTERN = Pattern.compile("([-\\w]+)\\[([-\\w]+)='([-\\w.]+)']");
     private final String expression;
 
     public XPathMatcher(String expression) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -147,6 +147,8 @@ class XPathMatcherTest {
           pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[artifactId='maven-compiler-plugin']/configuration/source",
           pomXml1)).isTrue();
+        assertThat(match("/project/build/plugins/plugin[groupId='org.apache.maven.plugins']/configuration/source",
+          pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[artifactId='somethingElse']/configuration/source",
           pomXml1)).isFalse();
         assertThat(match("/project/build//plugins/plugin/configuration/source",


### PR DESCRIPTION
## What's changed?
This PR fixes the Regex Pattern in XPathMatcher to support the 'dot' character in xPaths. 

## What's your motivation?
I was trying to use the xPathMatcher to find a match for a groupId in a pom file (e.g. `dependency[groupId='com.fasterxml.jackson']`). However, I noticed that the Regex pattern defined [here](https://github.com/kislam01/rewrite/blob/main/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java#L43) does not support the 'dot' character, which is why it wasn't able to find a match for the groupId. This PR aims to resolve this issue.



### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
