### PR TITLE
Correctly set `Cursor` in `Repeat`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Cursor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Cursor.java
@@ -26,6 +26,9 @@ import java.util.stream.Stream;
 
 import static java.util.stream.StreamSupport.stream;
 
+/**
+ * A cursor is linked path of LST elements that can be used to traverse down the tree towards the root.
+ */
 @EqualsAndHashCode(exclude = "messages")
 public class Cursor {
     public static final String ROOT_VALUE = "root";
@@ -49,6 +52,13 @@ public class Cursor {
             c = c.parent;
         }
         return c;
+    }
+
+    /**
+     * @return true if this cursor is the root of the tree, false otherwise
+     */
+    final boolean isRoot() {
+        return ROOT_VALUE.equals(value);
     }
 
     public Iterator<Cursor> getPathAsCursors() {

--- a/rewrite-core/src/main/java/org/openrewrite/Repeat.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Repeat.java
@@ -43,10 +43,39 @@ public class Repeat {
                     return tree;
                 }
 
+                if (tree != null && !(tree instanceof SourceFile) && getCursor().isRoot()) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Repeat visitor called on a non-source file tree without a cursor pointing to the root of the tree. " +
+                                    "Passed tree type: `%s`. " +
+                                    "This is likely a bug in the calling code. Use a `visit` method that accepts a cursor instead.",
+                                    tree.getClass().getName()
+                            ));
+                }
+
                 Tree previous = tree;
                 Tree current = null;
                 for (int i = 0; i < maxCycles; i++) {
                     current = v.visit(previous, ctx);
+                    if (current == previous) {
+                        break;
+                    }
+                    previous = current;
+                }
+
+                return current;
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx, Cursor parent) {
+                if (tree instanceof SourceFile && !v.isAcceptable((SourceFile) tree, ctx)) {
+                    return tree;
+                }
+
+                Tree previous = tree;
+                Tree current = null;
+                for (int i = 0; i < maxCycles; i++) {
+                    current = v.visit(previous, ctx, parent);
                     if (current == previous) {
                         break;
                     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/RepeatTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/RepeatTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.RecipeRunException;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
+
+public class RepeatTest implements RewriteTest {
+
+    /**
+     * This visitor verifies that the cursor is well-formed.
+     */
+    static class VerifyCursorWellFormed<P> extends JavaVisitor<P> {
+        @Override
+        public J preVisit(J tree, P p) {
+            assertNotNull(getCursor().firstEnclosing(JavaSourceFile.class), "JavaSourceFile should be accessible");
+            assertNotEquals(getCursor().getParentOrThrow().getValue(), tree, "Tree should not be the same as its parent");
+            return tree;
+        }
+    }
+
+    static class VerifyCursorWellFormedInRepeat extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J preVisit(J tree, ExecutionContext executionContext) {
+            return (J) Repeat.repeatUntilStable(new VerifyCursorWellFormed<>()).visitNonNull(tree, executionContext, getCursor().getParentTreeCursor());
+        }
+    }
+
+    @Test
+    void repeatInPreVisit() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(VerifyCursorWellFormedInRepeat::new)),
+          java("class A {}")
+        );
+    }
+
+    public static class VerifyCursorWellFormedRecipe extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Verify cursor well-formed";
+        }
+
+        @Override
+        public String getDescription() {
+            return "This recipe verifies that the cursor is well-formed.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return Repeat.repeatUntilStable(new VerifyCursorWellFormed<>());
+        }
+    }
+
+    @Test
+    void repeatInRecipe() {
+        rewriteRun(
+          spec -> spec.recipe(new VerifyCursorWellFormedRecipe()),
+          java("class A {}")
+        );
+    }
+
+    static class VisitorThatFailsToSetCursor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public @Nullable J preVisit(J tree, ExecutionContext executionContext) {
+            return (J) Repeat.repeatUntilStable(new JavaVisitor<>()).visitNonNull(tree, executionContext);
+        }
+    }
+
+    @Test
+    void repeatValidatesCursorIsPassed() {
+        AssertionError assertionError = assertThrows(AssertionError.class, () -> {
+            rewriteRun(
+              spec -> spec.recipe(RewriteTest.toRecipe(VisitorThatFailsToSetCursor::new)),
+              java("class A {}")
+            );
+        });
+        assertThat(assertionError).cause().isInstanceOf(RecipeRunException.class);
+        RecipeRunException e = (RecipeRunException) assertionError.getCause();
+        assertThat(e.getMessage())
+          .contains(
+            "Repeat visitor called on a non-source file tree without a cursor pointing to the root of the tree. " +
+            "Passed tree type: `org.openrewrite.java.tree.J$ClassDeclaration`. " +
+            "This is likely a bug in the calling code. " +
+            "Use a `visit` method that accepts a cursor instead."
+          );
+    }
+}


### PR DESCRIPTION
The `Cursor` wasn't being set in `Repeat` causing issues when
used for non `SourceFile` trees.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

## What's changed?

Adds a call to `setCursor` in the loop for `Repeat`.
Also adds internal validation that `Repeat` is being called with the correct
`Cursor` set.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

When using `Recipe` visitors on sub-trees, and those visitors called `autoFormat` they were failing
when the `JavaSourceFile` couldn't be located in the `Cursor` hierarchy.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
