### PR TITLE
Fix 🦶🔫: Validate `visitNonNull` arguments

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -200,6 +200,11 @@ public abstract class TreeVisitor<T extends Tree, P> {
     }
 
     public T visitNonNull(Tree tree, P p, Cursor parent) {
+        if (parent.getValue() instanceof Tree && ((Tree) parent.getValue()).isScope(tree)) {
+            throw new IllegalArgumentException(
+                    "The `parent` cursor must not point to the same `tree` as the tree to be visited"
+            );
+        }
         T t = visit(tree, p, parent);
         assert t != null;
         return t;


### PR DESCRIPTION
I often find myself shooting myself in the foot passing the wrong `Cursor` to `visitNonNull`.

This is a very easy mistake to make and often leads to quite a bit of confusion.

This fixes that by validating that a parent cursor is being passed, not the current cursor.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Adds a bit of sanity validation to `visitNonNull(Tree tree, P p, Cursor parent)`

AFAIK this method is really only called when composing one visitor of another visitor, and
isn't called in the hot-path for normal LST tree traversal.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Reduce how often I and other's new to OpenRewrite make the mistake of passing the `Cursor` for the tree, instead of passing the parent cursor.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
