### PR TITLE
`org.openrewrite.gradle.Assertions#withToolingModel` moved to `org.openrewrite.gradle.toolingapi.Assertions`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 public class Assertions {
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.groovy.Assertions.srcMainGroovy;
 import static org.openrewrite.java.Assertions.java;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -21,7 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class ChangeDependencyTest implements RewriteTest {
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class RemoveDependencyTest implements RewriteTest {
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.properties.Assertions.properties;
 
 class UpgradeDependencyVersionTest implements RewriteTest {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class AddBuildPluginTest implements RewriteTest {
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.test.SourceSpecs.dir;
 
 class AddDevelocityGradlePluginTest implements RewriteTest {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class AddSettingsPluginTest implements RewriteTest {
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class ChangePluginTest implements RewriteTest {
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.properties.Assertions.properties;
 
 class UpgradePluginVersionTest implements RewriteTest {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class DependencyInsightTest implements RewriteTest {
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindGradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindGradleProjectTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.test.SourceSpecs.text;
 


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.ChangeMethodTargetToStatic?organizationId=T3BlblJld3JpdGU%3D