### PR TITLE
Add `RecipesThatMadeChanges` in scanning phase when necessary

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -97,6 +97,12 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                             });
                         } catch (Throwable t) {
                             after = handleError(recipe, source, after, t);
+                            // while the scanner itself is not allowed to make any changes to the source, any
+                            // exception should still be recorded as a marker (so that it can be surfaced to the user)
+                            // and requires a corresponding `RecipesThatMadeChanges` marker
+                            if (after != null && after != source) {
+                                after = addRecipesThatMadeChanges(recipeStack, after);
+                            }
                         }
                     }
                     return after;


### PR DESCRIPTION
Any exceptions caught during the scanning phase may end up getting recorded using a `Markup.Error` marker on the source file. This however also requires a corresponding `RecipesThatMadeChanges` marker.