### PR TITLE
Fix `JavaTemplate` matching of repeated parameters

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
@@ -164,8 +164,8 @@ class JavaTemplateSemanticallyEqual extends SemanticallyEqual {
                 if (marker.getName() != null) {
                     for (Map.Entry<J, String> matchedParameter : matchedParameters.entrySet()) {
                         if (matchedParameter.getValue().equals(marker.getName())) {
-                            if (!SemanticallyEqual.areEqual(matchedParameter.getKey(), j)) {
-                                return false;
+                            if (SemanticallyEqual.areEqual(matchedParameter.getKey(), j)) {
+                                return true;
                             }
                         }
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplateSemanticallyEqual.java
@@ -164,9 +164,7 @@ class JavaTemplateSemanticallyEqual extends SemanticallyEqual {
                 if (marker.getName() != null) {
                     for (Map.Entry<J, String> matchedParameter : matchedParameters.entrySet()) {
                         if (matchedParameter.getValue().equals(marker.getName())) {
-                            if (SemanticallyEqual.areEqual(matchedParameter.getKey(), j)) {
-                                return true;
-                            }
+                            return SemanticallyEqual.areEqual(matchedParameter.getKey(), j);
                         }
                     }
                 }


### PR DESCRIPTION
When a `JavaTemplate` contains the same parameter repeated multiple times, the result returned by `find()` should only register it once.