### PR TITLE
refactor: Refaster rules related to expressions dealing with `String`s

### DIFF
--- a/rewrite-core/src/main/java/org/eclipse/jgit/util/FS.java
+++ b/rewrite-core/src/main/java/org/eclipse/jgit/util/FS.java
@@ -1417,7 +1417,7 @@ public abstract class FS {
 		GobblerThread(Process p, String[] command, File dir) {
 			this.p = p;
 			this.desc = Arrays.toString(command);
-			this.dir = Objects.toString(dir);
+			this.dir = String.valueOf(dir);
 		}
 
 		@Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/FindRecipes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/FindRecipes.java
@@ -36,7 +36,6 @@ import org.openrewrite.table.RewriteRecipeSource;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -153,7 +152,7 @@ public class FindRecipes extends Recipe {
                 } else if (value == null) {
                     return JsonNodeFactory.instance.nullNode();
                 }
-                throw new IllegalArgumentException(Objects.toString(value));
+                throw new IllegalArgumentException(String.valueOf(value));
             }
         });
     }


### PR DESCRIPTION
I'm really curious and want to try the new Error Prone Support integration! 

Use this link to re-run the recipe: https://app.moderne.io/recipes/tech.picnic.errorprone.refasterrules.StringRulesRecipes?organizationId=T3BlblJld3JpdGU%3D