### PR TITLE
Let `UsesMethod` add its own marker

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.search;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -97,7 +96,6 @@ class HasJavaVersionTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail
     @Test
     void combinedWithFindMethod() {
         rewriteRun(
@@ -111,7 +109,8 @@ class HasJavaVersionTest implements RewriteTest {
               - org.openrewrite.java.search.FindMethods:
                   methodPattern: java.util.List add(..)
             """, "org.openrewrite.CombinedWithFindMethod"),
-          java("""
+          java(
+            """
               import java.util.List;
               import java.util.ArrayList;
               class Test {
@@ -121,7 +120,6 @@ class HasJavaVersionTest implements RewriteTest {
                   }
               }
               """,
-
             """
               /*~~>*/import java.util.List;
               import java.util.ArrayList;
@@ -149,7 +147,8 @@ class HasJavaVersionTest implements RewriteTest {
                   version: 11
 
             """, "org.openrewrite.CombinedWithFindMethod"),
-          java("""
+          java(
+            """
               import java.util.List;
               import java.util.ArrayList;
               class Test {
@@ -159,7 +158,6 @@ class HasJavaVersionTest implements RewriteTest {
                   }
               }
               """,
-
             """
               /*~~>*/import java.util.List;
               import java.util.ArrayList;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/UsesMethodTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/UsesMethodTest.java
@@ -60,7 +60,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~(abc.Thing newConcurrentHashSet())~~>*/package abc;
+              /*~~>*/package abc;
                             
               import java.util.Set;
               class Test {
@@ -85,7 +85,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~(A singleArg(String))~~>*/class Test {
+              /*~~>*/class Test {
                   void test() {
                       new java.util.ArrayList<String>().forEach(new A()::singleArg);
                   }
@@ -114,7 +114,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~(java.util.Collections emptyList())~~>*/import java.util.Collections;
+              /*~~>*/import java.util.Collections;
               public class A {
                  Object o = Collections.emptyList();
               }
@@ -135,7 +135,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~(java.util.Collections emptyList())~~>*/import static java.util.Collections.emptyList;
+              /*~~>*/import static java.util.Collections.emptyList;
               public class A {
                  Object o = emptyList();
               }
@@ -157,7 +157,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~(A foo(String, Object...))~~>*/public class B {
+              /*~~>*/public class B {
                  public void test() {
                      new A().foo("s", "a", 1);
                  }
@@ -187,7 +187,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~(B.C foo())~~>*/public class A {
+              /*~~>*/public class A {
                  void test() {
                      new B.C().foo();
                  }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/UsesMethodTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/UsesMethodTest.java
@@ -60,7 +60,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~>*/package abc;
+              /*~~(abc.Thing newConcurrentHashSet())~~>*/package abc;
                             
               import java.util.Set;
               class Test {
@@ -85,7 +85,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~>*/class Test {
+              /*~~(A singleArg(String))~~>*/class Test {
                   void test() {
                       new java.util.ArrayList<String>().forEach(new A()::singleArg);
                   }
@@ -114,7 +114,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~>*/import java.util.Collections;
+              /*~~(java.util.Collections emptyList())~~>*/import java.util.Collections;
               public class A {
                  Object o = Collections.emptyList();
               }
@@ -135,7 +135,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~>*/import static java.util.Collections.emptyList;
+              /*~~(java.util.Collections emptyList())~~>*/import static java.util.Collections.emptyList;
               public class A {
                  Object o = emptyList();
               }
@@ -157,7 +157,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~>*/public class B {
+              /*~~(A foo(String, Object...))~~>*/public class B {
                  public void test() {
                      new A().foo("s", "a", 1);
                  }
@@ -187,7 +187,7 @@ class UsesMethodTest implements RewriteTest {
               }
               """,
             """
-              /*~~>*/public class A {
+              /*~~(B.C foo())~~>*/public class A {
                  void test() {
                      new B.C().foo();
                  }

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -379,6 +379,15 @@ public class MethodMatcher {
         return typePattern(method.getDeclaringType()) + " " +
                method.getName() + "(" + parameters + ")";
     }
+
+    @Override
+    public String toString() {
+        //noinspection DataFlowIssue
+        return (targetType != null ? targetType : targetTypePattern.pattern()) +
+               ' ' +
+               (methodName != null ? methodName : methodNamePattern.pattern()) +
+               '(' + argumentPattern.pattern() + ')';
+    }
 }
 
 class TypeVisitor extends MethodSignatureParserBaseVisitor<String> {

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -65,9 +65,10 @@ public class UseStaticImport extends Recipe {
     }
 
     private class UseStaticImportVisitor extends JavaIsoVisitor<ExecutionContext> {
+        final MethodMatcher methodMatcher = new MethodMatcher(methodPattern);
+
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-            MethodMatcher methodMatcher = new MethodMatcher(methodPattern);
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
             if (methodMatcher.matches(m)) {
                 if (m.getTypeParameters() != null && !m.getTypeParameters().isEmpty()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -67,8 +67,9 @@ public class FindMethods extends Recipe {
     @Override
     @SuppressWarnings("ConstantConditions")
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        MethodMatcher methodMatcher = new MethodMatcher(methodPattern, matchOverrides);
         return Preconditions.check(new UsesMethod<>(methodPattern, matchOverrides), new JavaIsoVisitor<ExecutionContext>() {
+            final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, matchOverrides);
+
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.search;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -28,6 +29,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
+import java.util.function.UnaryOperator;
 
 import static org.openrewrite.Tree.randomId;
 
@@ -106,5 +108,10 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
         UUID id;
         @EqualsAndHashCode.Include
         String methodMatcher;
+
+        @Override
+        public String print(Cursor cursor, UnaryOperator<String> commentWrapper, boolean verbose) {
+            return commentWrapper.apply("");
+        }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.search;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -27,9 +26,9 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.SearchResult;
 
 import java.util.UUID;
-import java.util.function.UnaryOperator;
 
 import static org.openrewrite.Tree.randomId;
 
@@ -73,8 +72,9 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
     }
 
     private <J2 extends J> J2 found(J2 j) {
-        return j.withMarkers(j.getMarkers()
-                .compute(new MethodMatch(randomId(), methodPattern), (s1, s2) -> s1 == null ? s2 : s1));
+        // also adding a `SearchResult` marker to get a visible diff
+        return SearchResult.found(j.withMarkers(j.getMarkers()
+                .compute(new MethodMatch(randomId(), methodPattern), (s1, s2) -> s1 == null ? s2 : s1)));
     }
 
     @Override
@@ -104,14 +104,9 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
     @Value
     @With
     @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-    static class MethodMatch implements Marker {
+    public static class MethodMatch implements Marker {
         UUID id;
         @EqualsAndHashCode.Include
         String methodMatcher;
-
-        @Override
-        public String print(Cursor cursor, UnaryOperator<String> commentWrapper, boolean verbose) {
-            return commentWrapper.apply("(" + methodMatcher + ")");
-        }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -15,6 +15,9 @@
  */
 package org.openrewrite.java.search;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -22,25 +25,35 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.marker.SearchResult;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+import static org.openrewrite.Tree.randomId;
 
 public class UsesMethod<P> extends JavaIsoVisitor<P> {
+    private final String methodPattern;
     private final MethodMatcher methodMatcher;
 
     public UsesMethod(String methodPattern) {
-        this(new MethodMatcher(methodPattern));
+        this(new MethodMatcher(methodPattern), methodPattern);
     }
 
     public UsesMethod(String methodPattern, boolean matchOverrides) {
-        this(new MethodMatcher(methodPattern, matchOverrides));
+        this(new MethodMatcher(methodPattern, matchOverrides), methodPattern);
     }
 
     public UsesMethod(String methodPattern, @Nullable Boolean matchOverrides) {
-        this(new MethodMatcher(methodPattern, Boolean.TRUE.equals(matchOverrides)));
+        this(new MethodMatcher(methodPattern, Boolean.TRUE.equals(matchOverrides)), methodPattern);
     }
 
     public UsesMethod(MethodMatcher methodMatcher) {
+        this(methodMatcher, methodMatcher.toString());
+    }
+
+    private UsesMethod(MethodMatcher methodMatcher, String methodPattern) {
         this.methodMatcher = methodMatcher;
+        this.methodPattern = methodPattern;
     }
 
     @Override
@@ -49,7 +62,7 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
             JavaSourceFile cu = (JavaSourceFile) tree;
             for (JavaType.Method type : cu.getTypesInUse().getUsedMethods()) {
                 if (methodMatcher.matches(type)) {
-                    return SearchResult.found(cu);
+                    return found(cu);
                 }
             }
             return (J) tree;
@@ -57,10 +70,15 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
         return super.visit(tree, p);
     }
 
+    private <J2 extends J> J2 found(J2 j) {
+        return j.withMarkers(j.getMarkers()
+                .compute(new MethodMatch(randomId(), methodPattern), (s1, s2) -> s1 == null ? s2 : s1));
+    }
+
     @Override
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
         if (methodMatcher.matches(method)) {
-            return SearchResult.found(method);
+            return found(method);
         }
         return super.visitMethodInvocation(method, p);
     }
@@ -68,7 +86,7 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
     @Override
     public J.MemberReference visitMemberReference(J.MemberReference memberRef, P p) {
         if (methodMatcher.matches(memberRef)) {
-            return SearchResult.found(memberRef);
+            return found(memberRef);
         }
         return super.visitMemberReference(memberRef, p);
     }
@@ -76,8 +94,17 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
     @Override
     public J.NewClass visitNewClass(J.NewClass newClass, P p) {
         if (methodMatcher.matches(newClass)) {
-            return SearchResult.found(newClass);
+            return found(newClass);
         }
         return super.visitNewClass(newClass, p);
+    }
+
+    @Value
+    @With
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    static class MethodMatch implements Marker {
+        UUID id;
+        @EqualsAndHashCode.Include
+        String methodMatcher;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesMethod.java
@@ -111,7 +111,7 @@ public class UsesMethod<P> extends JavaIsoVisitor<P> {
 
         @Override
         public String print(Cursor cursor, UnaryOperator<String> commentWrapper, boolean verbose) {
-            return commentWrapper.apply("");
+            return commentWrapper.apply("(" + methodMatcher + ")");
         }
     }
 }


### PR DESCRIPTION
When `FindMethods` is used on a source file that already has a `SearchResult` marker on the root node (as e.g. added by `HasJavaVersion`) then the recipe will not find anything, because its `UsesMethod` precondition evaluates to `false` (because the root node already has a `SearchResult` marker).

To avoid this aliasing issue and also avoid issues if `UsesMethod` is applied before another recipe / visitor that adds a `SearchResult` marker, the `UsesMethod` visitor now uses its own marker type. The marker will only be added if the source file doesn't already have a marker which was created for the same method pattern.