### PR TITLE
Fix documentation example for maven.AddPlugin

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -72,7 +72,7 @@ public class AddPlugin extends Recipe {
 
     @Option(displayName = "Executions",
             description = "Optional executions provided as raw XML.",
-            example = "<execution><phase>generate-sources</phase><goals><goal>add-source</goal></goals></execution>",
+            example = "<executions><execution><phase>generate-sources</phase><goals><goal>add-source</goal></goals></execution></executions>",
             required = false)
     @Nullable
     String executions;


### PR DESCRIPTION
## What's changed?
Fix documentation example for maven.AddPlugin

## What's your motivation?
The <executions> element has to be included by the user, as is made clear in AddPluginTest: https://github.com/openrewrite/rewrite/blob/main/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java#L125-L139

## Any additional context
One could possibly argue that the documentation is correct, but the implementation is wrong; but the implementation follows the same convention used by the other parameters (`configuration` and `dependencies`). 
