### PR TITLE
Only report unrecovered repositoryAccessFailed

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -744,11 +744,6 @@ public class MavenPomDownloader {
                         if (e.isServerReached()) {
                             normalized = repository.withUri(httpsUri);
                         }
-                        if (!"Directory listing forbidden".equals(e.getBody())) {
-                            ctx.getResolutionListener().repositoryAccessFailed(httpsUri, t);
-                        }
-                    } else {
-                        ctx.getResolutionListener().repositoryAccessFailed(httpsUri, t);
                     }
                     if (normalized == null) {
                         if (!httpsUri.equals(originalUrl)) {
@@ -776,11 +771,11 @@ public class MavenPomDownloader {
                                 }
                             } catch (Throwable e) {
                                 // ok to fall through here and cache a null
-                                ctx.getResolutionListener().repositoryAccessFailed(originalUrl, t);
                             }
                         }
                     }
-                    if (normalized == null) {
+                    if (normalized == null && !(t instanceof HttpSenderResponseException &&
+                                                ((HttpSenderResponseException) t).getBody().contains("Directory listing forbidden"))) {
                         ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), t);
                     }
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -731,6 +731,9 @@ public class MavenPomDownloader {
                 String httpsUri = repository.getUri().toLowerCase().startsWith("http:") ?
                         repository.getUri().replaceFirst("[hH][tT][tT][pP]://", "https://") :
                         repository.getUri();
+                if (!httpsUri.endsWith("/")) {
+                    httpsUri += "/";
+                }
 
                 HttpSender.Request.Builder request = applyAuthenticationToRequest(repository, httpSender.get(httpsUri));
                 MavenRepository normalized = null;


### PR DESCRIPTION
Following questions like https://github.com/openrewrite/rewrite-maven-plugin/issues/742

Now that we surface `repositoryAccessFailed` in download logs and the Maven plugin, we don't want to raise any false alarms. We seem to also have sufficiently troubleshot the issues that prompted the eager propagation of exceptions, such that a reduced case could now make sense again.