### PR TITLE
Fix gradle build files parsing issues

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -731,9 +731,10 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitClassExpression(ClassExpression clazz) {
-            queue.add(TypeTree.build(clazz.getType().getUnresolvedName())
+            String unresolvedName = clazz.getType().getUnresolvedName().replace('$', '.');
+            queue.add(TypeTree.build(unresolvedName)
                     .withType(typeMapping.type(clazz.getType()))
-                    .withPrefix(sourceBefore(clazz.getType().getUnresolvedName())));
+                    .withPrefix(sourceBefore(unresolvedName)));
         }
 
         @Override
@@ -1175,6 +1176,10 @@ public class GroovyParserVisitor {
                     jType = JavaType.Primitive.String;
                     // String literals value returned by getValue()/getText() has already processed sequences like "\\" -> "\"
                     int length = sourceLengthOfNext(expression);
+                    // this is an attribute selector
+                    if (source.startsWith("@"+value, cursor)) {
+                        length += 1;
+                    }
                     text = source.substring(cursor, cursor + length);
                     int delimiterLength = 0;
                     if (text.startsWith("$/")) {
@@ -1702,6 +1707,27 @@ public class GroovyParserVisitor {
         }
 
         @Override
+        public void visitAttributeExpression(AttributeExpression attr) {
+            Space fmt = whitespace();
+            Expression target = visit(attr.getObjectExpression());
+            Space beforeDot = attr.isSafe() ? sourceBefore("?.") :
+                    sourceBefore(attr.isSpreadSafe() ? "*." : ".");
+            J name = visit(attr.getProperty());
+            if (name instanceof J.Literal) {
+                String nameStr = ((J.Literal) name).getValueSource();
+                assert nameStr != null;
+                name = new J.Identifier(randomId(), name.getPrefix(), Markers.EMPTY, emptyList(), nameStr, null, null);
+            }
+            if (attr.isSpreadSafe()) {
+                name = name.withMarkers(name.getMarkers().add(new StarDot(randomId())));
+            }
+            if (attr.isSafe()) {
+                name = name.withMarkers(name.getMarkers().add(new NullSafe(randomId())));
+            }
+            queue.add(new J.FieldAccess(randomId(), fmt, Markers.EMPTY, target, padLeft(beforeDot, (J.Identifier) name), null));
+        }
+
+        @Override
         public void visitPropertyExpression(PropertyExpression prop) {
             Space fmt = whitespace();
             Expression target = visit(prop.getObjectExpression());
@@ -2039,7 +2065,7 @@ public class GroovyParserVisitor {
             String packageName = importNode.getPackageName();
             J.FieldAccess qualid;
             if (packageName == null) {
-                String type = importNode.getType().getName();
+                String type = importNode.getType().getName().replace('$', '.');
                 if (importNode.isStar()) {
                     type += ".*";
                 } else if (importNode.getFieldName() != null) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
@@ -83,12 +83,12 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
         throw new UnsupportedOperationException("Unknown type " + type.getClass().getName());
     }
 
-    private JavaType.Class classType(ClassNode node, String signature) {
-        JavaType.Class clazz;
+    private JavaType.FullyQualified classType(ClassNode node, String signature) {
         try {
             JavaType type = reflectionTypeMapping.type(node.getTypeClass());
-            clazz = (JavaType.Class) (type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type);
+            return (JavaType.FullyQualified) (type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type);
         } catch (GroovyBugError | NoClassDefFoundError ignored1) {
+            JavaType.Class clazz;
             clazz = new JavaType.Class(null, Flag.Public.getBitMask(), node.getName(), JavaType.Class.Kind.Class,
                     null, null, null, null, null, null, null);
             typeCache.put(signature, clazz);
@@ -130,16 +130,16 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
             List<JavaType.FullyQualified> annotations = getAnnotations(node);
 
             clazz.unsafeSet(null, supertype, owner, annotations, interfaces, fields, methods);
+            return clazz;
         }
 
-        return clazz;
     }
 
     private JavaType parameterizedType(ClassNode type, String signature) {
         JavaType.Parameterized pt = new JavaType.Parameterized(null, null, null);
         typeCache.put(signature, pt);
 
-        JavaType.Class clazz = classType(type, type.getPlainNodeReference().getName());
+        JavaType.FullyQualified clazz = classType(type, type.getPlainNodeReference().getName());
 
         List<JavaType> typeParameters = emptyList();
         if (type.getGenericsTypes() != null && type.getGenericsTypes().length > 0) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -20,43 +20,19 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
 
-class ClassExpressionTest implements RewriteTest {
+@SuppressWarnings({"GroovyUnusedAssignment", "GrUnnecessarySemicolon"})
+class AttributeTest implements RewriteTest {
 
     @Test
-    void classExpressions() {
+    void usingGroovyNode() {
         rewriteRun(
           groovy(
             """
-              maven( List , List ) {
-                  from(components.java)
-              }
+              def xml = new Node(null, "ivy")
+              def n = xml.dependencies.dependency.find { it.@name == 'test-module' }
+              n.@conf = 'runtime->default;docs->docs;sources->sources'
               """
           )
         );
-    }
-
-    @Test
-    void innerClassExpression() {
-        rewriteRun(
-          groovy(
-            """
-              ProcessBuilder.Redirect.to(new File("wat"))
-              """
-          )
-        );
-
-    }
-
-    @Test
-    void innerClassViaImport() {
-        rewriteRun(
-          groovy(
-            """
-              import java.lang.ProcessBuilder.Redirect
-              Redirect.to(new File("wat"))
-              """
-          )
-        );
-
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Improved the groovy parser to support:
- reference to FQNC like in the `ProcessBuilder.Redirect.to(..)` call
- groovy xml node attribute manipulation like `n.@conf = 'runtime->default;docs->docs;sources->sources'`

## What's your motivation?
I tried to use the ChangeDependency recipe on an old gradle build with lots of custom code

## Anything in particular you'd like reviewers to focus on?
- in `GroovyTypeMapping#classType`, in production i've encountered some `ClassCastException` where `JavaType.Unknown` cannot be casted to `JavaType.Class` but i was not able to reproduce in unit tests. I found that downcasting to `JavaType.FullyQualified` avoids the CCE and does not seem to break something else



## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases 
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
 
