### PR TITLE
`JavaParser` should favor public classes when naming source inputs

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -20,6 +20,8 @@ import io.github.classgraph.ScanResult;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.SourceFile;
@@ -129,5 +131,20 @@ class JavaParserTest implements RewriteTest {
                   i -> assertThat(i.getType()).hasToString("InterfaceB")
                 )));
         }
+    }
+
+    @ParameterizedTest
+    // language=java
+    @ValueSource(strings = {
+      "package my.example; class PrivateClass { void foo() {} } public class PublicClass { void bar() {} }",
+      "package my.example; public class PublicClass { void bar() {} } class PrivateClass { void foo() {} }"
+    })
+    void shouldResolvePathUsingPublicClasses(@Language("java") String source) {
+        rewriteRun(
+          java(
+            source,
+            spec -> spec.afterRecipe(cu -> assertThat(cu.getSourcePath()).hasToString("my/example/PublicClass.java"))
+          )
+        );
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -419,9 +419,14 @@ public interface JavaParser extends Parser {
     default Path sourcePathFromSourceText(Path prefix, String sourceCode) {
         Pattern packagePattern = Pattern.compile("^package\\s+([^;]+);");
         Pattern classPattern = Pattern.compile("(class|interface|enum|record)\\s*(<[^>]*>)?\\s+(\\w+)");
+        Pattern publicClassPattern = Pattern.compile("public\\s+" + classPattern.pattern());
 
         Function<String, String> simpleName = sourceStr -> {
-            Matcher classMatcher = classPattern.matcher(sourceStr);
+            Matcher classMatcher = publicClassPattern.matcher(sourceStr);
+            if (classMatcher.find()) {
+                return classMatcher.group(3);
+            }
+            classMatcher = classPattern.matcher(sourceStr);
             return classMatcher.find() ? classMatcher.group(3) : null;
         };
 


### PR DESCRIPTION
## What's changed?
This a follow-up on #4040, `JavaParser` should try to use public class names, when available.  

## What's your motivation?
Identified while testing #4030 

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
No

## Have you considered any alternatives or workarounds?
You can provide the correct source path when calling the Java Parser directly, but not when the parser is being called by a `JavaTemplate`.

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
