### PR TITLE
Add `AddNullMethodArgument` recipe

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class AddNullMethodArgumentTest implements RewriteTest {
+    @Language("java")
+    String b = """
+      class B {
+         public static void foo() {}
+         public static void foo(Integer n) {}
+         public static void foo(Integer n1, Integer n2) {}
+         public static void foo(Integer n1, Integer n2, Integer n3) {}
+         public B() {}
+         public B(Integer n) {}
+      }
+      """;
+
+    @Test
+    void addToMiddleArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new AddNullMethodArgument("B foo(Integer, Integer)", 1)),
+          java(b),
+          java(
+            "public class A {{ B.foo(0, 1); }}",
+            "public class A {{ B.foo(0, null, 1); }}"
+          )
+        );
+    }
+
+    @Test
+    void addArgumentsConsecutively() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new AddNullMethodArgument("B foo(Integer)", 1),
+            new AddNullMethodArgument("B foo(Integer, Integer)", 1)
+          ),
+          java(b),
+          java("public class A {{ B.foo(0); }}",
+            "public class A {{ B.foo(0, null, null); }}"
+          )
+        );
+    }
+
+    @Test
+    void addToConstructorArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new AddNullMethodArgument("B <constructor>()", 0)),
+          java(b),
+          java(
+            "public class A { B b = new B(); }",
+            "public class A { B b = new B(null); }"
+          )
+        );
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
@@ -15,23 +15,24 @@
  */
 package org.openrewrite.java;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
 class AddNullMethodArgumentTest implements RewriteTest {
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().dependsOn("""
           class B {
-             public static void foo() {}
-             public static void foo(Integer n) {}
-             public static void foo(Integer n1, Integer n2) {}
-             public static void foo(Integer n1, Integer n2, Integer n3) {}
-             public B() {}
-             public B(Integer n) {}
+             static void foo() {}
+             static void foo(Integer n) {}
+             static void foo(Integer n1, Integer n2) {}
+             static void foo(Integer n1, Integer n2, Integer n3) {}
+             B() {}
+             B(Integer n) {}
           }
           """));
     }
@@ -41,8 +42,8 @@ class AddNullMethodArgumentTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new AddNullMethodArgument("B foo(Integer, Integer)", 1)),
           java(
-            "public class A {{ B.foo(0, 1); }}",
-            "public class A {{ B.foo(0, null, 1); }}"
+            "class A {{ B.foo(0, 1); }}",
+            "class A {{ B.foo(0, null, 1); }}"
           )
         );
     }
@@ -54,7 +55,6 @@ class AddNullMethodArgumentTest implements RewriteTest {
             new AddNullMethodArgument("B foo(Integer)", 1),
             new AddNullMethodArgument("B foo(Integer, null)", 1)
           ),
-          java(b),
           java(
             "class A {{ B.foo(0); }}",
             "class A {{ B.foo(0, null, null); }}"
@@ -66,10 +66,9 @@ class AddNullMethodArgumentTest implements RewriteTest {
     void addToConstructorArgument() {
         rewriteRun(
           spec -> spec.recipe(new AddNullMethodArgument("B <constructor>()", 0)),
-          java(b),
           java(
-            "public class A { B b = new B(); }",
-            "public class A { B b = new B(null); }"
+            "class A { B b = new B(); }",
+            "class A { B b = new B(null); }"
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
@@ -81,7 +81,7 @@ class AddNullMethodArgumentTest implements RewriteTest {
           spec -> spec.recipe(new AddNullMethodArgument("B foo(Integer,Integer,Integer)", 3, "java.lang.String", "n2", true)),
           java(
             "class A {{ B.foo(0, 1, 2); }}",
-            "class A {{ B.foo(0, 1, 2, (String) null); }}"
+            "class A {{ B.foo(0, 1, 2, (java.lang.String) null); }}"
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
@@ -42,7 +42,7 @@ class AddNullMethodArgumentTest implements RewriteTest {
     @Test
     void addToMiddleArgument() {
         rewriteRun(
-          spec -> spec.recipe(new AddNullMethodArgument("B foo(Integer, Integer)", 1, Integer.class.getName(), "n2", false)),
+          spec -> spec.recipe(new AddNullMethodArgument("B foo(Integer, Integer)", 1, "java.lang.Integer", "n2", false)),
           java(
             "class A {{ B.foo(0, 1); }}",
             "class A {{ B.foo(0, null, 1); }}"
@@ -54,8 +54,8 @@ class AddNullMethodArgumentTest implements RewriteTest {
     void addArgumentsConsecutively() {
         rewriteRun(
           spec -> spec.recipes(
-            new AddNullMethodArgument("B foo(Integer)", 1, Integer.class.getName(), "n2", false),
-            new AddNullMethodArgument("B foo(Integer, Integer)", 1, Integer.class.getName(), "n2", false)
+            new AddNullMethodArgument("B foo(Integer)", 1, "java.lang.Integer", "n2", false),
+            new AddNullMethodArgument("B foo(Integer, Integer)", 1, "java.lang.Integer", "n2", false)
           ),
           java(
             "class A {{ B.foo(0); }}",
@@ -67,7 +67,7 @@ class AddNullMethodArgumentTest implements RewriteTest {
     @Test
     void addToConstructorArgument() {
         rewriteRun(
-          spec -> spec.recipe(new AddNullMethodArgument("B <constructor>()", 0, Integer.class.getName(), "arg", false)),
+          spec -> spec.recipe(new AddNullMethodArgument("B <constructor>()", 0, "java.lang.Integer", "arg", false)),
           java(
             "class A { B b = new B(); }",
             "class A { B b = new B(null); }"

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddNullMethodArgumentTest.java
@@ -51,7 +51,7 @@ class AddNullMethodArgumentTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipes(
             new AddNullMethodArgument("B foo(Integer)", 1),
-            new AddNullMethodArgument("B foo(Integer, Integer)", 1)
+            new AddNullMethodArgument("B foo(Integer, null)", 1)
           ),
           java(b),
           java("public class A {{ B.foo(0); }}",

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
@@ -127,7 +127,6 @@ public class AddNullMethodArgument extends Recipe {
                             new J.ControlParentheses<>(randomId(), EMPTY, Markers.EMPTY,
                                     new JRightPadded<>(TypeTree.build(parameterType), EMPTY, Markers.EMPTY)),
                             nullLiteral);
-                    maybeAddImport(parameterType);
                 }
                 m = m.withArguments(ListUtils.insert(args, nullLiteral, argumentIndex));
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.Tree.randomId;
+
+/**
+ * This recipe finds method invocations matching a method pattern and uses a zero-based argument index to determine
+ * which argument is added with a null value.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class AddNullMethodArgument extends Recipe {
+
+    /**
+     * A method pattern that is used to find matching method invocations.
+     * See {@link  MethodMatcher} for details on the expression's syntax.
+     */
+    @Option(displayName = "Method pattern",
+            description = "A method pattern that is used to find matching method invocations.",
+            example = "com.yourorg.A foo(int, int)")
+    String methodPattern;
+
+    /**
+     * A zero-based index that indicates which argument will be added as null to the method invocation.
+     */
+    @Option(displayName = "Argument index",
+            description = "A zero-based index that indicates which argument will be added as null to the method invocation.",
+            example = "0")
+    int argumentIndex;
+
+    @Override
+    public String getInstanceNameSuffix() {
+        return String.format("%d in methods `%s`", argumentIndex, methodPattern);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Delete method argument";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Delete an argument from method invocations.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(methodPattern), new AddNullMethodArgumentVisitor(new MethodMatcher(methodPattern)));
+    }
+
+    private class AddNullMethodArgumentVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final MethodMatcher methodMatcher;
+
+        public AddNullMethodArgumentVisitor(MethodMatcher methodMatcher) {
+            this.methodMatcher = methodMatcher;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+            return (J.MethodInvocation) visitMethodCall(m);
+        }
+
+        @Override
+        public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+            J.NewClass n = super.visitNewClass(newClass, ctx);
+            return (J.NewClass) visitMethodCall(n);
+        }
+
+        private MethodCall visitMethodCall(MethodCall methodCall) {
+            MethodCall m = methodCall;
+            List<Expression> originalArgs = m.getArguments();
+            if (methodMatcher.matches(m) && (long) originalArgs.size() >= argumentIndex) {
+                List<Expression> args = new ArrayList<>(originalArgs);
+
+                if(args.size() == 1 && args.get(0) instanceof J.Empty) {
+                    args.remove(0);
+                }
+
+                args.add(argumentIndex, new J.Literal(randomId(), args.isEmpty() ? Space.EMPTY : Space.SINGLE_SPACE, Markers.EMPTY, "null", "null", null, JavaType.Primitive.Null));
+                m = m.withArguments(args);
+
+                JavaType.Method methodType = m.getMethodType();
+                if (methodType != null) {
+                    List<String> parameterNames = new ArrayList<>(methodType.getParameterNames());
+                    parameterNames.add(argumentIndex, "null");
+                    List<JavaType> parameterTypes = new ArrayList<>(methodType.getParameterTypes());
+                    parameterTypes.add(argumentIndex, JavaType.Primitive.Null);
+
+                    m = m.withMethodType(methodType
+                            .withParameterNames(parameterNames)
+                            .withParameterTypes(parameterTypes));
+                    if (m instanceof J.MethodInvocation && ((J.MethodInvocation) m).getName().getType() != null) {
+                        m = ((J.MethodInvocation) m).withName(((J.MethodInvocation) m).getName().withType(m.getMethodType()));
+                    }
+                }
+            }
+            return m;
+        }
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
@@ -59,12 +59,12 @@ public class AddNullMethodArgument extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Add a `null` method argument"
+        return "Add a `null` method argument";
     }
 
     @Override
     public String getDescription() {
-        return "Add a `null` argument to method invocations."
+        return "Add a `null` argument to method invocations.";
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
@@ -133,14 +133,11 @@ public class AddNullMethodArgument extends Recipe {
 
                 JavaType.Method methodType = m.getMethodType();
                 if (methodType != null) {
-                    List<String> parameterNames = new ArrayList<>(methodType.getParameterNames());
-                    parameterNames.add(argumentIndex, parameterName == null ? "arg" + argumentIndex : parameterName);
-                    List<JavaType> parameterTypes = new ArrayList<>(methodType.getParameterTypes());
-                    parameterTypes.add(argumentIndex, JavaType.buildType(parameterType));
-
                     m = m.withMethodType(methodType
-                            .withParameterNames(parameterNames)
-                            .withParameterTypes(parameterTypes));
+                            .withParameterNames(ListUtils.insert(methodType.getParameterNames(),
+                                    parameterName == null ? "arg" + argumentIndex : parameterName, argumentIndex))
+                            .withParameterTypes(ListUtils.insert(methodType.getParameterTypes(),
+                                    JavaType.buildType(parameterType), argumentIndex)));
                     if (m instanceof J.MethodInvocation && ((J.MethodInvocation) m).getName().getType() != null) {
                         m = ((J.MethodInvocation) m).withName(((J.MethodInvocation) m).getName().withType(m.getMethodType()));
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,12 +59,12 @@ public class AddNullMethodArgument extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Delete method argument";
+        return "Add a `null` method argument"
     }
 
     @Override
     public String getDescription() {
-        return "Delete an argument from method invocations.";
+        return "Add a `null` argument to method invocations."
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
Add recipe `AddNullMethodArgument`

## What's your motivation?
When changing a method we often add a nullable argument. Sometimes overriding it as to not break existing consumers. With this recipe we can migrate more quickly by adding a null value as the argument.

## Anything in particular you'd like reviewers to focus on?
line 104 of the recipe, creating the actual `null` literal.
~Also `addArgumentsConsecutively` is not working as expected. Any suggestions? If not I'll give it another try soon.~

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
