### PR TITLE
Make unit test work correctly on Windows

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -143,7 +143,7 @@ class JavaParserTest implements RewriteTest {
         rewriteRun(
           java(
             source,
-            spec -> spec.afterRecipe(cu -> assertThat(cu.getSourcePath()).hasToString("my/example/PublicClass.java"))
+            spec -> spec.afterRecipe(cu -> assertThat(cu.getSourcePath()).isEqualTo(Path.of("my","example","PublicClass.java")))
           )
         );
     }


### PR DESCRIPTION
The String representation of a path is related to the OS (or more correctly the underlying file system implementation). Compare the path without converting to String to be OS agnostic.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's your motivation?
The unit test failed on Windows, because of slash-versus-backslash issues. With this change applied, all tests pass on my Windows system.