### PR TITLE
Fix build warning about generated equals/hash

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.ci.GithubActionsBuildEnvironment;
 import org.openrewrite.maven.search.FindPlugin;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.MavenMetadata;
@@ -167,6 +168,7 @@ public class UpgradePluginVersion extends Recipe {
     }
 
     @Value
+    @EqualsAndHashCode(callSuper = false)
     private static class ChangePluginVersionVisitor extends MavenVisitor<ExecutionContext> {
         String groupId;
         String artifactId;


### PR DESCRIPTION
## What's your motivation?

Before the change the build has this warning
```
C:\dev\openrewrite\git\rewrite\rewrite-maven\src\main\java\org\openrewrite\maven\UpgradePluginVersion.java:169: warning: Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.
    @Value
    ^
```
