### PR TITLE
Add recipe `AddLiteralMethodArgument`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddLiteralMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddLiteralMethodArgumentTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class AddLiteralMethodArgumentTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().dependsOn("""
+          class B {
+             static void foo() {}
+             static void foo(int n) {}
+             static void foo(int n1, int n2) {}
+             static void foo(int n1, int n2, int n3) {}
+             static void bar(String n) {}
+             static void bar(String n1, String n2) {}
+             static void bar(String n1, String n2, String n3) {}
+             static void baz(String n1) {}
+             static void baz(String n1, boolean n2) {}
+             static void baz(String n1, boolean n2, int n3) {}
+             static void baz(String n1, boolean n2, int n3, long n4) {}
+             static void baz(String n1, boolean n2, int n3, long n4, double n5) {}
+             static void baz(String n1, boolean n2, int n3, long n4, double n5, float n6) {}
+             static void baz(String n1, boolean n2, int n3, long n4, double n5, float n6, short n7) {}
+             static void baz(String n1, boolean n2, int n3, long n4, double n5, float n6, short n7, char n8) {}
+             B() {}
+             B(int n) {}
+          }
+          """));
+    }
+
+    @Test
+    void addToMiddleArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new AddLiteralMethodArgument("B foo(int, int)", 1, -1, "int")),
+          java(
+            "class A {{ B.foo(0, 1); }}",
+            "class A {{ B.foo(0, -1, 1); }}"
+          )
+        );
+    }
+
+    @Test
+    void addToMiddleArgumentAsString() {
+        rewriteRun(
+          spec -> spec.recipe(new AddLiteralMethodArgument("B foo(int, int)", 1, "-1", "int")),
+          java(
+            "class A {{ B.foo(0, 1); }}",
+            "class A {{ B.foo(0, -1, 1); }}"
+          )
+        );
+    }
+
+    @Test
+    void addToMiddleStringArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new AddLiteralMethodArgument("B bar(String, String)", 1, "-1", "String")),
+          java(
+            "class A {{ B.bar(\"0\", \"1\"); }}",
+            "class A {{ B.bar(\"0\", \"-1\", \"1\"); }}"
+          )
+        );
+    }
+
+    @Test
+    void addArgumentsConsecutively() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new AddLiteralMethodArgument("B foo(int)", 1, 1, "int"),
+            new AddLiteralMethodArgument("B foo(int, int)", 2, "2", "int")
+          ),
+          java(
+            "class A {{ B.foo(0); }}",
+            "class A {{ B.foo(0, 1, 2); }}"
+          )
+        );
+    }
+
+    @Test
+    void addToConstructorArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new AddLiteralMethodArgument("B <constructor>()", 0, 1, "int")),
+          java(
+            "class A { B b = new B(); }",
+            "class A { B b = new B(1); }"
+          )
+        );
+    }
+
+    @Test
+    void addOtherTypes() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new AddLiteralMethodArgument("B baz(String)", 1, true, "boolean"),
+            new AddLiteralMethodArgument("B baz(String, boolean)", 2, 1, "int"),
+            new AddLiteralMethodArgument("B baz(String, boolean, int)", 3, "2L", "long"),
+            new AddLiteralMethodArgument("B baz(String, boolean, int, long)", 4, 2.5, "double"),
+            new AddLiteralMethodArgument("B baz(String, boolean, int, long, double)", 5, "3.5f", "float"),
+            new AddLiteralMethodArgument("B baz(String, boolean, int, long, double, float)", 6, 32767, "short"),
+            new AddLiteralMethodArgument("B baz(String, boolean, int, long, double, float, short)", 7, 'c', "char")
+          ),
+          java(
+            "class A {{ B.baz(\"hi\"); }}",
+            "class A {{ B.baz(\"hi\", true, 1, 2L, 2.5, 3.5f, 32767, 'c'); }}"
+          )
+        );
+    }
+
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.java.tree.JavaType.Primitive;
+
+/**
+ * This recipe finds method invocations matching a method pattern and uses a zero-based argument index to determine
+ * which argument is added with a literal value.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class AddLiteralMethodArgument extends Recipe {
+
+    /**
+     * A method pattern that is used to find matching method invocations.
+     * See {@link  MethodMatcher} for details on the expression's syntax.
+     */
+    @Option(displayName = "Method pattern",
+            description = "A method pattern that is used to find matching method invocations.",
+            example = "com.yourorg.A foo(int, int)")
+    String methodPattern;
+
+    /**
+     * A zero-based index that indicates which argument will be added as null to the method invocation.
+     */
+    @Option(displayName = "Argument index",
+            description = "A zero-based index that indicates which argument will be added as null to the method invocation.",
+            example = "0")
+    int argumentIndex;
+
+    @Option(displayName = "Literal",
+            description = "The literal value that we add the argument for.",
+            example = "0")
+    Object literal;
+
+    @Option(displayName = "Parameter type",
+            description = "The type of the parameter that we add the argument for. Options are: `String`, `int`,`short`, " +
+                          "`long`, `float`, `double`, `boolean` or `char`. Defaults to `String`.",
+            required = false,
+            example = "String")
+    @Nullable
+    String primitiveType;
+
+    @Override
+    public String getInstanceNameSuffix() {
+        return String.format("%d in methods `%s`", argumentIndex, methodPattern);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Add a literal method argument";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add a literal `String` or `int` argument to method invocations.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(methodPattern), new AddLiteralMethodArgumentVisitor(new MethodMatcher(methodPattern)));
+    }
+
+    private class AddLiteralMethodArgumentVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final MethodMatcher methodMatcher;
+
+        public AddLiteralMethodArgumentVisitor(MethodMatcher methodMatcher) {
+            this.methodMatcher = methodMatcher;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+            return (J.MethodInvocation) visitMethodCall(m);
+        }
+
+        @Override
+        public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+            J.NewClass n = super.visitNewClass(newClass, ctx);
+            return (J.NewClass) visitMethodCall(n);
+        }
+
+        private MethodCall visitMethodCall(MethodCall methodCall) {
+            MethodCall m = methodCall;
+            List<Expression> originalArgs = m.getArguments();
+            if (methodMatcher.matches(m) && (long) originalArgs.size() >= argumentIndex) {
+                List<Expression> args = new ArrayList<>(originalArgs);
+
+                if (args.size() == 1 && args.get(0) instanceof J.Empty) {
+                    args.remove(0);
+                }
+                JavaType.Primitive primitive;
+                String valueSource;
+                if (StringUtils.isBlank(primitiveType) || "string".equalsIgnoreCase(primitiveType)) {
+                    primitive = Primitive.String;
+                    valueSource = String.format("\"%s\"", getLiteral());
+                } else if(primitiveType.equalsIgnoreCase("char")){
+                    primitive = Primitive.Char;
+                    valueSource = String.format("'%s'", getLiteral());
+                }else {
+                    primitive = Primitive.fromKeyword(primitiveType.toLowerCase());
+                    valueSource = String.valueOf(getLiteral());
+                }
+
+                if (Arrays.asList(Primitive.Byte, Primitive.Null, JavaType.Primitive.Void, Primitive.None).contains(primitive)) {
+                    throw new IllegalArgumentException("Invalid primitive type: " + primitiveType);
+                }
+
+                Expression literal = new J.Literal(randomId(), args.isEmpty() ? Space.EMPTY : Space.SINGLE_SPACE, Markers.EMPTY, getLiteral(), valueSource, null, primitive);
+                m = m.withArguments(ListUtils.insert(args, literal, argumentIndex));
+
+                JavaType.Method methodType = m.getMethodType();
+                if (methodType != null) {
+                    m = m.withMethodType(methodType
+                            .withParameterNames(ListUtils.insert(methodType.getParameterNames(), "arg" + argumentIndex, argumentIndex))
+                            .withParameterTypes(ListUtils.insert(methodType.getParameterTypes(), primitive, argumentIndex)));
+                    if (m instanceof J.MethodInvocation && ((J.MethodInvocation) m).getName().getType() != null) {
+                        m = ((J.MethodInvocation) m).withName(((J.MethodInvocation) m).getName().withType(m.getMethodType()));
+                    }
+                }
+            }
+            return m;
+        }
+
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
@@ -59,14 +59,14 @@ public class AddLiteralMethodArgument extends Recipe {
 
     @Option(displayName = "Literal",
             description = "The literal value that we add the argument for.",
-            example = "0")
+            example = "abc")
     Object literal;
 
     @Option(displayName = "Parameter type",
-            description = "The type of the parameter that we add the argument for. Options are: `String`, `int`,`short`, " +
-                          "`long`, `float`, `double`, `boolean` or `char`. Defaults to `String`.",
+            description = "The type of the parameter that we add the argument for. Defaults to `String`.",
             required = false,
-            example = "String")
+            example = "String",
+            valid = {"String", "int", "short", "long", "float", "double", "boolean", "char"})
     @Nullable
     String primitiveType;
 
@@ -129,10 +129,6 @@ public class AddLiteralMethodArgument extends Recipe {
                 }else {
                     primitive = Primitive.fromKeyword(primitiveType.toLowerCase());
                     valueSource = String.valueOf(getLiteral());
-                }
-
-                if (Arrays.asList(Primitive.Byte, Primitive.Null, JavaType.Primitive.Void, Primitive.None).contains(primitive)) {
-                    throw new IllegalArgumentException("Invalid primitive type: " + primitiveType);
                 }
 
                 Expression literal = new J.Literal(randomId(), args.isEmpty() ? Space.EMPTY : Space.SINGLE_SPACE, Markers.EMPTY, getLiteral(), valueSource, null, primitive);


### PR DESCRIPTION
This recipe finds a method and adds a literal argument at the specified index.

## What's changed?
Recipe was added

## What's your motivation?
In stead of only adding a null argument we can now also specify a literal. This means when adding an argument and fixing the calls with a recipe we no longer need to require the field to be boxed and nullable for primitives.

## Anything in particular you'd like reviewers to focus on?
-

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
No

## Any additional context
It's very similar to the `AddNullMethodArgument` recipe added last week.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
