### PR TITLE
Add core categories for third party recipes

### DIFF
--- a/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
+++ b/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
@@ -20,6 +20,10 @@ packageName: org.openrewrite
 root: true
 ---
 type: specs.openrewrite.org/v1beta/category
+packageName: ai
+root: true
+---
+type: specs.openrewrite.org/v1beta/category
 packageName: io
 root: true
 ---
@@ -30,3 +34,8 @@ root: true
 type: specs.openrewrite.org/v1beta/category
 packageName: org
 root: true
+---
+type: specs.openrewrite.org/v1beta/category
+packageName: tech
+root: true
+---


### PR DESCRIPTION
## What's your motivation?
Better presentation of packages contributed through
https://github.com/openrewrite/rewrite-third-party/blob/d5745f4a1e871f7f8f4eab1651a4f54645b9fed4/build.gradle.kts#L36-L39

## Have you considered any alternatives or workarounds?
We could try to rework the logic to not require additional roots, but that might have more impact for custom recipe libraries we are unable to see, so figured go for the likely low impact change first.