### PR TITLE
Previsit method invocations for `gradle.ChangePlugin`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
@@ -230,7 +230,7 @@ public class AddDependencyVisitor extends GroovyIsoVisitor<ExecutionContext> {
                     resolvedVersion = version;
                 } else {
                     try {
-                        resolvedVersion = new DependencyVersionSelector(metadataFailures, gp)
+                        resolvedVersion = new DependencyVersionSelector(metadataFailures, gp, null)
                                 .select(new GroupArtifact(groupId, artifactId), configuration, version, versionPattern, ctx);
                     } catch (MavenDownloadingException e) {
                         return e.warn(m);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -213,7 +213,7 @@ public class ChangeDependency extends Recipe {
                             if (!StringUtils.isBlank(newVersion) && (!StringUtils.isBlank(original.getVersion()) || Boolean.TRUE.equals(overrideManagedVersion))) {
                                 String resolvedVersion;
                                 try {
-                                    resolvedVersion = new DependencyVersionSelector(null, gradleProject)
+                                    resolvedVersion = new DependencyVersionSelector(null, gradleProject, null)
                                             .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                 } catch (MavenDownloadingException e) {
                                     return e.warn(m);
@@ -247,7 +247,7 @@ public class ChangeDependency extends Recipe {
                             if (!StringUtils.isBlank(newVersion)) {
                                 String resolvedVersion;
                                 try {
-                                    resolvedVersion = new DependencyVersionSelector(null, gradleProject)
+                                    resolvedVersion = new DependencyVersionSelector(null, gradleProject, null)
                                             .select(new GroupArtifact(updated.getGroupId(), updated.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                 } catch (MavenDownloadingException e) {
                                     return e.warn(m);
@@ -320,7 +320,7 @@ public class ChangeDependency extends Recipe {
                     if (!StringUtils.isBlank(newVersion) && (!StringUtils.isBlank(version) || Boolean.TRUE.equals(overrideManagedVersion))) {
                         String resolvedVersion;
                         try {
-                            resolvedVersion = new DependencyVersionSelector(null, gradleProject)
+                            resolvedVersion = new DependencyVersionSelector(null, gradleProject, null)
                                     .select(new GroupArtifact(updatedGroupId, updatedArtifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                         } catch (MavenDownloadingException e) {
                             return e.warn(m);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -222,7 +222,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             return m;
                         }
                         try {
-                            String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject)
+                            String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                     .select(new GroupArtifact(groupId, artifactId), m.getSimpleName(), newVersion, versionPattern, ctx);
                             acc.versionPropNameToGA.put(versionVariableName, ga);
                             acc.gaToNewVersion.put(ga, resolvedVersion);
@@ -253,7 +253,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                     continue;
                                 }
                                 try {
-                                    String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject)
+                                    String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                             .select(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()), m.getSimpleName(), newVersion, versionPattern, ctx);
                                     acc.versionPropNameToGA.put(versionVariableName, ga);
                                     acc.gaToNewVersion.put(ga, resolvedVersion);
@@ -396,7 +396,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                             }
 
                                             try {
-                                                String selectedVersion = new DependencyVersionSelector(metadataFailures, gradleProject)
+                                                String selectedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                                         .select(dep.getGav(), method.getSimpleName(), newVersion, versionPattern, ctx);
                                                 if (selectedVersion == null || dep.getVersion().equals(selectedVersion)) {
                                                     return arg;
@@ -453,7 +453,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                         String selectedVersion;
                                         try {
                                             GroupArtifactVersion gav = new GroupArtifactVersion((String) groupLiteral.getValue(), (String) artifactLiteral.getValue(), version);
-                                            selectedVersion = new DependencyVersionSelector(metadataFailures, gradleProject)
+                                            selectedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                                     .select(gav, m.getSimpleName(), newVersion, versionPattern, ctx);
                                         } catch (MavenDownloadingException e) {
                                             return e.warn(m);
@@ -524,7 +524,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 for (Map.Entry<GroupArtifact, Set<String>> gaEntry : gaToConfigurations.entrySet()) {
                     GroupArtifact ga = gaEntry.getKey();
                     GroupArtifactVersion gav = new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), version);
-                    DependencyVersionSelector selector = new DependencyVersionSelector(metadataFailures, gradleProject);
+                    DependencyVersionSelector selector = new DependencyVersionSelector(metadataFailures, gradleProject, null);
                     String selectedVersion = Optional.ofNullable(selector.select(gav, null, newVersion, versionPattern, ctx))
                             .orElse(selector.select(gav, "classpath", newVersion, versionPattern, ctx));
                     if (selectedVersion == null) {
@@ -579,7 +579,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 for (Map.Entry<GroupArtifact, Set<String>> gaEntry : gaToConfigurations.entrySet()) {
                     GroupArtifact ga = gaEntry.getKey();
                     GroupArtifactVersion gav = new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), version);
-                    DependencyVersionSelector selector = new DependencyVersionSelector(metadataFailures, gradleProject);
+                    DependencyVersionSelector selector = new DependencyVersionSelector(metadataFailures, gradleProject, null);
                     String selectedVersion = Optional.ofNullable(selector.select(gav, null, newVersion, versionPattern, ctx))
                             .orElse(selector.select(gav, "classpath", newVersion, versionPattern, ctx));
                     if (selectedVersion == null) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -136,7 +136,7 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
 
                 Map<GroupArtifact, Map<GradleDependencyConfiguration, String>> toUpdate = new HashMap<>();
 
-                DependencyVersionSelector versionSelector = new DependencyVersionSelector(metadataFailures, gradleProject);
+                DependencyVersionSelector versionSelector = new DependencyVersionSelector(metadataFailures, gradleProject, null);
                 for (GradleDependencyConfiguration configuration : gradleProject.getConfigurations()) {
                     for (ResolvedDependency resolved : configuration.getResolved()) {
                         if (resolved.getDepth() > 0 && dependencyMatcher.matches(resolved.getGroupId(),

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -18,6 +18,7 @@ package org.openrewrite.gradle.plugins;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.gradle.DependencyVersionSelector;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.gradle.IsSettingsGradle;
@@ -26,7 +27,6 @@ import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.style.TabsAndIndentsStyle;
@@ -35,17 +35,15 @@ import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.marker.BuildTool;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.table.MavenMetadataFailures;
-import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singletonList;
-import static org.openrewrite.gradle.plugins.AddPluginVisitor.resolvePluginVersion;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -158,7 +156,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
                         return cu;
                     }
                     GradleSettings gradleSettings = maybeGradleSettings.get();
-                    cu = withPlugin(cu, "com.gradle.enterprise", versionComparator, gradleSettings.getPluginRepositories(), ctx);
+                    cu = withPlugin(cu, "com.gradle.enterprise", versionComparator, null, gradleSettings, ctx);
                 } else if (!gradleSixOrLater && cu.getSourcePath().toString().equals("build.gradle")) {
                     // Older than 6.0 goes in root build.gradle only, not in build.gradle of subprojects
                     Optional<GradleProject> maybeGradleProject = cu.getMarkers().findFirst(GradleProject.class);
@@ -167,7 +165,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
                     }
                     GradleProject gradleProject = maybeGradleProject.get();
 
-                    cu = withPlugin(cu, "com.gradle.build-scan", versionComparator, gradleProject.getMavenPluginRepositories(), ctx);
+                    cu = withPlugin(cu, "com.gradle.build-scan", versionComparator, gradleProject, null, ctx);
                 }
 
                 return cu;
@@ -175,14 +173,15 @@ public class AddDevelocityGradlePlugin extends Recipe {
         });
     }
 
-    private G.CompilationUnit withPlugin(G.CompilationUnit cu, String pluginId, VersionComparator versionComparator, List<MavenRepository> repositories, ExecutionContext ctx) {
+    private G.CompilationUnit withPlugin(G.CompilationUnit cu, String pluginId, VersionComparator versionComparator, @Nullable GradleProject gradleProject, @Nullable GradleSettings gradleSettings, ExecutionContext ctx) {
         try {
-            Optional<String> maybeNewVersion = resolvePluginVersion(pluginId, "0", StringUtils.isBlank(version) ? "latest.release" : version, null, repositories, ctx);
-            if (!maybeNewVersion.isPresent()) {
+            String newVersion = new DependencyVersionSelector(null, gradleProject, gradleSettings)
+                    .select(new GroupArtifact("com.gradle.enterprise", "com.gradle.enterprise.gradle.plugin"), "classpath", version, null, ctx);
+            if (newVersion == null) {
                 return cu;
             }
-            String newVersion = maybeNewVersion.get();
-            cu = (G.CompilationUnit) new AddPluginVisitor(pluginId, newVersion, null, repositories)
+
+            cu = (G.CompilationUnit) new AddPluginVisitor(pluginId, newVersion, null)
                     .visitNonNull(cu, ctx);
             cu = (G.CompilationUnit) new UpgradePluginVersion(pluginId, newVersion, null).getVisitor()
                     .visitNonNull(cu, ctx);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -19,22 +19,20 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Parser;
+import org.openrewrite.gradle.DependencyVersionSelector;
 import org.openrewrite.gradle.GradleParser;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.gradle.search.FindPlugins;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.FindMethods;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.maven.MavenDownloadingException;
-import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.tree.GroupArtifact;
-import org.openrewrite.maven.tree.MavenMetadata;
-import org.openrewrite.maven.tree.MavenRepository;
-import org.openrewrite.semver.*;
 import org.openrewrite.tree.ParseError;
 
 import java.nio.file.Paths;
@@ -56,44 +54,6 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
 
     @Nullable
     String versionPattern;
-
-    List<MavenRepository> repositories;
-
-    public static Optional<String> resolvePluginVersion(String pluginId, String currentVersion, @Nullable String newVersion, @Nullable String versionPattern,
-                                                        List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
-        VersionComparator versionComparator = StringUtils.isBlank(newVersion) ?
-                new LatestRelease(null) :
-                requireNonNull(Semver.validate(newVersion, versionPattern).getValue());
-
-        Optional<String> version;
-        if (versionComparator instanceof ExactVersion) {
-            version = versionComparator.upgrade(currentVersion, Collections.singletonList(newVersion));
-        } else if (versionComparator instanceof LatestPatch && !versionComparator.isValid(currentVersion, currentVersion)) {
-            // in the case of "latest.patch", a new version can only be derived if the
-            // current version is a semantic version
-            return Optional.empty();
-        } else {
-            version = findNewerVersion(pluginId, pluginId + ".gradle.plugin", currentVersion, versionComparator, repositories, ctx);
-        }
-        return version;
-    }
-
-    private static Optional<String> findNewerVersion(String groupId, String artifactId, String version, VersionComparator versionComparator,
-                                                     List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
-        try {
-            MavenMetadata mavenMetadata = downloadMetadata(groupId, artifactId, repositories, ctx);
-            return versionComparator.upgrade(version, mavenMetadata.getVersioning().getVersions());
-        } catch (IllegalStateException e) {
-            // this can happen when we encounter exotic versions
-            return Optional.empty();
-        }
-    }
-
-    private static MavenMetadata downloadMetadata(String groupId, String artifactId, List<MavenRepository> repositories, ExecutionContext ctx) throws MavenDownloadingException {
-        return new MavenPomDownloader(ctx)
-                .downloadMetadata(new GroupArtifact(groupId, artifactId), null,
-                        repositories);
-    }
 
     private static @Nullable Comment getLicenseHeader(G.CompilationUnit cu) {
         if (!cu.getStatements().isEmpty()) {
@@ -133,13 +93,19 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
     @Override
     public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
         if (FindPlugins.find(cu, pluginId).isEmpty()) {
-            Optional<String> version;
+            String version;
             if (newVersion == null) {
                 // We have been requested to add a versionless plugin
-                version = Optional.empty();
+                version = null;
             } else {
+                Optional<GradleProject> maybeGp = cu.getMarkers().findFirst(GradleProject.class);
+                Optional<GradleSettings> maybeGs = cu.getMarkers().findFirst(GradleSettings.class);
+                if (!maybeGp.isPresent() && !maybeGs.isPresent()) {
+                    return cu;
+                }
+
                 try {
-                    version = resolvePluginVersion(pluginId, "0", newVersion, versionPattern, repositories, ctx);
+                    version = new DependencyVersionSelector(null, maybeGp.orElse(null), maybeGs.orElse(null)).select(new GroupArtifact(pluginId, pluginId + ".gradle.plugin"), "classpath", newVersion, versionPattern, ctx);
                 } catch (MavenDownloadingException e) {
                     return e.warn(cu);
                 }
@@ -170,7 +136,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
 
             String delimiter = singleQuote.get() < doubleQuote.get() ? "\"" : "'";
             String source = "plugins {\n" +
-                            "    id " + delimiter + pluginId + delimiter + (version.map(s -> " version " + delimiter + s + delimiter).orElse("")) + "\n" +
+                            "    id " + delimiter + pluginId + delimiter + (version != null ? " version " + delimiter + version + delimiter : "") + "\n" +
                             "}";
             Statement statement = GradleParser.builder().build()
                     .parseInputs(singletonList(Parser.Input.fromString(source)), null, ctx)

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPlugin.java
@@ -19,14 +19,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.gradle.IsSettingsGradle;
-import org.openrewrite.gradle.marker.GradleSettings;
-import org.openrewrite.groovy.GroovyIsoVisitor;
-import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.semver.Semver;
-
-import java.util.Optional;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -78,17 +73,7 @@ public class AddSettingsPlugin extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new IsSettingsGradle<>(),
-                new GroovyIsoVisitor<ExecutionContext>() {
-                    @Override
-                    public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
-                        Optional<GradleSettings> maybeGradleSettings = cu.getMarkers().findFirst(GradleSettings.class);
-                        if (!maybeGradleSettings.isPresent()) {
-                            return cu;
-                        }
-
-                        GradleSettings gradleSettings = maybeGradleSettings.get();
-                        return (G.CompilationUnit) new AddPluginVisitor(pluginId, StringUtils.isBlank(version) ? "latest.release" : version, versionPattern, gradleSettings.getPluginRepositories()).visitNonNull(cu, ctx);
-                    }
-                });
+                new AddPluginVisitor(pluginId, StringUtils.isBlank(version) ? "latest.release" : version, versionPattern)
+        );
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePlugin.java
@@ -18,6 +18,7 @@ package org.openrewrite.gradle.plugins;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.gradle.DependencyVersionSelector;
 import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.gradle.IsSettingsGradle;
 import org.openrewrite.gradle.marker.GradlePluginDescriptor;
@@ -34,14 +35,13 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.semver.Semver;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * When changing a plugin id that uses the `apply` syntax or versionless plugins syntax, the version is will not be changed.
@@ -174,8 +174,8 @@ public class ChangePlugin extends Recipe {
 
                         if (!StringUtils.isBlank(newVersion)) {
                             try {
-                                String resolvedVersion = AddPluginVisitor.resolvePluginVersion(newPluginId, "0", newVersion, null, getPluginRepositories(), ctx)
-                                        .orElse(null);
+                                String resolvedVersion = new DependencyVersionSelector(null, gradleProject, gradleSettings)
+                                        .select(new GroupArtifact(newPluginId, newPluginId + ".gradle.plugin"), "classpath", newVersion, null, ctx);
                                 if (resolvedVersion == null) {
                                     return m;
                                 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
@@ -126,4 +126,17 @@ class ChangePluginTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void dontChangeExisting() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'io.moderne.rewrite' version '1.0.34'
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
* Adapted to use new `DependencyVersionSelector`
* Previsit `J.MethodInvocation` instances such that we can properly migrate a plugin declaration only when it matches the previous plugin id.

## What's your motivation?
Previously, plugins would be downgraded as long as they matched the new plugin id.

## Have you considered any alternatives or workarounds?
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
