### PR TITLE
Parse property values starting with the delimiter character

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -238,16 +238,19 @@ public class PropertiesParser implements Parser {
                         break;
                     } else if (c == '=' || c == ':') {
                         delimiter = Properties.Entry.Delimiter.getDelimiter(String.valueOf(c));
+                        state++;
+                        break;
                     }
-                    state++;
                 case 4:
-                    if (c == '=' || c == ':') {
-                        continue;
-                    } else if (Character.isWhitespace(c)) {
+                    if (Character.isWhitespace(c)) {
                         valuePrefix.append(c);
                         break;
                     }
-                    state++;
+                    else {
+                        value.append(c);
+                        state++;
+                        break;
+                    }
                 case 5:
                     if (!Character.isWhitespace(c)) {
                         value.append(c);

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -179,48 +179,58 @@ public class PropertiesParser implements Parser {
         );
     }
 
+    static enum State {
+        WHITESPACE_BEFORE_KEY,
+        KEY,
+        KEY_OR_WHITESPACE,
+        WHITESPACE_OR_DELIMITER,
+        WHITESPACE_OR_VALUE,
+        VALUE,
+        VALUE_OR_TRAILING
+    }
+
     private Properties.Entry entryFromLine(String line, String prefix, StringBuilder trailingWhitespaceBuffer) {
         StringBuilder prefixBuilder = new StringBuilder(prefix),
                 key = new StringBuilder(),
                 equalsPrefix = new StringBuilder(),
                 valuePrefix = new StringBuilder(),
                 value = new StringBuilder();
-
+        
         Properties.Entry.Delimiter delimiter = Properties.Entry.Delimiter.NONE;
         char prev = '$';
-        int state = 0;
+        State state = State.WHITESPACE_BEFORE_KEY;
         for (int i = 0; i < line.length(); i++) {
             char c = line.charAt(i);
             switch (state) {
-                case 0:
+                case WHITESPACE_BEFORE_KEY:
                     if (Character.isWhitespace(c)) {
                         prefixBuilder.append(c);
                         break;
                     }
-                    state++;
-                case 1:
+                    state = State.KEY;
+                case KEY:
                     if (c == '=' || c == ':') {
                         if (prev == '\\') {
                             key.append(c);
                             break;
                         } else {
                             delimiter = Properties.Entry.Delimiter.getDelimiter(String.valueOf(c));
-                            state += 3;
+                            state = State.WHITESPACE_OR_VALUE;
                             break;
                         }
                     } else if (c == '\\') {
                         key.append(c);
-                        state++;
+                        state = State.KEY_OR_WHITESPACE;
                         break;
                     } else if (!Character.isWhitespace(c)) {
                         key.append(c);
                         break;
                     } else {
                         equalsPrefix.append(c);
-                        state += 2;
+                        state = State.WHITESPACE_OR_DELIMITER;
                         break;
                     }
-                case 2:
+                case KEY_OR_WHITESPACE:
                     if (Character.isWhitespace(c)) {
                         trailingWhitespaceBuffer.append(c);
                         break;
@@ -229,35 +239,35 @@ public class PropertiesParser implements Parser {
                         key.append(trailingWhitespaceBuffer);
                         trailingWhitespaceBuffer.setLength(0);
                         key.append(c);
-                        state--;
+                        state = State.KEY;
                         break;
                     }
-                case 3:
+                case WHITESPACE_OR_DELIMITER:
                     if (Character.isWhitespace(c)) {
                         equalsPrefix.append(c);
                         break;
                     } else if (c == '=' || c == ':') {
                         delimiter = Properties.Entry.Delimiter.getDelimiter(String.valueOf(c));
-                        state++;
+                        state = State.WHITESPACE_OR_VALUE;
                         break;
                     }
-                case 4:
+                case WHITESPACE_OR_VALUE:
                     if (Character.isWhitespace(c)) {
                         valuePrefix.append(c);
                         break;
                     }
                     else {
                         value.append(c);
-                        state++;
+                        state = State.VALUE;
                         break;
                     }
-                case 5:
+                case VALUE:
                     if (!Character.isWhitespace(c)) {
                         value.append(c);
                         break;
                     }
-                    state++;
-                case 6:
+                    state = State.VALUE_OR_TRAILING;
+                case VALUE_OR_TRAILING:
                     if (Character.isWhitespace(c)) {
                         trailingWhitespaceBuffer.append(c);
                     } else {
@@ -265,7 +275,7 @@ public class PropertiesParser implements Parser {
                         value.append(trailingWhitespaceBuffer);
                         trailingWhitespaceBuffer.setLength(0);
                         value.append(c);
-                        state--;
+                        state = State.VALUE;
                         break;
                     }
             }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
@@ -233,6 +233,23 @@ class PropertiesParserTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/4026")
+    @Test
+    void repeatedDelimiter() {
+        rewriteRun(
+          properties(
+            """
+              key1==value1
+              key2::value2
+              key3======value3
+              key4=:value4
+              key5 = = value5
+              """,
+            containsValues("=value1", ":value2", "=====value3", ":value4", "= value5")
+          )
+        );
+    }
+
     private static Consumer<SourceSpec<Properties.File>> containsValues(String... valueAssertions) {
         return spec -> spec.beforeRecipe(props -> {
             List<String> values = TreeVisitor.collect(new PropertiesVisitor<>() {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
In the state machine of the properties parser do not accept further delimiters after the first non escaped delimiter was found.

## What's your motivation?
Fixes #4026.

## Anything in particular you'd like reviewers to focus on?
The actual bug fix is in the first commit, so you may want to review it separately. The second commit removes all arithmetic from the state variable and gives readable names to the states to make debugging more simple for the next one looking into this.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
