### PR TITLE
Detect instanceof pattern variables in scope

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/VariableNameUtilsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/VariableNameUtilsTest.java
@@ -185,7 +185,24 @@ class VariableNameUtilsTest implements RewriteTest {
               """
           )
         );
+    }
 
+    @Test
+    void detectInstanceOf() {
+        rewriteRun(
+          baseTest("ifBlock", "ifBlock,pattern,methodParam"),
+          java(
+            """
+              class Test {
+                  void method(Object methodParam) {
+                      if (methodParam instanceof String pattern) {
+                          boolean ifBlock;
+                      }
+                  }
+              }
+              """
+          )
+        );
     }
 
     @Test

--- a/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
@@ -244,6 +244,17 @@ public class VariableNameUtils {
         }
 
         @Override
+        public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, Set<String> strings) {
+            if (instanceOf.getPattern() instanceof J.Identifier) {
+                Set<String> names = nameScopes.get(currentScope.peek());
+                if (names != null) {
+                    names.add(((J.Identifier)instanceOf.getPattern()).getSimpleName());
+                }
+            }
+            return super.visitInstanceOf(instanceOf, strings);
+        }
+
+        @Override
         public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<String> strings) {
             Set<String> names = nameScopes.get(currentScope.peek());
             if (names != null) {


### PR DESCRIPTION
## What's your motivation?
Used in `InstanceOfPatternMatch` to detect variables that exist in the surrounding context, which now fails to pick up pattern matching for instance of variables, and as such introduces two identically named variables.

- https://github.com/openrewrite/rewrite-static-analysis/pull/265
- https://github.com/openrewrite/rewrite-static-analysis/pull/175