### PR TITLE
Add table and version matcher to Maven FindProperties

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -22,8 +22,10 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.maven.table.MavenProperties;
 import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
 
@@ -35,11 +37,19 @@ import static org.openrewrite.Tree.randomId;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class FindProperties extends Recipe {
+    transient MavenProperties mavenProperties = new MavenProperties(this);
 
     @Option(displayName = "Property pattern",
             description = "Regular expression pattern used to match property tag names.",
             example = "guava.*")
     String propertyPattern;
+
+    @Option(displayName = "Value pattern",
+            description = "Regular expression pattern used to match property values.",
+            example = "28.*",
+            required = false)
+    @Nullable
+    String valuePattern;
 
     UUID searchId = randomId();
 
@@ -57,12 +67,22 @@ public class FindProperties extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         Pattern propertyMatcher = Pattern.compile(propertyPattern);
         Pattern propertyUsageMatcher = Pattern.compile(".*\\$\\{" + propertyMatcher.pattern() + "}.*");
+        Pattern valueMatcher = valuePattern == null ? null : Pattern.compile(valuePattern);
         return new MavenVisitor<ExecutionContext>() {
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
                 if (isPropertyTag() && propertyMatcher.matcher(t.getName()).matches()) {
-                    t = SearchResult.found(t);
+                    if (valueMatcher == null) {
+                        t = SearchResult.found(t);
+                        mavenProperties.insertRow(ctx, new MavenProperties.Row(t.getName(), t.getValue().orElse(null)));
+                    } else {
+                        Optional<String> value = t.getValue();
+                        if (value.isPresent() && valueMatcher.matcher(value.get()).matches()) {
+                            t = SearchResult.found(t);
+                            mavenProperties.insertRow(ctx, new MavenProperties.Row(t.getName(), value.get()));
+                        }
+                    }
                 }
 
                 Optional<String> value = t.getValue();
@@ -77,8 +97,7 @@ public class FindProperties extends Recipe {
     }
 
     /**
-     *
-     * @param xml The xml document of the pom.xml
+     * @param xml             The xml document of the pom.xml
      * @param propertyPattern Regular expression pattern used to match property tag names
      * @return Set of Maven project property tags that matches the {@code propertyPattern} within a pom.xml
      */

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/MavenProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/MavenProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.lang.Nullable;
+
+@JsonIgnoreType
+public class MavenProperties extends DataTable<MavenProperties.Row> {
+
+    public MavenProperties(Recipe recipe) {
+        super(recipe, Row.class,
+                MavenProperties.class.getName(),
+                "Maven properties", "Property and value.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Property",
+                description = "The Maven property that was found.")
+        String property;
+
+        @Column(displayName = "Value",
+                description = "The value associated with the property.")
+        @Nullable
+        String value;
+    }
+}


### PR DESCRIPTION
The valuePattern allows use as DevCenter measurement, while the table enables custom visualizations.

Target use is the `<jenkins.version>` used in Jenkins plugins.