### PR TITLE
Printable Recipe Datatables 

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeRun.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeRun.java
@@ -92,7 +92,7 @@ public class RecipeRun {
                     Field field = row.getClass().getDeclaredField(fieldName);
                     field.setAccessible(true);
                     //Assume every column value is printable with toString
-                    return field.get(row).toString();
+                    return String.format("\"%s\"", field.get(row).toString());
                 } catch (NoSuchFieldException | IllegalAccessException e) {
                     throw new RuntimeException(e);
                 }

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
@@ -1,0 +1,32 @@
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.table.SourcesFileResults;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.text.FindAndReplace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.test.SourceSpecs.text;
+
+public class RecipeRunTest implements RewriteTest {
+    @Test
+    void printDatatable() {
+        rewriteRun(
+          recipeSpec -> recipeSpec.recipe(new FindAndReplace("replace_me", "replacement", null, null, null, null, null))
+            .afterRecipe(recipeRun -> {
+                StringBuilder output = new StringBuilder();
+                final String dataTableName = SourcesFileResults.class.getName();
+                RecipeRun.exportCsv(new InMemoryExecutionContext(), recipeRun.getDataTable(dataTableName),
+                  s -> output.append(s).append("\n"), recipeRun.getDataTableRows(dataTableName));
+                assertThat(output.toString()).isEqualTo("""
+                  "Source path before the run","Source path after the run","Parent of the recipe that made changes","Recipe that made changes","Estimated time saving","Cycle"
+                  "The source path of the file before the run.","A recipe may modify the source path. This is the path after the run.","In a hierarchical recipe, the parent of the recipe that made a change. Empty if this is the root of a hierarchy or if the recipe is not hierarchical at all.","The specific recipe that made a change.","An estimated effort that a developer to fix manually instead of using this recipe, in unit of seconds.","The recipe cycle in which the change was made."
+                  "file.txt","file.txt","","org.openrewrite.text.FindAndReplace","300","1"
+                  """);
+            }), text("""
+            replace_me
+            """, """
+            replacement
+            """));
+    }
+}


### PR DESCRIPTION
## What's changed?
Added logic in the RewriteRun Class in Rewrite-Core to output Datatable values as a CSV

## What's your motivation?
Datatable information is currently only accessible in memory in OSS, rendering it extremely difficult to use/access.  This change (coupled with the Maven Plugin PR below) would allow easy access to any datatable information created by recipes. This is especially useful for OSS users wanting to use recipes designed to only output datatable information. 

See related [Maven Plugin PR](https://github.com/openrewrite/rewrite-maven-plugin/pull/751)