### PR TITLE
Failing test cases for Quarkus version matching using `metadataPattern`s

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
@@ -141,4 +141,10 @@ class LatestReleaseTest {
         assertThat(latestRelease.compare(null, "7.17.0-20211102.000501-28",
           "7.17.0-20211102.012229-29")).isLessThan(0);
     }
+
+    @Test
+    void matchCustomMetadata() {
+        assertThat(new LatestRelease(null).isValid(null, "3.2.9.Final")).isTrue();
+        assertThat(new LatestRelease("-custom-\\d+").isValid(null, "3.2.9.Final-custom-00003")).isTrue();
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
@@ -105,4 +105,10 @@ class XRangeTest {
         // The version pattern of javax.validation:validation-api
         assertThat(xRange.isValid("1.0", "2.0.1.Final")).isTrue();
     }
+
+    @Test
+    void matchCustomMetadata() {
+        assertThat(new XRange("3", "2", "x", "", null).isValid(null, "3.2.9.Final")).isTrue();
+        assertThat(new XRange("3", "2", "x", "", "-custom-\\d+").isValid(null, "3.2.9.Final-custom-00003")).isTrue();
+    }
 }


### PR DESCRIPTION
## What's changed?
`XRange` and `LatestVersion` are failing to validate versions when the version provided contains one of the hard-coded release versions suffixes (`.final`, `.ga`, `.release`) and a custom metadata pattern is provided (in this example, `-custom-\d+`, to match `-custom-00001`). 

This PR has only the failing cases. I can provide a fix after reviews.

Two possible fixes for this issue, AFAICS:
1. Remove the release prefixes from `VersionComparator` and `LatestRelease`, and let recipe consumers provide suffixes (might introduce breaking changes on recipes using Quarkus, Hibernate ORM, Hibernate Validator, older Spring Boot (before 2.4.0) and possible other libraries); or
2. Change `LatestRelease#normalizeVersion` to keep release suffixes, possibly introducing other breaking changes.

## What's your motivation?
Validate Quarkus versions.

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
@timtebeek @sambsnyd 

## Have you considered any alternatives or workarounds?
No known workaround.

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files