### PR TITLE
Fix for artifacts not found (surfacing in 500 internal server errors).

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -92,7 +92,7 @@ public class MavenArtifactDownloader {
             return null;
         }
         return mavenArtifactCache.computeArtifact(dependency, () -> {
-            String base = requireNonNull(dependency.getRepository(),
+            String baseUri = requireNonNull(dependency.getRepository(),
                     String.format("Repository for dependency '%s' was null.", dependency)).getUri();
             String path = dependency.getGroupId().replace('.', '/') + '/' +
                           dependency.getArtifactId() + '/' +
@@ -100,7 +100,7 @@ public class MavenArtifactDownloader {
                           dependency.getArtifactId() + '-' +
                           (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
                           ".jar";
-            String uri = base + (base.endsWith("/") ? "" : "/") + path;
+            String uri = baseUri + (baseUri.endsWith("/") ? "" : "/") + path;
 
             InputStream bodyStream;
 


### PR DESCRIPTION
When the repository url ends with a `/` we add another causing an incorrect URL, this results in a 404 returned from the maven repo which we translate to a `MavenDownloadingException` causing the 500 responses.
