### PR TITLE
Enhance ChangeParentPom to keep more projects compiling post-upgrade.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -21,25 +21,20 @@ import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.table.MavenMetadataFailures;
-import org.openrewrite.maven.tree.MavenMetadata;
-import org.openrewrite.maven.tree.Parent;
-import org.openrewrite.maven.tree.ResolvedPom;
-import org.openrewrite.maven.utilities.RetainVersions;
+import org.openrewrite.maven.tree.*;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.ChangeTagValueVisitor;
-import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @Value
@@ -105,15 +100,6 @@ public class ChangeParentPom extends Recipe {
     @Nullable
     Boolean allowVersionDowngrades;
 
-    @Option(displayName = "Retain versions",
-            description = "Accepts a list of GAVs. For each GAV, if it is a project direct dependency, and it is removed " +
-                          "from dependency management in the new parent pom, then it will be retained with an explicit version. " +
-                          "The version can be omitted from the GAV to use the old value from dependency management",
-            example = "com.jcraft:jsch",
-            required = false)
-    @Nullable
-    List<String> retainVersions;
-
     @Override
     public String getDisplayName() {
         return "Change Maven parent";
@@ -135,19 +121,6 @@ public class ChangeParentPom extends Recipe {
         //noinspection ConstantConditions
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
-        }
-        if (retainVersions != null) {
-            for (int i = 0; i < retainVersions.size(); i++) {
-                String retainVersion = retainVersions.get(i);
-                validated = validated.and(Validated.test(
-                        String.format("retainVersions[%d]", i),
-                        "did not look like a two-or-three-part GAV",
-                        retainVersion,
-                        maybeGav -> {
-                            int gavParts = maybeGav.split(":").length;
-                            return gavParts == 2 || gavParts == 3;
-                        }));
-            }
         }
         return validated;
     }
@@ -178,7 +151,8 @@ public class ChangeParentPom extends Recipe {
                 Xml.Tag t = super.visitTag(tag, ctx);
 
                 if (isParentTag()) {
-                    ResolvedPom resolvedPom = getResolutionResult().getPom();
+                    MavenResolutionResult mrr = getResolutionResult();
+                    ResolvedPom resolvedPom = mrr.getPom();
 
                     if (matchesGlob(resolvedPom.getValue(tag.getChildValue("groupId").orElse(null)), oldGroupId) &&
                         matchesGlob(resolvedPom.getValue(tag.getChildValue("artifactId").orElse(null)), oldArtifactId) &&
@@ -192,43 +166,71 @@ public class ChangeParentPom extends Recipe {
                         String targetRelativePath = newRelativePath == null ? tag.getChildValue("relativePath").orElse(oldRelativePath) : newRelativePath;
                         try {
                             Optional<String> targetVersion = findAcceptableVersion(targetGroupId, targetArtifactId, oldVersion, ctx);
-                            if (targetVersion.isPresent()) {
-                                List<XmlVisitor<ExecutionContext>> changeParentTagVisitors = new ArrayList<>();
-                                if (!currentGroupId.equals(targetGroupId)) {
-                                    changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("groupId").get(), targetGroupId));
-                                }
+                            if (!targetVersion.isPresent() ||
+                                (Objects.equals(targetGroupId, currentGroupId) &&
+                                 Objects.equals(targetArtifactId, currentArtifactId) &&
+                                 Objects.equals(targetVersion.get(), oldVersion) &&
+                                 Objects.equals(targetRelativePath, oldRelativePath))) {
+                                return t;
+                            }
 
-                                if (!currentArtifactId.equals(targetArtifactId)) {
-                                    changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("artifactId").get(), targetArtifactId));
-                                }
+                            List<TreeVisitor<?, ExecutionContext>> changeParentTagVisitors = new ArrayList<>();
 
-                                if (!oldVersion.equals(targetVersion.get())) {
-                                    changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("version").get(), targetVersion.get()));
-                                }
+                            if (!currentGroupId.equals(targetGroupId)) {
+                                changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("groupId").get(), targetGroupId));
+                            }
 
-                                // Update or add relativePath
-                                if (oldRelativePath != null && !oldRelativePath.equals(targetRelativePath)) {
-                                    changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("relativePath").get(), targetRelativePath));
-                                } else if (mismatches(tag.getChild("relativePath").orElse(null), targetRelativePath)) {
-                                    final Xml.Tag relativePathTag;
-                                    if (StringUtils.isBlank(targetRelativePath)) {
-                                        relativePathTag = Xml.Tag.build("<relativePath />");
-                                    } else {
-                                        relativePathTag = Xml.Tag.build("<relativePath>" + targetRelativePath + "</relativePath>");
-                                    }
-                                    doAfterVisit(new AddToTagVisitor<>(t, relativePathTag, new MavenTagInsertionComparator(t.getChildren())));
-                                    maybeUpdateModel();
-                                }
+                            if (!currentArtifactId.equals(targetArtifactId)) {
+                                changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("artifactId").get(), targetArtifactId));
+                            }
 
-                                if (!changeParentTagVisitors.isEmpty()) {
-                                    retainVersions();
-                                    doAfterVisit(new RemoveRedundantDependencyVersions(null, null, true, retainVersions).getVisitor());
-                                    for (XmlVisitor<ExecutionContext> visitor : changeParentTagVisitors) {
-                                        doAfterVisit(visitor);
-                                    }
-                                    maybeUpdateModel();
-                                    doAfterVisit(new RemoveRedundantDependencyVersions(null, null, true, null).getVisitor());
+                            if (!oldVersion.equals(targetVersion.get())) {
+                                changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("version").get(), targetVersion.get()));
+                            }
+
+                            // Retain managed versions from the old parent that are not managed in the new parent
+                            MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, null, null);
+                            Pom newParentPom = mpd.download(new GroupArtifactVersion(targetGroupId, targetArtifactId, targetVersion.get()), null, null, resolvedPom.getRepositories());
+                            List<ResolvedManagedDependency> dependenciesWithoutExplicitVersions = getDependenciesWithoutExplicitVersions(resolvedPom);
+                            for (ResolvedManagedDependency dep : dependenciesWithoutExplicitVersions) {
+                                changeParentTagVisitors.add(new AddManagedDependencyVisitor(
+                                        dep.getGav().getGroupId(), dep.getGav().getArtifactId(), dep.getGav().getVersion(),
+                                        dep.getScope() == null ? null : dep.getScope().toString().toLowerCase(), dep.getType(), dep.getClassifier()));
+                            }
+
+                            // Retain properties from the old parent that are not present in the new parent
+                            Map<String, String> propertiesInUse = getPropertiesInUse(getCursor().firstEnclosingOrThrow(Xml.Document.class), ctx);
+                            Map<String, String> newParentProps = newParentPom.getProperties();
+                            for (Map.Entry<String, String> propInUse : propertiesInUse.entrySet()) {
+                                if(!newParentProps.containsKey(propInUse.getKey())) {
+                                    // AddProperty recipe will try to avoid adding a redundant property
+                                    // But it doesn't know the property will soon no longer be redundant
+                                    // So use just its visitor without the precondition
+                                    changeParentTagVisitors.add(
+                                            new AddPropertyVisitor(propInUse.getKey(), propInUse.getValue(), false, false));
                                 }
+                            }
+
+                            // Update or add relativePath
+                            if (oldRelativePath != null && !oldRelativePath.equals(targetRelativePath)) {
+                                changeParentTagVisitors.add(new ChangeTagValueVisitor<>(t.getChild("relativePath").get(), targetRelativePath));
+                            } else if (mismatches(tag.getChild("relativePath").orElse(null), targetRelativePath)) {
+                                final Xml.Tag relativePathTag;
+                                if (StringUtils.isBlank(targetRelativePath)) {
+                                    relativePathTag = Xml.Tag.build("<relativePath />");
+                                } else {
+                                    relativePathTag = Xml.Tag.build("<relativePath>" + targetRelativePath + "</relativePath>");
+                                }
+                                doAfterVisit(new AddToTagVisitor<>(t, relativePathTag, new MavenTagInsertionComparator(t.getChildren())));
+                                maybeUpdateModel();
+                            }
+
+                            if (!changeParentTagVisitors.isEmpty()) {
+                                for (TreeVisitor<?, ExecutionContext> visitor : changeParentTagVisitors) {
+                                    doAfterVisit(visitor);
+                                }
+                                maybeUpdateModel();
+                                doAfterVisit(new RemoveRedundantDependencyVersions(null, null, false, null).getVisitor());
                             }
                         } catch (MavenDownloadingException e) {
                             return e.warn(tag);
@@ -249,19 +251,13 @@ public class ChangeParentPom extends Recipe {
                 return !relativePathValue.equals(targetRelativePath);
             }
 
-            private void retainVersions() {
-                for (Recipe retainVersionRecipe : RetainVersions.plan(this, retainVersions == null ?
-                        emptyList() : retainVersions)) {
-                    doAfterVisit(retainVersionRecipe.getVisitor());
-                }
-            }
-
             private Optional<String> findAcceptableVersion(String groupId, String artifactId, String currentVersion,
                                                                 ExecutionContext ctx) throws MavenDownloadingException {
                 String finalCurrentVersion = !Semver.isVersion(currentVersion) ? "0.0.0" : currentVersion;
 
                 if (availableVersions == null) {
                     MavenMetadata mavenMetadata = metadataFailures.insertRows(ctx, () -> downloadMetadata(groupId, artifactId, ctx));
+                    //noinspection EqualsWithItself
                     availableVersions = mavenMetadata.getVersioning().getVersions().stream()
                             .filter(v -> versionComparator.isValid(finalCurrentVersion, v))
                             .filter(v -> Boolean.TRUE.equals(allowVersionDowngrades) || versionComparator.compare(finalCurrentVersion, finalCurrentVersion, v) <= 0)
@@ -279,5 +275,44 @@ public class ChangeParentPom extends Recipe {
             }
         });
     }
-}
 
+    private static Pattern PROPERTY_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+
+    private static Map<String, String> getPropertiesInUse(Xml.Document pomXml, ExecutionContext ctx) {
+        Map<String, String> properties = new HashMap<>();
+        new MavenIsoVisitor<ExecutionContext>() {
+
+            @Nullable
+            ResolvedPom resolvedPom = null;
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext executionContext) {
+                Xml.Tag t = super.visitTag(tag, executionContext);
+                if(t.getContent() != null && t.getContent().size() == 1 && t.getContent().get(0) instanceof Xml.CharData) {
+                    String text = ((Xml.CharData) t.getContent().get(0)).getText().trim();
+                    Matcher m = PROPERTY_PATTERN.matcher(text);
+                    while(m.find()) {
+                        if(resolvedPom == null) {
+                            resolvedPom = getResolutionResult().getPom();
+                        }
+                        String propertyName = m.group(1).trim();
+                        properties.put(m.group(1).trim(), resolvedPom.getProperties().get(propertyName));
+                    }
+                }
+                return t;
+            }
+        }.visit(pomXml, ctx);
+        return properties;
+    }
+
+    private static List<ResolvedManagedDependency> getDependenciesWithoutExplicitVersions(ResolvedPom resolvedPom) {
+
+        Set<GroupArtifactVersion> requestedWithoutExplicitVersion = resolvedPom.getRequested().getDependencies().stream()
+                .filter(dep -> dep.getVersion() == null)
+                .map(dep -> new GroupArtifactVersion(dep.getGroupId(), dep.getArtifactId(), null))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return resolvedPom.getDependencyManagement().stream()
+                .filter(dep -> requestedWithoutExplicitVersion.contains(dep.getGav().withVersion(null)))
+                .collect(Collectors.toList());
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeParentVersion.java
@@ -22,8 +22,6 @@ import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.semver.Semver;
 
-import java.util.List;
-
 @Getter
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -52,15 +50,6 @@ public class UpgradeParentVersion extends Recipe {
     @Nullable
     String versionPattern;
 
-    @Option(displayName = "Retain versions",
-            description = "Accepts a list of GAVs. For each GAV, if it is a project direct dependency, and it is removed " +
-                          "from dependency management in the new parent pom, then it will be retained with an explicit version. " +
-                          "The version can be omitted from the GAV to use the old value from dependency management",
-            example = "com.jcraft:jsch",
-            required = false)
-    @Nullable
-    List<String> retainVersions;
-
     @Override
     public String getDisplayName() {
         return "Upgrade Maven parent project version";
@@ -73,7 +62,8 @@ public class UpgradeParentVersion extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Set the parent pom version number according to a node-style semver selector or to a specific version number.";
+        return "Set the parent pom version number according to a [version selector](https://docs.openrewrite.org/reference/dependency-version-selectors) " +
+               "or to a specific version number.";
     }
 
     @Override
@@ -93,6 +83,6 @@ public class UpgradeParentVersion extends Recipe {
 
     private ChangeParentPom changeParentPom() {
         return new ChangeParentPom(groupId, null, artifactId, null, newVersion, null, null,
-                versionPattern, false, retainVersions);
+                versionPattern, false);
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
@@ -281,7 +281,7 @@ class AddRepositoryTest implements RewriteTest {
             new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
               true, null, null,
               null, null, null),
-            new UpgradeParentVersion("org.springframework.boot", "spring-boot-starter-parent", "3.0.0-SNAPSHOT", null, null)
+            new UpgradeParentVersion("org.springframework.boot", "spring-boot-starter-parent", "3.0.0-SNAPSHOT", null)
           ),
           pomXml(
             """

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -15,16 +15,12 @@
  */
 package org.openrewrite.maven;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
-
-import java.util.Collections;
-import java.util.List;
 
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -44,8 +40,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -94,8 +89,7 @@ class ChangeParentPomTest implements RewriteTest {
             "",
             "../../pom.xml",
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -146,8 +140,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "",
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -197,8 +190,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             "../pom.xml",
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -238,7 +230,7 @@ class ChangeParentPomTest implements RewriteTest {
 
     @RepeatedTest(10)
     void multiModuleRelativePath() {
-      ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, "", null, false, null);
+      ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, "", null, false);
       rewriteRun(
         spec -> spec.recipe(recipe),
         mavenProject("parent",
@@ -322,7 +314,7 @@ class ChangeParentPomTest implements RewriteTest {
 
   @RepeatedTest(10)
   void multiModuleRelativePathChangeChildrens() {
-    ChangeParentPom recipe = new ChangeParentPom("org.sample", "org.springframework.boot", "sample", "spring-boot-starter-parent", "2.5.0", null, "", null, true, null);
+    ChangeParentPom recipe = new ChangeParentPom("org.sample", "org.springframework.boot", "sample", "spring-boot-starter-parent", "2.5.0", null, "", null, true);
     rewriteRun(
       spec -> spec.recipe(recipe),
       mavenProject("parent",
@@ -421,8 +413,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -473,8 +464,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -525,8 +515,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -561,8 +550,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            true,
-            null
+            true
           )),
           pomXml(
             """
@@ -613,8 +601,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -665,8 +652,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -732,8 +718,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -788,7 +773,7 @@ class ChangeParentPomTest implements RewriteTest {
     }
 
     @Test
-    void keepsRedundantExplicitVersionsNotMatchingOldOrNewParent() {
+    void takesNewVersionFromParent() {
         rewriteRun(
           spec -> spec.recipe(new ChangeParentPom(
             "org.junit",
@@ -799,8 +784,7 @@ class ChangeParentPomTest implements RewriteTest {
             null,
             null,
             null,
-            false,
-            null
+            false
           )),
           pomXml(
             """
@@ -846,7 +830,6 @@ class ChangeParentPomTest implements RewriteTest {
                   <dependency>
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter-api</artifactId>
-                    <version>5.8.0</version>
                   </dependency>
                 </dependencies>
               </project>
@@ -858,7 +841,7 @@ class ChangeParentPomTest implements RewriteTest {
     @Test
     void upgradeNonSemverVersion() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-starter-parent", null, "2021.0.5", null, null, null, false, null)),
+          spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-starter-parent", null, "2021.0.5", null, null, null, false)),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -901,8 +884,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void dependencyWithExplicitVersionRemovedFromDepMgmt() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null,
-                List.of("com.jcraft:jsch"))),
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null)),
               pomXml(
                 """
                   <?xml version="1.0" encoding="UTF-8"?>
@@ -911,13 +893,13 @@ class ChangeParentPomTest implements RewriteTest {
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
                     <version>1.0.0</version>
-                    
+                  
                     <parent>
                       <groupId>org.springframework.cloud</groupId>
                       <artifactId>spring-cloud-config-dependencies</artifactId>
                       <version>3.1.2</version>
                     </parent>
-                    
+                  
                     <dependencies>
                       <dependency>
                         <groupId>com.jcraft</groupId>
@@ -934,247 +916,18 @@ class ChangeParentPomTest implements RewriteTest {
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
                     <version>1.0.0</version>
-                    
+                  
                     <parent>
                       <groupId>org.springframework.cloud</groupId>
                       <artifactId>spring-cloud-config-dependencies</artifactId>
                       <version>3.1.4</version>
                     </parent>
-                    
+                  
                     <dependencies>
                       <dependency>
                         <groupId>com.jcraft</groupId>
                         <artifactId>jsch</artifactId>
                         <version>0.1.55</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """
-              )
-            );
-        }
-
-        @Test
-        void dependencyWithoutExplicitVersionRemovedFromDepMgmt() {
-            rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null,
-                Collections.singletonList("com.jcraft:jsch"))),
-              pomXml(
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-config-dependencies</artifactId>
-                      <version>3.1.2</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.jcraft</groupId>
-                        <artifactId>jsch</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """,
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-config-dependencies</artifactId>
-                      <version>3.1.4</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.jcraft</groupId>
-                        <artifactId>jsch</artifactId>
-                        <version>0.1.55</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """
-              )
-            );
-        }
-
-        @Test
-        void dependencyWithoutExplicitVersionRemovedFromDepMgmtRetainSpecificVersion() {
-            rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-config-dependencies", null, "3.1.4", null, null, null, null,
-                Collections.singletonList("com.jcraft:jsch:0.1.50"))),
-              pomXml(
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-config-dependencies</artifactId>
-                      <version>3.1.2</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.jcraft</groupId>
-                        <artifactId>jsch</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """,
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-config-dependencies</artifactId>
-                      <version>3.1.4</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.jcraft</groupId>
-                        <artifactId>jsch</artifactId>
-                        <version>0.1.50</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """
-              )
-            );
-        }
-
-        @Test
-        void multipleRetainVersions() {
-            rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true,
-                Lists.newArrayList("com.jcraft:jsch", "org.springframework.cloud:spring-cloud-schema-registry-*:1.1.1"))),
-              pomXml(
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-dependencies</artifactId>
-                      <version>2020.0.1</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.jcraft</groupId>
-                        <artifactId>jsch</artifactId>
-                      </dependency>
-                      <dependency>
-                        <groupId>org.springframework.cloud</groupId>
-                        <artifactId>spring-cloud-schema-registry-core</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """,
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-dependencies</artifactId>
-                      <version>2021.0.5</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.jcraft</groupId>
-                        <artifactId>jsch</artifactId>
-                        <version>0.1.55</version>
-                      </dependency>
-                      <dependency>
-                        <groupId>org.springframework.cloud</groupId>
-                        <artifactId>spring-cloud-schema-registry-core</artifactId>
-                        <version>1.1.1</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """
-              )
-            );
-        }
-
-        @Test
-        void globGavWithNoVersion() {
-            rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true,
-                Lists.newArrayList("org.springframework.cloud:spring-cloud-schema-registry-*"))),
-              pomXml(
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-dependencies</artifactId>
-                      <version>2020.0.1</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.springframework.cloud</groupId>
-                        <artifactId>spring-cloud-schema-registry-core</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """,
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    
-                    <parent>
-                      <groupId>org.springframework.cloud</groupId>
-                      <artifactId>spring-cloud-dependencies</artifactId>
-                      <version>2021.0.5</version>
-                    </parent>
-                    
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.springframework.cloud</groupId>
-                        <artifactId>spring-cloud-schema-registry-core</artifactId>
-                        <version>1.1.1</version>
                       </dependency>
                     </dependencies>
                   </project>
@@ -1186,8 +939,7 @@ class ChangeParentPomTest implements RewriteTest {
         @Test
         void preservesExplicitVersionIfNotRequested() {
             rewriteRun(
-              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true,
-                Lists.newArrayList("org.springframework.cloud:spring-cloud-schema-registry-*"))),
+              spec -> spec.recipe(new ChangeParentPom("org.springframework.cloud", null, "spring-cloud-dependencies", null, "2021.0.5", null, null, null, true)),
               pomXml(
                 """
                   <?xml version="1.0" encoding="UTF-8"?>
@@ -1238,12 +990,125 @@ class ChangeParentPomTest implements RewriteTest {
               )
             );
         }
+
+
+        @Test
+        void bringsDownRemovedProperty() {
+            rewriteRun(
+              spec -> spec.recipe(new ChangeParentPom(
+                "org.springframework.boot", "org.springframework.boot",
+                "spring-boot-dependencies", "spring-boot-dependencies",
+                "3.2.4",
+                null, null, null, null)),
+              pomXml("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-dependencies</artifactId>
+                        <version>2.4.0</version>
+                    </parent>
+                    <dependencies>
+                      <dependency>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                        <version>${servlet-api.version}</version>
+                      </dependency>
+                    </dependencies>
+                </project>
+                """,
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-dependencies</artifactId>
+                        <version>3.2.4</version>
+                    </parent>
+                    <properties>
+                        <servlet-api.version>4.0.1</servlet-api.version>
+                    </properties>
+                    <dependencies>
+                      <dependency>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                        <version>${servlet-api.version}</version>
+                      </dependency>
+                    </dependencies>
+                </project>
+                """)
+            );
+        }
+
+        @Test
+        void bringsDownRemovedManagedVersion() {
+            rewriteRun(
+              spec -> spec.recipe(new ChangeParentPom(
+                "org.springframework.boot", "org.springframework.boot",
+                "spring-boot-dependencies", "spring-boot-dependencies",
+                "3.2.4",
+                null, null, null, null)),
+              pomXml("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-dependencies</artifactId>
+                        <version>2.4.0</version>
+                    </parent>
+                    <dependencies>
+                      <dependency>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                      </dependency>
+                    </dependencies>
+                </project>
+                """,
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-dependencies</artifactId>
+                        <version>3.2.4</version>
+                    </parent>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.servlet</groupId>
+                                <artifactId>javax.servlet-api</artifactId>
+                                <version>4.0.1</version>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                      </dependency>
+                    </dependencies>
+                </project>
+                """)
+            );
+        }
     }
 
     @RepeatedTest(10)
     @Issue("https://github.com/openrewrite/rewrite/issues/1753")
     void multiModule() {
-        ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, null, null, true, null);
+        ChangeParentPom recipe = new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.6.7", null, null, null, true);
         rewriteRun(
           spec -> spec.recipe(recipe),
           mavenProject("parent",
@@ -1327,7 +1192,7 @@ class ChangeParentPomTest implements RewriteTest {
     @Test
     void changeParentToSameVersion() {
         rewriteRun(
-          spec -> spec.recipe(new ChangeParentPom("org.springframework.boot", null, "spring-boot-dependencies", "spring-boot-starter-parent", "latest.patch", null, null, null, null, null)),
+          spec -> spec.recipe(new ChangeParentPom("org.springframework.boot", null, "spring-boot-dependencies", "spring-boot-starter-parent", "latest.patch", null, null, null, null)),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -83,7 +83,7 @@ class MavenDependencyFailuresTest implements RewriteTest {
     void unresolvableParent() { // Dad said he was heading to the corner store for cigarettes, and hasn't been resolvable for the past 20 years :'(
         rewriteRun(
           spec -> spec
-            .recipe(new UpgradeParentVersion("*", "*", "latest.patch", null, null))
+            .recipe(new UpgradeParentVersion("*", "*", "latest.patch", null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
               .setRepositories(List.of(MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public").knownToExist(true).build())))
             .recipeExecutionContext(new InMemoryExecutionContext())

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -36,7 +36,6 @@ class UpgradeParentVersionTest implements RewriteTest {
             "org.springframework.boot",
             "spring-boot-starter-parent",
             "~1.5",
-            null,
             null
           )),
           pomXml(
@@ -62,7 +61,7 @@ class UpgradeParentVersionTest implements RewriteTest {
     void nonMavenCentralRepository() {
         rewriteRun(
           spec -> spec
-            .recipe(new UpgradeParentVersion("org.jenkins-ci.plugins", "plugin", "4.40", null, null))
+            .recipe(new UpgradeParentVersion("org.jenkins-ci.plugins", "plugin", "4.40", null))
             .executionContext(
               MavenExecutionContextView
                 .view(new InMemoryExecutionContext())
@@ -104,7 +103,6 @@ class UpgradeParentVersionTest implements RewriteTest {
             "org.springframework.boot",
             "spring-boot-starter-parent",
             "~1.5",
-            null,
             null
           )),
           pomXml(
@@ -145,7 +143,6 @@ class UpgradeParentVersionTest implements RewriteTest {
             "org.springframework.boot",
             "spring-boot-starter-parent",
             "1.5.22.RELEASE",
-            null,
             null
           )),
           pomXml(


### PR DESCRIPTION
When the new parent pom doesn't define all the same properties or managed dependencies as the old parent pom, they will now all be brought down to the child pom.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
