### PR TITLE
Fix for gradle configurations that do not extend another configuration to allow transitive dependency version upgrade

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -255,7 +255,7 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
                         return extended;
                     }
                 }
-                return null;
+                return config;
             }
         });
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -168,4 +168,37 @@ public class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addConstraintToConfigurationNotExtendingAnything() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins { id 'ear' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  earlib 'org.openrewrite:rewrite-java:7.0.0'
+                  
+                  constraints {
+                  }
+              }
+              """,
+            """
+              plugins { id 'ear' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  earlib 'org.openrewrite:rewrite-java:7.0.0'
+              
+                  constraints {
+                      earlib('com.fasterxml.jackson.core:jackson-databind:2.12.5') {
+                          because 'CVE-2024-BAD'
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
[See this Slack thread](https://rewriteoss.slack.com/archives/C01A843MWG5/p1711408293433509?thread_ts=1710442165.133859&cid=C01A843MWG5)

## What's your motivation?
We should have support for earlib which does not extend anything yet is a default gradle thing.

## Anything in particular you'd like reviewers to focus on?
Are we sure this null wasn't necessary earlier for some other reasons? Should we not add earlib as a separate if block or is any configuration okay? A manually created configuration would also be supported like this, I guess.

## Anyone you would like to review specifically?
@sambsnyd 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
