### PR TITLE
feat: Granular enable/disable adding default/fallback repositories

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -40,12 +40,13 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
     private static final String MAVEN_MIRRORS = "org.openrewrite.maven.mirrors";
     private static final String MAVEN_CREDENTIALS = "org.openrewrite.maven.auth";
     private static final String MAVEN_LOCAL_REPOSITORY = "org.openrewrite.maven.localRepo";
+    private static final String MAVEN_ADD_LOCAL_REPOSITORY = "org.openrewrite.maven.useLocalRepo";
+    private static final String MAVEN_ADD_CENTRAL_REPOSITORY = "org.openrewrite.maven.useCentralRepo";
     private static final String MAVEN_REPOSITORIES = "org.openrewrite.maven.repos";
     private static final String MAVEN_PINNED_SNAPSHOT_VERSIONS = "org.openrewrite.maven.pinnedSnapshotVersions";
     private static final String MAVEN_POM_CACHE = "org.openrewrite.maven.pomCache";
     private static final String MAVEN_RESOLUTION_LISTENER = "org.openrewrite.maven.resolutionListener";
     private static final String MAVEN_RESOLUTION_TIME = "org.openrewrite.maven.resolutionTime";
-    private static final String IS_ENABLE_DEFAULT_REPOSITORIES = "org.openrewrite.maven.isEnableDefaultRepositories";
 
     public MavenExecutionContextView(ExecutionContext delegate) {
         super(delegate);
@@ -143,6 +144,24 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
         return getMessage(MAVEN_LOCAL_REPOSITORY, MAVEN_LOCAL_DEFAULT);
     }
 
+    public MavenExecutionContextView setAddLocalRepository(boolean useLocalRepository) {
+        putMessage(MAVEN_ADD_LOCAL_REPOSITORY, useLocalRepository);
+        return this;
+    }
+
+    public boolean getAddLocalRepository() {
+        return getMessage(MAVEN_ADD_LOCAL_REPOSITORY, true);
+    }
+
+    public MavenExecutionContextView setAddCentralRepository(boolean useLocalRepository) {
+        putMessage(MAVEN_ADD_CENTRAL_REPOSITORY, useLocalRepository);
+        return this;
+    }
+
+    public boolean getAddCentralRepository() {
+        return getMessage(MAVEN_ADD_CENTRAL_REPOSITORY, true);
+    }
+
     public MavenExecutionContextView setRepositories(List<MavenRepository> repositories) {
         putMessage(MAVEN_REPOSITORIES, repositories);
         return this;
@@ -212,18 +231,8 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
         return getMessage(MAVEN_SETTINGS, null);
     }
 
-    @Nullable
-    public Boolean isEnableDefaultRepositories() {
-        return getMessage(IS_ENABLE_DEFAULT_REPOSITORIES, null);
-    }
-
-    public MavenExecutionContextView setEnableDefaultRepositories(@Nullable Boolean enableDefaultRepositories) {
-        putMessage(IS_ENABLE_DEFAULT_REPOSITORIES, enableDefaultRepositories);
-        return this;
-    }
-
     private static List<String> mapActiveProfiles(MavenSettings settings, String... activeProfiles) {
-        if(settings.getActiveProfiles() == null) {
+        if (settings.getActiveProfiles() == null) {
             return Arrays.asList(activeProfiles);
         }
         return Stream.concat(


### PR DESCRIPTION
## What's changed?
In stead of enabling disabling maven central and local together, make them configurable separately.

## What's your motivation?
For recipe installing we would like to use maven local in most cases but not maven central in all cases.

## Anything in particular you'd like reviewers to focus on?
I replaced [existing functionality added a few hours ago](https://github.com/openrewrite/rewrite/commit/152606fe7ab2a9d7f9f55e9bbadb2e7961da993b), but it was very new so might not be depended on yet 🙏 

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
We could keep both settings, but that would only be for backwards compatibility.

## Any additional context
Sometimes Maven central is blocked on a firewall and causes long waits for a timeout before the repo will not be considered.
