### PR TITLE
`SpacesVisitor`: Add space between annotations

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/MinimumViableSpacingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/MinimumViableSpacingTest.java
@@ -223,4 +223,22 @@ class MinimumViableSpacingTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void spaceBetweenAnnotations() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
+          java(
+            """
+              class A {
+                  void m(@Deprecated @SuppressWarnings int a) {
+                  }
+              }
+              """,
+            """
+              class A{void m(@Deprecated @SuppressWarnings int a){}}
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/MinimumViableSpacingTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/MinimumViableSpacingTest.java
@@ -223,22 +223,4 @@ class MinimumViableSpacingTest implements RewriteTest {
           )
         );
     }
-
-    @Test
-    void spaceBetweenAnnotations() {
-        rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
-          java(
-            """
-              class A {
-                  void m(@Deprecated @SuppressWarnings int a) {
-                  }
-              }
-              """,
-            """
-              class A{void m(@Deprecated @SuppressWarnings int a){}}
-              """
-          )
-        );
-    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/SpacesTest.java
@@ -4836,4 +4836,25 @@ class SpacesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void spaceBetweenAnnotations() {
+        rewriteRun(
+          spaces(),
+          java(
+            """
+              class A {
+                  void m(@Deprecated@SuppressWarnings("ALL") int a) {
+                  }
+              }
+              """,
+            """
+              class A {
+                  void m(@Deprecated @SuppressWarnings("ALL") int a) {
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
@@ -35,6 +35,9 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
 
         boolean first = c.getLeadingAnnotations().isEmpty();
+        if (!first) {
+            c = c.withLeadingAnnotations(spaceBetweenAnnotations(c.getLeadingAnnotations()));
+        }
         if (!c.getModifiers().isEmpty()) {
             if (!first && Space.firstPrefix(c.getModifiers()).getWhitespace().isEmpty()) {
                 c = c.withModifiers(Space.formatFirstPrefix(c.getModifiers(),
@@ -99,6 +102,9 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
 
         boolean first = m.getLeadingAnnotations().isEmpty();
+        if (!first) {
+            m = m.withLeadingAnnotations(spaceBetweenAnnotations(m.getLeadingAnnotations()));
+        }
         if (!m.getModifiers().isEmpty()) {
             if (!first && Space.firstPrefix(m.getModifiers()).getWhitespace().isEmpty()) {
                 m = m.withModifiers(Space.formatFirstPrefix(m.getModifiers(),
@@ -175,6 +181,9 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.VariableDeclarations v = super.visitVariableDeclarations(multiVariable, p);
 
         boolean first = v.getLeadingAnnotations().isEmpty();
+        if (!first) {
+            v = v.withLeadingAnnotations(spaceBetweenAnnotations(v.getLeadingAnnotations()));
+        }
 
         /*
          * We need at least one space between multiple modifiers, otherwise we could get a run-on like "publicstaticfinal".
@@ -209,6 +218,25 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         }
 
         return v;
+    }
+
+    @Override
+    public J.AnnotatedType visitAnnotatedType(J.AnnotatedType annotatedType, P p) {
+        J.AnnotatedType at = super.visitAnnotatedType(annotatedType, p);
+        if (at.getAnnotations().isEmpty()) {
+            at = at.withAnnotations(spaceBetweenAnnotations(at.getAnnotations()));
+        }
+        return at;
+    }
+
+    private static List<J.Annotation> spaceBetweenAnnotations(List<J.Annotation> annotations) {
+//        if (true) return annotations;
+        return ListUtils.map(annotations, (i, ann) -> {
+            if (i > 0 && ann.getPrefix().isEmpty()) {
+                return ann.withPrefix(Space.SINGLE_SPACE);
+            }
+            return ann;
+        });
     }
 
     @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
@@ -230,7 +230,6 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private static List<J.Annotation> spaceBetweenAnnotations(List<J.Annotation> annotations) {
-//        if (true) return annotations;
         return ListUtils.map(annotations, (i, ann) -> {
             if (i > 0 && ann.getPrefix().isEmpty()) {
                 return ann.withPrefix(Space.SINGLE_SPACE);

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
@@ -35,9 +35,6 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
 
         boolean first = c.getLeadingAnnotations().isEmpty();
-        if (!first) {
-            c = c.withLeadingAnnotations(spaceBetweenAnnotations(c.getLeadingAnnotations()));
-        }
         if (!c.getModifiers().isEmpty()) {
             if (!first && Space.firstPrefix(c.getModifiers()).getWhitespace().isEmpty()) {
                 c = c.withModifiers(Space.formatFirstPrefix(c.getModifiers(),
@@ -102,9 +99,6 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
 
         boolean first = m.getLeadingAnnotations().isEmpty();
-        if (!first) {
-            m = m.withLeadingAnnotations(spaceBetweenAnnotations(m.getLeadingAnnotations()));
-        }
         if (!m.getModifiers().isEmpty()) {
             if (!first && Space.firstPrefix(m.getModifiers()).getWhitespace().isEmpty()) {
                 m = m.withModifiers(Space.formatFirstPrefix(m.getModifiers(),
@@ -142,12 +136,12 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
                 if (returnTypeExpression instanceof J.AnnotatedType) {
                     J.AnnotatedType annotatedType = (J.AnnotatedType) returnTypeExpression;
                     List<J.Annotation> annotations = ListUtils.mapFirst(annotatedType.getAnnotations(), annotation ->
-                        annotation.withPrefix(annotation.getPrefix().withWhitespace(" "))
+                            annotation.withPrefix(annotation.getPrefix().withWhitespace(" "))
                     );
                     m = m.withReturnTypeExpression(annotatedType.withAnnotations(annotations));
                 } else {
                     m = m.withReturnTypeExpression(returnTypeExpression
-                        .withPrefix(returnTypeExpression.getPrefix().withWhitespace(" ")));
+                            .withPrefix(returnTypeExpression.getPrefix().withWhitespace(" ")));
                 }
             }
             first = false;
@@ -181,9 +175,6 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         J.VariableDeclarations v = super.visitVariableDeclarations(multiVariable, p);
 
         boolean first = v.getLeadingAnnotations().isEmpty();
-        if (!first) {
-            v = v.withLeadingAnnotations(spaceBetweenAnnotations(v.getLeadingAnnotations()));
-        }
 
         /*
          * We need at least one space between multiple modifiers, otherwise we could get a run-on like "publicstaticfinal".
@@ -218,24 +209,6 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
         }
 
         return v;
-    }
-
-    @Override
-    public J.AnnotatedType visitAnnotatedType(J.AnnotatedType annotatedType, P p) {
-        J.AnnotatedType at = super.visitAnnotatedType(annotatedType, p);
-        if (at.getAnnotations().isEmpty()) {
-            at = at.withAnnotations(spaceBetweenAnnotations(at.getAnnotations()));
-        }
-        return at;
-    }
-
-    private static List<J.Annotation> spaceBetweenAnnotations(List<J.Annotation> annotations) {
-        return ListUtils.map(annotations, (i, ann) -> {
-            if (i > 0 && ann.getPrefix().isEmpty()) {
-                return ann.withPrefix(Space.SINGLE_SPACE);
-            }
-            return ann;
-        });
     }
 
     @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -180,9 +180,21 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         return onlySpaces(str) && !" ".equals(str);
     }
 
+    private static List<J.Annotation> spaceBetweenAnnotations(List<J.Annotation> annotations) {
+        return ListUtils.map(annotations, (i, ann) -> {
+            if (i > 0 && ann.getPrefix().isEmpty()) {
+                return ann.withPrefix(Space.SINGLE_SPACE);
+            }
+            return ann;
+        });
+    }
+
     @Override
     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, P p) {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
+        if (c.getLeadingAnnotations().size() > 1) {
+            c = c.withLeadingAnnotations(spaceBetweenAnnotations(c.getLeadingAnnotations()));
+        }
         if (c.getBody() != null) {
             c = c.withBody(spaceBefore(c.getBody(), style.getBeforeLeftBrace().getClassLeftBrace()));
             if (c.getBody().getStatements().isEmpty()) {
@@ -242,6 +254,9 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
     @Override
     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, P p) {
         J.MethodDeclaration m = super.visitMethodDeclaration(method, p);
+        if (m.getLeadingAnnotations().size() > 1) {
+            m = m.withLeadingAnnotations(spaceBetweenAnnotations(m.getLeadingAnnotations()));
+        }
         m = m.getPadding().withParameters(
                 spaceBefore(m.getPadding().getParameters(), style.getBeforeParentheses().getMethodDeclaration()));
         if (m.getBody() != null) {
@@ -704,6 +719,15 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         a = padding.withOperator(operator.withBefore(updateSpace(operator.getBefore(), style.getAroundOperators().getAssignment())));
         a = a.withAssignment(spaceBefore(a.getAssignment(), style.getAroundOperators().getAssignment()));
         return a;
+    }
+
+    @Override
+    public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, P p) {
+        J.VariableDeclarations vd = super.visitVariableDeclarations(multiVariable, p);
+        if (vd.getLeadingAnnotations().size() > 1) {
+            vd = vd.withLeadingAnnotations(spaceBetweenAnnotations(vd.getLeadingAnnotations()));
+        }
+        return vd;
     }
 
     @Override


### PR DESCRIPTION
Adds a space between annotations for all cases where an `addAnnotation()` coordinate exists, which can be used together with `JavaTemplate` to add an annotation.

Fixes: #4115
