### PR TITLE
Remove unused imports after `RemoveObjectsIsNull`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -54,9 +54,11 @@ public class RemoveObjectsIsNull extends Recipe {
             }
 
             private Expression replace(ExecutionContext ctx, J.MethodInvocation m, String pattern) {
+                maybeRemoveImport("java.util.Objects");
+
                 Expression e = m.getArguments().get(0);
                 Expression replaced = JavaTemplate.apply(pattern, getCursor(), m.getCoordinates().replace(), e);
-                return (Expression) new UnnecessaryParenthesesVisitor()
+                return (Expression) new UnnecessaryParenthesesVisitor<>()
                         .visitNonNull(replaced, ctx, getCursor());
             }
         });


### PR DESCRIPTION
## What's changed?
The `RemoveObjectsIsNull` recipe will now remove unused imports.

## What's your motivation?
The `RemoveObjectsIsNull` recipe would sometimes leave unused imports, if the only usage of `java.util.Objects` was removed.

## Any additional context
I added a test case that was mentioned in the original issue when this recipe was added.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
