### PR TITLE
XPathMatcher does not support paths containing "//" and conditions #4119

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -95,7 +95,7 @@ public class XPathMatcher {
                     }
                     if (!partBefore.contains("@")) {
                         partWithCondition = partBefore;
-                        tagForCondition = path.get(path.size() - 1 - i);
+                        tagForCondition = path.get(parts.length - i);
                     }
                 }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -15,25 +15,32 @@
  */
 package org.openrewrite.xml;
 
-import org.openrewrite.Cursor;
-import org.openrewrite.internal.StringUtils;
-import org.openrewrite.xml.search.FindTags;
-import org.openrewrite.xml.tree.Xml;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.openrewrite.Cursor;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.xml.search.FindTags;
+import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.xml.tree.Xml.Attribute;
+import org.openrewrite.xml.tree.Xml.Tag;
 
 /**
- * Supports a limited set of XPath expressions, specifically those
- * documented on <a href="https://www.w3schools.com/xml/xpath_syntax.asp">this page</a>.
+ * Supports a limited set of XPath expressions, specifically those documented on <a
+ * href="https://www.w3schools.com/xml/xpath_syntax.asp">this page</a>.
  * <p>
  * Used for checking whether a visitor's cursor meets a certain XPath expression.
  * <p>
- * The "current node" for XPath evaluation is always the root node of the document.
- * As a result, '.' and '..' are not recognized.
+ * The "current node" for XPath evaluation is always the root node of the document. As a result, '.' and '..' are not
+ * recognized.
  */
 public class XPathMatcher {
+
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
     private static final Pattern PATTERN = Pattern.compile("([-\\w]+)\\[(@)?([-\\w]+)='([-\\w.]+)']");
 
@@ -56,9 +63,9 @@ public class XPathMatcher {
      * @return true if the expression matches the cursor, false otherwise
      */
     public boolean matches(Cursor cursor) {
-        List<Xml.Tag> path = new ArrayList<>();
+        List<Tag> path = new ArrayList<>();
         for (Cursor c = cursor; c != null; c = c.getParent()) {
-            if (c.getValue() instanceof Xml.Tag) {
+            if (c.getValue() instanceof Tag) {
                 path.add(c.getValue());
             }
         }
@@ -67,10 +74,30 @@ public class XPathMatcher {
             int pathIndex = 0;
             for (int i = parts.length - 1; i >= 0; i--, pathIndex++) {
                 String part = parts[i];
+
+                //todo check if part contains condition --> if it does check if its true
+
+                String partBefore = i > 0 ? parts[i - 1] : null;
+                Tag tagBefore = i < path.size() ? path.get(path.size() - 1 - i) : null;
+                //getPath beforeElement
+                String partName;
+
+                Matcher matcher = partBefore != null ? PATTERN.matcher(partBefore) : null;
+                if (tagBefore != null && partBefore != null && partBefore.endsWith("]")
+                        && matcher.matches()) {
+                    String optionalPartName = matchesCondition(matcher, tagBefore);
+                    if (optionalPartName == null) {
+                        return false;
+                    }
+                    partName = optionalPartName;
+                } else {
+                    partName = part;
+                }
+
                 if (part.startsWith("@")) {
-                    if (!(cursor.getValue() instanceof Xml.Attribute &&
-                          (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
-                          "*".equals(part.substring(1)))) {
+                    if (!(cursor.getValue() instanceof Attribute &&
+                            (((Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
+                            "*".equals(part.substring(1)))) {
                         return false;
                     }
 
@@ -78,7 +105,9 @@ public class XPathMatcher {
                     continue;
                 }
 
-                if (path.size() < i + 1 || (!path.get(pathIndex).getName().equals(part) && !"*".equals(part))) {
+                if (path.size() < i + 1 || (
+                        !path.get(pathIndex).getName().equals(part) && (tagBefore != null && !part.equals(partName) && !tagBefore.getName()
+                                .equals(partName)) && !"*".equals(part))) {
                     return false;
                 }
             }
@@ -119,33 +148,24 @@ public class XPathMatcher {
             for (int i = 0; i < parts.length; i++) {
                 String part = parts[i];
 
-                Xml.Tag tag = i < path.size() ? path.get(i) : null;
+                Tag tag = i < path.size() ? path.get(i) : null;
                 String partName;
 
-                Matcher matcher;
-                if (tag != null && part.endsWith("]") && (matcher = PATTERN.matcher(part)).matches()) {
-                    String name = matcher.group(1);
-                    boolean isAttribute = Objects.equals(matcher.group(2), "@");
-                    String selector = matcher.group(3);
-                    String value = matcher.group(4);
-
-                    boolean matchCondition = isAttribute ? tag.getAttributes().stream().anyMatch(a ->
-                            a.getKeyAsString().equals(selector) && a.getValueAsString().equals(value)) :
-                            FindTags.find(tag, selector).stream().anyMatch(t ->
-                                    t.getValue().map(v -> v.equals(value)).orElse(false)
-                            );
-                    if (!matchCondition) {
+                Matcher matcher = PATTERN.matcher(part);
+                if (tag != null && part.endsWith("]") && matcher.matches()) {
+                    String optionalPartName = matchesCondition(matcher, tag);
+                    if (optionalPartName == null) {
                         return false;
                     }
-                    partName = name;
+                    partName = optionalPartName;
                 } else {
                     partName = part;
                 }
 
                 if (part.startsWith("@")) {
-                    return cursor.getValue() instanceof Xml.Attribute &&
-                           (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
-                            "*".equals(part.substring(1)));
+                    return cursor.getValue() instanceof Attribute &&
+                            (((Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
+                                    "*".equals(part.substring(1)));
                 }
 
                 if (path.size() < i + 1 || (tag != null && !tag.getName().equals(partName) && !"*".equals(part))) {
@@ -153,7 +173,26 @@ public class XPathMatcher {
                 }
             }
 
-            return cursor.getValue() instanceof Xml.Tag && path.size() == parts.length;
+            return cursor.getValue() instanceof Tag && path.size() == parts.length;
         }
+    }
+
+    //nullable because Optional API is not available
+    @Nullable
+    private String matchesCondition(Matcher matcher, Xml.Tag tag) {
+        String name = matcher.group(1);
+        boolean isAttribute = Objects.equals(matcher.group(2), "@");
+        String selector = matcher.group(3);
+        String value = matcher.group(4);
+
+        boolean matchCondition = isAttribute ? tag.getAttributes().stream().anyMatch(a ->
+                a.getKeyAsString().equals(selector) && a.getValueAsString().equals(value)) :
+                FindTags.find(tag, selector).stream().anyMatch(t ->
+                        t.getValue().map(v -> v.equals(value)).orElse(false)
+                );
+        if (!matchCondition) {
+            return null;
+        }
+        return name;
     }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -123,11 +123,12 @@ public class XPathMatcher {
                     continue;
                 }
 
-                boolean conditionNotFulfilled = tagForCondition == null || (!part.equals(partName) && !tagForCondition.getName()
-                        .equals(partName));
+                boolean conditionNotFulfilled =
+                        tagForCondition == null || (!part.equals(partName) && !tagForCondition.getName()
+                                .equals(partName));
 
                 int idx = part.indexOf("[");
-                if(idx > 0){
+                if (idx > 0) {
                     part = part.substring(0, idx);
                 }
                 if (path.size() < i + 1 || (

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -75,8 +75,6 @@ public class XPathMatcher {
             for (int i = parts.length - 1; i >= 0; i--, pathIndex++) {
                 String part = parts[i];
 
-                //todo anpassen --> attribute und normale conditions
-
                 String partWithCondition = null;
                 Tag tagForCondition = null;
                 if (part.endsWith("]") && i < path.size()) {
@@ -125,11 +123,15 @@ public class XPathMatcher {
                     continue;
                 }
 
-                boolean conditionNotFulfilled = (tagForCondition != null
-                        && !part.equals(partName) && !tagForCondition.getName()
-                        .equals(partName)) && !"*".equals(part);
+                boolean conditionNotFulfilled = tagForCondition == null || (!part.equals(partName) && !tagForCondition.getName()
+                        .equals(partName));
+
+                int idx = part.indexOf("[");
+                if(idx > 0){
+                    part = part.substring(0, idx);
+                }
                 if (path.size() < i + 1 || (
-                        !path.get(pathIndex).getName().equals(part) && conditionNotFulfilled)) {
+                        !(path.get(pathIndex).getName().equals(part)) && !"*".equals(part)) && conditionNotFulfilled) {
                     return false;
                 }
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -75,23 +75,20 @@ public class XPathMatcher {
             for (int i = parts.length - 1; i >= 0; i--, pathIndex++) {
                 String part = parts[i];
 
-                //todo check if part contains condition --> if it does check if its true
-
-                String partBefore = i > 0 ? parts[i - 1] : null;
-                Tag tagBefore = i < path.size() ? path.get(path.size() - 1 - i) : null;
+                String partBefore = i > 0 ? parts[i - 1] : parts[0];
+                Tag tagBefore = partBefore.endsWith("]") && i < path.size() ? path.get(path.size() - 1 - i) : null;
                 //getPath beforeElement
                 String partName;
 
-                Matcher matcher = partBefore != null ? PATTERN.matcher(partBefore) : null;
-                if (tagBefore != null && partBefore != null && partBefore.endsWith("]")
-                        && matcher.matches()) {
+                Matcher matcher = PATTERN.matcher(partBefore);
+                if (tagBefore != null && matcher.matches()) {
                     String optionalPartName = matchesCondition(matcher, tagBefore);
                     if (optionalPartName == null) {
                         return false;
                     }
                     partName = optionalPartName;
                 } else {
-                    partName = part;
+                    partName = null;
                 }
 
                 if (part.startsWith("@")) {
@@ -106,7 +103,8 @@ public class XPathMatcher {
                 }
 
                 if (path.size() < i + 1 || (
-                        !path.get(pathIndex).getName().equals(part) && (tagBefore != null && !part.equals(partName) && !tagBefore.getName()
+                        !path.get(pathIndex).getName().equals(part) && (tagBefore != null
+                                && !part.equals(partName) && !tagBefore.getName()
                                 .equals(partName)) && !"*".equals(part))) {
                     return false;
                 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -125,10 +125,11 @@ public class XPathMatcher {
                     continue;
                 }
 
+                boolean conditionNotFulfilled = (tagForCondition != null
+                        && !part.equals(partName) && !tagForCondition.getName()
+                        .equals(partName)) && !"*".equals(part);
                 if (path.size() < i + 1 || (
-                        !path.get(pathIndex).getName().equals(part) && (tagForCondition != null
-                                && !part.equals(partName) && !tagForCondition.getName()
-                                .equals(partName)) && !"*".equals(part))) {
+                        !path.get(pathIndex).getName().equals(part) && conditionNotFulfilled)) {
                     return false;
                 }
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -197,7 +197,6 @@ public class XPathMatcher {
         }
     }
 
-    //nullable because Optional API is not available
     @Nullable
     private String matchesCondition(Matcher matcher, Xml.Tag tag) {
         String name = matcher.group(1);

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -15,20 +15,15 @@
  */
 package org.openrewrite.xml;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.openrewrite.Cursor;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.search.FindTags;
 import org.openrewrite.xml.tree.Xml;
-import org.openrewrite.xml.tree.Xml.Attribute;
-import org.openrewrite.xml.tree.Xml.Tag;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Supports a limited set of XPath expressions, specifically those documented on <a
@@ -63,9 +58,9 @@ public class XPathMatcher {
      * @return true if the expression matches the cursor, false otherwise
      */
     public boolean matches(Cursor cursor) {
-        List<Tag> path = new ArrayList<>();
+        List<Xml.Tag> path = new ArrayList<>();
         for (Cursor c = cursor; c != null; c = c.getParent()) {
-            if (c.getValue() instanceof Tag) {
+            if (c.getValue() instanceof Xml.Tag) {
                 path.add(c.getValue());
             }
         }
@@ -76,7 +71,7 @@ public class XPathMatcher {
                 String part = parts[i];
 
                 String partWithCondition = null;
-                Tag tagForCondition = null;
+                Xml.Tag tagForCondition = null;
                 if (part.endsWith("]") && i < path.size()) {
                     int index = part.indexOf("[");
                     if (index < 0) {
@@ -101,8 +96,8 @@ public class XPathMatcher {
 
                 String partName;
 
-                Matcher matcher = partWithCondition != null ? PATTERN.matcher(partWithCondition) : null;
-                if (tagForCondition != null && partWithCondition.endsWith("]") && matcher.matches()) {
+                Matcher matcher;
+                if (tagForCondition != null && partWithCondition.endsWith("]") && (matcher = PATTERN.matcher(partWithCondition)).matches()) {
                     String optionalPartName = matchesCondition(matcher, tagForCondition);
                     if (optionalPartName == null) {
                         return false;
@@ -113,8 +108,8 @@ public class XPathMatcher {
                 }
 
                 if (part.startsWith("@")) {
-                    if (!(cursor.getValue() instanceof Attribute &&
-                            (((Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
+                    if (!(cursor.getValue() instanceof Xml.Attribute &&
+                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
                             "*".equals(part.substring(1)))) {
                         return false;
                     }
@@ -173,11 +168,11 @@ public class XPathMatcher {
             for (int i = 0; i < parts.length; i++) {
                 String part = parts[i];
 
-                Tag tag = i < path.size() ? path.get(i) : null;
+                Xml.Tag tag = i < path.size() ? path.get(i) : null;
                 String partName;
 
-                Matcher matcher = PATTERN.matcher(part);
-                if (tag != null && part.endsWith("]") && matcher.matches()) {
+                Matcher matcher;
+                if (tag != null && part.endsWith("]") && (matcher = PATTERN.matcher(part)).matches()) {
                     String optionalPartName = matchesCondition(matcher, tag);
                     if (optionalPartName == null) {
                         return false;
@@ -188,8 +183,8 @@ public class XPathMatcher {
                 }
 
                 if (part.startsWith("@")) {
-                    return cursor.getValue() instanceof Attribute &&
-                            (((Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
+                    return cursor.getValue() instanceof Xml.Attribute &&
+                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
                                     "*".equals(part.substring(1)));
                 }
 
@@ -198,7 +193,7 @@ public class XPathMatcher {
                 }
             }
 
-            return cursor.getValue() instanceof Tag && path.size() == parts.length;
+            return cursor.getValue() instanceof Xml.Tag && path.size() == parts.length;
         }
     }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -109,8 +109,8 @@ public class XPathMatcher {
 
                 if (part.startsWith("@")) {
                     if (!(cursor.getValue() instanceof Xml.Attribute &&
-                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
-                            "*".equals(part.substring(1)))) {
+                          (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
+                          "*".equals(part.substring(1)))) {
                         return false;
                     }
 
@@ -127,7 +127,7 @@ public class XPathMatcher {
                     part = part.substring(0, idx);
                 }
                 if (path.size() < i + 1 || (
-                        !(path.get(pathIndex).getName().equals(part)) && !"*".equals(part)) && conditionNotFulfilled) {
+                                                   !(path.get(pathIndex).getName().equals(part)) && !"*".equals(part)) && conditionNotFulfilled) {
                     return false;
                 }
             }
@@ -184,8 +184,8 @@ public class XPathMatcher {
 
                 if (part.startsWith("@")) {
                     return cursor.getValue() instanceof Xml.Attribute &&
-                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
-                                    "*".equals(part.substring(1)));
+                           (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
+                            "*".equals(part.substring(1)));
                 }
 
                 if (path.size() < i + 1 || (tag != null && !tag.getName().equals(partName) && !"*".equals(part))) {
@@ -204,14 +204,23 @@ public class XPathMatcher {
         String selector = matcher.group(3);
         String value = matcher.group(4);
 
-        boolean matchCondition = isAttribute ? tag.getAttributes().stream().anyMatch(a ->
-                a.getKeyAsString().equals(selector) && a.getValueAsString().equals(value)) :
-                FindTags.find(tag, selector).stream().anyMatch(t ->
-                        t.getValue().map(v -> v.equals(value)).orElse(false)
-                );
-        if (!matchCondition) {
-            return null;
+        boolean matchCondition = false;
+        if (isAttribute) {
+            for (Xml.Attribute a : tag.getAttributes()) {
+                if (a.getKeyAsString().equals(selector) && a.getValueAsString().equals(value)) {
+                    matchCondition = true;
+                    break;
+                }
+            }
+        } else {
+            for (Xml.Tag t : FindTags.find(tag, selector)) {
+                if (t.getValue().map(v -> v.equals(value)).orElse(false)) {
+                    matchCondition = true;
+                    break;
+                }
+            }
         }
-        return name;
+
+        return matchCondition ? name : null;
     }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -76,12 +76,12 @@ public class XPathMatcher {
                 String part = parts[i];
 
                 String partBefore = i > 0 ? parts[i - 1] : parts[0];
-                Tag tagBefore = partBefore.endsWith("]") && i < path.size() ? path.get(path.size() - 1 - i) : null;
+                Tag tagBefore = i < path.size() ? path.get(path.size() - 1 - i) : null;
                 //getPath beforeElement
                 String partName;
 
                 Matcher matcher = PATTERN.matcher(partBefore);
-                if (tagBefore != null && matcher.matches()) {
+                if (tagBefore != null && partBefore.endsWith("]") && matcher.matches()) {
                     String optionalPartName = matchesCondition(matcher, tagBefore);
                     if (optionalPartName == null) {
                         return false;

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -188,7 +188,7 @@ class XPathMatcherTest {
             </root>
             """
         ).toList().get(0);
-        assertThat(match("//element1[foo='baz']", xml)).isTrue();
+        assertThat(match("//element1[@foo='bar']", xml)).isTrue();
         assertThat(match("//element1[foo='baz']/test", xml)).isTrue();
         assertThat(match("//element1[foo='bar']/test", xml)).isFalse();
     }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -176,7 +176,7 @@ class XPathMatcherTest {
     }
 
     @Test
-    void relativePathsWithConditions(){
+    void relativePathsWithConditions() {
         SourceFile xml = new XmlParser().parse(
           """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -147,6 +147,8 @@ class XPathMatcherTest {
           pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[artifactId='maven-compiler-plugin']/configuration/source",
           pomXml1)).isTrue();
+        assertThat(match("//plugin[artifactId='maven-compiler-plugin']/configuration/source",
+          pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[groupId='org.apache.maven.plugins']/configuration/source",
           pomXml1)).isTrue();
         assertThat(match("/project/build/plugins/plugin[artifactId='somethingElse']/configuration/source",
@@ -171,6 +173,8 @@ class XPathMatcherTest {
         assertThat(match("/root/element1[@foo='baz']", xml)).isFalse();
         assertThat(match("/root/element1[foo='bar']", xml)).isFalse();
         assertThat(match("/root/element1[foo='baz']", xml)).isTrue();
+        assertThat(match("//element1[foo='bar']", xml)).isFalse();
+        assertThat(match("//element1[foo='baz']", xml)).isTrue();
     }
 
     @Test

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -173,8 +173,24 @@ class XPathMatcherTest {
         assertThat(match("/root/element1[@foo='baz']", xml)).isFalse();
         assertThat(match("/root/element1[foo='bar']", xml)).isFalse();
         assertThat(match("/root/element1[foo='baz']", xml)).isTrue();
-        assertThat(match("//element1[foo='bar']", xml)).isFalse();
+    }
+
+    @Test
+    void relativePathsWithConditions(){
+        SourceFile xml = new XmlParser().parse(
+          """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <root>
+              <element1 foo="bar">
+                <foo>baz</foo>
+                <test>asdf</test>
+              </element1>
+            </root>
+            """
+        ).toList().get(0);
         assertThat(match("//element1[foo='baz']", xml)).isTrue();
+        assertThat(match("//element1[foo='baz']/test", xml)).isTrue();
+        assertThat(match("//element1[foo='bar']/test", xml)).isFalse();
     }
 
     @Test

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -127,10 +127,10 @@ class XPathMatcherTest {
 
     @Test
     void matchRelative() {
-        assertThat(match("dependencies", xmlDoc)).isTrue();
-        assertThat(match("dependency", xmlDoc)).isTrue();
-        assertThat(match("//dependency", xmlDoc)).isTrue();
-        assertThat(match("dependency/*", xmlDoc)).isTrue();
+//        assertThat(match("dependencies", xmlDoc)).isTrue();
+//        assertThat(match("dependency", xmlDoc)).isTrue();
+//        assertThat(match("//dependency", xmlDoc)).isTrue();
+//        assertThat(match("dependency/*", xmlDoc)).isTrue();
         assertThat(match("dne", xmlDoc)).isFalse();
     }
 

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -127,10 +127,10 @@ class XPathMatcherTest {
 
     @Test
     void matchRelative() {
-//        assertThat(match("dependencies", xmlDoc)).isTrue();
-//        assertThat(match("dependency", xmlDoc)).isTrue();
-//        assertThat(match("//dependency", xmlDoc)).isTrue();
-//        assertThat(match("dependency/*", xmlDoc)).isTrue();
+        assertThat(match("dependencies", xmlDoc)).isTrue();
+        assertThat(match("dependency", xmlDoc)).isTrue();
+        assertThat(match("//dependency", xmlDoc)).isTrue();
+        assertThat(match("dependency/*", xmlDoc)).isTrue();
         assertThat(match("dne", xmlDoc)).isFalse();
     }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
[Issue#4119](https://github.com/openrewrite/rewrite/issues/4119)
## What's changed?
<!-- A brief description of the changes in this pull request -->
the xPathmatcher supports relative Paths and conditions
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
[[XPathMatcher does not support paths containing "//" and conditions](https://github.com/openrewrite/rewrite/issues/4119#top)](https://github.com/openrewrite/rewrite/issues/4119)
## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
------
## Anyone you would like to review specifically?
<!-- @mention them here -->
-----
## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
------
## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
-----
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
