### PR TITLE
fix invalid jarPattern in JavaParser

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -124,7 +124,7 @@ public interface JavaParser extends Parser {
             File[] extracted = resourceTarget.listFiles();
             if (extracted != null) {
                 for (File file : extracted) {
-                    if (jarPattern.matcher(file.getName()).find()) {
+                    if (jarPattern.matcher(file.getPath()).find()) {
                         artifacts.add(file.toPath());
                         continue nextArtifact;
                     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Fix invalid pattern in https://github.com/openrewrite/rewrite/blob/main/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java#L123

The `file.getName()` and pattern `Pattern.compile("[/\\\\]" + artifactName + "-?.*\\.jar$")` is mismatch so that the pattern.matcher will always be `false`. The `file.getName()` returns a simple filename without any `/` but the pattern needs a `/`.

See more details in https://github.com/openrewrite/rewrite/issues/4123

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix https://github.com/openrewrite/rewrite/issues/4123

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
No

## Anyone you would like to review specifically?
<!-- @mention them here -->
No

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
No

### Checklist
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
