### PR TITLE
Add missing `visit()` methods to `XmlVisitor`

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/CountLinesVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/CountLinesVisitor.java
@@ -66,11 +66,17 @@ public class CountLinesVisitor extends XmlVisitor<AtomicInteger> {
         if(tag.getPrefix().contains("\n")) {
             count.incrementAndGet();
         }
-        if (tag.getClosing() != null && tag.getClosing().getPrefix().contains("\n")) {
+
+        return super.visitTag(tag, count);
+    }
+
+    @Override
+    public Xml visitTagClosing(Xml.Tag.Closing closing, AtomicInteger count) {
+        if (closing.getPrefix().contains("\n")) {
             count.incrementAndGet();
         }
 
-        return super.visitTag(tag, count);
+        return super.visitTagClosing(closing, count);
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlIsoVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlIsoVisitor.java
@@ -39,6 +39,11 @@ public class XmlIsoVisitor<P> extends XmlVisitor<P> {
     }
 
     @Override
+    public Xml.Tag.Closing visitTagClosing(Xml.Tag.Closing closing, P p) {
+        return (Xml.Tag.Closing) super.visitTagClosing(closing, p);
+    }
+
+    @Override
     public Xml.Attribute visitAttribute(Xml.Attribute attribute, P p) {
         return (Xml.Attribute) super.visitAttribute(attribute, p);
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlIsoVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlIsoVisitor.java
@@ -49,6 +49,11 @@ public class XmlIsoVisitor<P> extends XmlVisitor<P> {
     }
 
     @Override
+    public Xml.Attribute.Value visitAttributeValue(Xml.Attribute.Value value, P p) {
+        return (Xml.Attribute.Value) super.visitAttributeValue(value, p);
+    }
+
+    @Override
     public Xml.CharData visitCharData(Xml.CharData charData, P p) {
         return (Xml.CharData) super.visitCharData(charData, p);
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlIsoVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlIsoVisitor.java
@@ -69,6 +69,11 @@ public class XmlIsoVisitor<P> extends XmlVisitor<P> {
     }
 
     @Override
+    public Xml.DocTypeDecl.ExternalSubsets visitDocTypeDeclExternalSubsets(Xml.DocTypeDecl.ExternalSubsets externalSubsets, P p) {
+        return (Xml.DocTypeDecl.ExternalSubsets) super.visitDocTypeDeclExternalSubsets(externalSubsets, p);
+    }
+
+    @Override
     public Xml.Prolog visitProlog(Xml.Prolog prolog, P p) {
         return (Xml.Prolog) super.visitProlog(prolog, p);
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
@@ -125,6 +125,13 @@ public class XmlVisitor<P> extends TreeVisitor<Xml, P> {
         return d;
     }
 
+    public Xml visitDocTypeDeclExternalSubsets(Xml.DocTypeDecl.ExternalSubsets externalSubsets, P p) {
+        Xml.DocTypeDecl.ExternalSubsets e = externalSubsets;
+        e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        e = e.withElements(ListUtils.map(e.getElements(), i -> visitAndCast(i, p)));
+        return e;
+    }
+
     public Xml visitProlog(Xml.Prolog prolog, P p) {
         Xml.Prolog pl = prolog;
         pl = pl.withMarkers(visitMarkers(pl.getMarkers(), p));

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
@@ -94,6 +94,10 @@ public class XmlVisitor<P> extends TreeVisitor<Xml, P> {
         return t;
     }
 
+    public Xml visitTagClosing(Xml.Tag.Closing closing, P p) {
+        return closing.withMarkers(visitMarkers(closing.getMarkers(), p));
+    }
+
     public Xml visitAttribute(Xml.Attribute attribute, P p) {
         return attribute.withMarkers(visitMarkers(attribute.getMarkers(), p));
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlVisitor.java
@@ -99,7 +99,14 @@ public class XmlVisitor<P> extends TreeVisitor<Xml, P> {
     }
 
     public Xml visitAttribute(Xml.Attribute attribute, P p) {
-        return attribute.withMarkers(visitMarkers(attribute.getMarkers(), p));
+        Xml.Attribute a = attribute;
+        a = a.withMarkers(visitMarkers(a.getMarkers(), p));
+        a = a.withValue(visitAndCast(a.getValue(), p));
+        return a;
+    }
+
+    public Xml visitAttributeValue(Xml.Attribute.Value value, P p) {
+        return value.withMarkers(visitMarkers(value.getMarkers(), p));
     }
 
     public Xml visitCharData(Xml.CharData charData, P p) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
@@ -70,15 +70,21 @@ public class XmlPrinter<P> extends XmlVisitor<PrintOutputCapture<P>> {
         } else {
             p.append('>');
             visit(tag.getContent(), p);
-            p.append(tag.getClosing().getPrefix())
-                    .append("</")
-                    .append(tag.getClosing().getName())
-                    .append(tag.getClosing().getBeforeTagDelimiterPrefix())
-                    .append(">");
-
+            visit(tag.getClosing(), p);
         }
         afterSyntax(tag, p);
         return tag;
+    }
+
+    @Override
+    public Xml visitTagClosing(Xml.Tag.Closing closing, PrintOutputCapture<P> p) {
+        beforeSyntax(closing, p);
+        p.append("</")
+                .append(closing.getName())
+                .append(closing.getBeforeTagDelimiterPrefix())
+                .append(">");
+        afterSyntax(closing, p);
+        return closing;
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
@@ -159,16 +159,21 @@ public class XmlPrinter<P> extends XmlVisitor<PrintOutputCapture<P>> {
         visit(docTypeDecl.getName(), p);
         visit(docTypeDecl.getExternalId(), p);
         visit(docTypeDecl.getInternalSubset(), p);
-        if (docTypeDecl.getExternalSubsets() != null) {
-            p.append(docTypeDecl.getExternalSubsets().getPrefix())
-                    .append('[');
-            visit(docTypeDecl.getExternalSubsets().getElements(), p);
-            p.append(']');
-        }
+        visit(docTypeDecl.getExternalSubsets(), p);
         p.append(docTypeDecl.getBeforeTagDelimiterPrefix());
         p.append('>');
         afterSyntax(docTypeDecl, p);
         return docTypeDecl;
+    }
+
+    @Override
+    public Xml visitDocTypeDeclExternalSubsets(Xml.DocTypeDecl.ExternalSubsets externalSubsets, PrintOutputCapture<P> p) {
+        beforeSyntax(externalSubsets, p);
+        p.append('[');
+        visit(externalSubsets.getElements(), p);
+        p.append(']');
+        afterSyntax(externalSubsets, p);
+        return externalSubsets;
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlPrinter.java
@@ -89,25 +89,30 @@ public class XmlPrinter<P> extends XmlVisitor<PrintOutputCapture<P>> {
 
     @Override
     public Xml visitAttribute(Xml.Attribute attribute, PrintOutputCapture<P> p) {
-        char valueDelim;
-        if (Xml.Attribute.Value.Quote.Double.equals(attribute.getValue().getQuote())) {
-            valueDelim = '"';
-        } else {
-            valueDelim = '\'';
-        }
         beforeSyntax(attribute, p);
         p.append(attribute.getKey().getPrefix())
                 .append(attribute.getKeyAsString())
                 .append(attribute.getBeforeEquals())
-                .append('=')
-                .append(attribute.getValue().getPrefix())
-                .append(valueDelim)
-                .append(attribute.getValueAsString())
-                .append(valueDelim);
-
-
+                .append('=');
+        visit(attribute.getValue(), p);
         afterSyntax(attribute, p);
         return attribute;
+    }
+
+    @Override
+    public Xml visitAttributeValue(Xml.Attribute.Value value, PrintOutputCapture<P> p) {
+        beforeSyntax(value, p);
+        char valueDelim;
+        if (Xml.Attribute.Value.Quote.Double.equals(value.getQuote())) {
+            valueDelim = '"';
+        } else {
+            valueDelim = '\'';
+        }
+        p.append(valueDelim)
+                .append(value.getValue())
+                .append(valueDelim);
+        afterSyntax(value, p);
+        return value;
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -541,6 +541,11 @@ public interface Xml extends Tree {
             Markers markers;
             Quote quote;
             String value;
+
+            @Override
+            public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
+                return v.visitAttributeValue(this, p);
+            }
         }
 
         public String getKeyAsString() {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -683,6 +683,12 @@ public interface Xml extends Tree {
 
             Markers markers;
             List<Element> elements;
+
+            @Override
+            public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
+                return v.visitDocTypeDeclExternalSubsets(this, p);
+            }
+
         }
 
         @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -479,6 +479,11 @@ public interface Xml extends Tree {
             String beforeTagDelimiterPrefix;
 
             @Override
+            public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
+                return v.visitTagClosing(this, p);
+            }
+
+            @Override
             public String toString() {
                 return "</" + name + ">";
             }


### PR DESCRIPTION
* `visitTagClosing()` for `Xml.Tag.Closing`
* `visitAttributeValue()` for `Xml.Attribute.Value`
* `visitDocTypeDeclExternalSubsets` for `Xml.DocTypeDecl.ExternalSubsets`