### PR TITLE
Test case for XPath Matcher matches too many tags when using relative Paths and conditions

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -72,6 +72,7 @@ public class XPathMatcher {
 
                 String partWithCondition = null;
                 Xml.Tag tagForCondition = null;
+                boolean conditionIsBefore = false;
                 if (part.endsWith("]") && i < path.size()) {
                     int index = part.indexOf("[");
                     if (index < 0) {
@@ -89,6 +90,7 @@ public class XPathMatcher {
                         return false;
                     }
                     if (!partBefore.contains("@")) {
+                        conditionIsBefore = true;
                         partWithCondition = partBefore;
                         tagForCondition = path.get(parts.length - i);
                     }
@@ -97,7 +99,8 @@ public class XPathMatcher {
                 String partName;
 
                 Matcher matcher;
-                if (tagForCondition != null && partWithCondition.endsWith("]") && (matcher = PATTERN.matcher(partWithCondition)).matches()) {
+                if (tagForCondition != null && partWithCondition.endsWith("]") && (matcher = PATTERN.matcher(
+                        partWithCondition)).matches()) {
                     String optionalPartName = matchesCondition(matcher, tagForCondition);
                     if (optionalPartName == null) {
                         return false;
@@ -109,8 +112,8 @@ public class XPathMatcher {
 
                 if (part.startsWith("@")) {
                     if (!(cursor.getValue() instanceof Xml.Attribute &&
-                          (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
-                          "*".equals(part.substring(1)))) {
+                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
+                            "*".equals(part.substring(1)))) {
                         return false;
                     }
 
@@ -127,7 +130,7 @@ public class XPathMatcher {
                     part = part.substring(0, idx);
                 }
                 if (path.size() < i + 1 || (
-                                                   !(path.get(pathIndex).getName().equals(part)) && !"*".equals(part)) && conditionNotFulfilled) {
+                        !(path.get(pathIndex).getName().equals(part)) && !"*".equals(part)) || conditionIsBefore && conditionNotFulfilled) {
                     return false;
                 }
             }
@@ -184,8 +187,8 @@ public class XPathMatcher {
 
                 if (part.startsWith("@")) {
                     return cursor.getValue() instanceof Xml.Attribute &&
-                           (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
-                            "*".equals(part.substring(1)));
+                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
+                                    "*".equals(part.substring(1)));
                 }
 
                 if (path.size() < i + 1 || (tag != null && !tag.getName().equals(partName) && !"*".equals(part))) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -190,6 +190,7 @@ class XPathMatcherTest {
         ).toList().get(0);
         assertThat(match("//element1[@foo='bar']", xml)).isTrue();
         assertThat(match("//element1[foo='baz']/test", xml)).isTrue();
+        assertThat(match("//element1[foo='baz']/baz", xml)).isFalse();
         assertThat(match("//element1[foo='bar']/test", xml)).isFalse();
     }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
tbd
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
[#4120 ](https://github.com/openrewrite/rewrite/issues/4132)
## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
I am not 100% sure if my new condition is 100% correct but i cannot think of other testcases. Maybe the review can think of more
## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
The xPathMatcher did not check if the condition was forthe previous element in the xPath and accepted every tag a condition was met.
eg. //dependency[artifact-id='bla']/version and accepted //dependency[artifact-id='bla']/version and //dependency[artifact-id='bla']/artifact-id
### Checklist
- [x ] I've added unit tests to cover both positive and negative cases
- [x ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x ] I've used the IntelliJ IDEA auto-formatter on affected files (for some reason my IntelliJ-Default codestyle is different from the openrewrite/main)
