### PR TITLE
Correct UTF-8 BOM detection in `EncodingDetectingInputStream`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/EncodingDetectingInputStream.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/EncodingDetectingInputStream.java
@@ -74,11 +74,11 @@ public class EncodingDetectingInputStream extends InputStream {
     }
 
     private void guessCharset(int aByte) {
-        if (prev3 == 0xC3 && prev2 == 0xAF && prev == 0xC2) {
+        if (prev3 == 0xEF && prev2 == 0xBB && prev == 0xBF) {
             charsetBomMarked = true;
             charset = StandardCharsets.UTF_8;
         } else {
-            if (aByte == -1 || !(prev2 == 0 && prev == 0xC3 || prev3 == 0 && prev2 == 0xC3)) {
+            if (aByte == -1 || !(prev2 == 0 && prev == 0xEF || prev3 == 0 && prev2 == 0xEF)) {
                 if (maybeTwoByteSequence) {
                     if (aByte == -1 && !utf8SequenceEnd(prev) || aByte != -1 && !(utf8SequenceEnd(aByte))) {
                         charset = WINDOWS_1252;

--- a/rewrite-core/src/test/java/org/openrewrite/internal/EncodingDetectingInputStreamTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/EncodingDetectingInputStreamTest.java
@@ -33,7 +33,7 @@ class EncodingDetectingInputStreamTest {
 
     @Test
     void detectUTF8Bom() throws IOException {
-        String bom = "ï»¿";
+        String bom = "\uFEFF";
         try (EncodingDetectingInputStream is = read(bom, UTF_8)) {
             assertThat(is.isCharsetBomMarked()).isTrue();
         }


### PR DESCRIPTION
The sequence `C3 AF C2` is not actually the UTF-8 BOM sequence. The BOM sequence is the `\uFEFF` character, which in UTF-8 is encoded as `EF BB BF`. But if these three bytes were to get encoded as individual characters using UTF-8, then the sequence `C3 AF C2` is the first half of `C3 AF C2 BB C2 BF`. But note that this is not a proper UTF-8 BOM, but a BOM that erroneously got encoded again.
