### PR TITLE
Instead of throwing most MavenDownloadingException, record them into …

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -111,7 +111,7 @@ public class MavenParser implements Parser {
         for (Map.Entry<Xml.Document, Pom> docToPom : projectPoms.entrySet()) {
             try {
                 ResolvedPom resolvedPom = docToPom.getValue().resolve(activeProfiles, downloader, ctx);
-                MavenResolutionResult model = new MavenResolutionResult(randomId(), null, resolvedPom, emptyList(), null, emptyMap(), sanitizedSettings, mavenCtx.getActiveProfiles());
+                MavenResolutionResult model = new MavenResolutionResult(randomId(), null, resolvedPom, emptyList(), null, emptyMap(), sanitizedSettings, mavenCtx.getActiveProfiles(), null);
                 if (!skipDependencyResolution) {
                     model = model.resolveDependencies(downloader, ctx);
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -66,6 +66,12 @@ public class RawPom {
     @Nullable
     String version;
 
+    // This is an obsolete field that is no longer used, but it is present in some particularly old POMs
+    @EqualsAndHashCode.Include
+    @ToString.Include
+    @Nullable
+    String currentVersion;
+
     @EqualsAndHashCode.Include
     @ToString.Include
     @Nullable
@@ -330,7 +336,9 @@ public class RawPom {
 
     @Nullable
     public String getVersion() {
-        return version == null && parent != null ? parent.getVersion() : version;
+        return version == null ?
+                (parent == null ? currentVersion : parent.getVersion()) :
+                version;
     }
 
     public Pom toPom(@Nullable Path inputPath, @Nullable MavenRepository repo) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -65,6 +65,10 @@ public class MavenResolutionResult implements Marker {
     @With
     List<String> activeProfiles;
 
+    @With
+    @Nullable
+    MavenDownloadingExceptions exceptions;
+
     public List<String> getActiveProfiles() {
         // for backwards compatibility with ASTs that were serialized before activeProfiles was added
         return activeProfiles == null ? emptyList() : activeProfiles;
@@ -181,10 +185,11 @@ public class MavenResolutionResult implements Marker {
                 }
             }
         }
+        MavenResolutionResult result = withDependencies(dependencies);
         if (exceptions != null) {
-            throw exceptions;
+            result = result.withExceptions(exceptions);
         }
-        return withDependencies(dependencies);
+        return result;
     }
 
     public Map<Path, Pom> getProjectPoms() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -113,12 +113,12 @@ public class Pom {
      */
     public ResolvedPom resolve(Iterable<String> activeProfiles, MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingException {
         List<MavenRepository> repositories = getRepository() == null ? emptyList() : singletonList(getRepository());
-        return new ResolvedPom(this, activeProfiles, emptyMap(), emptyList(), repositories, emptyList(), emptyList(), emptyList(), emptyList())
+        return new ResolvedPom(this, activeProfiles, emptyMap(), emptyList(), repositories, emptyList(), emptyList(), emptyList(), emptyList(), null)
                 .resolve(ctx, downloader);
     }
 
     public ResolvedPom resolve(Iterable<String> activeProfiles, MavenPomDownloader downloader, List<MavenRepository> initialRepositories, ExecutionContext ctx) throws MavenDownloadingException {
-        return new ResolvedPom(this, activeProfiles, emptyMap(), emptyList(), initialRepositories, emptyList(), emptyList(), emptyList(), emptyList())
+        return new ResolvedPom(this, activeProfiles, emptyMap(), emptyList(), initialRepositories, emptyList(), emptyList(), emptyList(), emptyList(), null)
                 .resolve(ctx, downloader);
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import lombok.*;
 import lombok.experimental.NonFinal;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.MavenDownloadingException;
 
 import java.io.Serializable;
 import java.util.*;
@@ -68,6 +69,9 @@ public class ResolvedDependency implements Serializable {
     @Nullable
     @NonFinal
     List<GroupArtifact> effectiveExclusions;
+
+    @Nullable
+    MavenDownloadingException exception;
 
     public List<GroupArtifact> getEffectiveExclusions() {
         return effectiveExclusions == null ? emptyList() : effectiveExclusions;


### PR DESCRIPTION
…the resolution result. This allows for partial success when processing poms which are invalid or contain unresolvable dependencies without hiding the existence of these problems.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
