### PR TITLE
preconditions are no longer cached

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Preconditions.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Preconditions.java
@@ -18,6 +18,10 @@ package org.openrewrite;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 
+import java.util.Arrays;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 public class Preconditions {
 
     public static TreeVisitor<?, ExecutionContext> check(Recipe check, TreeVisitor<?, ExecutionContext> v) {
@@ -132,6 +136,16 @@ public class Preconditions {
                     }
                 }
                 return t2;
+            }
+        };
+    }
+    @SafeVarargs
+    public static Supplier<TreeVisitor<?, ExecutionContext>> and(Supplier<TreeVisitor<?, ExecutionContext>>... svs) {
+        return new Supplier<TreeVisitor<?, ExecutionContext>>() {
+            @Override
+            public TreeVisitor<?, ExecutionContext> get() {
+                TreeVisitor<?, ExecutionContext>[] visitors =  Arrays.stream(svs).map(Supplier::get).collect(Collectors.toList()).toArray(new TreeVisitor[]{});
+                return and(visitors);
             }
         };
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPluginTest.java
@@ -17,7 +17,14 @@ package org.openrewrite.maven.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.config.DeclarativeRecipe;
 import org.openrewrite.test.RewriteTest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -79,6 +86,67 @@ class FindPluginTest implements RewriteTest {
                 </reporting>
               </project>
               """
+          )
+        );
+    }
+
+    @Test
+    void testMultiModulePrecondition() throws URISyntaxException {
+        rewriteRun(
+          spec ->  spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.MultiModuleTest
+            preconditions:
+              - org.openrewrite.maven.search.FindPlugin:
+                  groupId: org.apache.maven.plugins
+                  artifactId: maven-compiler-plugin
+            recipeList:
+              - org.openrewrite.maven.RemoveDependency:
+                    groupId: com.google.guava
+                    artifactId: guava
+            """, "org.openrewrite.MultiModuleTest"),
+          pomXml(
+            """
+                  <project>
+                      <groupId>org.example</groupId>
+                      <artifactId>mvn_multi_module_test</artifactId>
+                      <version>1.0-SNAPSHOT</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                          <module>submodule</module>
+                      </modules>                
+                      <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>org.openrewrite.maven</groupId>
+                                  <artifactId>rewrite-maven-plugin</artifactId>
+                                  <version>5.28.0</version>
+                              </plugin>
+                          </plugins>
+                      </build>                  
+                  </project>
+                  """,sourceSpecs -> sourceSpecs.path("pom.xml")),
+          pomXml(
+            """
+                <project>
+                    <parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>mvn_multi_module_test</artifactId>
+                        <version>1.0-SNAPSHOT</version>            
+                    </parent>
+                    <artifactId>submodule</artifactId>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>findbugs-maven-plugin</artifactId>
+                                <version>3.0.5</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                    """,sourceSpecs -> sourceSpecs.path("submodule.pom.xml")
           )
         );
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Precondition Bellwether uses a supplier to fetch a new visitor each time

## What's your motivation?
This causes a bug when a certain condition is met

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
to use recipes instead of suppliers but the suppliers feel more correct

## Any additional context
see attachement below

### Checklist
- [ x] I've added unit tests to cover both positive and negative cases
- [x ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
