### PR TITLE
ChangeParentPom's property-preservation now checks the resolved new p…

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -192,8 +192,9 @@ public class ChangeParentPom extends Recipe {
 
                             // Retain managed versions from the old parent that are not managed in the new parent
                             MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
-                            Pom newParentPom = mpd.download(new GroupArtifactVersion(targetGroupId, targetArtifactId, targetVersion.get()), null, null, resolvedPom.getRepositories());
-                            List<ResolvedManagedDependency> dependenciesWithoutExplicitVersions = getDependenciesUnmanagedByNewParent(mrr, ctx);
+                            ResolvedPom newParent = mpd.download(new GroupArtifactVersion(targetGroupId, targetArtifactId, targetVersion.get()), null, resolvedPom, resolvedPom.getRepositories())
+                                    .resolve(emptyList(), mpd, ctx);
+                            List<ResolvedManagedDependency> dependenciesWithoutExplicitVersions = getDependenciesUnmanagedByNewParent(mrr, newParent);
                             for (ResolvedManagedDependency dep : dependenciesWithoutExplicitVersions) {
                                 changeParentTagVisitors.add(new AddManagedDependencyVisitor(
                                         dep.getGav().getGroupId(), dep.getGav().getArtifactId(), dep.getGav().getVersion(),
@@ -202,7 +203,7 @@ public class ChangeParentPom extends Recipe {
 
                             // Retain properties from the old parent that are not present in the new parent
                             Map<String, String> propertiesInUse = getPropertiesInUse(getCursor().firstEnclosingOrThrow(Xml.Document.class), ctx);
-                            Map<String, String> newParentProps = newParentPom.getProperties();
+                            Map<String, String> newParentProps = newParent.getProperties();
                             for (Map.Entry<String, String> propInUse : propertiesInUse.entrySet()) {
                                 if(!newParentProps.containsKey(propInUse.getKey())) {
                                     changeParentTagVisitors.add(new UnconditionalAddProperty(propInUse.getKey(), propInUse.getValue()));
@@ -231,6 +232,11 @@ public class ChangeParentPom extends Recipe {
                                 doAfterVisit(new RemoveRedundantDependencyVersions(null, null, false, null).getVisitor());
                             }
                         } catch (MavenDownloadingException e) {
+                            for (Map.Entry<MavenRepository, String> repositoryResponse : e.getRepositoryResponses().entrySet()) {
+                                MavenRepository repository = repositoryResponse.getKey();
+                                metadataFailures.insertRow(ctx, new MavenMetadataFailures.Row(targetGroupId, targetArtifactId, newVersion,
+                                        repository.getUri(), repository.getSnapshots(), repository.getReleases(), repositoryResponse.getValue()));
+                            }
                             return e.warn(tag);
                         }
                     }
@@ -304,7 +310,7 @@ public class ChangeParentPom extends Recipe {
         return properties;
     }
 
-    private List<ResolvedManagedDependency> getDependenciesUnmanagedByNewParent(MavenResolutionResult mrr, ExecutionContext ctx) {
+    private List<ResolvedManagedDependency> getDependenciesUnmanagedByNewParent(MavenResolutionResult mrr, ResolvedPom newParent) {
         ResolvedPom resolvedPom = mrr.getPom();
 
         // Dependencies managed by the current pom's own dependency management are irrelevant to parent upgrade
@@ -334,28 +340,13 @@ public class ChangeParentPom extends Recipe {
         }
 
         // Remove from the list any that would still be managed under the new parent
-        String groupId = newGroupId == null ? oldGroupId : newGroupId;
-        String artifactId = newArtifactId == null ? oldArtifactId : newArtifactId;
-        try {
-            GroupArtifactVersion newParentGav = new GroupArtifactVersion(groupId, artifactId, newVersion);
-            MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
-            MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), mctx, mctx.getSettings(), mctx.getActiveProfiles());
-            ResolvedPom newParent = mpd.download(newParentGav, null, resolvedPom, resolvedPom.getRepositories())
-                    .resolve(emptyList(), mpd, ctx);
-            Set<GroupArtifact> newParentManagedGa = newParent.getDependencyManagement().stream()
-                    .map(dep -> new GroupArtifact(dep.getGav().getGroupId(), dep.getGav().getArtifactId()))
-                    .collect(Collectors.toSet());
+        Set<GroupArtifact> newParentManagedGa = newParent.getDependencyManagement().stream()
+                .map(dep -> new GroupArtifact(dep.getGav().getGroupId(), dep.getGav().getArtifactId()))
+                .collect(Collectors.toSet());
 
-            depsWithoutExplicitVersion = depsWithoutExplicitVersion.stream()
-                    .filter(it -> !newParentManagedGa.contains(new GroupArtifact(it.getGav().getGroupId(), it.getGav().getArtifactId())))
-                    .collect(Collectors.toList());
-        } catch (MavenDownloadingException e) {
-            for (Map.Entry<MavenRepository, String> repositoryResponse : e.getRepositoryResponses().entrySet()) {
-                MavenRepository repository = repositoryResponse.getKey();
-                metadataFailures.insertRow(ctx, new MavenMetadataFailures.Row(groupId, artifactId, newVersion,
-                        repository.getUri(), repository.getSnapshots(), repository.getReleases(), repositoryResponse.getValue()));
-            }
-        }
+        depsWithoutExplicitVersion = depsWithoutExplicitVersion.stream()
+                .filter(it -> !newParentManagedGa.contains(new GroupArtifact(it.getGav().getGroupId(), it.getGav().getArtifactId())))
+                .collect(Collectors.toList());
         return depsWithoutExplicitVersion;
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -1418,4 +1418,51 @@ class ChangeParentPomTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotAddGrandparentProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom("org.springframework.boot", null, "spring-boot-starter-parent", null, "2.7.18", null, null, null, null)),
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.7.17</version>
+                </parent>
+                
+                <properties>
+                  <my-cool-prop>${junit.version}</my-cool-prop>
+                </properties>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>2.7.18</version>
+                </parent>
+                
+                <properties>
+                  <my-cool-prop>${junit.version}</my-cool-prop>
+                </properties>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
…arent (instead of unresolved new parent pom) when determining what properties will be available

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
see title

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The new test case would previously fail, having added `junit.version` to the pom's properties

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
this is mostly a tweak on @sambsnyd 's recent code in this recipe

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
