### PR TITLE
Add generic type variable bound to `JsonRightPadded<T>`

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonVisitor.java
@@ -96,7 +96,7 @@ public class JsonVisitor<P> extends TreeVisitor<Json, P> {
     }
 
     @SuppressWarnings("ConstantConditions")
-    public <T> JsonRightPadded<T> visitRightPadded(@Nullable JsonRightPadded<T> right, P p) {
+    public <T extends Json> JsonRightPadded<T> visitRightPadded(@Nullable JsonRightPadded<T> right, P p) {
         if (right == null) {
             //noinspection ConstantConditions
             return null;

--- a/rewrite-json/src/main/java/org/openrewrite/json/tree/JsonRightPadded.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/tree/JsonRightPadded.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 @Data
-public class JsonRightPadded<T> {
+public class JsonRightPadded<T extends Json> {
     @With
     T element;
 
@@ -52,7 +52,7 @@ public class JsonRightPadded<T> {
         return withElement(map.apply(element));
     }
 
-    public static <T> List<T> getElements(List<JsonRightPadded<T>> ls) {
+    public static <T extends Json> List<T> getElements(List<JsonRightPadded<T>> ls) {
         List<T> list = new ArrayList<>();
         for (JsonRightPadded<T> l : ls) {
             T elem = l.getElement();
@@ -92,7 +92,7 @@ public class JsonRightPadded<T> {
         return after;
     }
 
-    public static <T> JsonRightPadded<T> build(T element) {
+    public static <T extends Json> JsonRightPadded<T> build(T element) {
         return new JsonRightPadded<>(element, Space.EMPTY, Markers.EMPTY);
     }
 


### PR DESCRIPTION
Changes `<T>` to `<T extends Json>` as that is the only way it is currently being used.

Note: In the `J` model the padding constructs are also used to wrap non-`Tree` elements, but not in `Json`.
