### PR TITLE
fix: use aroundMethod for anonymous inner class in blankLines

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/BlankLinesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/BlankLinesTest.java
@@ -928,8 +928,8 @@ class BlankLinesTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4154")
     void eachMethodOnItsOwnLineAnonymousInnerClass() {
-
         rewriteRun(
           blankLines(),
           java(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/BlankLinesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/BlankLinesTest.java
@@ -926,4 +926,56 @@ class BlankLinesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void eachMethodOnItsOwnLineAnonymousInnerClass() {
+
+        rewriteRun(
+          blankLines(),
+          java(
+            """
+              public class Test {
+                  void a() {
+                      new Runnable() {
+                          void b() {
+                          }
+                          void c() {
+                          }
+                            
+                          public void run() {
+                          }
+            
+                          public void d() {
+                          }
+                      };
+                  }
+                  void e() {
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void a() {
+                      new Runnable() {
+                          void b() {
+                          }
+                              
+                          void c() {
+                          }
+                              
+                          public void run() {
+                          }
+            
+                          public void d() {
+                          }
+                      };
+                  }
+    
+                  void e() {
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/BlankLinesVisitor.java
@@ -227,6 +227,19 @@ public class BlankLinesVisitor<P> extends JavaIsoVisitor<P> {
                 }
 
                 j = keepMaximumLines(j, declMax);
+            } else if (grandparentTree instanceof J.NewClass && parentTree instanceof J.Block) {
+                J.Block block = (J.Block) parentTree;
+
+                int declMax = style.getKeepMaximum().getInDeclarations();
+
+                if (!block.getStatements().isEmpty() && !block.getStatements().iterator().next().isScope(j)) {
+                    if (j instanceof J.MethodDeclaration) {
+                        declMax = Math.max(declMax, style.getMinimum().getAroundMethod());
+                        j = minimumLines(j, style.getMinimum().getAroundMethod());
+                    }
+                }
+
+                j = keepMaximumLines(j, declMax);
             } else {
                 return keepMaximumLines(j, style.getKeepMaximum().getInCode());
             }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Make the `aroundMethod` in [java/style/BlankLinesStyle.java](https://github.com/openrewrite/rewrite/blob/main/rewrite-java/src/main/java/org/openrewrite/java/style/BlankLinesStyle.java#L53) also take effect in methods of anonymous inner class.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix https://github.com/openrewrite/rewrite/issues/4154.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
No.

## Anyone you would like to review specifically?
<!-- @mention them here -->
No.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
No.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
