### PR TITLE
Allow non-eager application of Gradle plugins

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddBuildPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddBuildPlugin.java
@@ -48,6 +48,13 @@ public class AddBuildPlugin extends Recipe {
     @Nullable
     String versionPattern;
 
+    @Option(displayName = "Apply plugin",
+            description = "Immediate apply the plugin. Defaults to `true`.",
+            valid = {"true", "false"},
+            required = false)
+    @Nullable
+    Boolean apply;
+
     @Override
     public String getDisplayName() {
         return "Add Gradle plugin";
@@ -71,7 +78,7 @@ public class AddBuildPlugin extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new FindGradleProject(FindGradleProject.SearchCriteria.Marker),
-                new AddPluginVisitor(pluginId, version, versionPattern)
+                new AddPluginVisitor(pluginId, version, versionPattern, apply)
         );
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -181,7 +181,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
                 return cu;
             }
 
-            cu = (G.CompilationUnit) new AddPluginVisitor(pluginId, newVersion, null)
+            cu = (G.CompilationUnit) new AddPluginVisitor(pluginId, newVersion, null, null)
                     .visitNonNull(cu, ctx);
             cu = (G.CompilationUnit) new UpgradePluginVersion(pluginId, newVersion, null).getVisitor()
                     .visitNonNull(cu, ctx);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddPluginVisitor.java
@@ -55,6 +55,9 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
     @Nullable
     String versionPattern;
 
+    @Nullable
+    Boolean apply;
+
     private static @Nullable Comment getLicenseHeader(G.CompilationUnit cu) {
         if (!cu.getStatements().isEmpty()) {
             Statement firstStatement = cu.getStatements().get(0);
@@ -136,7 +139,7 @@ public class AddPluginVisitor extends GroovyIsoVisitor<ExecutionContext> {
 
             String delimiter = singleQuote.get() < doubleQuote.get() ? "\"" : "'";
             String source = "plugins {\n" +
-                            "    id " + delimiter + pluginId + delimiter + (version != null ? " version " + delimiter + version + delimiter : "") + "\n" +
+                            "    id " + delimiter + pluginId + delimiter + (version != null ? " version " + delimiter + version + delimiter : "") + (version != null && Boolean.FALSE.equals(apply) ? " apply " + apply : "") + "\n" +
                             "}";
             Statement statement = GradleParser.builder().build()
                     .parseInputs(singletonList(Parser.Input.fromString(source)), null, ctx)

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddSettingsPlugin.java
@@ -50,6 +50,13 @@ public class AddSettingsPlugin extends Recipe {
     @Nullable
     String versionPattern;
 
+    @Option(displayName = "Apply plugin",
+            description = "Immediate apply the plugin. Defaults to `true`.",
+            valid = {"true", "false"},
+            required = false)
+    @Nullable
+    Boolean apply;
+
     @Override
     public String getDisplayName() {
         return "Add Gradle settings plugin";
@@ -73,7 +80,7 @@ public class AddSettingsPlugin extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new IsSettingsGradle<>(),
-                new AddPluginVisitor(pluginId, StringUtils.isBlank(version) ? "latest.release" : version, versionPattern)
+                new AddPluginVisitor(pluginId, StringUtils.isBlank(version) ? "latest.release" : version, versionPattern, apply)
         );
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
@@ -35,7 +35,7 @@ class AddBuildPluginTest implements RewriteTest {
     @Test
     void addPluginWithoutVersionToNewBlock() {
         rewriteRun(
-          spec -> spec.recipe(new AddBuildPlugin("java-library", null, null)),
+          spec -> spec.recipe(new AddBuildPlugin("java-library", null, null, null)),
           buildGradle(
             "",
             """
@@ -50,7 +50,7 @@ class AddBuildPluginTest implements RewriteTest {
     @Test
     void addPluginWithoutVersionToExistingBlock() {
         rewriteRun(
-          spec -> spec.recipe(new AddBuildPlugin("java-library", null, null)),
+          spec -> spec.recipe(new AddBuildPlugin("java-library", null, null, null)),
           buildGradle(
             """
               plugins {
@@ -70,7 +70,7 @@ class AddBuildPluginTest implements RewriteTest {
     @Test
     void addThirdPartyPluginWithoutVersion() {
         rewriteRun(
-          spec -> spec.recipe(new AddBuildPlugin("org.openrewrite.rewrite", null, null)),
+          spec -> spec.recipe(new AddBuildPlugin("org.openrewrite.rewrite", null, null, null)),
           buildGradle(
             """
               plugins {
@@ -90,7 +90,7 @@ class AddBuildPluginTest implements RewriteTest {
     @Test
     void addPluginWithVersionToNewBlock() {
         rewriteRun(
-          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null)),
+          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, null)),
           buildGradle(
             "",
             """
@@ -105,7 +105,7 @@ class AddBuildPluginTest implements RewriteTest {
     @Test
     void addPluginWithVersionToExistingBlock() {
         rewriteRun(
-          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null)),
+          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, null)),
           buildGradle(
             """
               plugins {
@@ -125,7 +125,7 @@ class AddBuildPluginTest implements RewriteTest {
     @Test
     void addPluginAfterBuildscriptBlock() {
         rewriteRun(
-          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null)),
+          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, null)),
           buildGradle(
             """
               import java.util.List
@@ -151,7 +151,7 @@ class AddBuildPluginTest implements RewriteTest {
     void addPluginToNewBlockWithLicenseHeader() {
         rewriteRun(
           spec -> {
-              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null));
+              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, null));
               spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")));
           },
           buildGradle(
@@ -182,7 +182,7 @@ class AddBuildPluginTest implements RewriteTest {
     void addPluginToNewBlockWithLicenseHeaderAndComment() {
         rewriteRun(
           spec -> {
-              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null));
+              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, null));
               spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")));
           },
           buildGradle(
@@ -215,7 +215,7 @@ class AddBuildPluginTest implements RewriteTest {
     void addPluginToNewBlockWithOnlyLicenseHeader() {
         rewriteRun(
           spec -> {
-              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null));
+              spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, null));
               spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")));
           },
           buildGradle(
@@ -232,6 +232,26 @@ class AddBuildPluginTest implements RewriteTest {
                   id 'com.jfrog.bintray' version '1.0'
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void addPluginApplyFalse() {
+        rewriteRun(
+          spec -> spec.recipe(new AddBuildPlugin("com.jfrog.bintray", "1.0", null, false)),
+          buildGradle(
+            """
+            plugins {
+                id "java"
+            }
+            """,
+            """
+            plugins {
+                id "java"
+                id "com.jfrog.bintray" version "1.0" apply false
+            }
+            """
           )
         );
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
@@ -34,7 +34,7 @@ class AddSettingsPluginTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.beforeRecipe(withToolingApi())
-          .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null));
+          .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null, null));
     }
 
     @Test
@@ -122,6 +122,24 @@ class AddSettingsPluginTest implements RewriteTest {
                 }
 
                 rootProject.name = 'my-project'
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void addPluginApplyFalse() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null, false)),
+          settingsGradle(
+            "",
+            interpolateResolvedVersion(
+              """
+                plugins {
+                    id 'com.gradle.enterprise' version '%s' apply false
+                }
                 """
             )
           )


### PR DESCRIPTION
## What's changed?
Enable non-eager application of plugins.

## What's your motivation?
As a Gradle user sometimes it is necessary to not eagerly apply a plugin, so that you can then later apply it in the project using alternative methods.

## Anything in particular you'd like reviewers to focus on?
Nothing in particular.

## Anyone you would like to review specifically?
Anybody.

## Have you considered any alternatives or workarounds?
Have my own version of the recipe.

## Any additional context
None.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
