### PR TITLE
Rename `J.InstanceOf.Padding#getExpr()` and `J.LambdaParameters.Padding#getParams()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -676,7 +676,7 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
     @Override
     public J visitInstanceOf(InstanceOf instanceOf, PrintOutputCapture<P> p) {
         beforeSyntax(instanceOf, Space.Location.INSTANCEOF_PREFIX, p);
-        visitRightPadded(instanceOf.getPadding().getExpr(), JRightPadded.Location.INSTANCEOF, "instanceof", p);
+        visitRightPadded(instanceOf.getPadding().getExpression(), JRightPadded.Location.INSTANCEOF, "instanceof", p);
         visit(instanceOf.getClazz(), p);
         visit(instanceOf.getPattern(), p);
         afterSyntax(instanceOf, p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -707,10 +707,10 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
         visitMarkers(lambda.getParameters().getMarkers(), p);
         if (lambda.getParameters().isParenthesized()) {
             p.append('(');
-            visitRightPadded(lambda.getParameters().getPadding().getParams(), JRightPadded.Location.LAMBDA_PARAM, ",", p);
+            visitRightPadded(lambda.getParameters().getPadding().getParameters(), JRightPadded.Location.LAMBDA_PARAM, ",", p);
             p.append(')');
         } else {
-            visitRightPadded(lambda.getParameters().getPadding().getParams(), JRightPadded.Location.LAMBDA_PARAM, ",", p);
+            visitRightPadded(lambda.getParameters().getPadding().getParameters(), JRightPadded.Location.LAMBDA_PARAM, ",", p);
         }
         visitSpace(lambda.getArrow(), Space.Location.LAMBDA_ARROW_PREFIX, p);
         p.append("->");

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -743,7 +743,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         } else {
             i = (J.InstanceOf) temp;
         }
-        i = i.getPadding().withExpr(visitRightPadded(i.getPadding().getExpr(), JRightPadded.Location.INSTANCEOF, p));
+        i = i.getPadding().withExpression(visitRightPadded(i.getPadding().getExpression(), JRightPadded.Location.INSTANCEOF, p));
         i = i.withClazz(visitAndCast(i.getClazz(), p));
         i = i.withPattern(visitAndCast(i.getPattern(), p));
         i = i.withType(visitType(i.getType(), p));

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -790,8 +790,8 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
                 )
         );
         l = l.withParameters(
-                l.getParameters().getPadding().withParams(
-                        ListUtils.map(l.getParameters().getPadding().getParams(),
+                l.getParameters().getPadding().withParameters(
+                        ListUtils.map(l.getParameters().getPadding().getParameters(),
                                 param -> visitRightPadded(param, JRightPadded.Location.LAMBDA_PARAM, p)
                         )
                 )

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -67,7 +67,7 @@ public class RemoveObjectsIsNull extends Recipe {
                 // Replace the method invocation with a simple null check
                 Expression e = m.getArguments().get(0);
                 Expression replaced = JavaTemplate.apply(pattern, getCursor(), m.getCoordinates().replace(), e);
-                return (Expression) new UnnecessaryParenthesesVisitor().visitNonNull(replaced, ctx, getCursor());
+                return (Expression) new UnnecessaryParenthesesVisitor<>().visitNonNull(replaced, ctx, getCursor());
             }
         });
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/OperatorWrap.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/OperatorWrap.java
@@ -168,8 +168,8 @@ public class OperatorWrap extends Recipe {
             if (Boolean.TRUE.equals(operatorWrapStyle.getLiteralInstanceof())) {
                 if (OperatorWrapStyle.WrapOption.NL.equals(operatorWrapStyle.getWrapOption())) {
                     if (i.getClazz().getPrefix().getWhitespace().contains("\n")) {
-                        i = i.getPadding().withExpr(
-                                i.getPadding().getExpr().withAfter(
+                        i = i.getPadding().withExpression(
+                                i.getPadding().getExpression().withAfter(
                                         i.getClazz().getPrefix()
                                 )
                         );
@@ -179,15 +179,15 @@ public class OperatorWrap extends Recipe {
                                 )
                         );
                     }
-                } else if (i.getPadding().getExpr().getAfter().getWhitespace().contains("\n")) {
+                } else if (i.getPadding().getExpression().getAfter().getWhitespace().contains("\n")) {
                     i = i.withClazz(
                             i.getClazz().withPrefix(
-                                    i.getPadding().getExpr().getAfter()
+                                    i.getPadding().getExpression().getAfter()
                             )
                     );
-                    i = i.getPadding().withExpr(
-                            i.getPadding().getExpr().withAfter(
-                                    i.getPadding().getExpr().getAfter().withWhitespace(" ")
+                    i = i.getPadding().withExpression(
+                            i.getPadding().getExpression().withAfter(
+                                    i.getPadding().getExpression().getAfter().withWhitespace(" ")
                             )
                     );
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -842,8 +842,8 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
         if (!(l.getParameters().getParameters().isEmpty() || l.getParameters().getParameters().iterator().next() instanceof J.Empty)) {
             int parametersSize = l.getParameters().getParameters().size();
             l = l.withParameters(
-                    l.getParameters().getPadding().withParams(
-                            ListUtils.map(l.getParameters().getPadding().getParams(),
+                    l.getParameters().getPadding().withParameters(
+                            ListUtils.map(l.getParameters().getPadding().getParameters(),
                                     (index, elemContainer) -> {
                                         if (index != 0) {
                                             elemContainer = elemContainer.withElement(

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -1126,7 +1126,7 @@ public class Autodetect extends NamedStyles {
         public J.Lambda visitLambda(J.Lambda lambda, SpacesStatistics stats) {
             List<J> parameters = lambda.getParameters().getParameters();
             if (parameters.size() > 1) {
-                List<JRightPadded<J>> paddedParameters = lambda.getParameters().getPadding().getParams();
+                List<JRightPadded<J>> paddedParameters = lambda.getParameters().getPadding().getParameters();
                 for (int i = 0; i < paddedParameters.size() - 1; i++) {
                     stats.beforeComma += hasSpace(paddedParameters.get(i).getAfter());
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2933,7 +2933,7 @@ public interface J extends Tree {
         }
 
         public InstanceOf withExpression(Expression expression) {
-            return getPadding().withExpr(this.expression.withElement(expression));
+            return getPadding().withExpression(this.expression.withElement(expression));
         }
 
         @With
@@ -2991,10 +2991,20 @@ public interface J extends Tree {
         public static class Padding {
             private final InstanceOf t;
 
+            public JRightPadded<Expression> getExpression() {
+                return t.expression;
+            }
+
+            public InstanceOf withExpression(JRightPadded<Expression> expression) {
+                return t.expression == expression ? t : new InstanceOf(t.id, t.prefix, t.markers, expression, t.clazz, t.pattern, t.type);
+            }
+
+            @Deprecated
             public JRightPadded<Expression> getExpr() {
                 return t.expression;
             }
 
+            @Deprecated
             public InstanceOf withExpr(JRightPadded<Expression> expression) {
                 return t.expression == expression ? t : new InstanceOf(t.id, t.prefix, t.markers, expression, t.clazz, t.pattern, t.type);
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3254,7 +3254,7 @@ public interface J extends Tree {
             }
 
             public Parameters withParameters(List<J> parameters) {
-                return getPadding().withParams(JRightPadded.withElements(this.parameters, parameters));
+                return getPadding().withParameters(JRightPadded.withElements(this.parameters, parameters));
             }
 
             @Transient
@@ -3281,10 +3281,20 @@ public interface J extends Tree {
             public static class Padding {
                 private final Parameters t;
 
+                public List<JRightPadded<J>> getParameters() {
+                    return t.parameters;
+                }
+
+                public Parameters withParameters(List<JRightPadded<J>> parameters) {
+                    return t.parameters == parameters ? t : new Parameters(t.id, t.prefix, t.markers, t.parenthesized, parameters);
+                }
+
+                @Deprecated
                 public List<JRightPadded<J>> getParams() {
                     return t.parameters;
                 }
 
+                @Deprecated
                 public Parameters withParams(List<JRightPadded<J>> parameters) {
                     return t.parameters == parameters ? t : new Parameters(t.id, t.prefix, t.markers, t.parenthesized, parameters);
                 }


### PR DESCRIPTION
The name should be in line with `J.InstanceOf#getExpression()` and the `J.InstanceOf#expression` field, therefore renaming. Keeping the old method as deprecated for backward compatibility.

For the same reason also renaming `J.LambdaParameters.Padding#getParams()` to align with `J.LambdaParameters#getParameters()`.