### PR TITLE
Remove `J.ClassDeclaration.Annotations` wrapper

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -497,8 +497,8 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
         for (Modifier m : classDecl.getModifiers()) {
             visitModifier(m, p);
         }
-        visit(classDecl.getAnnotations().getKind().getAnnotations(), p);
-        visitSpace(classDecl.getAnnotations().getKind().getPrefix(), Space.Location.CLASS_KIND, p);
+        visit(classDecl.getPadding().getKind().getAnnotations(), p);
+        visitSpace(classDecl.getPadding().getKind().getPrefix(), Space.Location.CLASS_KIND, p);
         p.append(kind);
         visit(classDecl.getName(), p);
         visitContainer("<", classDecl.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -457,14 +457,14 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
                 mod -> mod.withPrefix(visitSpace(mod.getPrefix(), Space.Location.MODIFIER_PREFIX, p))));
         c = c.withModifiers(ListUtils.map(c.getModifiers(), m -> visitAndCast(m, p)));
         //Kind can have annotations associated with it, need to visit those.
-        c = c.getAnnotations().withKind(
-                classDecl.getAnnotations().getKind().withAnnotations(
-                        ListUtils.map(classDecl.getAnnotations().getKind().getAnnotations(), a -> visitAndCast(a, p))
+        c = c.getPadding().withKind(
+                classDecl.getPadding().getKind().withAnnotations(
+                        ListUtils.map(classDecl.getPadding().getKind().getAnnotations(), a -> visitAndCast(a, p))
                 )
         );
-        c = c.getAnnotations().withKind(
-                c.getAnnotations().getKind().withPrefix(
-                        visitSpace(c.getAnnotations().getKind().getPrefix(), Space.Location.CLASS_KIND, p)
+        c = c.getPadding().withKind(
+                c.getPadding().getKind().withPrefix(
+                        visitSpace(c.getPadding().getKind().getPrefix(), Space.Location.CLASS_KIND, p)
                 )
         );
         c = c.withName(visitAndCast(c.getName(), p));
@@ -1404,16 +1404,13 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
 
         setCursor(getCursor().getParent());
-        if (t == null) {
-            // If nothing changed leave AST node the same
-            if (left.getElement() == null && before == left.getBefore()) {
-                return left;
-            }
-            //noinspection ConstantConditions
-            return null;
+        // If nothing changed leave AST node the same
+        if (left.getElement() == t && before == left.getBefore()) {
+            return left;
         }
 
-        return (before == left.getBefore() && t == left.getElement()) ? left : new JLeftPadded<>(before, t, left.getMarkers());
+        //noinspection ConstantConditions
+        return t == null ? null : new JLeftPadded<>(before, t, left.getMarkers());
     }
 
     public <J2 extends J> JContainer<J2> visitContainer(@Nullable JContainer<J2> container,

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationVisitor.java
@@ -47,7 +47,7 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
                 } else if (c.getPadding().getTypeParameters() != null) {
                     c = c.getPadding().withTypeParameters(c.getPadding().getTypeParameters().withBefore(c.getPadding().getTypeParameters().getBefore().withWhitespace("")));
                 } else {
-                    c = c.getAnnotations().withKind(c.getAnnotations().getKind().withPrefix(c.getAnnotations().getKind().getPrefix().withWhitespace("")));
+                    c = c.getPadding().withKind(c.getPadding().getKind().withPrefix(c.getPadding().getKind().getPrefix().withWhitespace("")));
                 }
             } else {
                 List<J.Annotation> newLeadingAnnotations = removeAnnotationOrEmpty(leadingAnnotations, annotationRemoved);

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NormalizeFormatVisitor.java
@@ -59,9 +59,9 @@ public class NormalizeFormatVisitor<P> extends JavaIsoVisitor<P> {
             return c;
         }
 
-        if (!c.getAnnotations().getKind().getPrefix().isEmpty()) {
-            c = concatenatePrefix(c, c.getAnnotations().getKind().getPrefix());
-            c = c.getAnnotations().withKind(c.getAnnotations().getKind().withPrefix(Space.EMPTY));
+        if (!c.getPadding().getKind().getPrefix().isEmpty()) {
+            c = concatenatePrefix(c, c.getPadding().getKind().getPrefix());
+            c = c.getPadding().withKind(c.getPadding().getKind().withPrefix(Space.EMPTY));
             return c;
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
@@ -140,9 +140,9 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
             if (!j.getModifiers().isEmpty()) {
                 j = j.withModifiers(withNewline(j.getModifiers()));
             } else {
-                J.ClassDeclaration.Kind kind = j.getAnnotations().getKind();
+                J.ClassDeclaration.Kind kind = j.getPadding().getKind();
                 if (!kind.getPrefix().getWhitespace().contains("\n")) {
-                    j = j.getAnnotations().withKind(kind.withPrefix(
+                    j = j.getPadding().withKind(kind.withPrefix(
                             kind.getPrefix().withWhitespace("\n" + kind.getPrefix().getWhitespace())
                     ));
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -146,7 +146,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     c = c.withTypeParameters(ListUtils.map(c.getTypeParameters(), tp -> tp.withAnnotations(emptyList())));
                                 }
                                 c = c.withModifiers(ListUtils.map(c.getModifiers(), m -> m.withAnnotations(emptyList())));
-                                c = c.getAnnotations().withKind(c.getAnnotations().getKind().withAnnotations(emptyList()));
+                                c = c.getPadding().withKind(c.getPadding().getKind().withAnnotations(emptyList()));
                             } else {
                                 for (J.Annotation a : gen) {
                                     c = c.withLeadingAnnotations(ListUtils.insertInOrder(c.getLeadingAnnotations(), a,

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1159,10 +1159,6 @@ public interface J extends Tree {
         @NonFinal
         transient WeakReference<Padding> padding;
 
-        @Nullable
-        @NonFinal
-        transient WeakReference<Annotations> annotations;
-
         @With
         @Getter
         @EqualsAndHashCode.Include
@@ -1191,11 +1187,11 @@ public interface J extends Tree {
         }
 
         public ClassDeclaration withKind(Kind.Type type) {
-            Kind k = getAnnotations().getKind();
+            Kind k = getPadding().getKind();
             if (k.type == type) {
                 return this;
             } else {
-                return getAnnotations().withKind(k.withType(type));
+                return getPadding().withKind(k.withType(type));
             }
         }
 
@@ -1418,34 +1414,6 @@ public interface J extends Tree {
 
             public ClassDeclaration withTypeParameters(@Nullable JContainer<TypeParameter> typeParameters) {
                 return t.typeParameters == typeParameters ? t : new ClassDeclaration(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.kind, t.name, typeParameters, t.primaryConstructor, t.extendings, t.implementings, t.permitting, t.body, t.type);
-            }
-        }
-
-        public Annotations getAnnotations() {
-            Annotations a;
-            if (this.annotations == null) {
-                a = new Annotations(this);
-                this.annotations = new WeakReference<>(a);
-            } else {
-                a = this.annotations.get();
-                if (a == null || a.t != this) {
-                    a = new Annotations(this);
-                    this.annotations = new WeakReference<>(a);
-                }
-            }
-            return a;
-        }
-
-        @RequiredArgsConstructor
-        public static class Annotations {
-            private final ClassDeclaration t;
-
-            public Kind getKind() {
-                return t.kind;
-            }
-
-            public ClassDeclaration withKind(Kind kind) {
-                return t.kind == kind ? t : new ClassDeclaration(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, kind, t.name, t.typeParameters, t.primaryConstructor, t.extendings, t.implementings, t.permitting, t.body, t.type);
             }
         }
     }
@@ -3586,19 +3554,20 @@ public interface J extends Tree {
         }
 
         public MethodDeclaration withTypeParameters(@Nullable List<TypeParameter> typeParameters) {
+            Annotations annotations = getAnnotations();
             if (typeParameters == null) {
-                if (this.getAnnotations().getTypeParameters() == null) {
+                if (annotations.getTypeParameters() == null) {
                     return this;
                 } else {
-                    return this.getAnnotations().withTypeParameters(null);
+                    return annotations.withTypeParameters(null);
                 }
             } else {
-                TypeParameters currentTypeParameters = this.getAnnotations().getTypeParameters();
+                TypeParameters currentTypeParameters = annotations.getTypeParameters();
                 if (currentTypeParameters == null) {
-                    return getAnnotations().withTypeParameters(new TypeParameters(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                    return annotations.withTypeParameters(new TypeParameters(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
                             null, typeParameters.stream().map(JRightPadded::build).collect(toList())));
                 } else {
-                    return getAnnotations().withTypeParameters(currentTypeParameters.withTypeParameters(typeParameters));
+                    return annotations.withTypeParameters(currentTypeParameters.withTypeParameters(typeParameters));
                 }
             }
         }


### PR DESCRIPTION
Instead, the already existing `Padding` wrapper can be used to access the raw `kind` property value.
