### PR TITLE
ChangePackage fails to migrate annotation argument enum in package-info

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -1582,16 +1582,16 @@ class ChangePackageTest implements RewriteTest {
             """
               @org.openrewrite.MyAnnotation(myEnum = org.openrewrite.MyEnum.BAR)
               package com.acme;
-               """,
+              """,
             """
               @org.openrewrite.test.MyAnnotation(myEnum = org.openrewrite.test.MyEnum.BAR)
               package com.acme;
-               """,
+              """,
             spec -> spec.afterRecipe(cu -> {
                 assertThat(cu.findType("org.openrewrite.MyAnnotation")).isEmpty();
                 assertThat(cu.findType("org.openrewrite.test.MyAnnotation")).isNotEmpty();
-                assertThat(cu.findType("org.openrewrite.MyEnum.BAR")).isEmpty();
-                assertThat(cu.findType("org.openrewrite.test.MyEnum.BAR")).isNotEmpty();
+                assertThat(cu.findType("org.openrewrite.MyEnum")).isEmpty();
+                assertThat(cu.findType("org.openrewrite.test.MyEnum")).isNotEmpty();
             })
           )
         );

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -1546,4 +1546,54 @@ class ChangePackageTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void packageInfoAnnotation() {
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite;
+                          
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Retention;
+              import java.lang.annotation.RetentionPolicy;
+              import java.lang.annotation.Target;
+                          
+              @Target(ElementType.PACKAGE)
+              @Retention(RetentionPolicy.RUNTIME)
+              public @interface MyAnnotation {
+                  MyEnum myEnum() default MyEnum.FOO;
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              package org.openrewrite;
+                          
+              public enum MyEnum {
+                  FOO,
+                  BAR
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              @org.openrewrite.MyAnnotation(myEnum = org.openrewrite.MyEnum.BAR)
+              package com.acme;
+               """,
+            """
+              @org.openrewrite.test.MyAnnotation(myEnum = org.openrewrite.test.MyEnum.BAR)
+              package com.acme;
+               """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.MyAnnotation")).isEmpty();
+                assertThat(cu.findType("org.openrewrite.test.MyAnnotation")).isNotEmpty();
+                assertThat(cu.findType("org.openrewrite.MyEnum.BAR")).isEmpty();
+                assertThat(cu.findType("org.openrewrite.test.MyEnum.BAR")).isNotEmpty();
+            })
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -146,7 +146,7 @@ public class ChangePackage extends Recipe {
         }
 
         @Override
-        public J.Package visitPackage(J.Package pkg, ExecutionContext ctx) {
+        public J visitPackage(J.Package pkg, ExecutionContext ctx) {
             String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
             getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, RENAME_FROM_KEY, original);
 
@@ -169,7 +169,7 @@ public class ChangePackage extends Recipe {
                         .apply(getCursor(), pkg.getCoordinates().replace());
             }
             //noinspection ConstantConditions
-            return pkg;
+            return super.visitPackage(pkg, ctx);
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -150,6 +150,8 @@ public class ChangePackage extends Recipe {
             String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
             getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, RENAME_FROM_KEY, original);
 
+            pkg = pkg.withAnnotations(ListUtils.map(pkg.getAnnotations(), a -> visitAndCast(a, ctx)));
+
             if (original.equals(oldPackageName)) {
                 getCursor().putMessageOnFirstEnclosing(JavaSourceFile.class, RENAME_TO_KEY, newPackageName);
 
@@ -169,7 +171,7 @@ public class ChangePackage extends Recipe {
                         .apply(getCursor(), pkg.getCoordinates().replace());
             }
             //noinspection ConstantConditions
-            return super.visitPackage(pkg, ctx);
+            return pkg;
         }
 
         @Override


### PR DESCRIPTION
## What's changed?
I found [this issue](https://github.com/openrewrite/rewrite/issues/3200) describing problems with migrating annotations in `package-info.java`. We seem to still have this problem.

In this MR, I have added a (failing) test showing our issue.

Our actual issue is regarding applying jakarta migration for this class:

```
@javax.xml.bind.annotation.XmlSchema(namespace = "http://example.com/schema", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
package org.example;
```

We have made it work using `org.openrewrite.java.ChangeType` for our migration, but would prefer if `org.openrewrite.java.ChangePackage` worked for this.

## Anything in particular you'd like reviewers to focus on?

Please note that this does not fix the issue, only adds a test case to it :-)

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
