### PR TITLE
YAML: Support lists of lists

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -416,10 +416,10 @@ public class YamlParser implements org.openrewrite.Parser {
                 }
             } else {
                 if (c == target) {
-                    lastFoundIndex = i;
                     if (strategy == FindIndexStrategy.FIRST) {
-                        break;
+                        return i;
                     }
+                    lastFoundIndex = i;
                 } else if (c == '#') {
                     inComment = true;
                 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -65,6 +65,24 @@ class YamlParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void listOfLists() {
+        rewriteRun(
+          yaml(
+            """
+              root:
+                  listOfLists:
+                    - - a
+                      - b
+                    - - c
+                      - d
+                      - - e
+                        - f
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @ParameterizedTest
     @ValueSource(strings = {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -66,6 +66,7 @@ class YamlParserTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4176")
     void listOfLists() {
         rewriteRun(
           yaml(


### PR DESCRIPTION
YAML supports lists of lists. They are not common but sometimes required, for example, in some AWS CloudFormation templates. Currently, the YamlParser doesn't correctly parse these lists. It adds additional hyphens.
```
Original     ->     After parsing
root:               root:
  - - a               - - - a
    - b                 - b
```
This happens for every line that contains multiple hyphens (like for the 'a' line in the example above).
That's because the parser interprets these hyphens twice. Once as a SequenceEntry and once as prefix for the last block of that line (in this example, the scalar 'a').

The bug is in SequenceBuilder.push. This method builds the prefix of a given block by using the substring between the FIRST hyphen and the block itself. So if there is more than one hyphen in that row, the additional hyphens will be included in the prefix, although they are already represented in the LST as SequenceEntries.

Fix it by using the substring between the LAST hyphen and the block itself. To do this, extend the functionality of the commentAwareIndexOf method, so that it can find the first or the last index. Don't create an additional method as not to duplicate the logic. Also use a dedicated enum because it is cleaner and much more expressive than using a boolean flag.

Fixes #4176

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
