### PR TITLE
Only allow Gradle `AddDependency` to add dependencies to the top-level `dependencies` block

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependency.java
@@ -241,10 +241,14 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
                         G.CompilationUnit g = (G.CompilationUnit) s;
                         for (String resolvedConfiguration : resolvedConfigurations) {
                             g = (G.CompilationUnit) new AddDependencyVisitor(groupId, artifactId, version, versionPattern, resolvedConfiguration,
-                                    classifier, extension, metadataFailures).visitNonNull(g, ctx);
+                                    classifier, extension, metadataFailures, this::isTopLevel).visitNonNull(g, ctx);
                         }
 
                         return g;
+                    }
+
+                    private boolean isTopLevel(Cursor cursor) {
+                        return cursor.getParent().firstEnclosing(J.MethodInvocation.class) == null;
                     }
                 })
         );

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java
@@ -41,6 +41,7 @@ import org.openrewrite.maven.tree.*;
 import org.openrewrite.tree.ParseError;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -75,6 +76,9 @@ public class AddDependencyVisitor extends GroovyIsoVisitor<ExecutionContext> {
 
     @Nullable
     private String resolvedVersion;
+
+    @Nullable
+    private final Predicate<Cursor> insertPredicate;
 
     @Override
     public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
@@ -217,6 +221,10 @@ public class AddDependencyVisitor extends GroovyIsoVisitor<ExecutionContext> {
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
             if (!DEPENDENCIES_DSL_MATCHER.matches(m)) {
+                return m;
+            }
+
+            if (!insertPredicate.test(getCursor())) {
                 return m;
             }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -1261,6 +1261,57 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4094")
+    void doNotAddToIncorrectBlocks() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath", null)),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id 'java'
+                    id 'io.spring.dependency-management' version '1.1.5'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencyManagement {
+                    dependencies {
+                        dependency "org.openrewrite:rewrite-core:8.0.0"
+                    }
+                }
+                """,
+              """
+                plugins {
+                    id 'java'
+                    id 'io.spring.dependency-management' version '1.1.5'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencyManagement {
+                    dependencies {
+                        dependency "org.openrewrite:rewrite-core:8.0.0"
+                    }
+                }
+                
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+                }
+                """
+            )
+          )
+        );
+    }
+
     private AddDependency addDependency(String gav, String onlyIfUsing) {
         return addDependency(gav, onlyIfUsing, null);
     }


### PR DESCRIPTION
## What's changed?
Due to the Groovy compiler misinterpreting receiver classes for the `dependencies` block, this can result in the `gradle.AddDependency` recipe placing new dependencies improperly.

## What's your motivation?
* Fixing gh-4094

## Anything in particular you'd like reviewers to focus on?
Just the pattern of using a `Predicate` from the recipe standpoint as the mechanism with which to invert the control flow and allow more specific insertion points from a dependency standpoint.

## Anyone you would like to review specifically?
Anybody who wants to double check the work.

## Have you considered any alternatives or workarounds?
None

## Any additional context
None

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
