### PR TITLE
Don't modify package declaration of siblings in ChangeType

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1823,7 +1823,9 @@ class ChangeTypeTest implements RewriteTest {
           java(
             """
               package org.openrewrite;
-
+              
+              import org.openrewrite.Test;
+              
               public class Sibling {
                   public Test test() {
                       return new Test();
@@ -1832,9 +1834,9 @@ class ChangeTypeTest implements RewriteTest {
               """,
             """
               package org.openrewrite;
-
+              
               import org.openrewrite.subpackage.Test;
-
+              
               public class Sibling {
                   public Test test() {
                       return new Test();

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1823,6 +1823,18 @@ class ChangeTypeTest implements RewriteTest {
           java(
             """
               package org.openrewrite;
+
+              public class Sibling {
+                  public Test test() {
+                      return new Test();
+                  }
+              }
+              """,
+            """
+              package org.openrewrite;
+
+              import org.openrewrite.subpackage.Test;
+
               public class Sibling {
                   public Test test() {
                       return new Test();

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1802,4 +1802,34 @@ class ChangeTypeTest implements RewriteTest {
         );
 
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4182")
+    @Test
+    void doesNotModifyPackageOfSibling() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("org.openrewrite.Test", "org.openrewrite.subpackage.Test", false)),
+          java(
+            """
+              package org.openrewrite;
+              public class Test {
+              }
+              """,
+            """
+              package org.openrewrite.subpackage;
+              public class Test {
+              }
+              """
+          ),
+          java(
+            """
+              package org.openrewrite;
+              public class Sibling {
+                  public Test test() {
+                      return new Test();
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -509,7 +509,7 @@ public class ChangeType extends Recipe {
 
                 Path newPath = Paths.get(oldPath.replaceFirst(oldFqn, newFqn));
                 if (updatePath(cu, oldPath, newPath.toString())) {
-                    getCursor().putMessage("UPDATE_PATH", true);
+                    getCursor().putMessage("UPDATE_PACKAGE", true);
                     cu = cu.withSourcePath(newPath);
                 }
                 return super.visit(cu, ctx);
@@ -532,8 +532,8 @@ public class ChangeType extends Recipe {
 
         @Override
         public J.Package visitPackage(J.Package pkg, ExecutionContext ctx) {
-            Boolean updatePath = getCursor().pollNearestMessage("UPDATE_PATH");
-            if (updatePath != null && updatePath) {
+            Boolean updatePackage = getCursor().pollNearestMessage("UPDATE_PACKAGE");
+            if (updatePackage != null && updatePackage) {
                 String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
                 if (original.equals(originalType.getPackageName())) {
                     JavaType.FullyQualified fq = TypeUtils.asFullyQualified(targetType);

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -491,6 +491,7 @@ public class ChangeType extends Recipe {
         private final JavaType.Class originalType;
         private final JavaType.Class targetType;
         private final MethodMatcher originalConstructor;
+        private boolean updatePath;
 
         private ChangeClassDefinition(String oldFullyQualifiedTypeName, String newFullyQualifiedTypeName) {
             this.originalType = JavaType.ShallowClass.build(oldFullyQualifiedTypeName);
@@ -508,7 +509,8 @@ public class ChangeType extends Recipe {
                 String newFqn = fqnToPath(targetType.getFullyQualifiedName());
 
                 Path newPath = Paths.get(oldPath.replaceFirst(oldFqn, newFqn));
-                if (updatePath(cu, oldPath, newPath.toString())) {
+                updatePath = updatePath(cu, oldPath, newPath.toString());
+                if (updatePath) {
                     cu = cu.withSourcePath(newPath);
                 }
                 return super.visit(cu, ctx);
@@ -532,7 +534,7 @@ public class ChangeType extends Recipe {
         @Override
         public J.Package visitPackage(J.Package pkg, ExecutionContext ctx) {
             String original = pkg.getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");
-            if (original.equals(originalType.getPackageName())) {
+            if (updatePath && original.equals(originalType.getPackageName())) {
                 JavaType.FullyQualified fq = TypeUtils.asFullyQualified(targetType);
                 if (fq != null) {
                     if (fq.getPackageName().isEmpty()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -502,6 +502,15 @@ public class ChangeType extends Recipe {
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 JavaSourceFile cu = (JavaSourceFile) tree;
+                for (J.ClassDeclaration declaration : cu.getClasses()) {
+                    // Check the class name instead of source path, as it might differ
+                    String fqn = declaration.getType().getFullyQualifiedName();
+                    if (fqn.equals(originalType.getFullyQualifiedName())) {
+                        getCursor().putMessage("UPDATE_PACKAGE", true);
+                        break;
+                    }
+                }
+
                 String oldPath = cu.getSourcePath().toString().replace('\\', '/');
                 // The old FQN must exist in the path.
                 String oldFqn = fqnToPath(originalType.getFullyQualifiedName());
@@ -509,7 +518,6 @@ public class ChangeType extends Recipe {
 
                 Path newPath = Paths.get(oldPath.replaceFirst(oldFqn, newFqn));
                 if (updatePath(cu, oldPath, newPath.toString())) {
-                    getCursor().putMessage("UPDATE_PACKAGE", true);
                     cu = cu.withSourcePath(newPath);
                 }
                 return super.visit(cu, ctx);

--- a/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/SourceSpec.java
@@ -106,7 +106,7 @@ public class SourceSpec<T extends SourceFile> implements SourceSpecs {
     protected boolean noTrim = false;
 
     /**
-     * @param sourcePath The source path after the recipe is run.
+     * @param sourcePath The source path before the recipe is run.
      * @return This source spec.
      */
     public SourceSpec<T> path(Path sourcePath) {
@@ -115,7 +115,7 @@ public class SourceSpec<T extends SourceFile> implements SourceSpecs {
     }
 
     /**
-     * @param sourcePath The source path after the recipe is run.
+     * @param sourcePath The source path before the recipe is run.
      * @return This source spec.
      */
     public SourceSpec<T> path(String sourcePath) {


### PR DESCRIPTION
## What's changed?
`ChangeClassDefinition` in `ChangeType` previously changed package declaration of sibling types, this PR restricts these to only the classes that should actually be changed

## What's your motivation?
Closes https://github.com/openrewrite/rewrite/issues/4182

## Anything in particular you'd like reviewers to focus on?
~~I'm not exactly sure as to whether this is the proper way to do it (tracking required modification in JavaSourceFile visits), but at the very least this should show what the root cause is. And I suppose this breaks the immutability rule~~ should be addressed now

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
