### PR TITLE
bug: Handle NoClassDefFoundError when loading YAML recipes with missing recipe dependencies

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -278,28 +278,42 @@ public class YamlResourceLoader implements ResourceLoader {
             }
         } else if (recipeData instanceof Map) {
             Map.Entry<String, Object> nameAndConfig = ((Map<String, Object>) recipeData).entrySet().iterator().next();
+            String recipeName = nameAndConfig.getKey();
+            Object recipeArgs = nameAndConfig.getValue();
             try {
-                if (nameAndConfig.getValue() instanceof Map) {
+                if (recipeArgs instanceof Map) {
                     try {
-                        addRecipe.accept(instantiateRecipe(nameAndConfig.getKey(),
-                                (Map<String, Object>) nameAndConfig.getValue()));
+                        addRecipe.accept(instantiateRecipe(recipeName, (Map<String, Object>) recipeArgs));
                     } catch (IllegalArgumentException e) {
                         if (e.getCause() instanceof InvalidTypeIdException) {
-                            addValidation.accept(Validated.invalid(nameAndConfig.getKey(),
-                                    nameAndConfig.getValue(), "Recipe class " +
-                                                              nameAndConfig.getKey() + " cannot be found"));
+                            addValidation.accept(
+                                    Validated.invalid(
+                                            recipeName,
+                                            recipeArgs,
+                                            "Recipe class " + recipeName + " cannot be found"));
                         } else {
-                            addValidation.accept(Validated.invalid(nameAndConfig.getKey(), nameAndConfig.getValue(),
-                                    "Unable to load Recipe: " + e));
+                            addValidation.accept(
+                                    Validated.invalid(
+                                            recipeName,
+                                            recipeArgs,
+                                            "Unable to load Recipe: " + e));
                         }
+                    } catch (NoClassDefFoundError e) {
+                        addValidation.accept(
+                                Validated.invalid(
+                                        recipeName,
+                                        recipeArgs,
+                                        "Recipe class " + nameAndConfig.getKey() + " cannot be found"));
                     }
                 } else {
-                    addValidation.accept(Validated.invalid(nameAndConfig.getKey(),
-                            nameAndConfig.getValue(),
-                            "Declarative recipeList entries are expected to be strings or mappings"));
+                    addValidation.accept(
+                            Validated.invalid(
+                                recipeName,
+                                recipeArgs,
+                                "Declarative recipeList entries are expected to be strings or mappings"));
                 }
             } catch (Exception e) {
-                addValidation.accept(Validated.invalid(nameAndConfig.getKey(), nameAndConfig.getValue(),
+                addValidation.accept(Validated.invalid(recipeName, recipeArgs,
                         "Unexpected declarative recipe parsing exception " +
                         e.getClass().getName()));
             }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -116,7 +116,10 @@ public class YamlResourceLoader implements ResourceLoader {
      * @param classLoader Optional classloader to use with jackson. If not specified, the runtime classloader will be used.
      * @throws UncheckedIOException On unexpected IOException
      */
-    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties, @Nullable ClassLoader classLoader) throws UncheckedIOException {
+    public YamlResourceLoader(InputStream yamlInput,
+                              URI source,
+                              Properties properties,
+                              @Nullable ClassLoader classLoader) throws UncheckedIOException {
         this(yamlInput, source, properties, classLoader, emptyList());
     }
 
@@ -130,7 +133,11 @@ public class YamlResourceLoader implements ResourceLoader {
      * @param classLoader Optional classloader to use with jackson. If not specified, the runtime classloader will be used.
      * @throws UncheckedIOException On unexpected IOException
      */
-    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties, @Nullable ClassLoader classLoader, Collection<? extends ResourceLoader> dependencyResourceLoaders) throws UncheckedIOException {
+    public YamlResourceLoader(InputStream yamlInput,
+                              URI source,
+                              Properties properties,
+                              @Nullable ClassLoader classLoader,
+                              Collection<? extends ResourceLoader> dependencyResourceLoaders) throws UncheckedIOException {
         this.source = source;
         this.dependencyResourceLoaders = dependencyResourceLoaders;
 
@@ -228,20 +235,39 @@ public class YamlResourceLoader implements ResourceLoader {
                     }
                 }
             }
-            DeclarativeRecipe recipe = new DeclarativeRecipe(name, displayName, description, tags,
-                    estimatedEffortPerOccurrence, source, (boolean) r.getOrDefault("causesAnotherCycle", false), maintainers);
+            DeclarativeRecipe recipe = new DeclarativeRecipe(
+                    name,
+                    displayName,
+                    description,
+                    tags,
+                    estimatedEffortPerOccurrence,
+                    source,
+                    (boolean) r.getOrDefault("causesAnotherCycle", false),
+                    maintainers);
 
             List<Object> recipeList = (List<Object>) r.get("recipeList");
             if (recipeList == null) {
                 throw new RecipeException("Invalid Recipe [" + name + "] recipeList is null");
             }
             for (int i = 0; i < recipeList.size(); i++) {
-                loadRecipe(name, i, recipeList.get(i), recipe::addUninitialized, recipe::addUninitialized, recipe::addValidation);
+                loadRecipe(
+                        name,
+                        i,
+                        recipeList.get(i),
+                        recipe::addUninitialized,
+                        recipe::addUninitialized,
+                        recipe::addValidation);
             }
             List<Object> preconditions = (List<Object>) r.get("preconditions");
-            if(preconditions != null) {
+            if (preconditions != null) {
                 for (int i = 0; i < preconditions.size(); i++) {
-                    loadRecipe(name, i, preconditions.get(i), recipe::addUninitializedPrecondition, recipe::addUninitializedPrecondition, recipe::addValidation);
+                    loadRecipe(
+                            name,
+                            i,
+                            preconditions.get(i),
+                            recipe::addUninitializedPrecondition,
+                            recipe::addUninitializedPrecondition,
+                            recipe::addValidation);
                 }
             }
             recipe.setContributors(contributors.get(recipe.getName()));
@@ -253,11 +279,11 @@ public class YamlResourceLoader implements ResourceLoader {
 
     @SuppressWarnings("unchecked")
     void loadRecipe(@Language("markdown") String name,
-                            int i,
-                            Object recipeData,
-                            Consumer<String> addLazyLoadRecipe,
-                            Consumer<Recipe> addRecipe,
-                            Consumer<Validated<Object>> addValidation) {
+                    int i,
+                    Object recipeData,
+                    Consumer<String> addLazyLoadRecipe,
+                    Consumer<Recipe> addRecipe,
+                    Consumer<Validated<Object>> addValidation) {
         if (recipeData instanceof String) {
             String recipeName = (String) recipeData;
             try {
@@ -266,14 +292,20 @@ public class YamlResourceLoader implements ResourceLoader {
                                 classLoader == null ? this.getClass().getClassLoader() : classLoader)
                         .getDeclaredConstructor()
                         .newInstance());
-            } catch (ReflectiveOperationException | NoClassDefFoundError e) {
+            } catch (ReflectiveOperationException e) {
                 try {
                     // then try jackson
                     addRecipe.accept(instantiateRecipe(recipeName, new HashMap<>()));
-                } catch (IllegalArgumentException | NoClassDefFoundError ee) {
+                } catch (IllegalArgumentException ignored) {
                     // else, it's probably declarative
                     addLazyLoadRecipe.accept(recipeName);
                 }
+            } catch (NoClassDefFoundError e) {
+                addInvalidRecipeValidation(
+                        addValidation,
+                        recipeName,
+                        null,
+                        "Recipe class " + recipeName + " cannot be found");
             }
         } else if (recipeData instanceof Map) {
             Map.Entry<String, Object> nameAndConfig = ((Map<String, Object>) recipeData).entrySet().iterator().next();
@@ -285,36 +317,38 @@ public class YamlResourceLoader implements ResourceLoader {
                         addRecipe.accept(instantiateRecipe(recipeName, (Map<String, Object>) recipeArgs));
                     } catch (IllegalArgumentException e) {
                         if (e.getCause() instanceof InvalidTypeIdException) {
-                            addValidation.accept(
-                                    Validated.invalid(
-                                            recipeName,
-                                            recipeArgs,
-                                            "Recipe class " + recipeName + " cannot be found"));
+                            addInvalidRecipeValidation(
+                                    addValidation,
+                                    recipeName,
+                                    recipeArgs,
+                                    "Recipe class " + recipeName + " cannot be found");
                         } else {
-                            addValidation.accept(
-                                    Validated.invalid(
-                                            recipeName,
-                                            recipeArgs,
-                                            "Unable to load Recipe: " + e));
+                            addInvalidRecipeValidation(
+                                    addValidation,
+                                    recipeName,
+                                    recipeArgs,
+                                    "Unable to load Recipe: " + e);
                         }
                     } catch (NoClassDefFoundError e) {
-                        addValidation.accept(
-                                Validated.invalid(
-                                        recipeName,
-                                        recipeArgs,
-                                        "Recipe class " + nameAndConfig.getKey() + " cannot be found"));
-                    }
-                } else {
-                    addValidation.accept(
-                            Validated.invalid(
+                        addInvalidRecipeValidation(
+                                addValidation,
                                 recipeName,
                                 recipeArgs,
-                                "Declarative recipeList entries are expected to be strings or mappings"));
+                                "Recipe class " + nameAndConfig.getKey() + " cannot be found");
+                    }
+                } else {
+                    addInvalidRecipeValidation(
+                            addValidation,
+                            recipeName,
+                            recipeArgs,
+                            "Declarative recipeList entries are expected to be strings or mappings");
                 }
             } catch (Exception e) {
-                addValidation.accept(Validated.invalid(recipeName, recipeArgs,
-                        "Unexpected declarative recipe parsing exception " +
-                        e.getClass().getName()));
+                addInvalidRecipeValidation(
+                        addValidation,
+                        recipeName,
+                        recipeArgs,
+                        "Unexpected declarative recipe parsing exception " + e.getClass().getName());
             }
         } else {
             addValidation.accept(invalid(
@@ -329,6 +363,11 @@ public class YamlResourceLoader implements ResourceLoader {
         Map<Object, Object> withJsonType = new HashMap<>(args);
         withJsonType.put("@c", recipeName);
         return mapper.convertValue(withJsonType, Recipe.class);
+    }
+
+    private void addInvalidRecipeValidation(Consumer<Validated<Object>> addValidation, String recipeName,
+                                            Object recipeArgs, String message) {
+        addValidation.accept(Validated.invalid(recipeName, recipeArgs, message));
     }
 
     @Override
@@ -377,7 +416,13 @@ public class YamlResourceLoader implements ResourceLoader {
                     if (rawTags != null) {
                         tags = new HashSet<>(rawTags);
                     }
-                    DeclarativeNamedStyles namedStyles = new DeclarativeNamedStyles(randomId(), name, displayName, description, tags, styles);
+                    DeclarativeNamedStyles namedStyles = new DeclarativeNamedStyles(
+                            randomId(),
+                            name,
+                            displayName,
+                            description,
+                            tags,
+                            styles);
                     List<Object> styleConfigs = (List<Object>) s.get("styleConfigs");
                     if (styleConfigs != null) {
                         for (int i = 0; i < styleConfigs.size(); i++) {
@@ -385,7 +430,9 @@ public class YamlResourceLoader implements ResourceLoader {
                             if (next instanceof String) {
                                 String styleClassName = (String) next;
                                 try {
-                                    styles.add((Style) Class.forName(styleClassName).getDeclaredConstructor().newInstance());
+                                    styles.add((Style) Class.forName(styleClassName)
+                                            .getDeclaredConstructor()
+                                            .newInstance());
                                 } catch (Exception e) {
                                     namedStyles.addValidation(invalid(
                                             name + ".styleConfigs[" + i + "] (in " + source + ")",
@@ -394,7 +441,9 @@ public class YamlResourceLoader implements ResourceLoader {
                                             e));
                                 }
                             } else if (next instanceof Map) {
-                                Map.Entry<String, Object> nameAndConfig = ((Map<String, Object>) next).entrySet().iterator().next();
+                                Map.Entry<String, Object> nameAndConfig = ((Map<String, Object>) next).entrySet()
+                                        .iterator()
+                                        .next();
                                 try {
                                     Map<Object, Object> withJsonType = new HashMap<>((Map<String, Object>) nameAndConfig.getValue());
                                     withJsonType.put("@c", nameAndConfig.getKey());
@@ -433,7 +482,7 @@ public class YamlResourceLoader implements ResourceLoader {
                     @Language("markdown")
                     String packageName = (String) c.get("packageName");
                     if (packageName.endsWith("." + CategoryTree.CORE) ||
-                        packageName.contains("." + CategoryTree.CORE + ".")) {
+                            packageName.contains("." + CategoryTree.CORE + ".")) {
                         throw new IllegalArgumentException("The package name 'core' is reserved.");
                     }
 
@@ -527,7 +576,8 @@ public class YamlResourceLoader implements ResourceLoader {
                     String recipeName = (String) attribution.get("recipeName");
 
                     //noinspection unchecked
-                    List<Map<String, Object>> rawContributors = (List<Map<String, Object>>) attribution.get("contributors");
+                    List<Map<String, Object>> rawContributors = (List<Map<String, Object>>) attribution.get(
+                            "contributors");
                     List<Contributor> contributors = new ArrayList<>(rawContributors.size());
                     for (Map<String, Object> rawContributor : rawContributors) {
                         contributors.add(new Contributor(

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -252,7 +252,7 @@ public class YamlResourceLoader implements ResourceLoader {
     }
 
     @SuppressWarnings("unchecked")
-    private void loadRecipe(@Language("markdown") String name,
+    void loadRecipe(@Language("markdown") String name,
                             int i,
                             Object recipeData,
                             Consumer<String> addLazyLoadRecipe,
@@ -261,17 +261,16 @@ public class YamlResourceLoader implements ResourceLoader {
         if (recipeData instanceof String) {
             String recipeName = (String) recipeData;
             try {
-
                 // first try an explicitly-declared zero-arg constructor
                 addRecipe.accept((Recipe) Class.forName(recipeName, true,
                                 classLoader == null ? this.getClass().getClassLoader() : classLoader)
                         .getDeclaredConstructor()
                         .newInstance());
-            } catch (ReflectiveOperationException reflectiveOperationException) {
+            } catch (ReflectiveOperationException | NoClassDefFoundError e) {
                 try {
                     // then try jackson
                     addRecipe.accept(instantiateRecipe(recipeName, new HashMap<>()));
-                } catch (IllegalArgumentException illegalArgumentException) {
+                } catch (IllegalArgumentException | NoClassDefFoundError ee) {
                     // else, it's probably declarative
                     addLazyLoadRecipe.accept(recipeName);
                 }

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -177,7 +177,10 @@ class YamlResourceLoaderTest implements RewriteTest {
         Collection<Recipe> recipes = env.listRecipes();
         assertThat(recipes).hasSize(1);
         Recipe recipe = recipes.iterator().next();
-        Optional<Contributor> maybeJon = recipe.getContributors().stream().filter(c -> c.getName().equals("Jonathan Schneider")).findFirst();
+        Optional<Contributor> maybeJon = recipe.getContributors()
+          .stream()
+          .filter(c -> c.getName().equals("Jonathan Schneider"))
+          .findFirst();
         assertThat(maybeJon).isPresent();
     }
 
@@ -240,15 +243,15 @@ class YamlResourceLoaderTest implements RewriteTest {
             assertThat(r.getExamples()).first().satisfies(e -> {
                 assertThat(e.getDescription()).isEqualTo("Change World to Hello in a text file");
                 assertThat(e.getSources()).hasSize(2);
-                assertThat(e.getSources()).first().satisfies( s -> {
-                    assertThat(s.getBefore()).isEqualTo("World");
-                    assertThat(s.getAfter()).isEqualTo("Hello!");
-                    assertThat(s.getPath()).isEqualTo("1.txt");
-                    assertThat(s.getLanguage()).isEqualTo("text");
+                assertThat(e.getSources()).first().satisfies(s -> {
+                      assertThat(s.getBefore()).isEqualTo("World");
+                      assertThat(s.getAfter()).isEqualTo("Hello!");
+                      assertThat(s.getPath()).isEqualTo("1.txt");
+                      assertThat(s.getLanguage()).isEqualTo("text");
                   }
                 );
 
-                assertThat(e.getSources().get(1)).satisfies( s -> {
+                assertThat(e.getSources().get(1)).satisfies(s -> {
                       assertThat(s.getBefore()).isEqualTo("World 2");
                       assertThat(s.getAfter()).isEqualTo("Hello 2!");
                       assertThat(s.getPath()).isEqualTo("2.txt");
@@ -264,7 +267,7 @@ class YamlResourceLoaderTest implements RewriteTest {
                 assertThat(e.getParameters().get(1)).isEqualTo("1");
 
                 assertThat(e.getSources()).hasSize(1);
-                assertThat(e.getSources()).first().satisfies( s -> {
+                assertThat(e.getSources()).first().satisfies(s -> {
                     //language=java
                     assertThat(s.getBefore()).isEqualTo("""
                       public class A {
@@ -329,8 +332,10 @@ class YamlResourceLoaderTest implements RewriteTest {
           0,
           RecipeWithBadStaticInitializer.class.getName(),
           recipe -> lazyLoadRecipes.add(recipe),
-          recipe -> {},
-          validated -> {});
+          recipe -> {
+          },
+          validated -> {
+          });
 
         assertEquals(1, lazyLoadRecipes.size());
         assertEquals(RecipeWithBadStaticInitializer.class.getName(), lazyLoadRecipes.get(0));
@@ -342,26 +347,28 @@ class YamlResourceLoaderTest implements RewriteTest {
         YamlResourceLoader resourceLoader = createYamlResourceLoader();
 
         resourceLoader.loadRecipe(
-            "org.company.CustomRecipe",
-            0,
-            Map.of(RecipeWithBadStaticInitializer.class.getName(), Map.of()),
-            recipe -> {},
-            recipe -> {},
-            validated -> invalidRecipes.add(validated));
+          "org.company.CustomRecipe",
+          0,
+          Map.of(RecipeWithBadStaticInitializer.class.getName(), Map.of()),
+          recipe -> {
+          },
+          recipe -> {
+          },
+          validated -> invalidRecipes.add(validated));
 
         assertEquals(1, invalidRecipes.size());
     }
 
     private YamlResourceLoader createYamlResourceLoader() {
         return new YamlResourceLoader(
-                new ByteArrayInputStream("type: specs.openrewrite.org/v1beta/recipe" .getBytes()),
-                URI.create("rewrite.yml"),
-                new Properties());
+          new ByteArrayInputStream("type: specs.openrewrite.org/v1beta/recipe" .getBytes()),
+          URI.create("rewrite.yml"),
+          new Properties());
     }
 
     private static class RecipeWithBadStaticInitializer extends Recipe {
         // Explicitly fail static initialization
-        static int val = 1/0;
+        static int val = 1 / 0;
 
         @Override
         public String getDisplayName() {

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -324,32 +324,24 @@ class YamlResourceLoaderTest implements RewriteTest {
 
     @Test
     void loadRecipeWithRecipeDataStringThatThrowsNoClassDefFoundError() {
-        final List<String> lazyLoadRecipes = new ArrayList<>();
-        YamlResourceLoader resourceLoader = createYamlResourceLoader();
-
-        resourceLoader.loadRecipe(
-          "org.company.CustomRecipe",
-          0,
-          RecipeWithBadStaticInitializer.class.getName(),
-          recipe -> lazyLoadRecipes.add(recipe),
-          recipe -> {
-          },
-          validated -> {
-          });
-
-        assertEquals(1, lazyLoadRecipes.size());
-        assertEquals(RecipeWithBadStaticInitializer.class.getName(), lazyLoadRecipes.get(0));
+        assertRecipeWithRecipeDataThatThrowsNoClassDefFoundError(
+          RecipeWithBadStaticInitializer.class.getName());
     }
 
     @Test
     void loadRecipeWithRecipeDataMapThatThrowsNoClassDefFoundError() {
+        assertRecipeWithRecipeDataThatThrowsNoClassDefFoundError(
+          Map.of(RecipeWithBadStaticInitializer.class.getName(), Map.of()));
+    }
+
+    private void assertRecipeWithRecipeDataThatThrowsNoClassDefFoundError(Object recipeData) {
         final List<Validated<Object>> invalidRecipes = new ArrayList<>();
         YamlResourceLoader resourceLoader = createYamlResourceLoader();
 
         resourceLoader.loadRecipe(
           "org.company.CustomRecipe",
           0,
-          Map.of(RecipeWithBadStaticInitializer.class.getName(), Map.of()),
+          recipeData,
           recipe -> {
           },
           recipe -> {
@@ -361,7 +353,7 @@ class YamlResourceLoaderTest implements RewriteTest {
 
     private YamlResourceLoader createYamlResourceLoader() {
         return new YamlResourceLoader(
-          new ByteArrayInputStream("type: specs.openrewrite.org/v1beta/recipe" .getBytes()),
+          new ByteArrayInputStream("type: specs.openrewrite.org/v1beta/recipe".getBytes()),
           URI.create("rewrite.yml"),
           new Properties());
     }


### PR DESCRIPTION

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added logic to catch NoClassDefFoundError errors when loading YAML recipes with missing recipe dependencies

## What's your motivation?
NoClassDefFoundError errors were previously not handled compromising troubleshooting.

## Anything in particular you'd like reviewers to focus on?
Potential for regressed behaviour.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
