### PR TITLE
org.openrewrite.java.ChangePackage precise package match

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -400,6 +400,7 @@ class ChangePackageTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/4189")
     void renamePackageNullRecursiveImportedCheckStrictPackageMatch() {
         rewriteRun(
           spec -> spec.recipe(new ChangePackage(
@@ -457,6 +458,7 @@ class ChangePackageTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/4189")
     void renamePackageImportedCheckStrictPackageMatch() {
         rewriteRun(
           spec -> spec.recipe(new ChangePackage(
@@ -514,6 +516,7 @@ class ChangePackageTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/4189")
     void renamePackageRecursiveImportedStrictPackageMatch() {
         rewriteRun(
           spec -> spec.recipe(new ChangePackage(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -399,6 +399,177 @@ class ChangePackageTest implements RewriteTest {
         );
     }
 
+    @Test
+    void renamePackageNullRecursiveImportedCheckStrictPackageMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackage(
+            "org.openrewrite.other",
+            "org.openrewrite.test.other",
+            null
+          )),
+          java(
+            """
+              package org.openrewrite.other;
+              public class Test {}
+              """,
+            """
+              package org.openrewrite.test.other;
+              public class Test {}
+              """
+          ),
+          java(
+            """
+              package org.openrewrite.otherone;
+              public class OtherTest {}
+              """
+          ),
+          java(
+            """
+              import org.openrewrite.otherone.OtherTest;
+              class B {
+                  OtherTest test = null;
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.otherone.OtherTest")).isNotEmpty();
+                assertThat(cu.findType("org.openrewrite.test.otherone.OtherTest")).isEmpty();
+            })
+          ),
+          java(
+            """
+              import org.openrewrite.other.Test;
+              class A {
+                  Test test = null;
+              }
+              """,
+            """
+              import org.openrewrite.test.other.Test;
+              class A {
+                  Test test = null;
+              }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.other.Test")).isEmpty();
+                assertThat(cu.findType("org.openrewrite.test.other.Test")).isNotEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void renamePackageImportedCheckStrictPackageMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackage(
+            "org.openrewrite.other",
+            "org.openrewrite.test.other",
+            false
+          )),
+          java(
+            """
+              package org.openrewrite.other;
+              public class Test {}
+              """,
+            """
+              package org.openrewrite.test.other;
+              public class Test {}
+              """
+          ),
+          java(
+            """
+              package org.openrewrite.otherone;
+              public class OtherTest {}
+              """
+          ),
+          java(
+            """
+              import org.openrewrite.otherone.OtherTest;
+              class B {
+                  OtherTest test = null;
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.otherone.OtherTest")).isNotEmpty();
+                assertThat(cu.findType("org.openrewrite.test.otherone.OtherTest")).isEmpty();
+            })
+          ),
+          java(
+            """
+              import org.openrewrite.other.Test;
+              class A {
+                  Test test = null;
+              }
+              """,
+            """
+              import org.openrewrite.test.other.Test;
+              class A {
+                  Test test = null;
+              }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.other.Test")).isEmpty();
+                assertThat(cu.findType("org.openrewrite.test.other.Test")).isNotEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void renamePackageRecursiveImportedStrictPackageMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackage(
+            "org.openrewrite.other",
+            "org.openrewrite.test.other",
+            true
+          )),
+          java(
+            """
+              package org.openrewrite.other;
+              public class Test {}
+              """,
+            """
+              package org.openrewrite.test.other;
+              public class Test {}
+              """
+          ),
+          java(
+            """
+              package org.openrewrite.otherone;
+              public class OtherTest {}
+              """
+          ),
+          java(
+            """
+              import org.openrewrite.otherone.OtherTest;
+              class B {
+                  OtherTest test = null;
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.otherone.OtherTest")).isNotEmpty();
+                assertThat(cu.findType("org.openrewrite.test.otherone.OtherTest")).isEmpty();
+            })
+          ),
+          java(
+            """
+              import org.openrewrite.other.Test;
+              class A {
+                  Test test = null;
+              }
+              """,
+            """
+              import org.openrewrite.test.other.Test;
+              class A {
+                  Test test = null;
+              }
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(cu.findType("org.openrewrite.other.Test")).isEmpty();
+                assertThat(cu.findType("org.openrewrite.test.other.Test")).isNotEmpty();
+            })
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1997")
     @Test
     void typeParameter() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -339,7 +339,12 @@ public class ChangePackage extends Recipe {
         }
 
         private boolean isTargetRecursivePackageName(String packageName) {
-            return (recursive == null || recursive) && packageName.startsWith(oldPackageName) && !packageName.startsWith(newPackageName);
+            String oldRecursivePackageName = oldPackageName + ".";
+
+            return (recursive == null || recursive)
+                   && packageName.startsWith(oldRecursivePackageName)
+                   && !packageName.startsWith(newPackageName);
         }
+
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -339,10 +339,8 @@ public class ChangePackage extends Recipe {
         }
 
         private boolean isTargetRecursivePackageName(String packageName) {
-            String oldRecursivePackageName = oldPackageName + ".";
-
             return (recursive == null || recursive)
-                   && packageName.startsWith(oldRecursivePackageName)
+                   && packageName.startsWith(oldPackageName + ".")
                    && !packageName.startsWith(newPackageName);
         }
 


### PR DESCRIPTION
The mistake was in `isTargetRecursivePackageName(String packageName)` not in package name match in `preVisit(..)`

When I tried to fix matching condition I found that `typeInNestedPackageInheritingFromTypeInBasePackage` test fails and then I found this

Fixes #4188
- #4188