### PR TITLE
Added gradle recipe to remove enableFeaturePreview method

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
@@ -1,0 +1,69 @@
+package org.openrewrite.gradle;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.MethodInvocation;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RemoveEnableFeaturePreview extends Recipe {
+
+  private static final String ENABLE_FEATURE_PREVIEW_METHOD_NAME = "enableFeaturePreview";
+
+  @Option(displayName = "The feature preview name",
+      description = "The name of the feature preview to remove.",
+      example = "ONE_LOCKFILE_PER_PROJECT"
+  )
+  public String previewFeatureName;
+
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Remove a Gradle enableFeaturePreview method";
+  }
+
+  @Override
+  public @NotNull String getDescription() {
+    return "Remove a Gradle enableFeaturePreview method from settings.gradle / settings.gradle.kts.";
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor() {
+    return Preconditions.check(
+        new IsSettingsGradle<>(),
+        new RemoveEnableFeaturePreviewVisitor());
+  }
+
+  public class RemoveEnableFeaturePreviewVisitor extends GroovyIsoVisitor<ExecutionContext> {
+
+    @Override
+    public MethodInvocation visitMethodInvocation(MethodInvocation method,
+        @NotNull ExecutionContext executionContext) {
+      if (ENABLE_FEATURE_PREVIEW_METHOD_NAME.equals(method.getSimpleName())) {
+        List<Expression> arguments = method.getArguments();
+        for (Expression argument : arguments) {
+          if (argument instanceof J.Literal) {
+            String candidatePreviewFeatureName = ((J.Literal) argument).getValue().toString();
+            // Remove leading and trailing single or double quotes.
+            candidatePreviewFeatureName = candidatePreviewFeatureName.substring(0,
+                candidatePreviewFeatureName.length());
+            if (candidatePreviewFeatureName.equals(previewFeatureName)) {
+              return null;
+            }
+          }
+        }
+      }
+      return method;
+    }
+  }
+
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
@@ -28,7 +28,7 @@ public class RemoveEnableFeaturePreview extends Recipe {
 
   @Override
   public @NotNull String getDisplayName() {
-    return "Remove a Gradle enableFeaturePreview method";
+    return "Remove an enabled Gradle preview feature";
   }
 
   @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
@@ -33,7 +33,7 @@ public class RemoveEnableFeaturePreview extends Recipe {
 
   @Override
   public @NotNull String getDescription() {
-    return "Remove a Gradle enableFeaturePreview method from settings.gradle / settings.gradle.kts.";
+    return "Remove an enabled Gradle preview feature from `settings.gradle`.";
   }
 
   @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveEnableFeaturePreview.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.gradle;
 
 import java.util.List;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -22,6 +22,13 @@ import org.openrewrite.test.RewriteTest;
 public class RemoveEnableFeaturePreviewTest implements RewriteTest {
 
     @Test
+    void testFail() {
+        org.junit.jupiter.api.Assertions.assertTrue(false,
+          "Tested this recipe manually by publishing to maven local and used it in a local project, "
+            + "doesn't seem to be working, so failing the build for now so it won't get merged yet");
+    }
+
+    @Test
     void testRemoveEnableFeaturePreviewMethodRecipe_singleQuotes() {
         //language=gradle
         rewriteRun(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -1,0 +1,121 @@
+package org.openrewrite.gradle;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+public class RemoveEnableFeaturePreviewTest implements RewriteTest {
+
+    @Test
+    void testRemoveEnableFeaturePreviewMethodRecipe_singleQuotes() {
+        //language=gradle
+        rewriteRun(
+          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
+          Assertions.settingsGradle(
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                              
+                rootProject.name = 'merge-service'
+                enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
+              """,
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                              
+                rootProject.name = 'merge-service'
+              """,
+            spec -> spec.path(Paths.get("settings.gradle"))
+          )
+        );
+    }
+
+    @Test
+    void testRemoveEnableFeaturePreviewMethodRecipe_doubleQuotes() {
+        //language=gradle
+        rewriteRun(
+          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
+          Assertions.settingsGradle(
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                              
+                rootProject.name = 'merge-service'
+                enableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")
+                              
+                include 'service'
+              """,
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                              
+                rootProject.name = 'merge-service'
+                              
+                include 'service'
+              """,
+            spec -> spec.path(Paths.get("settings.gradle"))
+          )
+        );
+    }
+
+    @Test
+    void testRemoveEnableFeaturePreviewMethodRecipe_noChange() {
+        //language=gradle
+        rewriteRun(
+          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
+          Assertions.settingsGradle(
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                
+                enableFeaturePreview("DIFFERENT_FEATURE")
+                              
+                rootProject.name = 'merge-service'
+                              
+                include 'service'
+              """,
+            spec -> spec.path(Paths.get("settings.gradle"))
+          )
+        );
+    }
+
+    @Test
+    void testRemoveEnableFeaturePreviewMethodRecipe_noChangeNullArgument() {
+        //language=gradle
+        rewriteRun(
+          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
+          Assertions.settingsGradle(
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                
+                enableFeaturePreview()
+                              
+                rootProject.name = 'merge-service'
+                              
+                include 'service'
+              """,
+            spec -> spec.path(Paths.get("settings.gradle"))
+          )
+        );
+    }
+
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.gradle;
 
 import java.nio.file.Paths;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -22,13 +22,6 @@ import org.openrewrite.test.RewriteTest;
 public class RemoveEnableFeaturePreviewTest implements RewriteTest {
 
     @Test
-    void testFail() {
-        org.junit.jupiter.api.Assertions.assertTrue(false,
-          "Tested this recipe manually by publishing to maven local and used it in a local project, "
-            + "doesn't seem to be working, so failing the build for now so it won't get merged yet");
-    }
-
-    @Test
     void testRemoveEnableFeaturePreviewMethodRecipe_singleQuotes() {
         //language=gradle
         rewriteRun(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -15,25 +15,32 @@
  */
 package org.openrewrite.gradle;
 
-import java.nio.file.Paths;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-public class RemoveEnableFeaturePreviewTest implements RewriteTest {
+import static org.openrewrite.gradle.Assertions.settingsGradle;
+
+class RemoveEnableFeaturePreviewTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT"));
+    }
 
     @Test
-    void testRemoveEnableFeaturePreviewMethodRecipe_singleQuotes() {
+    void singleQuotes() {
         //language=gradle
         rewriteRun(
-          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
-          Assertions.settingsGradle(
+          settingsGradle(
             """
                 pluginManagement {
                     repositories {
                         gradlePluginPortal()
                     }
                 }
-                              
+              
                 rootProject.name = 'merge-service'
                 enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
               """,
@@ -43,118 +50,111 @@ public class RemoveEnableFeaturePreviewTest implements RewriteTest {
                         gradlePluginPortal()
                     }
                 }
-                              
+              
                 rootProject.name = 'merge-service'
-              """,
-            spec -> spec.path(Paths.get("settings.gradle"))
+              """
           )
         );
     }
 
     @Test
-    void testRemoveEnableFeaturePreviewMethodRecipe_doubleQuotes() {
+    void doubleQuotes() {
         //language=gradle
         rewriteRun(
-          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
-          Assertions.settingsGradle(
+          settingsGradle(
             """
-                pluginManagement {
-                    repositories {
-                        gradlePluginPortal()
-                    }
-                }
-                              
-                rootProject.name = 'merge-service'
-                enableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")
-                              
-                include 'service'
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+              
+              rootProject.name = 'merge-service'
+              enableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")
+              
+              include 'service'
               """,
             """
-                pluginManagement {
-                    repositories {
-                        gradlePluginPortal()
-                    }
-                }
-                              
-                rootProject.name = 'merge-service'
-                              
-                include 'service'
-              """,
-            spec -> spec.path(Paths.get("settings.gradle"))
+              pluginManagement {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+              }
+              
+              rootProject.name = 'merge-service'
+              
+              include 'service'
+              """
           )
         );
     }
 
-    @Test
-    void testRemoveEnableFeaturePreviewMethodRecipe_noChange() {
-        //language=gradle
-        rewriteRun(
-          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
-          Assertions.settingsGradle(
-            """
-                pluginManagement {
-                    repositories {
-                        gradlePluginPortal()
-                    }
-                }
-                
-                enableFeaturePreview("DIFFERENT_FEATURE")
-                              
-                rootProject.name = 'merge-service'
-                              
-                include 'service'
-              """,
-            spec -> spec.path(Paths.get("settings.gradle"))
-          )
-        );
-    }
+    @Nested
+    class NoChange {
+        @Test
+        void differentFeature() {
+            //language=gradle
+            rewriteRun(
+              settingsGradle(
+                """
+                  pluginManagement {
+                      repositories {
+                          gradlePluginPortal()
+                      }
+                  }
+                  
+                  enableFeaturePreview("DIFFERENT_FEATURE")
+                  
+                  rootProject.name = 'merge-service'
+                  
+                  include 'service'
+                  """
+              )
+            );
+        }
 
-    @Test
-    void testRemoveEnableFeaturePreviewMethodRecipe_noChangeNoArgument() {
-        //language=gradle
-        rewriteRun(
-          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
-          Assertions.settingsGradle(
-            """
-                pluginManagement {
-                    repositories {
-                        gradlePluginPortal()
-                    }
-                }
-                
-                enableFeaturePreview()
-                              
-                rootProject.name = 'merge-service'
-                              
-                include 'service'
-              """,
-            spec -> spec.path(Paths.get("settings.gradle"))
-          )
-        );
-    }
+        @Test
+        void noArgument() {
+            //language=gradle
+            rewriteRun(
+              settingsGradle(
+                """
+                  pluginManagement {
+                      repositories {
+                          gradlePluginPortal()
+                      }
+                  }
+                  
+                  enableFeaturePreview()
+                  
+                  rootProject.name = 'merge-service'
+                  
+                  include 'service'
+                  """
+              )
+            );
+        }
 
-    @Test
-    void testRemoveEnableFeaturePreviewMethodRecipe_noChangeNullArgument() {
-        //language=gradle
-        rewriteRun(
-          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
-          Assertions.settingsGradle(
-            """
-                pluginManagement {
-                    repositories {
-                        gradlePluginPortal()
-                    }
-                }
-                
-                enableFeaturePreview(null)
-                              
-                rootProject.name = 'merge-service'
-                              
-                include 'service'
-              """,
-            spec -> spec.path(Paths.get("settings.gradle"))
-          )
-        );
+        @Test
+        void nullArgument() {
+            //language=gradle
+            rewriteRun(
+              settingsGradle(
+                """
+                  pluginManagement {
+                      repositories {
+                          gradlePluginPortal()
+                      }
+                  }
+                  
+                  enableFeaturePreview(null)
+                  
+                  rootProject.name = 'merge-service'
+                  
+                  include 'service'
+                  """
+              )
+            );
+        }
     }
-
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -95,7 +95,7 @@ public class RemoveEnableFeaturePreviewTest implements RewriteTest {
     }
 
     @Test
-    void testRemoveEnableFeaturePreviewMethodRecipe_noChangeNullArgument() {
+    void testRemoveEnableFeaturePreviewMethodRecipe_noChangeNoArgument() {
         //language=gradle
         rewriteRun(
           spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
@@ -108,6 +108,30 @@ public class RemoveEnableFeaturePreviewTest implements RewriteTest {
                 }
                 
                 enableFeaturePreview()
+                              
+                rootProject.name = 'merge-service'
+                              
+                include 'service'
+              """,
+            spec -> spec.path(Paths.get("settings.gradle"))
+          )
+        );
+    }
+
+    @Test
+    void testRemoveEnableFeaturePreviewMethodRecipe_noChangeNullArgument() {
+        //language=gradle
+        rewriteRun(
+          spec -> spec.recipe(new RemoveEnableFeaturePreview("ONE_LOCKFILE_PER_PROJECT")),
+          Assertions.settingsGradle(
+            """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                    }
+                }
+                
+                enableFeaturePreview(null)
                               
                 rootProject.name = 'merge-service'
                               

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveEnableFeaturePreviewTest.java
@@ -114,28 +114,6 @@ class RemoveEnableFeaturePreviewTest implements RewriteTest {
         }
 
         @Test
-        void noArgument() {
-            //language=gradle
-            rewriteRun(
-              settingsGradle(
-                """
-                  pluginManagement {
-                      repositories {
-                          gradlePluginPortal()
-                      }
-                  }
-                  
-                  enableFeaturePreview()
-                  
-                  rootProject.name = 'merge-service'
-                  
-                  include 'service'
-                  """
-              )
-            );
-        }
-
-        @Test
         void nullArgument() {
             //language=gradle
             rewriteRun(


### PR DESCRIPTION
## What's changed?
Added a gradle recipe to remove the `enableFeaturePreview` method from `settings.gradle`.
Provide the feature to remove via a property.
A `rewrite.yml` file would include the recipe like this:
```
  - og.openrewrite.gradle.RemoveEnableFeaturePreview:
      previewFeatureName: ONE_LOCKFILE_PER_PROJECT

```
It would remove the following line from `settings.gradle`
```
enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
```

## What's your motivation?
I wrote this recipe for use at my company and was encouraged to contribute it here by @shanman190 and @timtebeek. Slack thread: https://rewriteoss.slack.com/archives/C01A843MWG5/p1715414946440599?thread_ts=1715381394.713129&cid=C01A843MWG5

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
