### PR TITLE
Fix bug adding import to a list of imports containing duplicate imports.

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -120,29 +120,18 @@ public class ImportLayoutStyle implements JavaStyle {
             return singletonList(paddedToAdd);
         }
 
+        // Do not add the import if it is already present.
+        String qualifiedName = paddedToAdd.getElement().getQualid().toString();
+        if (originalImports.stream().anyMatch(i -> qualifiedName.equals(i.getElement().getQualid().toString()))) {
+            return originalImports;
+        }
+
         // don't star fold just yet, because we are only going to star fold adjacent imports along with
         // the import to add at most. we don't even want to star fold other non-adjacent imports in the same
         // block that should be star folded according to the layout style (minimally invasive change).
         List<JRightPadded<J.Import>> ideallyOrdered =
                 new ImportLayoutStyle(Integer.MAX_VALUE, Integer.MAX_VALUE, layout, packagesToFold)
                         .orderImports(ListUtils.concat(originalImports, paddedToAdd), new HashSet<>());
-
-        if (ideallyOrdered.size() == originalImports.size()) {
-            Set<String> originalPaths = new HashSet<>();
-            for (JRightPadded<J.Import> originalImport : originalImports) {
-                originalPaths.add(originalImport.getElement().getTypeName());
-            }
-            int sharedImports = 0;
-            for (JRightPadded<J.Import> importJRightPadded : ideallyOrdered) {
-                if (originalPaths.contains(importJRightPadded.getElement().getTypeName())) {
-                    sharedImports++;
-                }
-            }
-            if (sharedImports == originalImports.size()) {
-                // must be a duplicate of an existing import
-                return originalImports;
-            }
-        }
 
         JRightPadded<J.Import> before = null;
         JRightPadded<J.Import> after = null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -123,7 +123,7 @@ public class ImportLayoutStyle implements JavaStyle {
         // Do not add the import if it is already present.
         JavaType addedType = paddedToAdd.getElement().getQualid().getType();
         for (JRightPadded<J.Import> originalImport : originalImports) {
-            if (TypeUtils.isOfType(addedType, originalImport.getElement().getQualid().getType())) {
+            if (addedType != null && TypeUtils.isOfType(addedType, originalImport.getElement().getQualid().getType())) {
                 return originalImports;
             }
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -122,8 +122,10 @@ public class ImportLayoutStyle implements JavaStyle {
 
         // Do not add the import if it is already present.
         String qualifiedName = paddedToAdd.getElement().getQualid().toString();
-        if (originalImports.stream().anyMatch(i -> qualifiedName.equals(i.getElement().getQualid().toString()))) {
-            return originalImports;
+        for (JRightPadded<J.Import> originalImport : originalImports) {
+            if (qualifiedName.equals(originalImport.getElement().getQualid().toString())) {
+                return originalImports;
+            }
         }
 
         // don't star fold just yet, because we are only going to star fold adjacent imports along with

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/ImportLayoutStyle.java
@@ -121,9 +121,9 @@ public class ImportLayoutStyle implements JavaStyle {
         }
 
         // Do not add the import if it is already present.
-        String qualifiedName = paddedToAdd.getElement().getQualid().toString();
+        JavaType addedType = paddedToAdd.getElement().getQualid().getType();
         for (JRightPadded<J.Import> originalImport : originalImports) {
-            if (qualifiedName.equals(originalImport.getElement().getQualid().toString())) {
+            if (TypeUtils.isOfType(addedType, originalImport.getElement().getQualid().getType())) {
                 return originalImports;
             }
         }

--- a/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.config.DeclarativeNamedStyles;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JLeftPadded;
@@ -89,7 +90,8 @@ class ImportLayoutStyleTest {
     }
 
     @Test
-    void testAddImport() {
+    @Issue("https://github.com/openrewrite/rewrite/issues/4196")
+    void addImportInPresenceOfDuplicateOtherImport() {
         ImportLayoutStyle style = new ImportLayoutStyle(
                 Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyList(), Collections.emptyList());
         JRightPadded<J.Import> import1 = new JRightPadded<>(

--- a/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/style/ImportLayoutStyleTest.java
@@ -21,8 +21,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.DeclarativeNamedStyles;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.marker.Markers;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -79,5 +86,41 @@ class ImportLayoutStyleTest {
         );
 
         mapper.readValue(mapper.writeValueAsBytes(style), DeclarativeNamedStyles.class);
+    }
+
+    @Test
+    void testAddImport() {
+        ImportLayoutStyle style = new ImportLayoutStyle(
+                Integer.MAX_VALUE, Integer.MAX_VALUE, Collections.emptyList(), Collections.emptyList());
+        JRightPadded<J.Import> import1 = new JRightPadded<>(
+                new J.Import(
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        new JLeftPadded<>(Space.SINGLE_SPACE, true, Markers.EMPTY),
+                        TypeTree.build("pkg.Clazz.MEMBER_1").withPrefix(Space.SINGLE_SPACE),
+                        null),
+                Space.EMPTY,
+                Markers.EMPTY);
+        JRightPadded<J.Import> import2 = new JRightPadded<>(
+                new J.Import(
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        new JLeftPadded<>(Space.SINGLE_SPACE, true, Markers.EMPTY),
+                        TypeTree.build("pkg.Clazz.MEMBER_1").withPrefix(Space.SINGLE_SPACE),
+                        null),
+                Space.EMPTY,
+                Markers.EMPTY);
+        J.Import importToAdd = new J.Import(
+                randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                new JLeftPadded<>(Space.SINGLE_SPACE, true, Markers.EMPTY),
+                TypeTree.build("pkg.Clazz.MEMBER_2").withPrefix(Space.SINGLE_SPACE),
+            null);
+        assertThat(style.addImport(List.of(import1, import2), importToAdd, null, Collections.emptyList()))
+                .containsExactlyInAnyOrder(
+                        import1, import1, new JRightPadded<>(importToAdd, Space.EMPTY, Markers.EMPTY));
     }
 }


### PR DESCRIPTION
## What's changed?
Problem:
- The presence check does not take the member of static imports into consideration
- The comparison by size cannot handle the case where the original imports contain duplicated imports making its the size be equal to that of the ideally ordered, distinct imports even after adding a new import

Fix: check the presence using the fully qualified names of imports.

## What's your motivation?
Fix https://github.com/openrewrite/rewrite/issues/4196

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
