### PR TITLE
ChangeMethodTargetToStatic should also change instance usage

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
@@ -146,6 +146,45 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
         );
     }
 
+    @Test
+    void staticMethodCalledOnInstanceToCallOnClass() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A method()", "a.A", null, null)),
+          java(
+            """
+              package a;
+              public class A {
+                 public static void method() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+              class Test {
+                 public void test() {
+                     A.method();
+                     new A().method();
+                     A a = new A();
+                     a.method();
+                 }
+              }
+              """,
+            """
+              import a.A;
+              class Test {
+                 public void test() {
+                     A.method();
+                     A.method();
+                     A a = new A();
+                     A.method();
+                 }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3085")

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -113,11 +113,12 @@ public class ChangeMethodTargetToStatic extends Recipe {
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+            Expression select = method.getSelect();
             boolean isStatic = method.getMethodType() != null && method.getMethodType().hasFlags(Flag.Static);
-            boolean isSameReceiverType = method.getSelect() != null &&
-                                         TypeUtils.isOfClassType(method.getSelect().getType(), fullyQualifiedTargetTypeName);
-
-            if ((!isStatic || !isSameReceiverType) && methodMatcher.matches(method, matchUnknownTypes)) {
+            boolean isSameReceiverType = select != null && TypeUtils.isOfClassType(select.getType(), fullyQualifiedTargetTypeName);
+            boolean calledOnTargetType = select instanceof J.Identifier && ((J.Identifier) select).getFieldType() == null;
+            if ((!isStatic || !isSameReceiverType || !calledOnTargetType) &&
+                methodMatcher.matches(method, matchUnknownTypes)) {
                 JavaType.Method transformedType = null;
                 if (method.getMethodType() != null) {
                     maybeRemoveImport(method.getMethodType().getDeclaringType());
@@ -138,9 +139,9 @@ public class ChangeMethodTargetToStatic extends Recipe {
                     maybeAddImport(fullyQualifiedTargetTypeName, !matchUnknownTypes);
                     m = method.withSelect(
                             new J.Identifier(randomId(),
-                                    method.getSelect() == null ?
+                                    select == null ?
                                             Space.EMPTY :
-                                            method.getSelect().getPrefix(),
+                                            select.getPrefix(),
                                     Markers.EMPTY,
                                     emptyList(),
                                     classType.getClassName(),


### PR DESCRIPTION
For https://github.com/openrewrite/rewrite-migrate-java/pull/477

Previously any cases where a static method was called on an instance (improper use) then ChangeMethodTargetToStatic would not make any changes. With this change we now also flush those out.