### PR TITLE
Fix documentation discrepancy

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddProperty.java
@@ -45,7 +45,7 @@ public class AddProperty extends ScanningRecipe<AddProperty.NeedsProperty> {
 
     @Option(displayName = "Overwrite if exists",
             description = "If a property with the same key exists, overwrite.",
-            example = "Enable the Gradle build cache")
+            example = "true")
     @Nullable
     Boolean overwrite;
 


### PR DESCRIPTION
Change overwrite example to 'true'

## What's changed?
I just found in the `AddProperty` gradle recipe that the docs had a string example where it should have been boolean.
Here's the current docs: https://docs.openrewrite.org/recipes/gradle/addproperty
<img width="759" alt="image" src="https://github.com/openrewrite/rewrite/assets/2091062/4624145d-f5e0-4fad-b1b5-a0799867d3aa">

Overwrite example should be `true` or `false`, not `Enable the gradle build cache`