### PR TITLE
bug: yaml: DeleteProperty: do not remove unrelated empty sequences

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteProperty.java
@@ -118,6 +118,10 @@ public class DeleteProperty extends Recipe {
         public Yaml visitSequence(Yaml.Sequence sequence, P p) {
             sequence = (Yaml.Sequence) super.visitSequence(sequence, p);
             List<Yaml.Sequence.Entry> entries = sequence.getEntries();
+            if (entries.isEmpty()) {
+                return sequence;
+            }
+
             entries = ListUtils.map(entries, entry -> ToBeRemoved.hasMarker(entry) ? null : entry);
             return entries.isEmpty() ? ToBeRemoved.withMarker(sequence) : sequence.withEntries(entries);
         }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeletePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeletePropertyKeyTest.java
@@ -261,4 +261,21 @@ class DeletePropertyKeyTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4204")
+    @Test
+    void preserveEmptySequencesWithOtherKeys() {
+        rewriteRun(
+          spec -> spec.recipe(new DeleteProperty("my.key", false, null)),
+          yaml(
+            """
+                my.key: qwe
+                seq: []
+              """,
+            """
+                seq: []
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
fixes #4204

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Additional check added to `DeleteProperty` yaml recipe to not add `ToBeRemoved` marker if sequence was empty before the recipe has removed its entries.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
