### PR TITLE
Add HasBuildToolVersion

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/HasBuildToolVersion.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/HasBuildToolVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-java/src/test/java/org/openrewrite/java/search/HasBuildToolVersionTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/search/HasBuildToolVersionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.search;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.BuildTool;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class HasBuildToolVersionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new HasBuildToolVersion(BuildTool.Type.Maven, "3.6.0-9999"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "3.6.0",
+      "3.6.1",
+      "3.8.0",
+      "4.0.0"
+    })
+    @DocumentExample
+    void detectMavenVersion(String version) {
+        rewriteRun(
+          java("class A {}", "/*~~>*/class A {}",
+            spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, version)))
+        );
+    }
+
+    @Test
+    void doNotDetectOlderVersion() {
+        rewriteRun(
+          java("class A {}",
+            spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.5.4")))
+        );
+    }
+
+    @Test
+    void doNotDetectGradleVersion() {
+        rewriteRun(
+          java("class A {}",
+            spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "4.10.0")))
+        );
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/search/HasBuildToolVersionTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/search/HasBuildToolVersionTest.java
@@ -30,26 +30,29 @@ class HasBuildToolVersionTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new HasBuildToolVersion(BuildTool.Type.Maven, "3.6.0-9999"));
+        spec.recipe(new HasBuildToolVersion(BuildTool.Type.Maven, "3.6.0-3.8.0"));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {
       "3.6.0",
       "3.6.1",
-      "3.8.0",
-      "4.0.0"
+      "3.8.0"
     })
     @DocumentExample
-    void detectMavenVersion(String version) {
+    void detectMavenVersionWithinRange(String version) {
         rewriteRun(
           java("class A {}", "/*~~>*/class A {}",
             spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, version)))
         );
     }
 
-    @Test
-    void doNotDetectOlderVersion() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "3.5.4",
+      "3.8.1",
+      "4.0.0"
+    })    void doNotDetectVersionsOutsideRange() {
         rewriteRun(
           java("class A {}",
             spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.5.4")))


### PR DESCRIPTION
## What's changed?
Add HasBuildToolVersion

## What's your motivation?
Act as a filter such that we don't unnecessarily add build plugins, as seen on
- https://github.com/openrewrite/rewrite-testing-frameworks/compare/v2.9.0...v2.10.0

## Anything in particular you'd like reviewers to focus on?
Enums are fine as options right?

## Have you considered any alternatives or workarounds?
Place this in rewrite-testing-frameworks only.

## Any additional context
[Maven parent v32](https://github.com/apache/maven-parent/blob/maven-parent-32/pom.xml) was the first to use [Apache parent v20](https://repo1.maven.org/maven2/org/apache/apache/20/apache-20.pom).
Maven 3.5.4 [still used](https://github.com/apache/maven/blob/maven-3.6.0/pom.xml) maven-parent 31
Maven 3.6.0 [uses](https://github.com/apache/maven/blob/maven-3.6.0/pom.xml) maven-parent 33