### PR TITLE
Parse troublesome Yaml with new workaround in workaround for underying parser bug

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -384,12 +384,8 @@ public class YamlParser implements org.openrewrite.Parser {
     If the dashes of the sequence do not have an indentation, the end mark will point to the character AFTER the dash.
     */
     private boolean shouldUseYamlParserBugWorkaround(SequenceStartEvent event) {
-        int index = event.getStartMark().getIndex();
-        if (index > event.getStartMark().getBuffer().length - 1) {
-            return false;
-        }
-        int startChar = event.getStartMark().getBuffer()[index];
-        int endChar = event.getEndMark().getBuffer()[event.getEndMark().getIndex()];
+        int startChar = event.getStartMark().getBuffer()[event.getStartMark().getPointer()];
+        int endChar = event.getEndMark().getBuffer()[event.getEndMark().getPointer()];
         return startChar == '-' && endChar != '-';
     }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -384,7 +384,11 @@ public class YamlParser implements org.openrewrite.Parser {
     If the dashes of the sequence do not have an indentation, the end mark will point to the character AFTER the dash.
     */
     private boolean shouldUseYamlParserBugWorkaround(SequenceStartEvent event) {
-        int startChar = event.getStartMark().getBuffer()[event.getStartMark().getIndex()];
+        int index = event.getStartMark().getIndex();
+        if (index > event.getStartMark().getBuffer().length - 1) {
+            return false;
+        }
+        int startChar = event.getStartMark().getBuffer()[index];
         int endChar = event.getEndMark().getBuffer()[event.getEndMark().getIndex()];
         return startChar == '-' && endChar != '-';
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -168,4 +168,52 @@ class YamlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void troublesomeYaml() {
+        rewriteRun(
+          yaml(
+            """
+              configDefinitions:
+                appConfig:
+                  description: "App config for consumer."
+                  resolutionPaths:
+                    - default: "/envProfile"
+                  properties:
+                    container:
+                      description: "Container to use to the cosmos client."
+                      type: "STRING"
+                      kind: "SINGLE"
+                      defaultValue: "UUIDItem"
+                      rules:
+                        possibleValues: []
+                    database:
+                      description: "Database to connect and use."
+                      type: "STRING"
+                      kind: "SINGLE"
+                      defaultValue: "ForkliftPocDB"
+                      rules:
+                        possibleValues: []
+                appConfig2:
+                  description: "App config for consumer."
+                  resolutionPaths:
+                    - default: "/envProfile"
+                  properties:
+                    container:
+                      description: "Container to use to the cosmos client."
+                      type: "STRING"
+                      kind: "SINGLE"
+                      defaultValue: "CosmosSDKTest"
+                      rules:
+                        possibleValues: []
+                    database:
+                      description: "Database to connect and use."
+                      type: "STRING"
+                      kind: "SINGLE"
+                      rules:
+                        possibleValues: []
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Prevent `IndexOutOfBoundsException` with new workaround for issues in the underlying `YamlParser` events.

## What's your motivation?
Received reports about failures with a particular Yaml snippet; with this exact snippet you hit the new conditional.
Even if you change strings in the Yaml snippet, you will not hit the new conditional; Fun times to be had tracing that down.

## Have you considered any alternatives or workarounds?
Ideally we report this upstream and see it resolved there.

## Any additional context
The earlier workaround was introduced in these two commits to work around bugs with the underlying Yaml parser we use.
- https://github.com/openrewrite/rewrite/pull/4178
- https://github.com/openrewrite/rewrite/pull/4187
