### PR TITLE
Fix: synchronize lazy initialization of contributers of `DeclarativeRecipe`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -370,7 +370,6 @@ public class DeclarativeRecipe extends Recipe {
                 contributors.add(new Contributor(contributorEntry.getKey().getName(), contributorEntry.getKey().getEmail(), contributorEntry.getValue()));
             }
             contributors.sort(Comparator.comparing(Contributor::getLineCount).reversed());
-
         }
         return contributors;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -149,6 +149,7 @@ public class DeclarativeRecipe extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new TreeVisitor<Tree, ExecutionContext>() {
                 TreeVisitor<?, ExecutionContext> p = precondition.get();
+
                 @Override
                 public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
                     return p.isAcceptable(sourceFile, ctx);
@@ -355,7 +356,7 @@ public class DeclarativeRecipe extends Recipe {
     }
 
     @Override
-    public List<Contributor> getContributors() {
+    public synchronized List<Contributor> getContributors() {
         if (contributors == null) {
             Map<NameEmail, Integer> contributorToLineCount = new HashMap<>();
             contributors = new ArrayList<>();
@@ -369,6 +370,7 @@ public class DeclarativeRecipe extends Recipe {
                 contributors.add(new Contributor(contributorEntry.getKey().getName(), contributorEntry.getKey().getEmail(), contributorEntry.getValue()));
             }
             contributors.sort(Comparator.comparing(Contributor::getLineCount).reversed());
+
         }
         return contributors;
     }


### PR DESCRIPTION
fixes:

```
java.util.concurrent.ExecutionException: org.openrewrite.internal.RecipeRunException: java.util.ConcurrentModificationException
  java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
  java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
Caused by org.openrewrite.internal.RecipeRunException: java.util.ConcurrentModificationException
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:292)
  org.openrewrite.TreeVisitor.visitNonNull(TreeVisitor.java:164)
Caused by java.util.ConcurrentModificationException: null
  java.base/java.util.ArrayList.sort(ArrayList.java:1723)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:371)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:363)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:363)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:363)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:363)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:363)
  org.openrewrite.config.DeclarativeRecipe.getContributors(DeclarativeRecipe.java:363)
  ...
```
