### PR TITLE
Add recipe to replace Annotation

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceAnnotation.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceAnnotation.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ReplaceAnnotation extends Recipe {
+    @Option(displayName = "Annotation pattern to replace",
+            description = "An annotation pattern, expressed as a method pattern to replace.",
+            example = "@org.jetbrains.annotations.NotNull(\"Test\")")
+    String annotationPatternToReplace;
+    @Option(displayName = "Annotation template to insert",
+            description = "An annotation template to add instead of original one, will be parsed with `JavaTemplate`.",
+            example = "@NonNull")
+    String annotationTemplateToInsert;
+    @Option(displayName = "Type of inserted Annotation",
+            description = "The fully qualified class name of the annotation to insert.",
+            example = "lombok.NonNull")
+    String annotationFQN;
+    @Option(displayName = "Templates Artifact id",
+            description = "The Maven artifactId to load the inserted annotations type from, defaults to JDK internals.",
+            example = "lombok",
+            required = false)
+    String artifactId;
+
+    @Override
+    public String getDisplayName() {
+        return "Replace Annotation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace an Annotation with another one if the annotation pattern matches. " +
+               "Only fixed parameters can be set in the replacement.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>(annotationFQN, false),
+                new ReplaceAnnotationVisitor(
+                        new AnnotationMatcher(annotationPatternToReplace),
+                        JavaTemplate.builder(annotationTemplateToInsert)
+                                .imports(annotationFQN)
+                                .javaParser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true)
+                                        .classpath(artifactId))
+                                .build()));
+    }
+
+    public static class ReplaceAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final AnnotationMatcher matcher;
+        private final JavaTemplate replacement;
+
+        public ReplaceAnnotationVisitor(AnnotationMatcher annotationMatcher, JavaTemplate replacement) {
+            super();
+            this.matcher = annotationMatcher;
+            this.replacement = replacement;
+        }
+
+        @Override
+        public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+            annotation = super.visitAnnotation(annotation, ctx);
+
+            boolean replaceAnnotation = matcher.matches(annotation);
+            if (replaceAnnotation) {
+                JavaType replacedAnnotationType = annotation.getType();
+                annotation = replacement.apply(getCursor(), annotation.getCoordinates().replace());
+                JavaType insertedAnnotationType = annotation.getType();
+                maybeRemoveImport(TypeUtils.asFullyQualified(replacedAnnotationType));
+                maybeAddImport(TypeUtils.asFullyQualified(insertedAnnotationType).getFullyQualifiedName(), false);
+            }
+
+            return annotation;
+        }
+    }
+}
+

--- a/rewrite-java/src/test/java/org/openrewrite/java/ReplaceAnnotationTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ReplaceAnnotationTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
@@ -23,87 +24,71 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+@Disabled
 class ReplaceAnnotationTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion()
-          .logCompilationWarningsAndErrors(false)
-          .classpath("lombok", "annotations"));
+        spec.parser(JavaParser.fromJavaVersion().classpath("lombok", "annotations"));
     }
 
     @Nested
     class OnMatch {
         @Test
         void matchNoPrams() {
-            rewriteRun(
-              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull",
-                "@NonNull", "lombok.NonNull", "lombok")),
-              java(
-                """
-                  import org.jetbrains.annotations.NotNull;
-                  
-                  class A {
-                      @NotNull
-                      String testMethod() {}
-                  }
-                  """, """
-                  import lombok.NonNull;
-                
-                  class A {
-                      @NonNull
-                      String testMethod() {}
-                  }
-                  """
-              ));
+            rewriteRun(spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull", "@lombok.NonNull")), java("""
+              import org.jetbrains.annotations.NotNull;
+                                
+              class A {
+                  @NotNull
+                  String testMethod() {}
+              }
+              """, """
+              import lombok.NonNull;
+                              
+              class A {
+                  @NonNull
+                  String testMethod() {}
+              }
+              """));
         }
 
         @Test
         @DocumentExample
         void matchWithPrams() {
-            rewriteRun(
-              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull(\"Test\")",
-                "@NonNull", "lombok.NonNull", "lombok")),
-              java(
-                """
-                  import org.jetbrains.annotations.NotNull;
-                  
-                  class A {
-                      @NotNull("Test")
-                      String testMethod() {}
-                  }
-                  """, """
-                  import lombok.NonNull;
-                
-                  class A {
-                      @NonNull
-                      String testMethod() {}
-                  }
-                  """
-              ));
+            rewriteRun(spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull(\"Test\")", "@lombok.NonNull")), java("""
+              import org.jetbrains.annotations.NotNull;
+                                
+              class A {
+                  @NotNull("Test")
+                  String testMethod() {}
+              }
+              """, """
+              import lombok.NonNull;
+                              
+              class A {
+                  @NonNull
+                  String testMethod() {}
+              }
+              """));
         }
 
         @Test
         void insertWithParams() {
-            rewriteRun(
-              spec -> spec.recipe(new ReplaceAnnotation("@lombok.NonNull",
-                "@NotNull(\"Test\")", "org.jetbrains.annotations.NotNull", "annotations")),
-              java(
-                """
-                  import lombok.NonNull;
-                  
-                  class A {
-                      @NonNull
-                      String testMethod() {}
-                  }
-                  """, """
-                  import org.jetbrains.annotations.NotNull;
-                
-                  class A {
-                      @NotNull("Test")
-                      String testMethod() {}
-                  }
-                  """
-              ));
+            rewriteRun(spec -> spec.recipe(new ReplaceAnnotation("@lombok.NonNull", "@org.jetbrains.annotations.NotNull(\"Test\")")), java("""
+              import lombok.NonNull;
+                                
+              class A {
+                  @NonNull
+                  String testMethod() {}
+              }
+              """, """
+              import org.jetbrains.annotations.NotNull;
+                              
+              class A {
+                  @NotNull("Test")
+                  String testMethod() {}
+              }
+              """));
         }
     }
 
@@ -111,36 +96,26 @@ class ReplaceAnnotationTest implements RewriteTest {
     class NoMatch {
         @Test
         void noMatchOtherType() {
-            rewriteRun(
-              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull",
-                "@NonNull", "lombok.NonNull", "lombok")),
-              java(
-                """
-                  import org.jetbrains.annotations.Nullable;
-                  
-                  class A {
-                      @Nullable("Test")
-                      String testMethod() {}
-                  }
-                  """
-              ));
+            rewriteRun(spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull", "@lombok.NonNull")), java("""
+              import org.jetbrains.annotations.Nullable;
+                                
+              class A {
+                  @Nullable("Test")
+                  String testMethod() {}
+              }
+              """));
         }
 
         @Test
         void noMatchParameter() {
-            rewriteRun(
-              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull(\"Test\")",
-                "@NonNull", "lombok.NonNull", "lombok")),
-              java(
-                """
-                  import org.jetbrains.annotations.Nullable;
-                  
-                  class A {
-                      @Nullable("Other")
-                      String testMethod() {}
-                  }
-                  """
-              ));
+            rewriteRun(spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull(\"Test\")", "@lombok.NonNull")), java("""
+              import org.jetbrains.annotations.Nullable;
+                                
+              class A {
+                  @Nullable("Other")
+                  String testMethod() {}
+              }
+              """));
         }
     }
 }

--- a/rewrite-java/src/test/java/org/openrewrite/java/ReplaceAnnotationTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ReplaceAnnotationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReplaceAnnotationTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion()
+          .logCompilationWarningsAndErrors(false)
+          .classpath("lombok", "annotations"));
+    }
+
+    @Nested
+    class OnMatch {
+        @Test
+        void matchNoPrams() {
+            rewriteRun(
+              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull",
+                "@NonNull", "lombok.NonNull", "lombok")),
+              java(
+                """
+                  import org.jetbrains.annotations.NotNull;
+                  
+                  class A {
+                      @NotNull
+                      String testMethod() {}
+                  }
+                  """, """
+                  import lombok.NonNull;
+                
+                  class A {
+                      @NonNull
+                      String testMethod() {}
+                  }
+                  """
+              ));
+        }
+
+        @Test
+        @DocumentExample
+        void matchWithPrams() {
+            rewriteRun(
+              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull(\"Test\")",
+                "@NonNull", "lombok.NonNull", "lombok")),
+              java(
+                """
+                  import org.jetbrains.annotations.NotNull;
+                  
+                  class A {
+                      @NotNull("Test")
+                      String testMethod() {}
+                  }
+                  """, """
+                  import lombok.NonNull;
+                
+                  class A {
+                      @NonNull
+                      String testMethod() {}
+                  }
+                  """
+              ));
+        }
+
+        @Test
+        void insertWithParams() {
+            rewriteRun(
+              spec -> spec.recipe(new ReplaceAnnotation("@lombok.NonNull",
+                "@NotNull(\"Test\")", "org.jetbrains.annotations.NotNull", "annotations")),
+              java(
+                """
+                  import lombok.NonNull;
+                  
+                  class A {
+                      @NonNull
+                      String testMethod() {}
+                  }
+                  """, """
+                  import org.jetbrains.annotations.NotNull;
+                
+                  class A {
+                      @NotNull("Test")
+                      String testMethod() {}
+                  }
+                  """
+              ));
+        }
+    }
+
+    @Nested
+    class NoMatch {
+        @Test
+        void noMatchOtherType() {
+            rewriteRun(
+              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull",
+                "@NonNull", "lombok.NonNull", "lombok")),
+              java(
+                """
+                  import org.jetbrains.annotations.Nullable;
+                  
+                  class A {
+                      @Nullable("Test")
+                      String testMethod() {}
+                  }
+                  """
+              ));
+        }
+
+        @Test
+        void noMatchParameter() {
+            rewriteRun(
+              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull(\"Test\")",
+                "@NonNull", "lombok.NonNull", "lombok")),
+              java(
+                """
+                  import org.jetbrains.annotations.Nullable;
+                  
+                  class A {
+                      @Nullable("Other")
+                      String testMethod() {}
+                  }
+                  """
+              ));
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a Recipe which replaces an Annotation with a JavaTemplate.

## What's your motivation?
While writing a cross Framework Migration from TestNG to JUnit Jupiter I implemented the replacement of annotations repeatedly.
This could become handy for other cross Framework Migrations as well.

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
