### PR TITLE
fix: Recognize bundle POM packaging type as jars when verifying recipe dependency downloads

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -554,7 +554,7 @@ public class MavenPomDownloader {
                             RawPom rawPom = RawPom.parse(fis, Objects.equals(versionMaybeDatedSnapshot, gav.getVersion()) ? null : versionMaybeDatedSnapshot);
                             Pom pom = rawPom.toPom(inputPath, repo).withGav(resolvedGav);
 
-                            if (pom.getPackaging() == null || "jar".equals(pom.getPackaging())) {
+                            if (pom.getPackaging() == null || pom.hasJarPackaging()) {
                                 File jar = f.toPath().resolveSibling(gav.getArtifactId() + '-' + versionMaybeDatedSnapshot + ".jar").toFile();
                                 if (!jar.exists() || jar.length() == 0) {
                                     // The jar has not been downloaded, making this dependency unusable.

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -26,13 +26,15 @@ import org.openrewrite.maven.internal.MavenPomDownloader;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.openrewrite.internal.ListUtils.concatAll;
 
 /**
@@ -47,6 +49,8 @@ import static org.openrewrite.internal.ListUtils.concatAll;
 @Builder
 @AllArgsConstructor
 public class Pom {
+
+    private static final List<String> JAR_PACKAGING_TYPES = Arrays.asList("jar", "bundle");
 
     /**
      * The model version can be used to verify the structure of the serialized object, in cache, is compatible
@@ -155,4 +159,7 @@ public class Pom {
         return ResolvedPom.placeholderHelper.replacePlaceholders(value, this.properties::get);
     }
 
+    public boolean hasJarPackaging() {
+        return JAR_PACKAGING_TYPES.contains(packaging);
+    }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -129,14 +129,20 @@ public class Pom {
         return Stream.concat(Stream.of(getRepository()), getRepositories().stream())
                 .filter(Objects::nonNull)
                 .map(r -> {
-                    if(r.getUri().startsWith("~")) {
-                        r = r.withUri(Paths.get(System.getProperty("user.home") + r.getUri().substring(1)).toUri().toString());
+                    if (r.getUri().startsWith("~")) {
+                        r = r.withUri(Paths.get(System.getProperty("user.home") + r.getUri().substring(1))
+                                .toUri()
+                                .toString());
                     }
-                    if(r.getId() != null && ResolvedPom.placeholderHelper.hasPlaceholders(r.getUri())) {
-                        r = r.withId(ResolvedPom.placeholderHelper.replacePlaceholders(r.getId(), this.properties::get));
+                    if (r.getId() != null && ResolvedPom.placeholderHelper.hasPlaceholders(r.getUri())) {
+                        r = r.withId(ResolvedPom.placeholderHelper.replacePlaceholders(
+                                r.getId(),
+                                this.properties::get));
                     }
-                    if(ResolvedPom.placeholderHelper.hasPlaceholders(r.getUri())) {
-                        r = r.withUri(ResolvedPom.placeholderHelper.replacePlaceholders(r.getUri(), this.properties::get));
+                    if (ResolvedPom.placeholderHelper.hasPlaceholders(r.getUri())) {
+                        r = r.withUri(ResolvedPom.placeholderHelper.replacePlaceholders(
+                                r.getUri(),
+                                this.properties::get));
                     }
                     return r;
                 })
@@ -150,12 +156,26 @@ public class Pom {
      * @return A new instance with dependencies resolved.
      * @throws MavenDownloadingException When problems are encountered downloading dependencies or parents.
      */
-    public ResolvedPom resolve(Iterable<String> activeProfiles, MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingException {
+    public ResolvedPom resolve(Iterable<String> activeProfiles,
+                               MavenPomDownloader downloader,
+                               ExecutionContext ctx) throws MavenDownloadingException {
         return resolve(activeProfiles, downloader, emptyList(), ctx);
     }
 
-    public ResolvedPom resolve(Iterable<String> activeProfiles, MavenPomDownloader downloader, List<MavenRepository> initialRepositories, ExecutionContext ctx) throws MavenDownloadingException {
-        return new ResolvedPom(this, activeProfiles, properties, emptyList(), concatAll(initialRepositories, getEffectiveRepositories()), repositories, dependencies, plugins, pluginManagement)
+    public ResolvedPom resolve(Iterable<String> activeProfiles,
+                               MavenPomDownloader downloader,
+                               List<MavenRepository> initialRepositories,
+                               ExecutionContext ctx) throws MavenDownloadingException {
+        return new ResolvedPom(
+                this,
+                activeProfiles,
+                properties,
+                emptyList(),
+                concatAll(initialRepositories, getEffectiveRepositories()),
+                repositories,
+                dependencies,
+                plugins,
+                pluginManagement)
                 .resolve(ctx, downloader);
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/PomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/PomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/PomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/PomTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.tree;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PomTest {
+
+    @ParameterizedTest
+    @ValueSource(strings={"jar", "bundle"})
+    void hasJarPackagingWithJarPackagingTypes(String type) {
+        Pom pom = Pom.builder().packaging(type).build();
+        assertThat(pom.hasJarPackaging()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings={"pom", "ejb"})
+    void hasJarPackagingWithNonJarPackagingTypes(String type) {
+        Pom pom = Pom.builder().packaging(type).build();
+        assertThat(pom.hasJarPackaging()).isFalse();
+    }
+
+    @Test
+    void hasJarPackagingWithNullJarPackaging() {
+        Pom pom = Pom.builder() .build();
+        assertThat(pom.hasJarPackaging()).isFalse();
+    }
+}


### PR DESCRIPTION

## What's changed?
When ascertaining if a recipe dependency was downloaded in `MavenPomDownloader` only POM packaging types of "jar" where verified to have a non-empty jar file downloaded. The POM packaging type "bundle" is also a single jar and the current code was skipping validation for such dependencies resulting in failures to install recipes. These changes include the "bundle" packaging type when verifying a recipe dependency was downloaded.

## What's your motivation?
Fixes a customer issue when attempting to install a recipe with a dependency having a bundle packaging type. Eg https://mvnrepository.com/artifact/net.minidev/json-smart/2.5.1

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
