### PR TITLE
Added classifier support to DependencyUseStringNotation recipe

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
@@ -136,6 +136,10 @@ public class DependencyUseStringNotation extends Recipe {
                     String version = coerceToStringNotation(mapNotation.get("version"));
                     if (version != null) {
                         stringNotation += ":" + version;
+                        String classifier = coerceToStringNotation(mapNotation.get("classifier"));
+                        if (classifier != null) {
+                            stringNotation += ":" + classifier;
+                        }
                     }
 
                     return new J.Literal(randomId(), prefix, markers, stringNotation, "\"" + stringNotation + "\"", Collections.emptyList(), JavaType.Primitive.String);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -59,6 +59,34 @@ class DependencyUseStringNotationTest implements RewriteTest {
     }
 
     @Test
+    void withClassifier() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              dependencies {
+                  api(group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release', classifier: 'sources')
+                  implementation group: 'group', name: 'artifact', version: 'version', classifier: 'sources'
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              dependencies {
+                  api("org.openrewrite:rewrite-core:latest.release:sources")
+                  implementation "group:artifact:version:sources"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void basicMapLiteral() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
## What's changed?
The existing recipe does not take classifiers into consideration and simply removes them. 
We should either support it, or not change the dependencies with classifiers. 
Decided we want to support it.

## What's your motivation?
Classifiers are supported by both notations.

## Anything in particular you'd like reviewers to focus on?
I only add the classifier if a version is specified. Otherwise, if no version is specified, it would be added to the string like it is a version.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
Not migrating to string notation if classifier is mentioned could also be done, but less optimal

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
