### PR TITLE
Do not add constraints inside version J.MethodInvocations part of the constraint itself.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -366,6 +366,9 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
         String because;
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            if ("version".equals(method.getSimpleName())) {
+                return method;
+            }
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
             Optional<G.CompilationUnit> withConstraint = GradleParser.builder().build().parse(String.format(
                     "plugins {\n" +
@@ -419,6 +422,9 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
 
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            if ("version".equals(method.getSimpleName())) {
+                return method;
+            }
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
             if(existingConstraint.isScope(m)) {
                 AtomicBoolean updatedBecause = new AtomicBoolean(false);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -441,6 +442,61 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                   deploy 'org.openrewrite:rewrite-java:7.0.0'
               
                   constraints {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4228")
+    void constraintDoesNotGetAddedInsideConstraint() {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new UpgradeTransitiveDependencyVersion("com.fasterxml.jackson.core", "jackson-core","2.12.5", null, "CVE-2024-BAD")),
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+              
+                  constraints {
+                      implementation("org.apache.logging.log4j:log4j-core") {
+                          version {
+                              strictly("2.17.0")
+                          }
+                          because 'security'
+                      }
+                  }
+              }
+              """, """
+              plugins {
+                  id 'java'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+              
+                  constraints {
+                      implementation('com.fasterxml.jackson.core:jackson-core:2.12.5') {
+                          because 'CVE-2024-BAD'
+                      }
+                      implementation("org.apache.logging.log4j:log4j-core") {
+                          version {
+                              strictly("2.17.0")
+                          }
+                          because 'security'
+                      }
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Added a simple method name check to avoid a bug int he current recipe.

## What's your motivation?
Current created constraints are invalid. This PR closes #4228

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
We could stop the recursive self calls at a sooner point but I tried and could not find the correct point to do this.
We could check for other calls, but did not find any other J.MethodInvocations in our codebase/my experience.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
