### PR TITLE
Ignore configurations for constraints

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -98,6 +98,13 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
     @Nullable
     String because;
 
+    @Option(displayName = "Exclude configurations",
+            description = "A list of configurations to exclude from the upgrade. For example, `testCompile`. \n This is useful when you have certain plugins applied that create configurations that you don't want to apply constraints to.",
+            required = false,
+            example = "testCompile, testRuntime")
+    @Nullable
+    List<String> ignoreConfigurations;
+
     @Override
     public String getDisplayName() {
         return "Upgrade transitive Gradle dependencies";
@@ -251,6 +258,9 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
                     case "testRuntime":
                         constraintConfigName = "testRuntimeOnly";
                         break;
+                }
+                if (ignoreConfigurations != null && ignoreConfigurations.contains(constraintConfigName)) {
+                    return null;
                 }
 
                 GradleDependencyConfiguration configuration = gradleProject.getConfiguration(constraintConfigName);


### PR DESCRIPTION
## What's changed?
As discussed offline, we need to be able to exclude certain configurations for constraint creation in certain cases (vulnerabilities etc).

## What's your motivation?
Close our issue openend through slack on moderne.

## Any additional context
I will raise fix for java-rewrite-dependencies

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
