### PR TITLE
Only consider specified configurations for UpgradeTransitiveDependencies created constraints

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -98,6 +98,13 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
     @Nullable
     String because;
 
+    @Option(displayName = "Include configurations",
+            description = "A list of configurations to consider during the upgrade. For example, For example using `implementation, runtimeOnly`, we could be responding to a deployable asset vulnerability only (ignoring test scoped vulnerabilities).",
+            required = false,
+            example = "implementation, runtimeOnly")
+    @Nullable
+    List<String> onlyForConfigurations;
+
     @Override
     public String getDisplayName() {
         return "Upgrade transitive Gradle dependencies";
@@ -253,10 +260,23 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
                         break;
                 }
 
+                if (onlyForConfigurations != null) {
+                    if (!onlyForConfigurations.contains(constraintConfigName)) {
+                        return null;
+                    }
+                } else {
+                    for (GradleDependencyConfiguration extended : config.getExtendsFrom()) {
+                        if (extended.getName().equals(constraintConfigName)) {
+                            return extended;
+                        }
+                    }
+                }
+
                 GradleDependencyConfiguration configuration = gradleProject.getConfiguration(constraintConfigName);
                 if (configuration != null && configuration.isTransitive()) {
                     return configuration;
                 }
+
                 return null;
             }
         });

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -21,6 +21,8 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
@@ -31,7 +33,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
         spec
           .beforeRecipe(withToolingApi())
           .recipe(new UpgradeTransitiveDependencyVersion(
-            "com.fasterxml*", "jackson-core", "2.12.5", null, "CVE-2024-BAD"));
+            "com.fasterxml*", "jackson-core", "2.12.5", null, "CVE-2024-BAD", null));
     }
 
     @DocumentExample
@@ -98,6 +100,29 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                       }
                   }
               
+                  foo 'org.openrewrite:rewrite-java:7.0.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void customNonTransitiveConfigurationCannotAddConstraint() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+              }
+              configurations {
+                  foo {
+                      transitive = false
+                  }
+              }
+              repositories { mavenCentral() }
+              
+              dependencies {
                   foo 'org.openrewrite:rewrite-java:7.0.0'
               }
               """
@@ -455,7 +480,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
         rewriteRun(
           spec -> spec
             .beforeRecipe(withToolingApi())
-            .recipe(new UpgradeTransitiveDependencyVersion("com.fasterxml.jackson.core", "jackson-core","2.12.5", null, "CVE-2024-BAD")),
+            .recipe(new UpgradeTransitiveDependencyVersion("com.fasterxml.jackson.core", "jackson-core","2.12.5", null, "CVE-2024-BAD", null)),
           //language=groovy
           buildGradle(
             """
@@ -498,6 +523,113 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                           because 'security'
                       }
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void includedConfigurationsReceiveOnlyConfiguredConstraints() {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new UpgradeTransitiveDependencyVersion(
+              "org.apache.commons", "commons-lang3", "3.14.0", null, null, List.of("pitest"))),
+          buildGradle(
+            """
+              plugins {
+                  id 'info.solidsoft.pitest' version '1.15.0'
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  testImplementation 'org.apache.activemq:artemis-jakarta-server:2.28.0'
+              }
+              """, """
+              plugins {
+                  id 'info.solidsoft.pitest' version '1.15.0'
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  constraints {
+                      pitest('org.apache.commons:commons-lang3:3.14.0')
+                  }
+              
+                  testImplementation 'org.apache.activemq:artemis-jakarta-server:2.28.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noIncludedConfigurationsReceiveAllConstraints() {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new UpgradeTransitiveDependencyVersion(
+              "org.apache.commons", "commons-lang3", "3.14.0", null, null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'info.solidsoft.pitest' version '1.15.0'
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  testImplementation 'org.apache.activemq:artemis-jakarta-server:2.28.0'
+              }
+              """, """
+              plugins {
+                  id 'info.solidsoft.pitest' version '1.15.0'
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  constraints {
+                      pitest('org.apache.commons:commons-lang3:3.14.0')
+                      testImplementation('org.apache.commons:commons-lang3:3.14.0')
+                  }
+              
+                  testImplementation 'org.apache.activemq:artemis-jakarta-server:2.28.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @DocumentExample
+    void IncludedDefaultConfigurationsReceiveRuntimeConstraints() {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new UpgradeTransitiveDependencyVersion(
+              "org.apache.commons", "commons-lang3", "3.14.0", null, null, List.of("implementation", "runtimeOnly"))),
+          buildGradle(
+            """
+              plugins {
+                  id 'info.solidsoft.pitest' version '1.15.0'
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  compileOnly 'org.apache.activemq:artemis-jakarta-server:2.28.0'
+              }
+              """, """
+              plugins {
+                  id 'info.solidsoft.pitest' version '1.15.0'
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+              dependencies {
+                  constraints {
+                      implementation('org.apache.commons:commons-lang3:3.14.0')
+                  }
+              
+                  compileOnly 'org.apache.activemq:artemis-jakarta-server:2.28.0'
               }
               """
           )


### PR DESCRIPTION
## What's changed?
In this version, the recipe will by default consider all transitive configurations to be adding constraints. 
One can limit this behaviour by specifying constraints that need to be considered. 
Eg. in the light of vulnerability patching, a recipe runner might only be interested in running against `runtime` jars. 
That would be feasible by specifying both default runtime available configurations(implementation, runtimeOnly) + any manually added **transitive** ones.

## Anything in particular you'd like reviewers to focus on?
This change will only have impact if a configurations list was specified. We reintroduce/combine earlier behaviour by checking for the extendsFrom + must be transitive. 
Added some test cases to further explain expectations/behaviour.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
See #4230 for a blacklist approach

## Any additional context
Our preference goes towards a whitelist approach as that list is afaik better maintainable for wide usage of plugins, custom configurations... 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
