### PR TITLE
Add Property Resolution to RemoveRedundantDependencyVersions

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -229,7 +229,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
              */
             private boolean matchesVersion(ResolvedManagedDependency d, ExecutionContext ctx) {
                 MavenResolutionResult mrr = getResolutionResult();
-                if (d.getRequested().getVersion() == null || d.getRequested().getVersion().contains("${") || mrr.getPom().getRequested().getParent() == null) {
+                if (d.getRequested().getVersion() == null || mrr.getPom().getRequested().getParent() == null) {
                     return false;
                 }
                 try {
@@ -255,7 +255,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
             }
 
             private boolean matchesVersion(ResolvedDependency d) {
-                if (d.getRequested().getVersion() == null || d.getRequested().getVersion().contains("${")) {
+                if (d.getRequested().getVersion() == null) {
                     return false;
                 }
                 String managedVersion = getResolutionResult().getPom().getManagedVersion(d.getGroupId(),
@@ -264,7 +264,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
             }
 
             private boolean matchesVersion(Plugin p) {
-                if (p.getVersion() == null || p.getVersion().contains("${")) {
+                if (p.getVersion() == null) {
                     return false;
                 }
                 String managedVersion = getManagedPluginVersion(getResolutionResult().getPom(), p.getGroupId(), p.getArtifactId());
@@ -279,7 +279,8 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                     return true;
                 }
                 int comparison = new LatestIntegration(null)
-                        .compare(null, managedVersion, requestedVersion);
+                        .compare(null, managedVersion,
+                                Objects.requireNonNull(getResolutionResult().getPom().getValue(requestedVersion)));
                 if (comparison < 0) {
                     return comparator.equals(Comparator.LT) || comparator.equals(Comparator.LTE);
                 } else if (comparison > 0) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
@@ -1293,7 +1293,7 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
-    void propertySubstitution() {
+    void pluginPropertySubstitution() {
         rewriteRun(
           spec -> spec.recipe(new RemoveRedundantDependencyVersions(null, null, RemoveRedundantDependencyVersions.Comparator.GTE, null)),
           pomXml(
@@ -1320,6 +1320,84 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                         </plugin>
                     </plugins>
                 </build>
+            </project>
+            """, """
+            <project>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.3.0.RELEASE</version>
+                    <relativePath/>
+                </parent>
+            
+                <groupId>com.example</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            
+                <modelVersion>4.0.0</modelVersion>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <artifactId>kotlin-maven-plugin</artifactId>
+                            <groupId>org.jetbrains.kotlin</groupId>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """
+          )
+        );
+    }
+
+    @Test
+    void dependencyPropertySubstitution() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencyVersions(null, null, RemoveRedundantDependencyVersions.Comparator.GTE, null)),
+          pomXml(
+            """
+            <project>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.4</version>
+                    <relativePath/>
+                </parent>
+            
+                <groupId>com.example</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            
+                <modelVersion>4.0.0</modelVersion>
+                
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-web</artifactId>
+                        <version>${spring-framework.version}</version>
+                    </dependency>
+                </dependencies>
+            </project>
+            """, """
+            <project>
+                <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>2.5.4</version>
+                    <relativePath/>
+                </parent>
+            
+                <groupId>com.example</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            
+                <modelVersion>4.0.0</modelVersion>
+                
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-web</artifactId>
+                    </dependency>
+                </dependencies>
             </project>
             """
           )


### PR DESCRIPTION
## What's changed?
Added property version resolution for dependencies/plugins using the maven property syntax to define versions and removed the early exit logic for this case.

## What's your motivation?
Redundant Dependencies and Plugin versions defined through maven properties should still be removed by this recipe instead of being ignored. 
