### PR TITLE
Fix `Parameterized` is hidden by `withFullyQualifiedName`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -715,7 +715,12 @@ public interface JavaType {
 
         @Override
         public FullyQualified withFullyQualifiedName(String fullyQualifiedName) {
-            return type.withFullyQualifiedName(fullyQualifiedName);
+            FullyQualified qualified = type.withFullyQualifiedName(fullyQualifiedName);
+            if (type.equals(qualified)) {
+                return this;
+            }
+
+            return new Parameterized(managedReference, qualified, typeParameters);
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -716,7 +716,7 @@ public interface JavaType {
         @Override
         public FullyQualified withFullyQualifiedName(String fullyQualifiedName) {
             FullyQualified qualified = type.withFullyQualifiedName(fullyQualifiedName);
-            if (type.equals(qualified)) {
+            if (type == qualified) {
                 return this;
             }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/template/TypeParameterTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/template/TypeParameterTest.java
@@ -89,6 +89,25 @@ class TypeParameterTest {
         assertThat(TypeUtils.toString(type)).isEqualTo(name);
     }
 
+	@ParameterizedTest
+	@ValueSource(strings = {
+	  "java.util.List<java.lang.String>",
+	  "java.util.Map<java.lang.String, java.lang.Integer>",
+	  "java.util.List<? extends java.lang.Object>",
+	  "java.util.List<? super java.lang.Integer>",
+	  "java.util.List<java.util.List<? super java.lang.Integer>>",
+	})
+	void parameterizedWithModifierShouldNeverHideParametrizedType(String name) {
+		TemplateParameterParser parser = new TemplateParameterParser(new CommonTokenStream(new TemplateParameterLexer(
+		  CharStreams.fromString(name))));
+		JavaType type = TypeParameter.toFullyQualifiedName(parser.type());
+
+		JavaType.Parameterized pType = (JavaType.Parameterized) type;
+		assertThat(pType.withFullyQualifiedName("test")).isInstanceOf(JavaType.Parameterized.class);
+		assertThat(pType.withFullyQualifiedName("test")).isNotSameAs(pType);
+		assertThat(pType.withFullyQualifiedName(pType.getFullyQualifiedName())).isSameAs(pType);
+	}
+
     @ParameterizedTest
     @ValueSource(strings = {
       "java.util.List<?>",


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR ensures that withFullyQualifiedName never hides the original `Parametrized` type, which includes info about generic params
## What's your motivation?
I noticed that bug, so I decided to fix it right away by PR

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
