### PR TITLE
Use `@Nls` annotations to hint at sentence-case requirements

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/DataTable.java
+++ b/rewrite-core/src/main/java/org/openrewrite/DataTable.java
@@ -37,10 +37,10 @@ public class DataTable<Row> {
     private final Class<Row> type;
 
     @Language("markdown")
-    private final String displayName;
+    private final @NlsRewrite.DisplayName String displayName;
 
     @Language("markdown")
-    private final String description;
+    private final @NlsRewrite.Description String description;
 
     @Setter
     private boolean enabled = true;

--- a/rewrite-core/src/main/java/org/openrewrite/MyRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/MyRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.config;
+package org.openrewrite;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
-import org.openrewrite.NlsRewrite;
+public class MyRecipe extends Recipe {
 
-import java.util.List;
+    @Override
+    public String getDisplayName() {
+        return "My Title";
+    }
 
-@Value
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class DataTableDescriptor {
-
-    @EqualsAndHashCode.Include
-    String name;
-
-    @NlsRewrite.DisplayName
-    String displayName;
-
-    @NlsRewrite.Description
-    String description;
-
-    @EqualsAndHashCode.Include
-    List<ColumnDescriptor> columns;
+    @Override
+    public String getDescription() {
+        return "";
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/NlsRewrite.java
+++ b/rewrite-core/src/main/java/org/openrewrite/NlsRewrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.config;
+package org.openrewrite;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
-import org.openrewrite.NlsRewrite;
+import org.jetbrains.annotations.Nls;
 
-import java.util.List;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
-@Value
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class DataTableDescriptor {
+public class NlsRewrite {
+    @Target({ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.METHOD})
+    public @Nls(capitalization = Nls.Capitalization.Sentence) @interface DisplayName {
+    }
 
-    @EqualsAndHashCode.Include
-    String name;
-
-    @NlsRewrite.DisplayName
-    String displayName;
-
-    @NlsRewrite.Description
-    String description;
-
-    @EqualsAndHashCode.Include
-    List<ColumnDescriptor> columns;
+    @Target({ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.METHOD})
+    public @Nls(capitalization = Nls.Capitalization.Sentence) @interface Description {
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/Option.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Option.java
@@ -25,9 +25,13 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Option {
-    @Language("markdown") String displayName() default "";
-    @Language("markdown") String description() default "";
+    @Language("markdown") @NlsRewrite.DisplayName String displayName() default "";
+
+    @Language("markdown") @NlsRewrite.Description String description() default "";
+
     String example() default "";
+
     String[] valid() default "";
+
     boolean required() default true;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Setter;
 import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.Nls;
 import org.openrewrite.config.DataTableDescriptor;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
@@ -103,7 +104,7 @@ public abstract class Recipe implements Cloneable {
      * @return The display name.
      */
     @Language("markdown")
-    public abstract String getDisplayName();
+    public abstract @NlsRewrite.DisplayName String getDisplayName();
 
     /**
      * A human-readable display name for this recipe instance, including some descriptive
@@ -179,7 +180,7 @@ public abstract class Recipe implements Cloneable {
      * @return The display name.
      */
     @Language("markdown")
-    public abstract String getDescription();
+    public abstract @NlsRewrite.Description String getDescription();
 
     /**
      * A set of strings used for categorizing related recipes. For example

--- a/rewrite-core/src/main/java/org/openrewrite/config/CategoryDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/CategoryDescriptor.java
@@ -18,6 +18,7 @@ package org.openrewrite.config;
 import lombok.Value;
 import lombok.With;
 import org.intellij.lang.annotations.Language;
+import org.openrewrite.NlsRewrite;
 
 import java.util.Set;
 
@@ -29,11 +30,13 @@ public class CategoryDescriptor {
     public static final int HIGHEST_PRECEDENCE = Integer.MAX_VALUE;
 
     @Language("markdown")
+    @NlsRewrite.DisplayName
     String displayName;
 
     String packageName;
 
     @Language("markdown")
+    @NlsRewrite.Description
     String description;
 
     Set<String> tags;

--- a/rewrite-core/src/main/java/org/openrewrite/config/ColumnDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ColumnDescriptor.java
@@ -17,6 +17,7 @@ package org.openrewrite.config;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.NlsRewrite;
 import org.openrewrite.internal.lang.Nullable;
 
 @Value
@@ -30,8 +31,10 @@ public class ColumnDescriptor {
     String type;
 
     @Nullable
+    @NlsRewrite.DisplayName
     String displayName;
 
     @Nullable
+    @NlsRewrite.Description
     String description;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/OptionDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/OptionDescriptor.java
@@ -17,6 +17,7 @@ package org.openrewrite.config;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.NlsRewrite;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.List;
@@ -32,9 +33,11 @@ public class OptionDescriptor {
     String type;
 
     @Nullable
+    @NlsRewrite.DisplayName
     String displayName;
 
     @Nullable
+    @NlsRewrite.Description
     String description;
 
     @Nullable

--- a/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.With;
+import org.openrewrite.NlsRewrite;
 import org.openrewrite.Tree;
 import org.openrewrite.Validated;
 import org.openrewrite.internal.lang.Nullable;
@@ -42,9 +43,11 @@ public class NamedStyles implements Marker {
     @EqualsAndHashCode.Include
     String name;
 
+    @NlsRewrite.DisplayName
     String displayName;
 
     @Nullable
+    @NlsRewrite.Description
     String description;
 
     Set<String> tags;


### PR DESCRIPTION
When implementing recipes, the `@Nls` annotation will help guide folks to case the display name and description correctly.

<img width="825" alt="image" src="https://github.com/openrewrite/rewrite/assets/1697736/aa5ec998-274d-4f1c-be78-773f62f5a92d">
