### PR TITLE
Allow JavaTemplate to throw new Exception

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
@@ -141,7 +141,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               """,
             """
               class Test {
-                            
+              
                   @SuppressWarnings("ALL")
                   void test2() {
                   }
@@ -412,10 +412,10 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
               """,
             """
               import java.util.Arrays;
-                            
+              
               abstract class Test {
                   abstract String[] array();
-                  
+              
                   void test(boolean condition) {
                       Object any = Arrays.asList(condition ? array() : new String[]{"Hello!"});
                   }
@@ -452,6 +452,36 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                void test(Map<String, ?> map) {
                    System.out.println(map.get("test"));
                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void throwNewException() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext executionContext) {
+                  return JavaTemplate.builder("throw new RuntimeException()")
+                    .build()
+                    .apply(getCursor(), methodInvocation.getCoordinates().replace());
+              }
+          })),
+          java(
+            """
+              public class Test {
+                  void test() {
+                      System.out.println("Hello");
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void test() {
+                      throw new RuntimeException();
+                  }
               }
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -212,11 +212,17 @@ public class BlockStatementTemplateGenerator {
             throw new IllegalArgumentException(
                     "Templating a method reference requires a cursor so that it can be properly parsed and type-attributed. " +
                     "Mark this template as context-sensitive by calling JavaTemplate.Builder#contextSensitive().");
+        } else if (j instanceof J.MethodInvocation) {
+            before.insert(0, "class Template {{\n");
+            JavaType.Method methodType = ((J.MethodInvocation) j).getMethodType();
+            if (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void) {
+                before.append("Object o = ");
+            }
+            after.append(";\n}}");
         } else if (j instanceof Expression && !(j instanceof J.Assignment)) {
             before.insert(0, "class Template {\n");
             before.append("Object o = ");
-            after.append(";");
-            after.append("\n}");
+            after.append(";\n}");
         } else if ((j instanceof J.MethodDeclaration || j instanceof J.VariableDeclarations || j instanceof J.Block || j instanceof J.ClassDeclaration)
                    && cursor.getValue() instanceof J.Block
                    && (cursor.getParent().getValue() instanceof J.ClassDeclaration || cursor.getParent().getValue() instanceof J.NewClass)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.internal.template;
 
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.antlr.v4.runtime.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.PropertyPlaceholderHelper;
@@ -34,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @RequiredArgsConstructor
+@ToString
 public class Substitutions {
     private static final Pattern PATTERN_COMMENT = Pattern.compile("__p(\\d+)__");
 


### PR DESCRIPTION
## What's changed?
Update `BlockStatementTemplateGenerator` to separately handle `J.MethodInvocation`, and not produce an assignment when the methodInvocation has a void return type. This prevents a compiler error for such templates. Additionally wrap any generated template for J.MethodInvocation in a block (`class Template {{ ... }}`, as opposed to `class Template { ... }`) to allow for throwing exceptions.

## What's your motivation?
Broke the recipes generated for this one, which contained `final JavaTemplate after = JavaTemplate.builder("throw new AssertionError();").build();`.
https://github.com/PicnicSupermarket/error-prone-support/blob/d81fe19836db9f0001fb9c01370a3b808c46b440/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java#L156-L167

## Have you considered any alternatives or workarounds?
Could have nested the generated template in the `j instanceof Expression` conditional just below it, but this seemed cleaner.

## Any additional context
As part of the work done towards
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/520 