### PR TITLE
Allow J.Empty type parameters in SemanticallyEqual

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -298,6 +298,19 @@ class SemanticallyEqualTest {
         );
     }
 
+    @Test
+    void generics() {
+        assertExpressionsEqual(
+          """
+            import java.util.List;
+            class T {
+                List<String> a = new java.util.ArrayList<String>();
+                List<String> b = new java.util.ArrayList<>();
+            }
+            """
+        );
+    }
+
     private void assertEqualToSelf(@Language("java") String a) {
         assertEqual(a, a);
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.search;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
 import org.junitpioneer.jupiter.ExpectedToFail;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -298,17 +299,59 @@ class SemanticallyEqualTest {
         );
     }
 
-    @Test
-    void generics() {
-        assertExpressionsEqual(
-          """
-            import java.util.List;
-            class T {
-                List<String> a = new java.util.ArrayList<String>();
-                List<String> b = new java.util.ArrayList<>();
-            }
-            """
-        );
+    @Nested
+    class Generics {
+        @Test
+        void firstEmpty() {
+            assertExpressionsEqual(
+              """
+                import java.util.List;
+                class T {
+                    List<String> a = new java.util.ArrayList<String>();
+                    List<String> b = new java.util.ArrayList<>();
+                }
+                """
+            );
+        }
+
+        @Test
+        void secondEmpty() {
+            assertExpressionsEqual(
+              """
+                import java.util.List;
+                class T {
+                    List<String> a = new java.util.ArrayList<>();
+                    List<String> b = new java.util.ArrayList<String>();
+                }
+                """
+            );
+        }
+
+        @Test
+        void bothEmpty() {
+            assertExpressionsEqual(
+              """
+                import java.util.List;
+                class T {
+                    List<String> a = new java.util.ArrayList<>();
+                    List<String> b = new java.util.ArrayList<>();
+                }
+                """
+            );
+        }
+
+        @Test
+        void bothEmptyButDifferent() {
+            assertExpressionsNotEqual(
+              """
+                import java.util.List;
+                class T {
+                    List<String> a = new java.util.ArrayList<>();
+                    List<Integer> b = new java.util.ArrayList<>();
+                }
+                """
+            );
+        }
     }
 
     private void assertEqualToSelf(@Language("java") String a) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -1088,7 +1088,9 @@ public class SemanticallyEqual {
                     return type;
                 }
 
-                this.visitList(type.getTypeParameters(), compareTo.getTypeParameters());
+                if (!(type.getTypeParameters().get(0) instanceof J.Empty || compareTo.getTypeParameters().get(0) instanceof J.Empty)) {
+                    this.visitList(type.getTypeParameters(), compareTo.getTypeParameters());
+                }
             }
             return type;
         }


### PR DESCRIPTION
## What's changed?
Allow either side of type parameters to be empty while still being equal.

## What's your motivation?
We noticed mismatches in some Refaster templates which should ideally still match.