### PR TITLE
feat: If DeclarativeRecipe only has already-initialized recipes, don't require initialization

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -150,6 +150,7 @@ public class DeclarativeRecipe extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new TreeVisitor<Tree, ExecutionContext>() {
                 TreeVisitor<?, ExecutionContext> p = precondition.get();
+
                 @Override
                 public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
                     return p.isAcceptable(sourceFile, ctx);
@@ -314,11 +315,17 @@ public class DeclarativeRecipe extends Recipe {
 
     @Override
     public Validated<Object> validate() {
-        return Validated.<Object>test("initialization",
-                        "initialize(..) must be called on DeclarativeRecipe prior to use.",
-                        this, r -> initValidation != null)
-                .and(validation)
-                .and(initValidation);
+        Validated<Object> validated = Validated.none();
+
+        if (!uninitializedRecipes.isEmpty() && uninitializedRecipes.size() != recipeList.size()) {
+            validated = validated.and(Validated.invalid("initialization", recipeList, "DeclarativeRecipe must not contain uninitialized recipes. Be sure to call .initialize() on DeclarativeRecipe."));
+        }
+        if (!uninitializedPreconditions.isEmpty() && uninitializedPreconditions.size() != preconditions.size()) {
+            validated = validated.and(Validated.invalid("initialization", preconditions, "DeclarativeRecipe must not contain uninitialized preconditions. Be sure to call .initialize() on DeclarativeRecipe."));
+        }
+
+        return validated.and(validation)
+                .and(initValidation == null ? Validated.none() : initValidation);
     }
 
     @Value


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

I've updated the way that DeclarativeRecipe.validate() works. Before, it was always required to call `DeclarativeRecipe.initialize()` in order to validate that all recipes were initialized before using the recipe.

## What's your motivation?

There are use cases where a DeclarativeRecipe can be constructed with already-instantiated recipe objects. In this case, we don't want to require initialization. 

## Anything in particular you'd like reviewers to focus on?

N/A

## Anyone you would like to review specifically?

@sambsnyd 

## Have you considered any alternatives or workarounds?

Yes, the most important part here was to fix a null pointer. Before this change, the validation code was as follows:

```
        return Validated.<Object>test("initialization",
                        "initialize(..) must be called on DeclarativeRecipe prior to use.",
                        this, r -> initValidation != null)
                .and(validation)
                .and(initValidation);
```

If `initialize` was not called, then `initValidation` would be null. the `.and(initValidation)` would throw a NullPointerException.

The most important aspect of this PR was to fix that NullPointerException, and I considered doing so and keeping the validation the same otherwise:

```
        return Validated.<Object>test("initialization",
                        "initialize(..) must be called on DeclarativeRecipe prior to use.",
                        this, r -> initValidation != null)
                .and(validation)
                .and(initValidation == null ? Validated.none() : initValidation);
```

This would have the effect that a DeclarativeRecipe that didn't have `.initialize()` called on it would still throw a warning, but not blow up.

## Any additional context

N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
