### PR TITLE
Ignore method invocation arguments that are not string J.Literals

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -435,6 +435,9 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     }
                 } else if (arg instanceof J.Literal) {
                     J.Literal literal = (J.Literal) arg;
+                    if (literal.getType() != JavaType.Primitive.String) {
+                        return arg;
+                    }
                     String gav = (String) literal.getValue();
                     if (gav == null) {
                         getCursor().putMessage(UPDATE_VERSION_ERROR_KEY, new IllegalStateException("Unable to update version"));

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -882,4 +882,29 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4275")
+    void noActionForNonStringLiterals() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+              }
+              
+              repositories {
+                mavenCentral()
+              }
+              
+              dependencies {
+                implementation(gradleApi())
+                jar {
+                  enabled(true)
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Fixes: #4275

## What's changed?
A check before casting. If it is not a string, it is most likely not a dependency notation. 

## What's your motivation?
In line with: "Do not change anything if we are not sure", I propose to just give back this argument as is without touching. 

## Any additional context
This is actually not meant to be coded like this in gradle, yet it is working unfortunately and has been copy/pasted througout some of our repo's.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
