### PR TITLE
Add PlaintextOnly Option to FindAndReplace Recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/FindAndReplace.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.text;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -106,34 +105,6 @@ public class FindAndReplace extends Recipe {
             required = false)
     @Nullable
     Boolean plaintextOnly;
-
-    @Deprecated
-    public FindAndReplace(final String find, @Nullable final String replace, @Nullable final Boolean regex,
-            @Nullable final Boolean caseSensitive, @Nullable final Boolean multiline, @Nullable final Boolean dotAll,
-            @Nullable final String filePattern) {
-        this.find = find;
-        this.replace = replace;
-        this.regex = regex;
-        this.caseSensitive = caseSensitive;
-        this.multiline = multiline;
-        this.dotAll = dotAll;
-        this.filePattern = filePattern;
-        this.plaintextOnly = null;
-    }
-
-    @JsonCreator
-    public FindAndReplace(final String find, @Nullable final String replace, @Nullable final Boolean regex,
-            @Nullable final Boolean caseSensitive, @Nullable final Boolean multiline, @Nullable final Boolean dotAll,
-            @Nullable final String filePattern, @Nullable final Boolean plaintextOnly) {
-        this.find = find;
-        this.replace = replace;
-        this.regex = regex;
-        this.caseSensitive = caseSensitive;
-        this.multiline = multiline;
-        this.dotAll = dotAll;
-        this.filePattern = filePattern;
-        this.plaintextOnly = plaintextOnly;
-    }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -102,7 +102,7 @@ class RecipeLifecycleTest implements RewriteTest {
         public List<Recipe> getRecipeList() {
             return Arrays.asList(
               new DeleteSourceFiles("test.txt"),
-              new FindAndReplace("test", "", null, null, null, null, null));
+              new FindAndReplace("test", "", null, null, null, null, null, null));
         }
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
@@ -28,7 +28,7 @@ class RecipeRunTest implements RewriteTest {
     @Test
     void printDatatable() {
         rewriteRun(
-          recipeSpec -> recipeSpec.recipe(new FindAndReplace("replace_me", "replacement", null, null, null, null, null))
+          recipeSpec -> recipeSpec.recipe(new FindAndReplace("replace_me", "replacement", null, null, null, null, null, null))
             .afterRecipe(recipeRun -> {
                 StringBuilder output = new StringBuilder();
                 final String dataTableName = SourcesFileResults.class.getName();

--- a/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindAndReplaceTest.java
@@ -32,7 +32,7 @@ class FindAndReplaceTest implements RewriteTest {
     @Test
     void nonTxtExtension() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace(".", "G", null, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace(".", "G", null, null, null, null, null, null)),
           text(
             """
               This is text.
@@ -48,7 +48,7 @@ class FindAndReplaceTest implements RewriteTest {
     @Test
     void removeWhenNullOrEmpty() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace("Bar", null, null, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace("Bar", null, null, null, null, null, null, null)),
           text(
             """
               Foo
@@ -67,7 +67,7 @@ class FindAndReplaceTest implements RewriteTest {
     @Test
     void defaultNonRegex() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace(".", "G", null, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace(".", "G", null, null, null, null, null, null)),
           text(
             """
               This is text.
@@ -82,7 +82,7 @@ class FindAndReplaceTest implements RewriteTest {
     @Test
     void regexReplace() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace(".", "G", true, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace(".", "G", true, null, null, null, null, null)),
           text(
             """
               This is text.
@@ -97,7 +97,7 @@ class FindAndReplaceTest implements RewriteTest {
     @Test
     void captureGroups() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace("This is ([^.]+).", "I like $1.", true, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace("This is ([^.]+).", "I like $1.", true, null, null, null, null, null)),
           text(
             """
               This is text.
@@ -112,7 +112,7 @@ class FindAndReplaceTest implements RewriteTest {
     @Test
     void noRecursive() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace("test", "tested", false, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace("test", "tested", false, null, null, null, null, null)),
           text("test", "tested")
         );
     }
@@ -122,7 +122,7 @@ class FindAndReplaceTest implements RewriteTest {
         String find = "This is text ${dynamic}.";
         String replace = "This is text ${dynamic}. Stuff";
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace(find, replace, null, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace(find, replace, null, null, null, null, null, null)),
           text(find, replace)
         );
     }
@@ -144,9 +144,9 @@ class FindAndReplaceTest implements RewriteTest {
         @Override
         public List<Recipe> getRecipeList() {
             return Arrays.asList(
-              new FindAndReplace("one", "two", null, null, null, null, null),
-              new FindAndReplace("two", "three", null, null, null, null, null),
-              new FindAndReplace("three", "four", null, null, null, null, null));
+              new FindAndReplace("one", "two", null, null, null, null, null, null),
+              new FindAndReplace("two", "three", null, null, null, null, null, null),
+              new FindAndReplace("three", "four", null, null, null, null, null, null));
         }
     }
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/text/FindAndReplaceJavaTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/text/FindAndReplaceJavaTest.java
@@ -29,11 +29,19 @@ class FindAndReplaceJavaTest implements RewriteTest {
     @Test
     void findAndReplaceJava() {
         rewriteRun(
-          spec -> spec.recipe(new FindAndReplace("Test", "Replaced", null, null, null, null, null)),
+          spec -> spec.recipe(new FindAndReplace("Test", "Replaced", null, null, null, null, null, null)),
           java(
             "class Test {}",
             "class Replaced {}"
           )
+        );
+    }
+
+    @Test
+    void ignoresJavaFileWithPlaintextFlagEnabled() {
+        rewriteRun(
+          spec -> spec.recipe(new FindAndReplace("Test", "Replaced", null, null, null, null, null, true)),
+          java("class Test {}")
         );
     }
 


### PR DESCRIPTION
## What's changed?
Added a Plaintext Only option to the find and replace recipe, which when enabled, limits the recipe to only act on plaintext files. This option defaults to false.

## What's your motivation?
FindAndReplace by default replaces text in for most sourcefile types, which may not be desirable in certain cases since this recipe coverts any sourcefile to a plaintext file, thereby causing information loss for the rest of the recipe run. Enabling this flag limits the recipe scope to plaintext files for cases where a user only wants to replace something thats already parsed as a plaintext file. 

For example, this flag could prove useful in [this](https://github.com/openrewrite/rewrite-spring/pull/538) PR where we only want to touch manifest and dockerfiles. 