### PR TITLE
fix: fix bellwether decorated recipe ignoring causesAnotherCycle

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -250,6 +250,11 @@ public class DeclarativeRecipe extends Recipe {
         public List<Recipe> getRecipeList() {
             return decorateWithPreconditionBellwether(bellwether, delegate.getRecipeList());
         }
+
+        @Override
+        public boolean causesAnotherCycle() {
+            return delegate.causesAnotherCycle();
+        }
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -197,6 +197,11 @@ public class DeclarativeRecipe extends Recipe {
         public List<Recipe> getRecipeList() {
             return decorateWithPreconditionBellwether(bellwether, delegate.getRecipeList());
         }
+
+        @Override
+        public boolean causesAnotherCycle() {
+            return delegate.causesAnotherCycle();
+        }
     }
 
     @Value


### PR DESCRIPTION
## What's changed?
Declarative recipes with preconditions no longer ignore "causesAnotherCycle" of bundled recipes.

## Anything in particular you'd like reviewers to focus on?
I don't know how to test this as I couldn't reproduce it in unit tests (seems to always run extra cycles when testing?). I'm fairly new to OpenRewrite so any guidance would be welcome.

## Any additional context
A declarative recipe I'm working on was not completing as expected.
It looked like additional cycles caused by one of the recipes in the list were not being processed.
Since I couldn't reproduce it in my unit tests, I debugged the use case and noticed that causesAnotherCycle was not properly delegated to my recipe causing the run to end prematurely.
I run OpenRewrite via the IntelliJ plugin.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X]  I've used the IntelliJ IDEA auto-formatter on affected files
