### PR TITLE
Fix StackOverflowError in case of circular import deps

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -812,13 +812,8 @@ public class ResolvedPom {
         }
 
         private boolean isAlreadyResolved(GroupArtifactVersion groupArtifactVersion, List<Pom> pomAncestry) {
-            // skip current pom
-            boolean first = true;
-            for (Pom pom : pomAncestry) {
-                if (first) {
-                    first = false;
-                    continue;
-                }
+            for (int i = 1; i < pomAncestry.size(); i++) { // skip current pom
+                Pom pom = pomAncestry.get(i);
                 ResolvedGroupArtifactVersion alreadyResolvedGav = pom.getGav();
                 if (alreadyResolvedGav.getGroupId().equals(groupArtifactVersion.getGroupId())
                     && alreadyResolvedGav.getArtifactId().equals(groupArtifactVersion.getArtifactId())

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -780,7 +780,7 @@ public class ResolvedPom {
                 for (ManagedDependency d : incomingDependencyManagement) {
                     if (d instanceof Imported) {
                         GroupArtifactVersion groupArtifactVersion = getValues(((Imported) d).getGav());
-                        if (isAlreadyResolved(pomAncestry, groupArtifactVersion)) {
+                        if (isAlreadyResolved(groupArtifactVersion, pomAncestry)) {
                             continue;
                         }
                         ResolvedPom bom = downloader.download(groupArtifactVersion, null, ResolvedPom.this, repositories)
@@ -811,7 +811,7 @@ public class ResolvedPom {
             }
         }
 
-        private boolean isAlreadyResolved(List<Pom> pomAncestry, GroupArtifactVersion groupArtifactVersion) {
+        private boolean isAlreadyResolved(GroupArtifactVersion groupArtifactVersion, List<Pom> pomAncestry) {
             // skip current pom
             boolean first = true;
             for (Pom pom : pomAncestry) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -22,7 +22,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import lombok.With;
 import lombok.experimental.NonFinal;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
@@ -156,7 +159,7 @@ public class ResolvedPom {
     @SuppressWarnings("DuplicatedCode")
     public ResolvedPom resolve(ExecutionContext ctx, MavenPomDownloader downloader) throws MavenDownloadingException {
         // If this resolved pom represents an obsolete pom format, refuse to resolve in same as Maven itself would
-        if(requested.getObsoletePomVersion() != null) {
+        if (requested.getObsoletePomVersion() != null) {
             return this;
         }
 
@@ -809,12 +812,21 @@ public class ResolvedPom {
         }
 
         private boolean isAlreadyResolved(List<Pom> pomAncestry, GroupArtifactVersion groupArtifactVersion) {
-            return pomAncestry.stream()
-                              .skip(1) // skip current pom
-                              .map(Pom::getGav)
-                              .anyMatch(alreadyResolvedGav -> alreadyResolvedGav.getGroupId().equals(groupArtifactVersion.getGroupId())
-                                                              && alreadyResolvedGav.getArtifactId().equals(groupArtifactVersion.getArtifactId())
-                                                              && alreadyResolvedGav.getVersion().equals(groupArtifactVersion.getVersion()));
+            // skip current pom
+            boolean first = true;
+            for (Pom pom : pomAncestry) {
+                if (first) {
+                    first = false;
+                    continue;
+                }
+                ResolvedGroupArtifactVersion alreadyResolvedGav = pom.getGav();
+                if (alreadyResolvedGav.getGroupId().equals(groupArtifactVersion.getGroupId())
+                    && alreadyResolvedGav.getArtifactId().equals(groupArtifactVersion.getArtifactId())
+                    && alreadyResolvedGav.getVersion().equals(groupArtifactVersion.getVersion())) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3064,7 +3064,14 @@ class MavenParserTest implements RewriteTest {
                     </dependencies>
                   </dependencyManagement>
                 </project>
-                """
+                """,
+              spec -> spec.afterRecipe(pomXml -> {
+                  MavenResolutionResult resolution = pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                  GroupArtifactVersion gav = resolution.getPom().getDependencyManagement().get(0).getGav();
+                  assertThat(gav.getGroupId()).isEqualTo("junit");
+                  assertThat(gav.getArtifactId()).isEqualTo("junit");
+                  assertThat(gav.getVersion()).isEqualTo("4.13.2");
+              })
             ),
             mavenProject("circular-example-child",
               pomXml(
@@ -3077,8 +3084,24 @@ class MavenParserTest implements RewriteTest {
                     </parent>
                     <artifactId>circular-example-child</artifactId>
                     <version>0.0.1-SNAPSHOT</version>
+                    <dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.13.2</version>
+                        </dependency>
+                      </dependencies>
+                    </dependencyManagement>
                   </project>
-                  """
+                  """,
+                spec -> spec.afterRecipe(pomXml -> {
+                    MavenResolutionResult resolution = pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                    GroupArtifactVersion gav = resolution.getPom().getDependencyManagement().get(0).getGav();
+                    assertThat(gav.getGroupId()).isEqualTo("junit");
+                    assertThat(gav.getArtifactId()).isEqualTo("junit");
+                    assertThat(gav.getVersion()).isEqualTo("4.13.2");
+                })
               )
             )
           )

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3038,4 +3038,56 @@ class MavenParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void circularImportDependency() {
+        rewriteRun(
+          mavenProject("root",
+                       pomXml(
+                         """
+                           <project>
+                           
+                             <groupId>com.example</groupId>
+                             <artifactId>circular-example-parent</artifactId>
+                             <version>0.0.1-SNAPSHOT</version>
+                           
+                             <modules>
+                               <module>circular-example-child</module>
+                             </modules>
+                           
+                             <dependencyManagement>
+                               <dependencies>
+                                 <dependency>
+                                   <groupId>com.example</groupId>
+                                   <artifactId>circular-example-child</artifactId>
+                                   <version>0.0.1-SNAPSHOT</version>
+                                   <scope>import</scope>
+                                 </dependency>
+                               </dependencies>
+                             </dependencyManagement>
+                           </project>
+                           """,
+                         spec -> spec.path("pom.xml")
+                       ),
+                       mavenProject("circular-example-child",
+                                    pomXml(
+                                      """
+                                        <project>
+                                          <parent>
+                                            <groupId>com.example</groupId>
+                                            <artifactId>circular-example-parent</artifactId>
+                                            <version>0.0.1-SNAPSHOT</version>
+                                          </parent>
+                                        
+                                          <artifactId>circular-example-child</artifactId>
+                                          <version>0.0.1-SNAPSHOT</version>
+                                        </project>
+                                        """,
+                                      spec -> spec.path("circular-example-child/pom.xml")
+                                    )
+                       )
+
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3040,53 +3040,47 @@ class MavenParserTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4093")
     void circularImportDependency() {
         rewriteRun(
           mavenProject("root",
-                       pomXml(
-                         """
-                           <project>
-                           
-                             <groupId>com.example</groupId>
-                             <artifactId>circular-example-parent</artifactId>
-                             <version>0.0.1-SNAPSHOT</version>
-                           
-                             <modules>
-                               <module>circular-example-child</module>
-                             </modules>
-                           
-                             <dependencyManagement>
-                               <dependencies>
-                                 <dependency>
-                                   <groupId>com.example</groupId>
-                                   <artifactId>circular-example-child</artifactId>
-                                   <version>0.0.1-SNAPSHOT</version>
-                                   <scope>import</scope>
-                                 </dependency>
-                               </dependencies>
-                             </dependencyManagement>
-                           </project>
-                           """,
-                         spec -> spec.path("pom.xml")
-                       ),
-                       mavenProject("circular-example-child",
-                                    pomXml(
-                                      """
-                                        <project>
-                                          <parent>
-                                            <groupId>com.example</groupId>
-                                            <artifactId>circular-example-parent</artifactId>
-                                            <version>0.0.1-SNAPSHOT</version>
-                                          </parent>
-                                        
-                                          <artifactId>circular-example-child</artifactId>
-                                          <version>0.0.1-SNAPSHOT</version>
-                                        </project>
-                                        """,
-                                      spec -> spec.path("circular-example-child/pom.xml")
-                                    )
-                       )
-
+            pomXml(
+              """
+                <project>
+                  <groupId>com.example</groupId>
+                  <artifactId>circular-example-parent</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <modules>
+                    <module>circular-example-child</module>
+                  </modules>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>circular-example-child</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """
+            ),
+            mavenProject("circular-example-child",
+              pomXml(
+                """
+                  <project>
+                    <parent>
+                      <groupId>com.example</groupId>
+                      <artifactId>circular-example-parent</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>circular-example-child</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                  </project>
+                  """
+              )
+            )
           )
         );
     }


### PR DESCRIPTION
Check if import dependency was already resolved before

## What's changed?
Add a check if import dependency was already resolved before

## What's your motivation?
To avoid StackOverflowError in case of circular import deps 
- https://github.com/openrewrite/rewrite/issues/4093

Fixes https://github.com/openrewrite/rewrite/issues/4093

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
