### PR TITLE
Handle MavenMetadata parser result NPE as reported by community member

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -267,11 +267,17 @@ public class MavenPomDownloader {
                         // A maven repository can be expressed as a URI with a file scheme
                         Path path = Paths.get(URI.create(uri));
                         if (Files.exists(path)) {
-                            result = Optional.of(MavenMetadata.parse(Files.readAllBytes(path)));
+                            MavenMetadata parsed = MavenMetadata.parse(Files.readAllBytes(path));
+                            if (parsed != null) {
+                                result = Optional.of(parsed);
+                            }
                         }
                     } else {
                         byte[] responseBody = requestAsAuthenticatedOrAnonymous(repo, uri);
-                        result = Optional.of(MavenMetadata.parse(responseBody));
+                        MavenMetadata parsed = MavenMetadata.parse(responseBody);
+                        if (parsed != null) {
+                            result = Optional.of(parsed);
+                        }
                     }
                 } catch (HttpSenderResponseException e) {
                     repositoryResponses.put(repo, e.getMessage());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenMetadata.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenMetadata.java
@@ -80,9 +80,9 @@ public class MavenMetadata {
         }
     }
 
-    public static MavenMetadata parse(byte[] document) throws IOException {
+    public static @Nullable MavenMetadata parse(byte[] document) throws IOException {
         MavenMetadata metadata = MavenXmlMapper.readMapper().readValue(document, MavenMetadata.class);
-        if (metadata.getVersioning() != null && metadata.getVersioning().getVersions() == null) {
+        if (metadata != null && metadata.getVersioning() != null && metadata.getVersioning().getVersions() == null) {
             return new MavenMetadata(new Versioning(emptyList(), metadata.getVersioning().getSnapshotVersions(), metadata.getVersioning().getSnapshot()));
         }
         return metadata;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenMetadataTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenMetadataTest.java
@@ -28,20 +28,20 @@ class MavenMetadataTest {
     @Test
     void deserializeMetadata() throws IOException {
         @Language("xml") String metadata = """
-            <metadata>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot</artifactId>
-                <versioning>
-                    <latest>2.4.2</latest>
-                    <release>2.4.2</release>
-                    <versions>
-                        <version>2.4.1</version>
-                        <version>2.4.2</version>
-                    </versions>
-                    <lastUpdated>20210115042754</lastUpdated>
-                </versioning>
-            </metadata>
-        """;
+          <metadata>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot</artifactId>
+              <versioning>
+                  <latest>2.4.2</latest>
+                  <release>2.4.2</release>
+                  <versions>
+                      <version>2.4.1</version>
+                      <version>2.4.2</version>
+                  </versions>
+                  <lastUpdated>20210115042754</lastUpdated>
+              </versioning>
+          </metadata>
+          """;
 
         MavenMetadata parsed = MavenMetadata.parse(metadata.getBytes());
         assertThat(parsed.getVersioning().getVersions()).hasSize(2);
@@ -51,39 +51,40 @@ class MavenMetadataTest {
     @Test
     void deserializeSnapshotMetadata() throws IOException {
         @Language("xml") String metadata = """
-            <metadata modelVersion="1.1.0">
-                <groupId>org.openrewrite.recipe</groupId>
-                <artifactId>rewrite-recommendations</artifactId>
-                <version>0.1.0-SNAPSHOT</version>
-                <versioning>
-                    <snapshot>
-                        <timestamp>20220927.033510</timestamp>
-                        <buildNumber>223</buildNumber>
-                    </snapshot>
-                    <snapshotVersions>
-                        <snapshotVersion>
-                            <extension>pom.asc</extension>
-                            <value>0.1.0-20220927.033510-223</value>
-                            <updated>20220927033510</updated>
-                        </snapshotVersion>
-                        <snapshotVersion>
-                            <extension>pom</extension>
-                            <value>0.1.0-20220927.033510-223</value>
-                            <updated>20220927033510</updated>
-                        </snapshotVersion>
-                    </snapshotVersions>
-                </versioning>
-            </metadata>
-        """;
+          <metadata modelVersion="1.1.0">
+              <groupId>org.openrewrite.recipe</groupId>
+              <artifactId>rewrite-recommendations</artifactId>
+              <version>0.1.0-SNAPSHOT</version>
+              <versioning>
+                  <snapshot>
+                      <timestamp>20220927.033510</timestamp>
+                      <buildNumber>223</buildNumber>
+                  </snapshot>
+                  <snapshotVersions>
+                      <snapshotVersion>
+                          <extension>pom.asc</extension>
+                          <value>0.1.0-20220927.033510-223</value>
+                          <updated>20220927033510</updated>
+                      </snapshotVersion>
+                      <snapshotVersion>
+                          <extension>pom</extension>
+                          <value>0.1.0-20220927.033510-223</value>
+                          <updated>20220927033510</updated>
+                      </snapshotVersion>
+                  </snapshotVersions>
+              </versioning>
+          </metadata>
+          """;
 
         MavenMetadata parsed = MavenMetadata.parse(metadata.getBytes());
+        MavenMetadata.Versioning versioning = parsed.getVersioning();
 
-        assertThat(parsed.getVersioning().getSnapshot().getTimestamp()).isEqualTo("20220927.033510");
-        assertThat(parsed.getVersioning().getSnapshot().getBuildNumber()).isEqualTo("223");
-        assertThat(parsed.getVersioning().getVersions()).isNotNull();
-        assertThat(parsed.getVersioning().getSnapshotVersions()).hasSize(2);
-        assertThat(parsed.getVersioning().getSnapshotVersions().get(0).getExtension()).isNotNull();
-        assertThat(parsed.getVersioning().getSnapshotVersions().get(0).getValue()).isNotNull();
-        assertThat(parsed.getVersioning().getSnapshotVersions().get(0).getUpdated()).isNotNull();
+        assertThat(versioning.getSnapshot().getTimestamp()).isEqualTo("20220927.033510");
+        assertThat(versioning.getSnapshot().getBuildNumber()).isEqualTo("223");
+        assertThat(versioning.getVersions()).isNotNull();
+        assertThat(versioning.getSnapshotVersions()).hasSize(2);
+        assertThat(versioning.getSnapshotVersions().get(0).getExtension()).isNotNull();
+        assertThat(versioning.getSnapshotVersions().get(0).getValue()).isNotNull();
+        assertThat(versioning.getSnapshotVersions().get(0).getUpdated()).isNotNull();
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenMetadataTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenMetadataTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.maven.internal;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.maven.tree.MavenMetadata;
 
 import java.io.IOException;
@@ -86,5 +87,12 @@ class MavenMetadataTest {
         assertThat(versioning.getSnapshotVersions().get(0).getExtension()).isNotNull();
         assertThat(versioning.getSnapshotVersions().get(0).getValue()).isNotNull();
         assertThat(versioning.getSnapshotVersions().get(0).getUpdated()).isNotNull();
+    }
+
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/4285")
+    void deserializeMetadataWithEmptyVersions() throws IOException {
+        assertThat(MavenMetadata.parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><metadata/>\n".getBytes())).isNull();
     }
 }


### PR DESCRIPTION
## What's changed?
Prevent an NPE by adding a null check, and changing the API response to be nullable to handle it downstream.

## What's your motivation?
A community member [reported seeing an exception](https://rewriteoss.slack.com/archives/C01A843MWG5/p1719241761219139?thread_ts=1719084080.404999&cid=C01A843MWG5) that I can't explain otherwise.
```
[ERROR] Failed to execute goal org.openrewrite.maven:rewrite-maven-plugin:5.34.1:run (default-cli) on project xxx-v1: Execution default-cli of goal org.openrewrite.maven:rewrite-maven-plugin:5.34.1:run failed: Error while visiting pom.xml: java.lang.NullPointerException: Cannot invoke "org.openrewrite.maven.tree.MavenMetadata.getVersioning()" because "metadata" is null
[ERROR]   org.openrewrite.maven.tree.MavenMetadata.parse(MavenMetadata.java:85)
[ERROR]   org.openrewrite.maven.internal.MavenPomDownloader.downloadMetadata(MavenPomDownloader.java:273)
[ERROR]   org.openrewrite.maven.internal.MavenPomDownloader.downloadMetadata(MavenPomDownloader.java:224)
[ERROR]   org.openrewrite.maven.MavenVisitor.downloadMetadata(MavenVisitor.java:363)
[ERROR]   org.openrewrite.maven.MavenVisitor.downloadMetadata(MavenVisitor.java:358)
[ERROR]   org.openrewrite.maven.UpgradeDependencyVersion$2.lambda$findNewerVersion$0(UpgradeDependencyVersion.java:340)
[ERROR]   org.openrewrite.maven.table.MavenMetadataFailures.insertRows(MavenMetadataFailures.java:55)
[ERROR]   org.openrewrite.maven.UpgradeDependencyVersion$2.findNewerVersion(UpgradeDependencyVersion.java:340)
[ERROR]   org.openrewrite.maven.UpgradeDependencyVersion$2.upgradeDependency(UpgradeDependencyVersion.java:217)
[ERROR]   org.openrewrite.maven.UpgradeDependencyVersion$2.visitTag(UpgradeDependencyVersion.java:157)
[ERROR]   org.openrewrite.maven.UpgradeDependencyVersion$2.visitTag(UpgradeDependencyVersion.java:149)
[ERROR]   org.openrewrite.xml.tree.Xml$Tag.acceptXml(Xml.java:466)
[ERROR]   org.openrewrite.xml.tree.Xml.accept(Xml.java:53)
[ERROR]   org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
[ERROR]   org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:324)
[ERROR]   org.openrewrite.xml.XmlVisitor.lambda$visitTag$2(XmlVisitor.java:91)
[ERROR]   ...
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1]
http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```

## Have you considered any alternatives or workarounds?
Not yet; this was mostly a quick attempt at replicating the issue, which failed, and then a subsequent at preventing the issue to kick off discussion on what avenues to explore.

## Any additional context
Tried to replicate this with a test using various values for the byte array, but none immediately lead to `MavenMetadata metadata` being null, as found in the stack trace above.

In the surrounding code there seem to be some edge cases where it concerns Nexus specifically; I've asked if this is what the user has in their environment.