### PR TITLE
fix: Add DelegatingRecipe to find underlying recipe for loading options

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -421,7 +421,7 @@ public abstract class Recipe implements Cloneable {
         }
     }
 
-    public abstract static class DelegatingRecipe extends Recipe {
-        public abstract Recipe getDelegate();
+    public interface DelegatingRecipe {
+        Recipe getDelegate();
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Setter;
 import org.intellij.lang.annotations.Language;
-import org.jetbrains.annotations.Nls;
 import org.openrewrite.config.DataTableDescriptor;
 import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
@@ -131,7 +130,7 @@ public abstract class Recipe implements Cloneable {
             return getDisplayName() + " " + suffix;
         }
 
-        List<OptionDescriptor> options = new ArrayList<>(getOptionDescriptors(getClass()));
+        List<OptionDescriptor> options = new ArrayList<>(getOptionDescriptors(this.getRecipeClass()));
         options.removeIf(opt -> !opt.isRequired());
         if (options.isEmpty()) {
             return getDisplayName();
@@ -209,7 +208,7 @@ public abstract class Recipe implements Cloneable {
     }
 
     protected RecipeDescriptor createRecipeDescriptor() {
-        List<OptionDescriptor> options = getOptionDescriptors(this.getClass());
+        List<OptionDescriptor> options = getOptionDescriptors(this.getRecipeClass());
         List<RecipeDescriptor> recipeList1 = new ArrayList<>();
         for (Recipe next : getRecipeList()) {
             recipeList1.add(next.getDescriptor());
@@ -226,7 +225,8 @@ public abstract class Recipe implements Cloneable {
                 getMaintainers(), getContributors(), getExamples(), recipeSource);
     }
 
-    private List<OptionDescriptor> getOptionDescriptors(Class<?> recipeClass) {
+    private List<OptionDescriptor> getOptionDescriptors(Class<? extends Recipe> recipeClass) {
+
         List<OptionDescriptor> options = new ArrayList<>();
 
         for (Field field : recipeClass.getDeclaredFields()) {
@@ -415,5 +415,13 @@ public abstract class Recipe implements Cloneable {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Implement this when wrapping and delegating a {@link Recipe}.
+     * @return the class of the (possibly wrapped) {@link Recipe}
+     */
+    public Class<? extends Recipe> getRecipeClass(){
+        return this.getClass();
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -168,7 +168,7 @@ public class DeclarativeRecipe extends Recipe {
 
     @EqualsAndHashCode(callSuper = false)
     @Value
-    static class BellwetherDecoratedRecipe extends Recipe {
+    static class BellwetherDecoratedRecipe extends DelegatingRecipe {
 
         DeclarativeRecipe.PreconditionBellwether bellwether;
         Recipe delegate;
@@ -201,11 +201,6 @@ public class DeclarativeRecipe extends Recipe {
         @Override
         public boolean causesAnotherCycle() {
             return delegate.causesAnotherCycle();
-        }
-
-        @Override
-        public Class<? extends Recipe> getRecipeClass() {
-            return delegate.getRecipeClass();
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -206,7 +206,7 @@ public class DeclarativeRecipe extends Recipe {
 
     @Value
     @EqualsAndHashCode(callSuper = false)
-    static class BellwetherDecoratedScanningRecipe<T> extends ScanningRecipe<T> {
+    static class BellwetherDecoratedScanningRecipe<T> extends ScanningRecipe<T> implements DelegatingRecipe {
 
         DeclarativeRecipe.PreconditionBellwether bellwether;
         ScanningRecipe<T> delegate;

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -168,7 +168,7 @@ public class DeclarativeRecipe extends Recipe {
 
     @EqualsAndHashCode(callSuper = false)
     @Value
-    static class BellwetherDecoratedRecipe extends DelegatingRecipe {
+    static class BellwetherDecoratedRecipe extends Recipe implements DelegatingRecipe {
 
         DeclarativeRecipe.PreconditionBellwether bellwether;
         Recipe delegate;

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -202,6 +202,11 @@ public class DeclarativeRecipe extends Recipe {
         public boolean causesAnotherCycle() {
             return delegate.causesAnotherCycle();
         }
+
+        @Override
+        public Class<? extends Recipe> getRecipeClass() {
+            return delegate.getRecipeClass();
+        }
     }
 
     @Value

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -64,8 +64,6 @@ class DeclarativeRecipeTest implements RewriteTest {
                 new ChangeText("3")
               );
               dr.initialize(List.of(), Map.of());
-              assertThat(dr.getDescriptor().getRecipeList().get(1).getOptions()).extracting(OptionDescriptor::getName).containsExactly("toText");
-              assertThat(dr.getDescriptor().getRecipeList().get(2).getOptions()).extracting(OptionDescriptor::getName).containsExactly("toText");
               spec.recipe(dr);
           },
           text("1", "3"),


### PR DESCRIPTION
Fixes a problem where RecipeDescriptor does not have the options on it when a recipe has preconditions.

## What's changed?
When a recipe is actually a delegate it can return that delegate to be used in option extraction.

## What's your motivation?
Currently a recipe with preconditions will have no options on the descriptors of children

## Have you considered any alternatives or workarounds?
Adding a specific check for the Bellwether wrapper, but I think this is cleaner.