### PR TITLE
Add XPath support for namespace-uri() condition and attribute elements

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020, 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -271,7 +271,7 @@ public class XPathMatcher {
         } else if (selector.equals("local-name()")) {
             return tagOrAttribute.getLocalName().equals(value);
         } else if (selector.equals("namespace-uri()")) {
-            Optional<String> nsUri= tagOrAttribute.getNamespaceUri(cursor);
+            Optional<String> nsUri = tagOrAttribute.getNamespaceUri(cursor);
             return nsUri.isPresent() && nsUri.get().equals(value);
         }
         return false;

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -19,6 +19,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.xml.search.FindTags;
+import org.openrewrite.xml.tree.Namespaced;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.*;
@@ -37,7 +38,7 @@ import java.util.regex.Pattern;
 public class XPathMatcher {
 
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
-    private static final Pattern PATTERN = Pattern.compile("([-\\w]+|\\*)\\[((local-name|namespace-uri)\\(\\)|(@)?([-\\w]+|\\*))='([-\\w.]+)']");
+    private static final Pattern PATTERN = Pattern.compile("(@)?([-\\w]+|\\*)\\[((local-name|namespace-uri)\\(\\)|(@)?([-\\w]+|\\*))='(.*)']");
 
     private final String expression;
     private final boolean startsWithSlash;
@@ -48,7 +49,17 @@ public class XPathMatcher {
         this.expression = expression;
         startsWithSlash = expression.startsWith("/");
         startsWithDoubleSlash = expression.startsWith("//");
-        parts = expression.substring(startsWithDoubleSlash ? 2 : startsWithSlash ? 1 : 0).split("/");
+        parts = splitOnXPathSeparator(expression.substring(startsWithDoubleSlash ? 2 : startsWithSlash ? 1 : 0));
+    }
+
+    private String[] splitOnXPathSeparator(String input) {
+        List<String> matches = new ArrayList<>();
+        Pattern p = Pattern.compile("((?<=/)(?=/)|[^/\\[]|\\[[^]]*\\])+");
+        Matcher m = p.matcher(input);
+        while (m.find()) {
+            matches.add(m.group());
+        }
+        return matches.toArray(new String[0]);
     }
 
     /**
@@ -102,24 +113,28 @@ public class XPathMatcher {
                 }
 
                 String partName;
+                boolean matchedCondition = false;
 
                 Matcher matcher;
                 if (tagForCondition != null && partWithCondition.endsWith("]") && (matcher = PATTERN.matcher(
                         partWithCondition)).matches()) {
-                    String optionalPartName = matchesCondition(matcher, tagForCondition, cursor);
+                    String optionalPartName = matchesElementWithConditionFunction(matcher, tagForCondition, cursor);
                     if (optionalPartName == null) {
                         return false;
                     }
                     partName = optionalPartName;
+                    matchedCondition = true;
                 } else {
                     partName = null;
                 }
 
                 if (part.startsWith("@")) {
-                    if (!(cursor.getValue() instanceof Xml.Attribute &&
-                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
-                            "*".equals(part.substring(1)))) {
-                        return false;
+                    if (!matchedCondition) {
+                        if (!(cursor.getValue() instanceof Xml.Attribute &&
+                              (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
+                              "*".equals(part.substring(1)))) {
+                            return false;
+                        }
                     }
 
                     pathIndex--;
@@ -145,7 +160,7 @@ public class XPathMatcher {
             Collections.reverse(path);
 
             // Deal with the two forward slashes in the expression; works, but I'm not proud of it.
-            if (expression.contains("//") && Arrays.stream(parts).anyMatch(StringUtils::isBlank)) {
+            if (expression.contains("//") && !expression.contains("://") && Arrays.stream(parts).anyMatch(StringUtils::isBlank)) {
                 int blankPartIndex = Arrays.asList(parts).indexOf("");
                 int doubleSlashIndex = expression.indexOf("//");
 
@@ -178,22 +193,27 @@ public class XPathMatcher {
 
                 Xml.Tag tag = i < path.size() ? path.get(i) : null;
                 String partName;
+                boolean matchedCondition = false;
 
                 Matcher matcher;
                 if (tag != null && part.endsWith("]") && (matcher = PATTERN.matcher(part)).matches()) {
-                    String optionalPartName = matchesCondition(matcher, tag, cursor);
+                    String optionalPartName = matchesElementWithConditionFunction(matcher, tag, cursor);
                     if (optionalPartName == null) {
                         return false;
                     }
                     partName = optionalPartName;
+                    matchedCondition = true;
                 } else {
                     partName = part;
                 }
 
                 if (part.startsWith("@")) {
+                    if (matchedCondition) {
+                        return true;
+                    }
                     return cursor.getValue() instanceof Xml.Attribute &&
-                            (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
-                                    "*".equals(part.substring(1)));
+                           (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1)) ||
+                            "*".equals(part.substring(1)));
                 }
 
                 if (path.size() < i + 1 || (tag != null && !tag.getName().equals(partName) && !partName.equals("*") && !"*".equals(part))) {
@@ -206,32 +226,32 @@ public class XPathMatcher {
     }
 
     @Nullable
-    private String matchesCondition(Matcher matcher, Xml.Tag tag, Cursor cursor) {
-        String name = matcher.group(1);
-        boolean isAttribute = matcher.group(4) != null; // either group4 != null, or group 2 startsWith @
-        String selector = isAttribute ? matcher.group(5) : matcher.group(2);
-        boolean isFunction = selector.endsWith("()");
-        String value = matcher.group(6);
+    private String matchesElementWithConditionFunction(Matcher matcher, Xml.Tag tag, Cursor cursor) {
+        boolean isAttributeElement = matcher.group(1) != null;
+        String element = matcher.group(2);
+        boolean isAttributeCondition = matcher.group(5) != null; // either group4 != null, or group 2 startsWith @
+        String selector = isAttributeCondition ? matcher.group(6) : matcher.group(3);
+        boolean isFunctionCondition = selector.endsWith("()");
+        String value = matcher.group(7);
 
         boolean matchCondition = false;
-        if (isAttribute) {
+        if (isAttributeCondition) {
             for (Xml.Attribute a : tag.getAttributes()) {
                 if ((a.getKeyAsString().equals(selector) || "*".equals(selector)) && a.getValueAsString().equals(value)) {
                     matchCondition = true;
                     break;
                 }
             }
-        } else if (isFunction) {
-            if (!name.equals("*") && !tag.getLocalName().equals(name)) {
-                matchCondition = false;
-            } else if (selector.equals("local-name()")) {
-                if (tag.getLocalName().equals(value)) {
-                    matchCondition = true;
+        } else if (isFunctionCondition) {
+            if (isAttributeElement) {
+                for (Xml.Attribute a : tag.getAttributes()) {
+                    if (matchesElementAndFunction(a, cursor, element, selector, value)) {
+                        matchCondition = true;
+                        break;
+                    }
                 }
-            } else if (selector.equals("namespace-uri()")) {
-                if (tag.getNamespaceUri(cursor).get().equals(value)) {
-                    matchCondition = true;
-                }
+            } else {
+                matchCondition = matchesElementAndFunction(tag, cursor, element, selector, value);
             }
         } else { // other [] conditions
             for (Xml.Tag t : FindTags.find(tag, selector)) {
@@ -242,6 +262,18 @@ public class XPathMatcher {
             }
         }
 
-        return matchCondition ? name : null;
+        return matchCondition ? element : null;
+    }
+
+    private static boolean matchesElementAndFunction(Namespaced tagOrAttribute, Cursor cursor, String element, String selector, String value) {
+        if (!element.equals("*") && !tagOrAttribute.getName().equals(element)) {
+            return false;
+        } else if (selector.equals("local-name()")) {
+            return tagOrAttribute.getLocalName().equals(value);
+        } else if (selector.equals("namespace-uri()")) {
+            Optional<String> nsUri= tagOrAttribute.getNamespaceUri(cursor);
+            return nsUri.isPresent() && nsUri.get().equals(value);
+        }
+        return false;
     }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -89,13 +89,18 @@ public class XPathMatcher {
                     if (index < 0) {
                         return false;
                     }
-                    //if is Attribute
-                    if (part.charAt(index + 1) == '@') {
+                    if (part.startsWith("@")) { // is attribute selector
                         partWithCondition = part;
-                        tagForCondition = path.get(i);
-                    } else if (part.contains("(") && part.contains(")")) { //if is function
-                        partWithCondition = part;
-                        tagForCondition = path.get(i);
+                        tagForCondition = i > 0 ? path.get(i-1) : path.get(i);
+                    }
+                    else { // is element selector
+                        if (part.charAt(index + 1) == '@') { // is Attribute condition
+                            partWithCondition = part;
+                            tagForCondition = path.get(i);
+                        } else if (part.contains("(") && part.contains(")")) { // is function condition
+                            partWithCondition = part;
+                            tagForCondition = path.get(i);
+                        }
                     }
                 } else if (i < path.size() && i > 0 && parts[i - 1].endsWith("]")) {
                     String partBefore = parts[i - 1];
@@ -130,9 +135,11 @@ public class XPathMatcher {
 
                 if (part.startsWith("@")) {
                     if (!matchedCondition) {
-                        if (!(cursor.getValue() instanceof Xml.Attribute &&
-                              (((Xml.Attribute) cursor.getValue()).getKeyAsString().equals(part.substring(1))) ||
-                              "*".equals(part.substring(1)))) {
+                        if (!(cursor.getValue() instanceof  Xml.Attribute)) {
+                            return false;
+                        }
+                        Xml.Attribute attribute = cursor.getValue();
+                        if (!attribute.getKeyAsString().equals(part.substring(1)) && !"*".equals(part.substring(1))) {
                             return false;
                         }
                     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -91,9 +91,8 @@ public class XPathMatcher {
                     }
                     if (part.startsWith("@")) { // is attribute selector
                         partWithCondition = part;
-                        tagForCondition = i > 0 ? path.get(i-1) : path.get(i);
-                    }
-                    else { // is element selector
+                        tagForCondition = i > 0 ? path.get(i - 1) : path.get(i);
+                    } else { // is element selector
                         if (part.charAt(index + 1) == '@') { // is Attribute condition
                             partWithCondition = part;
                             tagForCondition = path.get(i);
@@ -135,7 +134,7 @@ public class XPathMatcher {
 
                 if (part.startsWith("@")) {
                     if (!matchedCondition) {
-                        if (!(cursor.getValue() instanceof  Xml.Attribute)) {
+                        if (!(cursor.getValue() instanceof Xml.Attribute)) {
                             return false;
                         }
                         Xml.Attribute attribute = cursor.getValue();

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
 public class XPathMatcher {
 
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
-    private static final Pattern PATTERN = Pattern.compile("(@)?([-\\w]+|\\*)\\[((local-name|namespace-uri)\\(\\)|(@)?([-\\w]+|\\*))='(.*)']");
+    private static final Pattern PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)\\[((local-name|namespace-uri)\\(\\)|(@)?([-\\w]+|\\*))='(.*)']");
 
     private final String expression;
     private final boolean startsWithSlash;
@@ -197,7 +197,8 @@ public class XPathMatcher {
             for (int i = 0; i < parts.length; i++) {
                 String part = parts[i];
 
-                Xml.Tag tag = i < path.size() ? path.get(i) : null;
+                int isAttr = part.startsWith("@") ? 1 : 0;
+                Xml.Tag tag = i - isAttr < path.size() ? path.get(i - isAttr) : null;
                 String partName;
                 boolean matchedCondition = false;
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
  */
 public class XPathMatcher {
 
+    private static final Pattern XPATH_ELEMENT_SPLITTER = Pattern.compile("((?<=/)(?=/)|[^/\\[]|\\[[^]]*\\])+");
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
     private static final Pattern PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)\\[((local-name|namespace-uri)\\(\\)|(@)?([-\\w]+|\\*))='(.*)']");
 
@@ -54,8 +55,7 @@ public class XPathMatcher {
 
     private String[] splitOnXPathSeparator(String input) {
         List<String> matches = new ArrayList<>();
-        Pattern p = Pattern.compile("((?<=/)(?=/)|[^/\\[]|\\[[^]]*\\])+");
-        Matcher m = p.matcher(input);
+        Matcher m = XPATH_ELEMENT_SPLITTER.matcher(input);
         while (m.find()) {
             matches.add(m.group());
         }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2024 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Namespaced.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Namespaced.java
@@ -1,0 +1,15 @@
+package org.openrewrite.xml.tree;
+
+import org.openrewrite.Cursor;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface Namespaced extends Xml{
+
+    String getName();
+    String getLocalName();
+    Optional<String> getNamespacePrefix();
+    Optional<String> getNamespaceUri(Cursor cursor);
+    Map<String, String> getAllNamespaces(Cursor cursor);
+}

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Namespaced.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Namespaced.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.xml.tree;
 
 import org.openrewrite.Cursor;

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Namespaced.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Namespaced.java
@@ -20,11 +20,14 @@ import org.openrewrite.Cursor;
 import java.util.Map;
 import java.util.Optional;
 
-public interface Namespaced extends Xml{
-
+public interface Namespaced extends Xml {
     String getName();
+
     String getLocalName();
+
     Optional<String> getNamespacePrefix();
+
     Optional<String> getNamespaceUri(Cursor cursor);
+
     Map<String, String> getAllNamespaces(Cursor cursor);
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -345,6 +345,7 @@ public interface Xml extends Tree {
          * @param cursor     the cursor to search from
          * @return a map containing all namespaces defined in the current scope, including all parent scopes.
          */
+        @Override
         public Map<String, String> getAllNamespaces(Cursor cursor) {
             Map<String, String> namespaces = getNamespaces();
             while (cursor != null) {
@@ -615,6 +616,7 @@ public interface Xml extends Tree {
         /**
          * @return The local name for this tag, without any namespace prefix.
          */
+        @Override
         public String getLocalName() {
             return extractLocalName(name);
         }
@@ -622,6 +624,7 @@ public interface Xml extends Tree {
         /**
          * @return The namespace prefix for this tag, if any.
          */
+        @Override
         public Optional<String> getNamespacePrefix() {
             String extractedNamespacePrefix = extractNamespacePrefix(name);
             return Optional.ofNullable(StringUtils.isNotEmpty(extractedNamespacePrefix) ? extractedNamespacePrefix : null);
@@ -630,6 +633,7 @@ public interface Xml extends Tree {
         /**
          * @return The namespace URI for this tag, if any.
          */
+        @Override
         public Optional<String> getNamespaceUri(Cursor cursor) {
             Optional<String> maybeNamespacePrefix = getNamespacePrefix();
             return maybeNamespacePrefix.flatMap(s -> Optional.ofNullable(getAllNamespaces(cursor).get(s)));

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020, 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -755,6 +755,7 @@ public interface Xml extends Tree {
             return value.getValue();
         }
 
+        @Override
         public String getName() {
             return key.getName();
         }
@@ -762,6 +763,7 @@ public interface Xml extends Tree {
         /**
          * @return The local name for this attribute, without any namespace prefix.
          */
+        @Override
         public String getLocalName() {
             return extractLocalName(getKeyAsString());
         }
@@ -769,6 +771,7 @@ public interface Xml extends Tree {
         /**
          * @return The namespace prefix for this attribute, if any.
          */
+        @Override
         public Optional<String> getNamespacePrefix() {
             String extractedNamespacePrefix = extractNamespacePrefix(getKeyAsString());
             return Optional.ofNullable(StringUtils.isNotEmpty(extractedNamespacePrefix) ? extractedNamespacePrefix : null);
@@ -777,6 +780,7 @@ public interface Xml extends Tree {
         /**
          * @return The namespace URI for this attribute, if any.
          */
+        @Override
         public Optional<String> getNamespaceUri(Cursor cursor) {
             Optional<String> maybeNamespacePrefix = getNamespacePrefix();
             return maybeNamespacePrefix.flatMap(s -> Optional.ofNullable(getAllNamespaces(cursor).get(s)));
@@ -788,6 +792,7 @@ public interface Xml extends Tree {
          * @param cursor     the cursor to search from
          * @return a map containing all namespaces defined in the current scope, including all parent scopes.
          */
+        @Override
         public Map<String, String> getAllNamespaces(Cursor cursor) {
             Map<String, String> namespaces = new HashMap<>();
             while (cursor != null) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2024 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020, 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -132,6 +132,8 @@ class XPathMatcherTest {
         assertThat(match("//dependency", xmlDoc)).isTrue();
         assertThat(match("dependency/*", xmlDoc)).isTrue();
         assertThat(match("dne", xmlDoc)).isFalse();
+        assertThat(match("/dependencies//dependency", xmlDoc)).isTrue();
+        assertThat(match("/dependencies//dependency/groupId", xmlDoc)).isTrue();
     }
 
     @Test
@@ -251,7 +253,7 @@ class XPathMatcherTest {
     }
 
     @Test
-    void testMatchLocalName() {
+    void matchLocalNameFunctionCondition() {
         assertThat(match("/*[local-name()='root']", namespacedXml)).isTrue();
         assertThat(match("/*[local-name()='element1']", namespacedXml)).isFalse();
         assertThat(match("/*[local-name()='element2']", namespacedXml)).isFalse();
@@ -264,10 +266,13 @@ class XPathMatcherTest {
         assertThat(match("//element2[local-name()='element2']", namespacedXml)).isFalse();
         assertThat(match("//ns2:element2[local-name()='element2']", namespacedXml)).isTrue();
         assertThat(match("//dne[local-name()='dne']", namespacedXml)).isFalse();
+
+        // TODO: fix mid-path // with condition
+//        assertThat(match("/root//element1[local-name()='element1']", namespacedXml)).isTrue();
     }
 
     @Test
-    void matchNamespaceUri() {
+    void matchNamespaceUriFunctionCondition() {
         assertThat(match("/root/*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
         assertThat(match("/*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
         assertThat(match("//*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
@@ -276,20 +281,42 @@ class XPathMatcherTest {
     }
 
     @Test
-    void matchAttributes() {
+    void matchAttributeCondition() {
+        assertThat(match("//*[@*='content3']", namespacedXml)).isTrue();
+        assertThat(match("//*[@*='content2']", namespacedXml)).isFalse();
+        assertThat(match("//*[@ns3:attribute1='content3']", namespacedXml)).isTrue();
+        assertThat(match("//*[@attribute1='content3']", namespacedXml)).isFalse();
+        assertThat(match("//element1[@ns3:attribute1='content3']", namespacedXml)).isTrue();
+        assertThat(match("//element1[@attribute1='content3']", namespacedXml)).isFalse();
+        assertThat(match("//element1[@*='content3']", namespacedXml)).isTrue();
+        assertThat(match("//element1[@*='dne']", namespacedXml)).isFalse();
+        assertThat(match("/root/element1[@*='content3']", namespacedXml)).isTrue();
+        assertThat(match("/root/element1[@*='dne']", namespacedXml)).isFalse();
+        // TODO: fix mid-path // match with condition
+//        assertThat(match("/root//element1[@*='content3']", namespacedXml)).isTrue();
+//        assertThat(match("/root//element1[@*='dne']", namespacedXml)).isFalse();
+    }
+
+    @Test
+    void matchAttributeElement() {
         assertThat(match("//@ns3:attribute1", namespacedXml)).isTrue();
         assertThat(match("//@attribute1", namespacedXml)).isFalse();
+        assertThat(match("//@*", namespacedXml)).isTrue();
         assertThat(match("//@*[local-name()='attribute1']", namespacedXml)).isTrue();
         assertThat(match("//@*[local-name()='attribute2']", namespacedXml)).isFalse();
         assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
         assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
-        assertThat(match("//@*", namespacedXml)).isTrue();
+
         assertThat(match("//element1/@*", namespacedXml)).isTrue();
         assertThat(match("/root/element1/@*", namespacedXml)).isTrue();
-//        assertThat(match("//element1/@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue(); // TODO: fix
+        assertThat(match("//element1/@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
         assertThat(match("//element1/@*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
-//        assertThat(match("//ns2:element2/@*", namespacedXml)).isFalse(); // TODO: fix
+        assertThat(match("//ns2:element2/@*", namespacedXml)).isFalse();
         assertThat(match("/root/ns2:element2/@*", namespacedXml)).isFalse();
+
+        // TODO: fix mid-path // match with attribute element
+//        assertThat(match("/root//element1/@*", namespacedXml)).isTrue();
+//        assertThat(match("/root//element1/@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
     }
 
     private boolean match(String xpath, SourceFile x) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -157,6 +157,7 @@ class XPathMatcherTest {
           pomXml1)).isTrue();
         assertThat(match("/project/build//plugins/plugin/configuration/source",
           pomXml2)).isTrue();
+//        assertThat(match("/project//configuration/source", pomXml2)).isTrue(); // TODO: was already failing previously
     }
 
     private final SourceFile attributeXml = new XmlParser().parse(
@@ -263,6 +264,32 @@ class XPathMatcherTest {
         assertThat(match("//element2[local-name()='element2']", namespacedXml)).isFalse();
         assertThat(match("//ns2:element2[local-name()='element2']", namespacedXml)).isTrue();
         assertThat(match("//dne[local-name()='dne']", namespacedXml)).isFalse();
+    }
+
+    @Test
+    void matchNamespaceUri() {
+        assertThat(match("/root/*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        assertThat(match("/*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+        assertThat(match("//*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        assertThat(match("//ns2:element2[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        assertThat(match("//element2[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+    }
+
+    @Test
+    void matchAttributes() {
+        assertThat(match("//@ns3:attribute1", namespacedXml)).isTrue();
+        assertThat(match("//@attribute1", namespacedXml)).isFalse();
+        assertThat(match("//@*[local-name()='attribute1']", namespacedXml)).isTrue();
+        assertThat(match("//@*[local-name()='attribute2']", namespacedXml)).isFalse();
+        assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
+        assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+        assertThat(match("//@*", namespacedXml)).isTrue();
+        assertThat(match("//element1/@*", namespacedXml)).isTrue();
+        assertThat(match("/root/element1/@*", namespacedXml)).isTrue();
+//        assertThat(match("//element1/@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue(); // TODO: fix
+        assertThat(match("//element1/@*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+//        assertThat(match("//ns2:element2/@*", namespacedXml)).isFalse(); // TODO: fix
+        assertThat(match("/root/ns2:element2/@*", namespacedXml)).isFalse();
     }
 
     private boolean match(String xpath, SourceFile x) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -105,6 +105,9 @@ class XPathMatcherTest {
                                   http://www.example.com/namespace3 http://www.example.com/namespace3.xsd">
           <element1 ns3:attribute1="content3">content1</element1>
           <ns2:element2>content2</ns2:element2>
+          <parent>
+              <element3 ns3:attr='test'>content3</element3>
+          </parent>
         </root>
         """
     ).toList().get(0);
@@ -159,6 +162,7 @@ class XPathMatcherTest {
           pomXml1)).isTrue();
         assertThat(match("/project/build//plugins/plugin/configuration/source",
           pomXml2)).isTrue();
+//        assertThat(match("/project/build//plugin/configuration/source", pomXml2)).isTrue(); // TODO: seems parser only handles // up to 1 level
 //        assertThat(match("/project//configuration/source", pomXml2)).isTrue(); // TODO: was already failing previously
     }
 
@@ -313,6 +317,11 @@ class XPathMatcherTest {
         assertThat(match("//element1/@*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
         assertThat(match("//ns2:element2/@*", namespacedXml)).isFalse();
         assertThat(match("/root/ns2:element2/@*", namespacedXml)).isFalse();
+
+        assertThat(match("/root/parent/element3/@attr", namespacedXml)).isFalse();
+        assertThat(match("/root/parent/element3/@ns3:attr", namespacedXml)).isTrue();
+        assertThat(match("/root/parent/element3/@ns3:attr[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
+        assertThat(match("//element3/@ns3:attr[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
 
         // TODO: fix mid-path // match with attribute element
 //        assertThat(match("/root//element1/@*", namespacedXml)).isTrue();

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2024 the original author or authors.
+ * Copyright 2020 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/search/HasNamespaceUriTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/search/HasNamespaceUriTest.java
@@ -84,30 +84,6 @@ class HasNamespaceUriTest implements RewriteTest {
     }
 
     @Test
-    void staticFindElement() {
-        rewriteRun(
-          spec -> spec.recipe(new HasNamespaceUri("http://cxf.apache.org/jaxws", "/beans/client/conduitSelector")),
-          xml(
-            source,
-            """
-              <beans xmlns="http://www.springframework.org/schema/beans"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="
-                      http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
-                      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-
-                  <jaxws:client name="{http://cxf.apache.org/hello_world_soap_http}SoapPort" createdFromAPI="true" xmlns:jaxws="http://cxf.apache.org/jaxws">
-                      <!--~~>--><jaxws:conduitSelector>
-                          <bean class="org.apache.cxf.endpoint.DeferredConduitSelector"/>
-                      </jaxws:conduitSelector>
-                  </jaxws:client>
-              </beans>
-              """
-          )
-        );
-    }
-
-    @Test
     void noMatchOnXPath() {
         rewriteRun(
           spec -> spec.recipe(new HasNamespaceUri("xsi", "/jaxws:client")),

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/search/HasNamespaceUriTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/search/HasNamespaceUriTest.java
@@ -84,6 +84,30 @@ class HasNamespaceUriTest implements RewriteTest {
     }
 
     @Test
+    void staticFindElement() {
+        rewriteRun(
+          spec -> spec.recipe(new HasNamespaceUri("http://cxf.apache.org/jaxws", "/beans/client/conduitSelector")),
+          xml(
+            source,
+            """
+              <beans xmlns="http://www.springframework.org/schema/beans"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="
+                      http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
+                      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+                  <jaxws:client name="{http://cxf.apache.org/hello_world_soap_http}SoapPort" createdFromAPI="true" xmlns:jaxws="http://cxf.apache.org/jaxws">
+                      <!--~~>--><jaxws:conduitSelector>
+                          <bean class="org.apache.cxf.endpoint.DeferredConduitSelector"/>
+                      </jaxws:conduitSelector>
+                  </jaxws:client>
+              </beans>
+              """
+          )
+        );
+    }
+
+    @Test
     void noMatchOnXPath() {
         rewriteRun(
           spec -> spec.recipe(new HasNamespaceUri("xsi", "/jaxws:client")),


### PR DESCRIPTION
## What's changed?
Add support for `namespace-uri()` conditions in XPathMatcher, along with tests
Add attribute match support in XPathMatcher (`/@attributeName`)
Update XPath splitter to handle URLs

## What's your motivation?
Be able to use namespace filters in XPathMatcher

## Anything in particular you'd like reviewers to focus on?


## Anyone you would like to review specifically?
@sambsnyd @timtebeek 
FYI: @ammachado 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
Unsure about the addition of the new Interface `Namespaced` (or its naming). Just wanted to be able to run one of my methods on both `Xml.Tag` and `Xml.Attribute` objects.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
