### PR TITLE
Preserve multiple dependencyManagement with different types

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -270,8 +270,9 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 .orElse(getResolutionResult().getPom().getGroupId()));
         String artifactId = getResolutionResult().getPom().getValue(tag.getChildValue("artifactId").orElse(""));
         String classifier = getResolutionResult().getPom().getValue(tag.getChildValue("classifier").orElse(null));
+        String type = getResolutionResult().getPom().getValue(tag.getChildValue("type").orElse(null));
         if (groupId != null && artifactId != null) {
-            return findManagedDependency(groupId, artifactId, classifier);
+            return findManagedDependency(groupId, artifactId, classifier, type);
         }
         return null;
     }
@@ -283,10 +284,16 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
 
     @Nullable
     private ResolvedManagedDependency findManagedDependency(String groupId, String artifactId, @Nullable String classifier) {
+        return findManagedDependency(groupId, artifactId, classifier, null);
+    }
+
+    @Nullable
+    private ResolvedManagedDependency findManagedDependency(String groupId, String artifactId, @Nullable String classifier, @Nullable String type) {
         for (ResolvedManagedDependency d : getResolutionResult().getPom().getDependencyManagement()) {
             if (groupId.equals(d.getGroupId()) &&
                 artifactId.equals(d.getArtifactId()) &&
-                (classifier == null || classifier.equals(d.getClassifier()))) {
+                (classifier == null || classifier.equals(d.getClassifier())) &&
+                (type == null || type.equals(d.getType()))) {
                 return d;
             }
         }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -345,6 +345,39 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
         );
     }
 
+	@Test
+	void keepDependencyManagementWithType() {
+		rewriteRun(
+		  pomXml(
+			"""
+ 			  <project>
+				<modelVersion>4.0.0</modelVersion>
+				
+				<groupId>com.mycompany.app</groupId>
+				<artifactId>my-app</artifactId>
+				<version>1</version>
+				
+				<dependencyManagement>
+				  <dependencies>
+					<dependency>
+					  <groupId>com.acme</groupId>
+					  <artifactId>example-dependency</artifactId>
+				      <version>1.0.0</version>
+					</dependency>
+					<dependency>
+				      <groupId>com.acme</groupId>
+				      <artifactId>example-dependency</artifactId>
+				      <version>1.0.0</version>
+				      <type>test-jar</type>
+					</dependency>
+				  </dependencies>
+				</dependencyManagement>
+			  </project>
+			  """
+		  )
+		);
+	}
+
     @Test
     void keepDependencyWithDifferentScope() {
         rewriteRun(


### PR DESCRIPTION

## What's changed?

Find managedDependency() did not take type into account


## What's your motivation?

It is a valid case to specify different dependencyManagement dependencies for the same artifact but with different types (used for example if you create a test-jar of a dependency and manage its version). Without this fix, the RemoveDuplicateDependencies recipe removed duplicate dependencyManagement dependencies with same artifact but different types


