### PR TITLE
Recreate static imports for identifiers in ChangeType

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -310,6 +310,20 @@ public class ChangeType extends Recipe {
                         ident = ident.withSimpleName(((JavaType.Primitive) targetType).getKeyword());
                     }
                 }
+
+                // Recreate any static imports as needed
+                JavaSourceFile cu = getCursor().firstEnclosingOrThrow(JavaSourceFile.class);
+                for (J.Import anImport : cu.getImports()) {
+                    if (anImport.isStatic() && anImport.getQualid().getTarget().getType() != null) {
+                        JavaType.FullyQualified fqn = TypeUtils.asFullyQualified(anImport.getQualid().getTarget().getType());
+                        if (fqn != null && TypeUtils.isOfClassType(fqn, originalType.getFullyQualifiedName()) &&
+                            ident.getSimpleName().equals(anImport.getQualid().getSimpleName())) {
+                            JavaType.FullyQualified targetFqn = (JavaType.FullyQualified) targetType;
+                            maybeAddImport((targetFqn).getFullyQualifiedName(), ident.getSimpleName());
+                            break;
+                        }
+                    }
+                }
             }
             ident = ident.withType(updateType(ident.getType()));
             return visitAndCast(ident, ctx, super::visitIdentifier);


### PR DESCRIPTION
## What's changed?
When we change the type of identifiers, also recreate any static imports, same as we do for method invocations.
These static imports are also removed when the RemoveImport visitor removes non-static imports, so we really need to recreate these as opposed to changing the type of an existing import.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-jackson/pull/6