### PR TITLE
ChangeType leads to botched imports for nested fields

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -181,7 +181,7 @@ class ChangeTypeTest implements RewriteTest {
               class Test {
                   List p;
                   List p2;
-                  List p3;
+                  java.util.List p3;
               }
               """
           )
@@ -1852,47 +1852,6 @@ class ChangeTypeTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-jackson/pull/6")
     @Test
-    @Disabled
-    void changeTypeOfStaticImportOfNestedEnumValueUnused() {
-        rewriteRun(
-          recipeSpec -> recipeSpec.recipes(
-            new ChangeType(
-              "org.codehaus.jackson.map.SerializationConfig$Feature",
-              "com.fasterxml.jackson.databind.SerializationFeature", true)
-          ),
-          java(
-            """
-              package org.codehaus.jackson.map;
-              public class SerializationConfig {
-                  public static enum Feature {
-                      WRAP_ROOT_VALUE
-                  }
-              }
-              """,
-            SourceSpec::skip
-          ),
-          java(
-            """
-              import static org.codehaus.jackson.map.SerializationConfig.Feature.WRAP_ROOT_VALUE;
-
-              class A {
-                  org.codehaus.jackson.map.SerializationConfig.Feature feature = WRAP_ROOT_VALUE;
-              }
-              """,
-            """
-              import static com.fasterxml.jackson.databind.SerializationFeature.WRAP_ROOT_VALUE;
-
-              class A {
-                  com.fasterxml.jackson.databind.SerializationFeature feature = WRAP_ROOT_VALUE;
-              }
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite-jackson/pull/6")
-    @Test
-    @Disabled
     void changeTypeOfStaticImportOfNestedEnumValueUsed() {
         rewriteRun(
           recipeSpec -> recipeSpec.recipes(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1852,9 +1852,14 @@ class ChangeTypeTest implements RewriteTest {
     @Test
     void changeTypeOfStaticImportOfNestedEnumValue() {
         rewriteRun(
-          recipeSpec -> recipeSpec.recipe(new ChangeType(
-            "org.codehaus.jackson.map.SerializationConfig$Feature",
-            "com.fasterxml.jackson.databind.SerializationFeature", true)),
+          recipeSpec -> recipeSpec.recipes(
+            new ChangeType(
+              "org.codehaus.jackson.map.ObjectMapper",
+              "com.fasterxml.jackson.databind.ObjectMapper", true),
+            new ChangeType(
+              "org.codehaus.jackson.map.SerializationConfig$Feature",
+              "com.fasterxml.jackson.databind.SerializationFeature", true)
+            ),
           java(
             """
               package org.codehaus.jackson.map;
@@ -1868,37 +1873,37 @@ class ChangeTypeTest implements RewriteTest {
           ),
           java(
             """
-              package com.fasterxml.jackson.databind;
-              public enum SerializationFeature {
-                  WRAP_ROOT_VALUE
+              package org.codehaus.jackson.map;
+              public class ObjectMapper {
+                  public ObjectMapper configure(SerializationConfig.Feature f, boolean state) {
+                      return this;
+                  }
               }
               """,
             SourceSpec::skip
           ),
           java(
             """
-              import org.codehaus.jackson.map.SerializationConfig.Feature;
+              import org.codehaus.jackson.map.ObjectMapper;
 
               import static org.codehaus.jackson.map.SerializationConfig.Feature.WRAP_ROOT_VALUE;
 
               class A {
                   void test() {
-                      configure(WRAP_ROOT_VALUE, true);
-                  }
-                  void configure(Feature f, boolean b) {
+                      ObjectMapper mapper = new ObjectMapper();
+                      mapper.configure(WRAP_ROOT_VALUE, true);
                   }
               }
               """,
             """
-              import com.fasterxml.jackson.databind.SerializationFeature;
+              import com.fasterxml.jackson.databind.ObjectMapper;
 
               import static com.fasterxml.jackson.databind.SerializationFeature.WRAP_ROOT_VALUE;
 
               class A {
                   void test() {
-                      configure(WRAP_ROOT_VALUE, true);
-                  }
-                  void configure(SerializationFeature f, boolean b) {
+                      ObjectMapper mapper = new ObjectMapper();
+                      mapper.configure(WRAP_ROOT_VALUE, true);
                   }
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1850,7 +1850,44 @@ class ChangeTypeTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-jackson/pull/6")
     @Test
-    void changeTypeOfStaticImportOfNestedEnumValue() {
+    void changeTypeOfStaticImportOfNestedEnumValueUnused() {
+        rewriteRun(
+          recipeSpec -> recipeSpec.recipes(
+            new ChangeType(
+              "org.codehaus.jackson.map.SerializationConfig$Feature",
+              "com.fasterxml.jackson.databind.SerializationFeature", true)
+          ),
+          java(
+            """
+              package org.codehaus.jackson.map;
+              public class SerializationConfig {
+                  public static enum Feature {
+                      WRAP_ROOT_VALUE
+                  }
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import static org.codehaus.jackson.map.SerializationConfig.Feature.WRAP_ROOT_VALUE;
+
+              class A {
+              }
+              """,
+            """
+              import static com.fasterxml.jackson.databind.SerializationFeature.WRAP_ROOT_VALUE;
+
+              class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-jackson/pull/6")
+    @Test
+    void changeTypeOfStaticImportOfNestedEnumValueUsed() {
         rewriteRun(
           recipeSpec -> recipeSpec.recipes(
             new ChangeType(
@@ -1859,7 +1896,7 @@ class ChangeTypeTest implements RewriteTest {
             new ChangeType(
               "org.codehaus.jackson.map.SerializationConfig$Feature",
               "com.fasterxml.jackson.databind.SerializationFeature", true)
-            ),
+          ),
           java(
             """
               package org.codehaus.jackson.map;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -172,6 +172,7 @@ class ChangeTypeTest implements RewriteTest {
               class Test {
                   Entry p;
                   Map.Entry p2;
+                  java.util.Map.Entry p3;
               }
               """,
             """
@@ -180,6 +181,7 @@ class ChangeTypeTest implements RewriteTest {
               class Test {
                   List p;
                   List p2;
+                  List p3;
               }
               """
           )
@@ -1850,6 +1852,7 @@ class ChangeTypeTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-jackson/pull/6")
     @Test
+    @Disabled
     void changeTypeOfStaticImportOfNestedEnumValueUnused() {
         rewriteRun(
           recipeSpec -> recipeSpec.recipes(
@@ -1873,12 +1876,14 @@ class ChangeTypeTest implements RewriteTest {
               import static org.codehaus.jackson.map.SerializationConfig.Feature.WRAP_ROOT_VALUE;
 
               class A {
+                  org.codehaus.jackson.map.SerializationConfig.Feature feature = WRAP_ROOT_VALUE;
               }
               """,
             """
               import static com.fasterxml.jackson.databind.SerializationFeature.WRAP_ROOT_VALUE;
 
               class A {
+                  com.fasterxml.jackson.databind.SerializationFeature feature = WRAP_ROOT_VALUE;
               }
               """
           )
@@ -1887,6 +1892,7 @@ class ChangeTypeTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-jackson/pull/6")
     @Test
+    @Disabled
     void changeTypeOfStaticImportOfNestedEnumValueUsed() {
         rewriteRun(
           recipeSpec -> recipeSpec.recipes(

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -227,7 +227,7 @@ public class ChangeType extends Recipe {
                 }
 
                 if (sf != null) {
-                    sf = sf.withImports(ListUtils.map(sf.getImports(), originalImport -> visitAndCast(originalImport, ctx, super::visitImport)));
+                    sf = sf.withImports(ListUtils.map(sf.getImports(), i -> visitAndCast(i, ctx, super::visitImport)));
                 }
 
                 j = sf;

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -227,7 +227,10 @@ public class ChangeType extends Recipe {
                 }
 
                 if (sf != null) {
-                    sf = sf.withImports(ListUtils.map(sf.getImports(), i -> visitAndCast(i, ctx, super::visitImport)));
+                    sf = sf.withImports(ListUtils.map(sf.getImports(), originalImport -> {
+                        J.Import modifiedImport = visitAndCast(originalImport, ctx, super::visitImport);
+                        return modifiedImport; // FIXME Mangles import
+                    }));
                 }
 
                 j = sf;

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -227,10 +227,7 @@ public class ChangeType extends Recipe {
                 }
 
                 if (sf != null) {
-                    sf = sf.withImports(ListUtils.map(sf.getImports(), originalImport -> {
-                        J.Import modifiedImport = visitAndCast(originalImport, ctx, super::visitImport);
-                        return modifiedImport; // FIXME Mangles import
-                    }));
+                    sf = sf.withImports(ListUtils.map(sf.getImports(), originalImport -> visitAndCast(originalImport, ctx, super::visitImport)));
                 }
 
                 j = sf;
@@ -279,6 +276,10 @@ public class ChangeType extends Recipe {
                         e = i.withType(targetType);
                     }
                     return e;
+                } else if (maybeClass.toString().equals(oldType.getFullyQualifiedName().replace('$', '.'))) {
+                    maybeRemoveImport(oldType.getOwningClass());
+                    return updateOuterClassTypes(TypeTree.build(((JavaType.FullyQualified) targetType).getFullyQualifiedName())
+                            .withPrefix(fieldAccess.getPrefix()));
                 }
             }
             return super.visitFieldAccess(fieldAccess, ctx);


### PR DESCRIPTION
After 
- https://github.com/openrewrite/rewrite/pull/4291

We continued to see issues in
- https://github.com/openrewrite/rewrite-jackson/pull/6

I've updated the test to better replicate the issue there. With this change the test fails with left imports.

```diff
Unexpected result in "A.java":
diff --git a/A.java b/A.java
index 98d3bcb..da17811 100644
--- a/A.java
+++ b/A.java
@@ -1,6 +1,8 @@ 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRAP_ROOT_VALUE;
+import static org.codehaus.jackson.map.SerializationConfig.SerializationFeature.WRAP_ROOT_VALUE;
 
 class A {
     void test() {

```