### PR TITLE
RemoveObjectsIsNull fails on negated expressions fixed

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
@@ -169,7 +169,7 @@ class RemoveObjectsIsNullTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4244")
-    void negatedRemoveObjectsIsNull() {
+    void negatedCallToIsNull() {
         rewriteRun(
           java(
             """
@@ -197,4 +197,37 @@ class RemoveObjectsIsNullTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4244")
+    void comparisonOfCallToFalse() {
+        rewriteRun(
+          java(
+            """
+            package com.helloworld;
+            
+            import java.util.Objects;
+
+            class Hello {
+              public boolean hello(String abc) {
+                if (Objects.isNull(abc) == false) {
+                  return;
+                }
+              }
+            }
+            """,
+            // "!abc == null" is not a valid expression
+            """
+            package com.helloworld;
+
+            class Hello {
+              public boolean hello(String abc) {
+                if (!(abc == null)) {
+                  return;
+                }
+              }
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
@@ -166,4 +166,35 @@ class RemoveObjectsIsNullTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4244")
+    void negatedRemoveObjectsIsNull() {
+        rewriteRun(
+          java(
+            """
+            package com.helloworld;
+            
+            import java.util.Objects;
+
+            class Hello {
+              public boolean hello(String abc) {
+                return !Objects.isNull(abc);
+              }
+            }
+            """,
+            // "!abc == null" is not a valid expression
+            """
+            package com.helloworld;
+
+            class Hello {
+              public boolean hello(String abc) {
+                return !(abc == null);
+              }
+            }
+            """
+          )
+        );
+    }
+
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveObjectsIsNullTest.java
@@ -189,7 +189,7 @@ class RemoveObjectsIsNullTest implements RewriteTest {
 
             class Hello {
               public boolean hello(String abc) {
-                return !(abc == null);
+                return abc != null;
               }
             }
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -71,9 +71,9 @@ public class RemoveObjectsIsNull extends Recipe {
             }
 
             @Override
-            public J postVisit(J tree, ExecutionContext executionContext) {
-                J j = super.postVisit(tree, executionContext);
-                if (getCursor().getMessage("REMOVE_PARENTHESES", false)) {
+            public J postVisit(J tree, ExecutionContext ctx) {
+                J j = super.postVisit(tree, ctx);
+                    return new UnnecessaryParenthesesVisitor<>().visit(j, ctx);
                     return new UnnecessaryParenthesesVisitor<>().visit(j, executionContext);
                 }
                 return j;

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -65,7 +65,7 @@ public class RemoveObjectsIsNull extends Recipe {
                 }
 
                 // Replace the method invocation with a simple null check
-                getCursor().getParentOrThrow().putMessage("REMOVE_PARENTHESES", true);
+                getCursor().getParentTreeCursor().putMessage("REMOVE_PARENTHESES", true);
                 Expression replaced = JavaTemplate.apply(pattern, getCursor(), m.getCoordinates().replace(), m.getArguments().get(0));
                 return (Expression) new UnnecessaryParenthesesVisitor<>().visitNonNull(replaced, ctx, getCursor());
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -74,7 +74,7 @@ public class RemoveObjectsIsNull extends Recipe {
             @Override
             public J postVisit(J tree, ExecutionContext ctx) {
                 J j = super.postVisit(tree, ctx);
-                if (getCursor().getNearestMessage("SIMPLIFY_BOOLEAN_EXPRESSION", false)) {
+                if (Boolean.TRUE.equals(getCursor().pollMessage("SIMPLIFY_BOOLEAN_EXPRESSION"))) {
                     return new SimplifyBooleanExpressionVisitor().visit(j, ctx, getCursor().getParentOrThrow());
                 }
                 return j;

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -73,8 +73,8 @@ public class RemoveObjectsIsNull extends Recipe {
             @Override
             public J postVisit(J tree, ExecutionContext ctx) {
                 J j = super.postVisit(tree, ctx);
-                    return new UnnecessaryParenthesesVisitor<>().visit(j, ctx);
-                    return new UnnecessaryParenthesesVisitor<>().visit(j, executionContext);
+                if (getCursor().getNearestMessage("REMOVE_PARENTHESES", false)) {
+                    return new UnnecessaryParenthesesVisitor<>().visit(j, ctx, getCursor().getParentOrThrow());
                 }
                 return j;
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveObjectsIsNull.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java;
 
 import org.openrewrite.*;
+import org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor;
 import org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
@@ -65,7 +66,7 @@ public class RemoveObjectsIsNull extends Recipe {
                 }
 
                 // Replace the method invocation with a simple null check
-                getCursor().getParentTreeCursor().putMessage("REMOVE_PARENTHESES", true);
+                getCursor().getParentTreeCursor().putMessage("SIMPLIFY_BOOLEAN_EXPRESSION", true);
                 Expression replaced = JavaTemplate.apply(pattern, getCursor(), m.getCoordinates().replace(), m.getArguments().get(0));
                 return (Expression) new UnnecessaryParenthesesVisitor<>().visitNonNull(replaced, ctx, getCursor());
             }
@@ -73,8 +74,8 @@ public class RemoveObjectsIsNull extends Recipe {
             @Override
             public J postVisit(J tree, ExecutionContext ctx) {
                 J j = super.postVisit(tree, ctx);
-                if (getCursor().getNearestMessage("REMOVE_PARENTHESES", false)) {
-                    return new UnnecessaryParenthesesVisitor<>().visit(j, ctx, getCursor().getParentOrThrow());
+                if (getCursor().getNearestMessage("SIMPLIFY_BOOLEAN_EXPRESSION", false)) {
+                    return new SimplifyBooleanExpressionVisitor().visit(j, ctx, getCursor().getParentOrThrow());
                 }
                 return j;
             }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This version includes parentheses around the JavaTemplate expressions to ensure correct negation handling, and uses SimplifyBooleanExpressionVisitor to simplify expressions as needed.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
- Fixes #4244 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
