### PR TITLE
Remove property in maven model

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RenamePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RenamePropertyKey.java
@@ -78,8 +78,8 @@ public class RenamePropertyKey extends Recipe {
             }
 
             @Override
-            public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
-                Xml.Document d = super.visitDocument(document, executionContext);
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+                Xml.Document d = super.visitDocument(document, ctx);
                 if (d != document) {
                     maybeUpdateModel();
                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RenamePropertyKey.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RenamePropertyKey.java
@@ -66,7 +66,6 @@ public class RenamePropertyKey extends Recipe {
                 Xml.Tag t = super.visitTag(tag, ctx);
                 if (isPropertyTag() && oldKey.equals(t.getName())) {
                     t = t.withName(newKey);
-                    maybeUpdateModel();
                 }
                 if (t.getChildren().isEmpty()) {
                     Optional<String> value = t.getValue();
@@ -76,6 +75,15 @@ public class RenamePropertyKey extends Recipe {
                     }
                 }
                 return t;
+            }
+
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
+                Xml.Document d = super.visitDocument(document, executionContext);
+                if (d != document) {
+                    maybeUpdateModel();
+                }
+                return d;
             }
         };
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -40,6 +40,7 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
         Pom requested = resolutionResult.getPom().getRequested();
 
         Optional<Xml.Tag> properties = document.getRoot().getChild("properties");
+        requested.getProperties().clear();
         if (properties.isPresent()) {
             for (final Xml.Tag propertyTag : properties.get().getChildren()) {
                 requested.getProperties().put(propertyTag.getName(),

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemovePropertyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemovePropertyTest.java
@@ -17,9 +17,13 @@ package org.openrewrite.maven;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RemovePropertyTest implements RewriteTest {
@@ -60,7 +64,15 @@ class RemovePropertyTest implements RewriteTest {
                   <a.version>a</a.version>
                 </properties>
               </project>
-              """
+              """,
+            sourceSpecs -> {
+                sourceSpecs.afterRecipe(d -> {
+                    MavenResolutionResult resolution = d.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                    Map<String, String> properties = resolution.getPom().getRequested().getProperties();
+                    assertThat(properties.get("a.version")).isEqualTo("a");
+                    assertThat(properties.get("bla.version")).isNull();
+                });
+            }
           )
         );
     }
@@ -90,7 +102,14 @@ class RemovePropertyTest implements RewriteTest {
                 <artifactId>my-app</artifactId>
                 <version>1</version>
               </project>
-              """
+              """,
+            sourceSpecs -> {
+                sourceSpecs.afterRecipe(d -> {
+                    MavenResolutionResult resolution = d.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                    Map<String, String> properties = resolution.getPom().getRequested().getProperties();
+                    assertThat(properties.isEmpty()).isTrue();
+                });
+            }
           )
         );
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RenamePropertyKeyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RenamePropertyKeyTest.java
@@ -15,11 +15,16 @@
  */
 package org.openrewrite.maven;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RenamePropertyKeyTest implements RewriteTest {
@@ -222,4 +227,27 @@ class RenamePropertyKeyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void nothingToRename() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <properties>
+                  <a.version>a</a.version>
+                  <bla.version>b</bla.version>
+                </properties>
+              </project>
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
`UpdateMavenModel` visitor only adds or modifies properties but never removes them.
Consequently, `RemoveProperty` recipe would only remove property from XML but leave it in the model unless parent or dependencies have changed. Tests are modified to demonstrate the issue and test for it.