### PR TITLE
Switch to a single timeout for MavenSettings and MavenRepositoryMirror

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -278,8 +278,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
                                     knownRepo.isKnownToExist() && knownRepo.getUri().equals(repo.getUrl()),
                                     knownRepo.getUsername(),
                                     knownRepo.getPassword(),
-                                    knownRepo.getConnectTimeout(),
-                                    knownRepo.getReadTimeout(),
+                                    knownRepo.getTimeout(),
                                     knownRepo.getDeriveMetadataIfMissing()
                             );
                         } else {
@@ -288,7 +287,6 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
                                     repo.getUrl(),
                                     repo.getReleases() == null ? null : repo.getReleases().getEnabled(),
                                     repo.getSnapshots() == null ? null : repo.getSnapshots().getEnabled(),
-                                    null,
                                     null,
                                     null,
                                     null

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.*;
 import java.util.function.UnaryOperator;
 
@@ -245,8 +246,7 @@ public class MavenSettings {
             }
             return new ServerConfiguration(
                     ListUtils.map(configuration.httpHeaders, this::interpolate),
-                    configuration.connectTimeout,
-                    configuration.readTimeout
+                    configuration.timeout
             );
         }
 
@@ -422,17 +422,8 @@ public class MavenSettings {
         @Nullable
         List<HttpHeader> httpHeaders;
 
-        /**
-         * Timeout in milliseconds for establishing a connection.
-         */
         @Nullable
-        Long connectTimeout;
-
-        /**
-         * Timeout in milliseconds for reading from the connection.
-         */
-        @Nullable
-        Long readTimeout;
+        Long timeout;
     }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSettings.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
 import java.util.*;
 import java.util.function.UnaryOperator;
 
@@ -422,6 +421,9 @@ public class MavenSettings {
         @Nullable
         List<HttpHeader> httpHeaders;
 
+        /**
+         * Timeout in milliseconds for reading connecting to and reading from the connection.
+         */
         @Nullable
         Long timeout;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -121,7 +121,6 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
                     t.getChild("snapshots").flatMap(s -> s.getChildValue("enabled")).orElse(null),
                     null,
                     null,
-                    null,
                     null
             )).collect(Collectors.toList()));
         } else {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -868,11 +868,11 @@ public class MavenPomDownloader {
                             request.withHeader(header.getName(), header.getValue());
                         }
                     }
-                    if (configuration.getConnectTimeout() != null) {
-                        request.withConnectTimeout(Duration.ofMillis(configuration.getConnectTimeout()));
+                    if (configuration.getTimeout() != null) {
+                        request.withConnectTimeout(Duration.ofMillis(configuration.getTimeout()));
                     }
-                    if (configuration.getReadTimeout() != null) {
-                        request.withReadTimeout(Duration.ofMillis(configuration.getReadTimeout()));
+                    if (configuration.getTimeout() != null) {
+                        request.withReadTimeout(Duration.ofMillis(configuration.getTimeout()));
                     }
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -781,8 +781,7 @@ public class MavenPomDownloader {
                                         repository.getSnapshots(),
                                         repository.getUsername(),
                                         repository.getPassword(),
-                                        repository.getConnectTimeout(),
-                                        repository.getReadTimeout());
+                                        repository.getTimeout());
                             } catch (HttpSenderResponseException e) {
                                 //Response was returned from the server, but it was not a 200 OK. The server therefore exists.
                                 if (e.isServerReached()) {
@@ -793,8 +792,7 @@ public class MavenPomDownloader {
                                             repository.getSnapshots(),
                                             repository.getUsername(),
                                             repository.getPassword(),
-                                            repository.getConnectTimeout(),
-                                            repository.getReadTimeout());
+                                            repository.getTimeout());
                                 }
                             } catch (Throwable e) {
                                 // ok to fall through here and cache a null

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -824,8 +824,8 @@ public class MavenPomDownloader {
     private byte[] requestAsAuthenticatedOrAnonymous(MavenRepository repo, String uriString) throws HttpSenderResponseException, IOException {
         try {
             HttpSender.Request.Builder request = httpSender.get(uriString)
-                    .withConnectTimeout(repo.getConnectTimeout())
-                    .withReadTimeout(repo.getReadTimeout());
+                    .withConnectTimeout(repo.getTimeout())
+                    .withReadTimeout(repo.getTimeout());
             return sendRequest(applyAuthenticationToRequest(repo, request).build());
         } catch (HttpSenderResponseException e) {
             if (hasCredentials(repo) && e.isClientSideException()) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -439,7 +439,7 @@ public class RawPom {
                     pomRepositories.add(new MavenRepository(r.getId(), r.getUrl(),
                             r.getReleases() == null ? null : r.getReleases().getEnabled(),
                             r.getSnapshots() == null ? null : r.getSnapshots().getEnabled(),
-                            false, null, null, null, null, null));
+                            false, null, null, null, null));
                 }
 
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -39,9 +39,9 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class MavenRepository implements Serializable {
 
-    public static final MavenRepository MAVEN_LOCAL_USER_NEUTRAL = new MavenRepository("local", new File("~/.m2/repository").toString(), "true", "true", true, null, null, null, null, false);
-    public static final MavenRepository MAVEN_LOCAL_DEFAULT = new MavenRepository("local", Paths.get(System.getProperty("user.home"), ".m2", "repository").toUri().toString(), "true", "true", true, null, null, null, null, false);
-    public static final MavenRepository MAVEN_CENTRAL = new MavenRepository("central", "https://repo.maven.apache.org/maven2", "true", "false", true, null, null, null, null, true);
+    public static final MavenRepository MAVEN_LOCAL_USER_NEUTRAL = new MavenRepository("local", new File("~/.m2/repository").toString(), "true", "true", true, null, null, null, false);
+    public static final MavenRepository MAVEN_LOCAL_DEFAULT = new MavenRepository("local", Paths.get(System.getProperty("user.home"), ".m2", "repository").toUri().toString(), "true", "true", true, null, null, null, false);
+    public static final MavenRepository MAVEN_CENTRAL = new MavenRepository("central", "https://repo.maven.apache.org/maven2", "true", "false", true, null, null, null, true);
 
     @EqualsAndHashCode.Include
     @With
@@ -83,11 +83,7 @@ public class MavenRepository implements Serializable {
 
     @With
     @Nullable
-    Duration connectTimeout;
-
-    @With
-    @Nullable
-    Duration readTimeout;
+    Duration timeout;
 
     @Nullable
     @NonFinal
@@ -96,7 +92,7 @@ public class MavenRepository implements Serializable {
     /**
      * Constructor required by {@link org.openrewrite.maven.tree.OpenRewriteModelSerializableTest}.
      *
-     * @deprecated Use {@link #MavenRepository(String, String, String, String, boolean, String, String, Duration, Duration, Boolean)}
+     * @deprecated Use {@link #MavenRepository(String, String, String, String, boolean, String, String, Duration, Boolean)}
      */
     @Deprecated
     @JsonIgnore
@@ -104,13 +100,13 @@ public class MavenRepository implements Serializable {
             @Nullable String id, String uri, @Nullable String releases, @Nullable String snapshots,
             @Nullable String username, @Nullable String password
     ) {
-        this(id, uri, releases, snapshots, false, username, password, null, null, null);
+        this(id, uri, releases, snapshots, false, username, password, null, null);
     }
 
     /**
      * Constructor required by {@link org.openrewrite.gradle.marker.GradleProject}.
      *
-     * @deprecated Use {@link #MavenRepository(String, String, String, String, boolean, String, String, Duration, Duration, Boolean)}
+     * @deprecated Use {@link #MavenRepository(String, String, String, String, boolean, String, String, Duration, Boolean)}
      */
     @Deprecated
     @JsonIgnore
@@ -118,14 +114,13 @@ public class MavenRepository implements Serializable {
             @Nullable String id, String uri, @Nullable String releases, @Nullable String snapshots, boolean knownToExist,
             @Nullable String username, @Nullable String password, @Nullable Boolean deriveMetadataIfMissing
     ) {
-        this(id, uri, releases, snapshots, knownToExist, username, password, null, null, deriveMetadataIfMissing);
+        this(id, uri, releases, snapshots, knownToExist, username, password, null, deriveMetadataIfMissing);
     }
 
     @JsonIgnore
     public MavenRepository(
             @Nullable String id, String uri, @Nullable String releases, @Nullable String snapshots, boolean knownToExist,
-            @Nullable String username, @Nullable String password, @Nullable Duration connectTimeout,
-            @Nullable Duration readTimeout, @Nullable Boolean deriveMetadataIfMissing
+            @Nullable String username, @Nullable String password, @Nullable Duration timeout, @Nullable Boolean deriveMetadataIfMissing
     ) {
         this.id = id;
         this.uri = uri;
@@ -134,8 +129,7 @@ public class MavenRepository implements Serializable {
         this.knownToExist = knownToExist;
         this.username = username;
         this.password = password;
-        this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
+        this.timeout = timeout;
         this.deriveMetadataIfMissing = deriveMetadataIfMissing;
     }
 
@@ -157,14 +151,13 @@ public class MavenRepository implements Serializable {
         String username;
         String password;
         Boolean deriveMetadataIfMissing;
-        Duration connectTimeout;
-        Duration readTimeout;
+        Duration timeout;
 
         private Builder() {
         }
 
         public MavenRepository build() {
-            return new MavenRepository(id, uri, releases, snapshots, knownToExist, username, password, connectTimeout, readTimeout, deriveMetadataIfMissing);
+            return new MavenRepository(id, uri, releases, snapshots, knownToExist, username, password, timeout, deriveMetadataIfMissing);
         }
 
         public Builder releases(boolean releases) {
@@ -207,13 +200,8 @@ public class MavenRepository implements Serializable {
             return this;
         }
 
-        public Builder connectTimeout(Duration connectTimeout) {
-            this.connectTimeout = connectTimeout;
-            return this;
-        }
-
-        public Builder readTimeout(Duration readTimeout) {
-            this.readTimeout = readTimeout;
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
             return this;
         }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
@@ -55,10 +55,7 @@ public class MavenRepositoryMirror {
     Boolean snapshots;
 
     @Nullable
-    Long connectTimeout;
-
-    @Nullable
-    Long readTimeout;
+    Long timeout;
 
     private final boolean externalOnly;
     private final List<String> mirrorsOf;
@@ -98,25 +95,20 @@ public class MavenRepositoryMirror {
                 Optional<MavenSettings.Server> maybeServer = servers.getServers().stream()
                         .filter(s -> id.equals(s.getId()) && s.getConfiguration() != null)
                         .findFirst();
-                if (maybeServer.isPresent()) {
-                    MavenSettings.ServerConfiguration serverConfig = maybeServer.get().getConfiguration();
-                    connectTimeout = serverConfig.getConnectTimeout();
-                    readTimeout = serverConfig.getReadTimeout();
+                if (maybeServer.isPresent() && maybeServer.get().getConfiguration() != null){
+                    timeout = maybeServer.get().getConfiguration().getTimeout();
                 } else {
-                    connectTimeout = null;
-                    readTimeout = null;
+                    timeout = null;
                 }
             } else {
-                connectTimeout = null;
-                readTimeout = null;
+                timeout = null;
             }
         } else {
             externalOnly = false;
             mirrorsOf = null;
             includedRepos = null;
             excludedRepos = null;
-            connectTimeout = null;
-            readTimeout = null;
+            timeout = null;
         }
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java
@@ -130,8 +130,7 @@ public class MavenRepositoryMirror {
                     .withSnapshots(!Boolean.FALSE.equals(snapshots) ? "true" : "false")
                     // Since the URL has likely changed we cannot assume that the new repository is known to exist
                     .withKnownToExist(false)
-                    .withConnectTimeout(repo.getConnectTimeout())
-                    .withReadTimeout(repo.getReadTimeout());
+                    .withTimeout(repo.getTimeout());
         }
         return repo;
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -736,8 +736,7 @@ public class ResolvedPom {
                             incomingRepository.isKnownToExist(),
                             incomingRepository.getUsername(),
                             incomingRepository.getPassword(),
-                            incomingRepository.getConnectTimeout(),
-                            incomingRepository.getReadTimeout(),
+                            incomingRepository.getTimeout(),
                             incomingRepository.getDeriveMetadataIfMissing()
                     );
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -163,7 +163,7 @@ class MavenSettingsTest {
 
         assertThat(ctx.getRepositories())
           .as("When multiple repositories have the same id in a maven settings file the last one wins. In a pom.xml an error would be thrown.")
-          .containsExactly(new MavenRepository("repo", "https://lastwins.com", null, null, null, null, null, null));
+          .containsExactly(new MavenRepository("repo", "https://lastwins.com", null, null, null, null, null));
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/131")

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -343,6 +343,8 @@ class MavenSettingsTest {
 
     @Test
     void serverTimeouts() {
+        // Deliberately supporting the simpler old configuration of a single timeout
+        // https://maven.apache.org/guides/mini/guide-http-settings.html#connection-timeouts
         var settings = MavenSettings.parse(new Parser.Input(Paths.get("settings.xml"), () -> new ByteArrayInputStream(
           //language=xml
           """
@@ -353,8 +355,7 @@ class MavenSettingsTest {
                         <server>
                           <id>server001</id>
                           <configuration>
-                            <connectTimeout>40000</connectTimeout>
-                            <readTimeout>50000</readTimeout>
+                            <timeout>40000</timeout>
                           </configuration>
                         </server>
                       </servers>
@@ -366,8 +367,7 @@ class MavenSettingsTest {
         assertThat(settings.getServers().getServers()).hasSize(1);
         assertThat(settings.getServers().getServers().get(0))
           .matches(repo -> repo.getId().equals("server001"))
-          .matches(repo -> repo.getConfiguration().getConnectTimeout().equals(40000L))
-          .matches(repo -> repo.getConfiguration().getReadTimeout().equals(50000L));
+          .matches(repo -> repo.getConfiguration().getTimeout().equals(40000L));
     }
 
     @Nested
@@ -801,7 +801,7 @@ class MavenSettingsTest {
             """).findFirst().get();
 
         MavenSettings.HttpHeader httpHeader = new MavenSettings.HttpHeader("X-JFrog-Art-Api", "myApiToken");
-        MavenSettings.ServerConfiguration configuration = new MavenSettings.ServerConfiguration(java.util.Collections.singletonList(httpHeader), 10000L, null);
+        MavenSettings.ServerConfiguration configuration = new MavenSettings.ServerConfiguration(java.util.Collections.singletonList(httpHeader), 10000L);
         MavenSettings.Server server = new MavenSettings.Server("maven-snapshots", null, null, configuration);
         MavenSettings.Servers servers = new MavenSettings.Servers(java.util.Collections.singletonList(server));
         MavenSettings settings = new MavenSettings(null, null, null, null, servers);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -787,7 +787,7 @@ class MavenSettingsTest {
                 <server>
                   <id>maven-snapshots</id>
                   <configuration>
-                    <connectTimeout>10000</connectTimeout>
+                    <timeout>10000</timeout>
                     <httpHeaders>
                       <property>
                         <name>X-JFrog-Art-Api</name>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -139,7 +139,7 @@ class MavenPomDownloaderTest {
             repository.setKnownToExist(true);
         }
 
-        MavenRepository nonexistentRepo = new MavenRepository("repo", "http://internalartifactrepository.yourorg.com", null, null, true, null, null, null, null, null);
+        MavenRepository nonexistentRepo = new MavenRepository("repo", "http://internalartifactrepository.yourorg.com", null, null, true, null, null, null, null);
         List<String> attemptedUris = new ArrayList<>();
         List<MavenRepository> discoveredRepositories = new ArrayList<>();
         ctx.setResolutionListener(new ResolutionEventListener() {
@@ -171,7 +171,7 @@ class MavenPomDownloaderTest {
         var ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
         // Avoid actually trying to reach a made-up URL
         String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
-        MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null, null);
+        MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
         Map<String, Throwable> attemptedUris = new HashMap<>();
         List<MavenRepository> discoveredRepositories = new ArrayList<>();
         ctx.setResolutionListener(new ResolutionEventListener() {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/MavenRepositoryMirrorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/MavenRepositoryMirrorTest.java
@@ -25,7 +25,7 @@ class MavenRepositoryMirrorTest {
 
     MavenRepositoryMirror one = new MavenRepositoryMirror("one", "https://one.org/m2", "*", true, true, null);
     MavenRepositoryMirror two = new MavenRepositoryMirror("two", "https://two.org/m2", "*", true, true, null);
-    MavenRepository foo = new MavenRepository("foo", "https://foo.org/m2", "true", "true", null, null, null, null);
+    MavenRepository foo = new MavenRepository("foo", "https://foo.org/m2", "true", "true", null, null, null);
 
     @Test
     void useFirstMirror() {


### PR DESCRIPTION
## What's changed?
Replace the `connectTimeout` and `readTimeout` on `MavenSettings` and `MavenRepositoryMirror` with a singular `timeout`.

## What's your motivation?
Based on what's available by default according to the docs, as opposed to our accidental custom format previously. https://maven.apache.org/guides/mini/guide-http-settings.html#connection-timeouts

## Anything in particular you'd like reviewers to focus on?
There's a change to a tree class in here that's likely the only one serialized
`rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepositoryMirror.java`
In practice these won't have had a non-null value, as we diverged from the standard.
That's why I think it ought to be safe(r) to change this serialized class, as opposed to when there would have been values present to migrate over.

## Have you considered any alternatives or workarounds?
There's also the more challenging per-http-method-connect/read-timeout. That's perhaps more than we need, and a headache to parse and pass along, whereas the singular `timeout` is still supported going forward, and likely enough for our use cases.
```xml
<settings>
  <servers>
    <server>
      <id>my-server</id>
      <configuration>
        <httpConfiguration>
          <put>
            <connectionTimeout>10000</connectionTimeout> <!-- milliseconds -->
          </put>
        </httpConfiguration>
      </configuration>
    </server>
  </servers>
</settings>
```

## Any additional context
Follow up from
- https://github.com/openrewrite/rewrite/pull/3951 
