### PR TITLE
XPath condition enhancements - multiple conditions and and/or operators

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -38,10 +38,10 @@ import java.util.regex.Pattern;
  */
 public class XPathMatcher {
 
-    private static final Pattern XPATH_ELEMENT_SPLITTER = Pattern.compile("((?<=/)(?=/)|[^/\\[]|\\[[^]]*\\])+");
+    private static final Pattern XPATH_ELEMENT_SPLITTER = Pattern.compile("((?<=/)(?=/)|[^/\\[]|\\[[^]]*])+");
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
-    private static final Pattern ELEMENT_WITH_CONDITION_PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)(\\[.+\\])");
-    private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[.*?\\])+?");
+    private static final Pattern ELEMENT_WITH_CONDITION_PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)(\\[.+])");
+    private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[.*?])+?");
     private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))='(.*?)'(\\h?(or|and)\\h?)?)+?");
 
     private final String expression;

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -40,7 +40,7 @@ public class XPathMatcher {
     private static final Pattern XPATH_ELEMENT_SPLITTER = Pattern.compile("((?<=/)(?=/)|[^/\\[]|\\[[^]]*\\])+");
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
     private static final Pattern ELEMENT_WITH_CONDITION_PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)(\\[.+\\])");
-    private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))='(.*?)'])+?");
+    private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[.*?\\])+?");
     private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))='(.*?)'(\\h?(or|and)\\h?)?)+?");
 
     private final String expression;

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 /**
  * Supports a limited set of XPath expressions, specifically those documented on <a
  * href="https://www.w3schools.com/xml/xpath_syntax.asp">this page</a>.
+ * Additionally, supports `local-name()` and `namespace-uri()` conditions, `and`/`or` operators, and chained conditions.
  * <p>
  * Used for checking whether a visitor's cursor meets a certain XPath expression.
  * <p>

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -123,7 +123,7 @@ public class XPathMatcher {
 
                 Matcher matcher;
                 if (tagForCondition != null && partWithCondition.endsWith("]")
-                        && (matcher = ELEMENT_WITH_CONDITION_PATTERN.matcher(partWithCondition)).matches()) {
+                    && (matcher = ELEMENT_WITH_CONDITION_PATTERN.matcher(partWithCondition)).matches()) {
                     String optionalPartName = matchesElementWithConditionFunction(matcher, tagForCondition, cursor);
                     if (optionalPartName == null) {
                         return false;
@@ -150,15 +150,15 @@ public class XPathMatcher {
                 }
 
                 boolean conditionNotFulfilled = tagForCondition == null
-                        || (!part.equals(partName) && !tagForCondition.getName().equals(partName));
+                                                || (!part.equals(partName) && !tagForCondition.getName().equals(partName));
 
                 int idx = part.indexOf("[");
                 if (idx > 0) {
                     part = part.substring(0, idx);
                 }
-                if (path.size() < i + 1 || (
-                        !(path.get(pathIndex).getName().equals(part)) && !"*".equals(part)) ||
-                        conditionIsBefore && conditionNotFulfilled) {
+                if (path.size() < i + 1
+                    || (!(path.get(pathIndex).getName().equals(part)) && !"*".equals(part))
+                    || conditionIsBefore && conditionNotFulfilled) {
                     return false;
                 }
             }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -107,6 +107,7 @@ class XPathMatcherTest {
           <ns2:element2>content2</ns2:element2>
           <parent>
               <element3 ns3:attr='test'>content3</element3>
+              <ns2:element4 ns3:attr='test2'>content4</ns2:element4>
           </parent>
         </root>
         """
@@ -326,6 +327,27 @@ class XPathMatcherTest {
         // TODO: fix mid-path // match with attribute element
 //        assertThat(match("/root//element1/@*", namespacedXml)).isTrue();
 //        assertThat(match("/root//element1/@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
+    }
+
+    @Test
+    void matchMultipleConditions() {
+        assertThat(match("//*[namespace-uri()='http://www.example.com/namespace2'][local-name()='element2']", namespacedXml)).isTrue();
+        assertThat(match("//*[local-name()='element2'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+
+        assertThat(match("//*[namespace-uri()='http://www.example.com/namespace2'][local-name()='dne']", namespacedXml)).isFalse();
+        assertThat(match("//*[local-name()='dne'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+
+        assertThat(match("//*[local-name()='element1'][@ns3:attribute1='content3']", namespacedXml)).isTrue();
+        assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace3'][local-name()='attribute1']", namespacedXml)).isTrue();
+        assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace3'][local-name()='dne']", namespacedXml)).isFalse();
+
+        assertThat(match("//*[@ns3:attr='test'][local-name()='element3']", namespacedXml)).isTrue();
+        assertThat(match("//*[@ns3:attr='test'][local-name()='elementX']", namespacedXml)).isFalse();
+
+        assertThat(match("//*[@ns3:attr='test2'][local-name()='element4'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        assertThat(match("//*[@ns3:attr='testX'][local-name()='element4'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+        assertThat(match("//*[@ns3:attr='test2'][local-name()='elementX'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
+        assertThat(match("//*[@ns3:attr='test2'][local-name()='element4'][namespace-uri()='http://www.example.com/namespaceX']", namespacedXml)).isFalse();
     }
 
     private boolean match(String xpath, SourceFile x) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -365,6 +365,21 @@ class XPathMatcherTest {
         assertThat(match("//*[local-name()='dne' or local-name()='dne2']", namespacedXml)).isFalse();
 
         assertThat(match("//@*[namespace-uri()='dne' or namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
+
+        // T&T&T = T
+        assertThat(match("//*[local-name()='element4' and namespace-uri()='http://www.example.com/namespace2' and @ns3:attr='test2']", namespacedXml)).isTrue();
+        // T&T&F = F
+        assertThat(match("//*[local-name()='element4' and namespace-uri()='http://www.example.com/namespace2' and @ns3:attr='dne']", namespacedXml)).isFalse();
+        // T&T|F = T
+        assertThat(match("//*[local-name()='element4' and namespace-uri()='http://www.example.com/namespace2' or @ns3:attr='dne']", namespacedXml)).isTrue();
+        // T&F|T = T
+        assertThat(match("//*[local-name()='element4' and @ns3:attr='dne' or namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        // T&F|F = F
+        assertThat(match("//*[local-name()='element4' and @ns3:attr='dne' or namespace-uri()='http://www.example.com/namespaceX']", namespacedXml)).isFalse();
+
+        // F|F|T = T
+        assertThat(match("//*[local-name()='dne' or local-name()='dne2' or local-name()='element2']", namespacedXml)).isTrue();
+
         // [T&T][T] = T
         assertThat(match("//*[local-name()='element4' and namespace-uri()='http://www.example.com/namespace2'][@ns3:attr='test2']", namespacedXml)).isTrue();
         // [T&T][F] = F
@@ -375,6 +390,18 @@ class XPathMatcherTest {
         assertThat(match("//*[local-name()='dne' or local-name()='element4'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
         // [F|T][F] = F
         assertThat(match("//*[local-name()='dne' or local-name()='element4'][namespace-uri()='http://www.example.com/namespaceX']", namespacedXml)).isFalse();
+
+        // F|T&T = T
+        assertThat(match("//*[local-name()='dne' or local-name()='element4' and namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        // F|T&F = F
+        assertThat(match("//*[local-name()='dne' or local-name()='element4' and namespace-uri()='http://www.example.com/namespaceX']", namespacedXml)).isFalse();
+        // F|F&T = F
+        assertThat(match("//*[local-name()='dne' or namespace-uri()='http://www.example.com/namespaceX' and local-name()='element4']", namespacedXml)).isFalse();
+
+        // T|F & T = T
+        assertThat(match("//*[local-name()='element4' or local-name()='dne' and namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
+        // T|F & F = T
+        assertThat(match("//*[local-name()='element4' or local-name()='dne' and namespace-uri()='http://www.example.com/namespaceX']", namespacedXml)).isTrue();
     }
 
     private boolean match(String xpath, SourceFile x) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -229,9 +229,8 @@ class XPathMatcherTest {
     }
 
     @Test
-    @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/3919")
-    void matchFunctions() {
+    void namespaceMatchFunctions() {
         assertThat(match("/root/element1", namespacedXml)).isTrue();
         assertThat(match("/root/ns2:element2", namespacedXml)).isTrue();
         assertThat(match("/root/dne", namespacedXml)).isFalse();
@@ -244,17 +243,21 @@ class XPathMatcherTest {
         assertThat(match("/*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isFalse();
         assertThat(match("//*[namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
         assertThat(match("//@*[namespace-uri()='http://www.example.com/namespace3']", namespacedXml)).isTrue();
+    }
 
+    @Test
+    @Disabled
+    void otherUncoveredXpathFunctions() {
         // Other common XPath functions
-        assertThat(match("contains(/root/element1, 'content1')", namespacedXml)).isTrue();
-        assertThat(match("not(contains(/root/element1, 'content1'))", namespacedXml)).isFalse();
-        assertThat(match("string-length(/root/element1) > 2", namespacedXml)).isTrue();
-        assertThat(match("starts-with(/root/element1, 'content1')", namespacedXml)).isTrue();
-        assertThat(match("ends-with(/root/element1, 'content1')", namespacedXml)).isTrue();
-        assertThat(match("substring-before(/root/element1, '1') = 'content'", namespacedXml)).isTrue();
-        assertThat(match("substring-after(/root/element1, 'content') = '1'", namespacedXml)).isTrue();
-        assertThat(match("/root/element1/text()", namespacedXml)).isTrue();
-        assertThat(match("count(/root/*)", namespacedXml)).isTrue();
+       assertThat(match("contains(/root/element1, 'content1')", namespacedXml)).isTrue();
+       assertThat(match("not(contains(/root/element1, 'content1'))", namespacedXml)).isFalse();
+       assertThat(match("string-length(/root/element1) > 2", namespacedXml)).isTrue();
+       assertThat(match("starts-with(/root/element1, 'content1')", namespacedXml)).isTrue();
+       assertThat(match("ends-with(/root/element1, 'content1')", namespacedXml)).isTrue();
+       assertThat(match("substring-before(/root/element1, '1') = 'content'", namespacedXml)).isTrue();
+       assertThat(match("substring-after(/root/element1, 'content') = '1'", namespacedXml)).isTrue();
+       assertThat(match("/root/element1/text()", namespacedXml)).isTrue();
+       assertThat(match("count(/root/*)", namespacedXml)).isTrue();
     }
 
     @Test

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -375,7 +375,6 @@ class XPathMatcherTest {
         assertThat(match("//*[local-name()='dne' or local-name()='element4'][namespace-uri()='http://www.example.com/namespace2']", namespacedXml)).isTrue();
         // [F|T][F] = F
         assertThat(match("//*[local-name()='dne' or local-name()='element4'][namespace-uri()='http://www.example.com/namespaceX']", namespacedXml)).isFalse();
-
     }
 
     private boolean match(String xpath, SourceFile x) {


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Add XPath support for:
- chained conditions   eg. `//*[condition1][condition2']`
- `and`/`or` operators   eg. `//*[condition1 or condition2]` and `//*[condition1 and condition2]`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
