### PR TITLE
Fix method name collisions with UseStaticImport

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -18,10 +18,7 @@ package org.openrewrite.java;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
-import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.test.RewriteTest;
-
-import java.util.List;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -44,9 +41,9 @@ class UseStaticImportTest implements RewriteTest {
           java(
             """
               package test;
-                            
+
               import asserts.Assert;
-                            
+
               class Test {
                   void test() {
                       Assert.assertTrue(true);
@@ -57,9 +54,9 @@ class UseStaticImportTest implements RewriteTest {
               """,
             """
               package test;
-                            
+
               import static asserts.Assert.*;
-                            
+
               class Test {
                   void test() {
                       assertTrue(true);
@@ -79,15 +76,15 @@ class UseStaticImportTest implements RewriteTest {
           spec -> spec.recipe(new UseStaticImport("java.util.Collections emptyList()")),
           java(
             """
-            import java.util.Collections;
-            import java.util.List;
+              import java.util.Collections;
+              import java.util.List;
 
-            public class Reproducer {
-                public void methodWithTypeParameter() {
-                    List<Object> list = Collections.<Object>emptyList();
-                }
-            }
-            """
+              public class Reproducer {
+                  public void methodWithTypeParameter() {
+                      List<Object> list = Collections.<Object>emptyList();
+                  }
+              }
+              """
           )
         );
     }
@@ -98,60 +95,64 @@ class UseStaticImportTest implements RewriteTest {
           spec -> spec.recipe(new UseStaticImport("java.util.Collections emptyList()")),
           java(
             """
-            package com.helloworld;
+              package com.helloworld;
 
-            import java.util.Collections;
-            import java.util.List;
+              import java.util.Collections;
+              import java.util.List;
 
-            public class SameMethodNameLocally {
-                public void avoidCollision() {
-                    List<Object> list = Collections.emptyList();
-                }
+              public class SameMethodNameLocally {
+                  public void avoidCollision() {
+                      List<Object> list = Collections.emptyList();
+                  }
 
-                private int emptyList(String canHaveDifferentArguments) {
-                }
-            }
+                  private int emptyList(String canHaveDifferentArguments) {
+                  }
+              }
+                """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4304")
+    void sameMethodImportedNoStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.lang.String valueOf(..)")),
+          java(
+            """
+              package com.helloworld;
+
+              import static java.lang.Integer.valueOf;
+
+              public class SameMethodNameImported {
+                  public void avoidCollision() {
+                      String a = String.valueOf("1");
+                      int b = valueOf("1");
+                  }
+              }
               """
           )
         );
     }
 
     @Test
-    void sameMethodImportedNoStaticImport() {
-        rewriteRun(
-          spec -> spec.recipe(new UseStaticImport("java.lang.String valueOf(..)")),
-          java(
-            """
-            package com.helloworld;
-
-            import static java.lang.Integer.valueOf;
-
-            public class SameMethodNameImported {
-                public void avoidCollision() {
-                    String a = String.valueOf("1");
-                    int b = valueOf("1");
-                }
-            }
-            """
-          )
-        );
-    }
-
-    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4304")
     void sameMethodsNoStaticImport() {
         rewriteRun(
-          spec -> spec.recipe(new CompositeRecipe(List.of(new UseStaticImport("java.lang.String valueOf(..)"), new UseStaticImport("java.lang.Integer valueOf(..)")))),
+          spec -> spec.recipes(
+            new UseStaticImport("java.lang.String valueOf(..)"),
+            new UseStaticImport("java.lang.Integer valueOf(..)")),
           java(
             """
-            package com.helloworld;
+              package com.helloworld;
 
-            public class SameMethodNames {
-                public void avoidCollision() {
-                    String a = String.valueOf("1");
-                    int b = Integer.valueOf("1");
-                }
-            }
-          """
+              public class SameMethodNames {
+                  public void avoidCollision() {
+                      String a = String.valueOf("1");
+                      int b = Integer.valueOf("1");
+                  }
+              }
+              """
           )
         );
     }
@@ -162,26 +163,26 @@ class UseStaticImportTest implements RewriteTest {
           spec -> spec.recipe(new UseStaticImport("java.util.Collections *()")),
           java(
             """
-            import java.util.Collections;
-            import java.util.List;
+              import java.util.Collections;
+              import java.util.List;
 
-            class SameMethodNameLocally {
-                void avoidCollision() {
-                    List<Object> list = Collections.emptyList();
-                }
-            }
-            """,
+              class SameMethodNameLocally {
+                  void avoidCollision() {
+                      List<Object> list = Collections.emptyList();
+                  }
+              }
+              """,
             """
-            import java.util.List;
-            
-            import static java.util.Collections.emptyList;
+              import java.util.List;
 
-            class SameMethodNameLocally {
-                void avoidCollision() {
-                    List<Object> list = emptyList();
-                }
-            }
-            """
+              import static java.util.Collections.emptyList;
+
+              class SameMethodNameLocally {
+                  void avoidCollision() {
+                      List<Object> list = emptyList();
+                  }
+              }
+              """
           )
         );
     }
@@ -231,33 +232,33 @@ class UseStaticImportTest implements RewriteTest {
           spec -> spec.recipe(new UseStaticImport("java.util.Collections emptyList()")),
           java(
             """
-            import java.util.Collections;
-            import java.util.List;
+              import java.util.Collections;
+              import java.util.List;
 
-            public class WithJavadoc {
-                /**
-                 * This method uses {@link Collections#emptyList()}.
-                 */
-                public void mustNotChangeTheJavadocAbove() {
-                    List<Object> list = Collections.emptyList();
-                }
-            }
-            """,
+              public class WithJavadoc {
+                  /**
+                   * This method uses {@link Collections#emptyList()}.
+                   */
+                  public void mustNotChangeTheJavadocAbove() {
+                      List<Object> list = Collections.emptyList();
+                  }
+              }
+              """,
             """
-            import java.util.Collections;
-            import java.util.List;
+              import java.util.Collections;
+              import java.util.List;
 
-            import static java.util.Collections.emptyList;
+              import static java.util.Collections.emptyList;
 
-            public class WithJavadoc {
-                /**
-                 * This method uses {@link Collections#emptyList()}.
-                 */
-                public void mustNotChangeTheJavadocAbove() {
-                    List<Object> list = emptyList();
-                }
-            }
-            """
+              public class WithJavadoc {
+                  /**
+                   * This method uses {@link Collections#emptyList()}.
+                   */
+                  public void mustNotChangeTheJavadocAbove() {
+                      List<Object> list = emptyList();
+                  }
+              }
+              """
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -152,6 +152,18 @@ class UseStaticImportTest implements RewriteTest {
                       int b = Integer.valueOf("1");
                   }
               }
+              """,
+            """
+              package com.helloworld;
+
+              import static java.lang.String.valueOf;
+
+              public class SameMethodNames {
+                  public void avoidCollision() {
+                      String a = valueOf("1");
+                      int b = Integer.valueOf("1");
+                  }
+              }
               """
           )
         );

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -18,7 +18,10 @@ package org.openrewrite.java;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
+import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -95,6 +98,8 @@ class UseStaticImportTest implements RewriteTest {
           spec -> spec.recipe(new UseStaticImport("java.util.Collections emptyList()")),
           java(
             """
+            package com.helloworld;
+
             import java.util.Collections;
             import java.util.List;
 
@@ -102,11 +107,51 @@ class UseStaticImportTest implements RewriteTest {
                 public void avoidCollision() {
                     List<Object> list = Collections.emptyList();
                 }
-                
+
                 private int emptyList(String canHaveDifferentArguments) {
                 }
             }
+              """
+          )
+        );
+    }
+
+    @Test
+    void sameMethodImportedNoStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.lang.String valueOf(..)")),
+          java(
             """
+            package com.helloworld;
+
+            import static java.lang.Integer.valueOf;
+
+            public class SameMethodNameImported {
+                public void avoidCollision() {
+                    String a = String.valueOf("1");
+                    int b = valueOf("1");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void sameMethodsNoStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(new CompositeRecipe(List.of(new UseStaticImport("java.lang.String valueOf(..)"), new UseStaticImport("java.lang.Integer valueOf(..)")))),
+          java(
+            """
+            package com.helloworld;
+
+            public class SameMethodNames {
+                public void avoidCollision() {
+                    String a = String.valueOf("1");
+                    int b = Integer.valueOf("1");
+                }
+            }
+          """
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/MaybeUsesImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/MaybeUsesImportTest.java
@@ -27,8 +27,7 @@ class MaybeUsesImportTest implements RewriteTest {
     @Test
     void usesType() {
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new
-            MaybeUsesImport<>("java.util.Collections"))),
+          spec -> spec.recipe(toRecipe(() -> new MaybeUsesImport<>("java.util.Collections"))),
           java(
             """
               import java.io.File;
@@ -40,7 +39,7 @@ class MaybeUsesImportTest implements RewriteTest {
               import static java.util.Collections.singleton;
               import static java.util.Collections.*;
               import java.util.Map;
-                              
+
               class Test {
               }
               """,
@@ -54,7 +53,7 @@ class MaybeUsesImportTest implements RewriteTest {
               /*~~>*/import static java.util.Collections.singleton;
               /*~~>*/import static java.util.Collections.*;
               import java.util.Map;
-                              
+
               class Test {
               }
               """
@@ -80,7 +79,7 @@ class MaybeUsesImportTest implements RewriteTest {
               import static java.util.Collections.singleton;
               import static java.util.Collections.*;
               import java.util.concurrent.ConcurrentHashMap;
-                            
+
               class Test {
               }
               """,
@@ -94,7 +93,7 @@ class MaybeUsesImportTest implements RewriteTest {
               /*~~>*/import static java.util.Collections.singleton;
               /*~~>*/import static java.util.Collections.*;
               /*~~>*/import java.util.concurrent.ConcurrentHashMap;
-                            
+
               class Test {
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -59,7 +59,7 @@ public class UseStaticImport extends Recipe {
             int indexBrace = methodPattern.indexOf('(', indexSpace);
             String methodNameMatcher = methodPattern.substring(indexSpace, indexBrace);
             preconditions = Preconditions.and(preconditions,
-                    Preconditions.not(new DeclaresMethod<>("* " + methodNameMatcher + "(..)")));
+                    Preconditions.not(new DeclaresMethod<>("*..* " + methodNameMatcher + "(..)")));
         }
         return Preconditions.check(preconditions, new UseStaticImportVisitor());
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.marker.SearchResult;
 
 @ToString
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
@@ -59,7 +60,17 @@ public class UseStaticImport extends Recipe {
             int indexBrace = methodPattern.indexOf('(', indexSpace);
             String methodNameMatcher = methodPattern.substring(indexSpace, indexBrace);
             preconditions = Preconditions.and(preconditions,
-                    Preconditions.not(new DeclaresMethod<>("*..* " + methodNameMatcher + "(..)")));
+                    Preconditions.not(new DeclaresMethod<>("*..* " + methodNameMatcher + "(..)")),
+                    Preconditions.not(new JavaIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public J.Import visitImport(J.Import _import, ExecutionContext executionContext) {
+                            if (_import.isStatic() && _import.getQualid().getSimpleName().equals(methodNameMatcher.substring(1))) {
+                                return SearchResult.found(_import);
+                            }
+                            return _import;
+                        }
+                    })
+            );
         }
         return Preconditions.check(preconditions, new UseStaticImportVisitor());
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -63,7 +63,7 @@ public class UseStaticImport extends Recipe {
                     Preconditions.not(new DeclaresMethod<>("*..* " + methodNameMatcher + "(..)")),
                     Preconditions.not(new JavaIsoVisitor<ExecutionContext>() {
                         @Override
-                        public J.Import visitImport(J.Import _import, ExecutionContext executionContext) {
+                        public J.Import visitImport(J.Import _import, ExecutionContext ctx) {
                             if (_import.isStatic() && _import.getQualid().getSimpleName().equals(methodNameMatcher.substring(1))) {
                                 return SearchResult.found(_import);
                             }


### PR DESCRIPTION
Ensure that an import static is not created if a method with the same name already exists, either locally (this fixes this to take into account package name) or already imported statically.

- Fixes https://github.com/openrewrite/rewrite/issues/4304