### PR TITLE
Migrate add Develocity recipes to handle the new develocity configurations

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
@@ -138,7 +138,7 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
               """,
             interpolateResolvedVersion("""
               plugins {
-                  id 'com.gradle.enterprise' version '%s'
+                  id 'com.gradle.develocity' version '%s'
               }
                             
               rootProject.name = 'my-project'
@@ -164,7 +164,7 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
               """,
             interpolateResolvedVersion("""
               plugins {
-                  id 'com.gradle.enterprise' version '%s'
+                  id 'com.gradle.develocity' version '%s'
               }
                             
               rootProject.name = 'my-project'
@@ -176,10 +176,10 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2697")
     @Test
-    void withConfigurationInSettings() {
+    void withGradleEnterpriseConfigurationInSettings() {
         rewriteRun(
           spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
-            .recipe(new AddDevelocityGradlePlugin("3.x", "https://ge.sam.com/", true, true, true, AddDevelocityGradlePlugin.PublishCriteria.Always)),
+            .recipe(new AddDevelocityGradlePlugin("3.16.x", "https://ge.sam.com/", true, true, true, AddDevelocityGradlePlugin.PublishCriteria.Always)),
           buildGradle(
             ""
           ),
@@ -197,6 +197,37 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
                       uploadInBackground = true
                       capture {
                           taskInputFiles = true
+                      }
+                  }
+              }
+              """
+            )
+          )
+        );
+    }
+
+    @Test
+    void withDevelocityConfigurationInSettings() {
+        rewriteRun(
+          spec -> spec.allSources(s -> s.markers(new BuildTool(randomId(), BuildTool.Type.Gradle, "7.6.1")))
+            .recipe(new AddDevelocityGradlePlugin("3.x", "https://ge.sam.com/", true, true, true, AddDevelocityGradlePlugin.PublishCriteria.Always)),
+          buildGradle(
+            ""
+          ),
+          settingsGradle(
+            "",
+            interpolateResolvedVersion("""
+              plugins {
+                  id 'com.gradle.develocity' version '%s'
+              }
+              develocity {
+                  server = 'https://ge.sam.com/'
+                  allowUntrustedServer = true
+                  buildScan {
+                      publishing.onlyIf { true }
+                      uploadInBackground = true
+                      capture {
+                          fileFingerprints = true
                       }
                   }
               }
@@ -242,7 +273,7 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
           settingsGradle(
             "",
             spec -> spec.after(after -> {
-                Matcher versionMatcher = Pattern.compile("id 'com\\.gradle\\.enterprise' version '(.*?)'").matcher(after);
+                Matcher versionMatcher = Pattern.compile("id 'com\\.gradle\\.develocity' version '(.*?)'").matcher(after);
                 assertThat(versionMatcher.find()).isTrue();
                 String version = versionMatcher.group(1);
                 VersionComparator versionComparator = requireNonNull(Semver.validate("[3.14,)", null).getValue());
@@ -250,7 +281,7 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
 
                 return """
                   plugins {
-                      id 'com.gradle.enterprise' version '%s'
+                      id 'com.gradle.develocity' version '%s'
                   }
                   """.formatted(version);
             })
@@ -279,7 +310,7 @@ class AddDevelocityGradlePluginTest implements RewriteTest {
                */
                
               plugins {
-                  id 'com.gradle.enterprise' version '%s'
+                  id 'com.gradle.develocity' version '%s'
               }
                             
               rootProject.name = 'my-project'

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
@@ -34,6 +34,7 @@ import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.tree.MavenMetadata;
 import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.semver.LatestRelease;
+import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.xml.AddToTagVisitor;
@@ -52,8 +53,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @EqualsAndHashCode(callSuper = false)
 public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMavenExtension.Accumulator> {
     private static final String GRADLE_ENTERPRISE_MAVEN_EXTENSION_ARTIFACT_ID = "gradle-enterprise-maven-extension";
+    private static final String DEVELOCITY_MAVEN_EXTENSION_ARTIFACT_ID = "develocity-maven-extension";
     private static final String EXTENSIONS_XML_PATH = ".mvn/extensions.xml";
     private static final String GRADLE_ENTERPRISE_XML_PATH = ".mvn/gradle-enterprise.xml";
+    private static final String DEVELOCITY_XML_PATH = ".mvn/develocity.xml";
 
     @Language("xml")
     private static final String EXTENSIONS_XML_FORMAT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -61,9 +64,9 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
                                                         "</extensions>";
 
     @Language("xml")
-    private static final String ENTERPRISE_TAG_FORMAT = "<extension>\n" +
+    private static final String EXTENSION_TAG_FORMAT = "<extension>\n" +
                                                         "  <groupId>com.gradle</groupId>\n" +
-                                                        "  <artifactId>gradle-enterprise-maven-extension</artifactId>\n" +
+                                                        "  <artifactId>%s</artifactId>\n" +
                                                         "  <version>%s</version>\n" +
                                                         "</extension>";
 
@@ -87,13 +90,13 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
     @Nullable
     Boolean allowUntrustedServer;
 
-    @Option(displayName = "Capture goal input files",
+    @Option(displayName = "Capture file fingerprints",
             description = "When set to `true` the extension will capture additional information about the inputs to Maven goals. " +
                           "This increases the size of build scans, but is useful for diagnosing issues with goal caching. ",
             required = false,
             example = "true")
     @Nullable
-    Boolean captureGoalInputFiles;
+    Boolean fileFingerprints;
 
     @Option(displayName = "Upload in background",
             description = "When set to `false` the extension will not upload build scan in the background. " +
@@ -134,8 +137,8 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
     @Override
     public String getDescription() {
         return "To integrate the Develocity Maven extension into Maven projects, ensure that the " +
-               "`gradle-enterprise-maven-extension` is added to the `.mvn/extensions.xml` file if not already present. " +
-               "Additionally, configure the extension by adding the `.mvn/gradle-enterprise.xml` configuration file.";
+               "`develocity-maven-extension` is added to the `.mvn/extensions.xml` file if not already present. " +
+               "Additionally, configure the extension by adding the `.mvn/develocity.xml` configuration file.";
     }
 
     @Data
@@ -175,6 +178,7 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
                         acc.setMatchingExtensionsXmlFile(sourceFile.getSourcePath());
                         break;
                     case GRADLE_ENTERPRISE_XML_PATH:
+                    case DEVELOCITY_XML_PATH:
                         acc.setMatchingGradleEnterpriseXmlFile(sourceFile.getSourcePath());
                         break;
                     default:
@@ -192,12 +196,29 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
             return Collections.emptyList();
         }
 
+        VersionComparator versionComparator = Semver.validate("(,1.21)", null).getValue();
+        if (versionComparator == null) {
+            return Collections.emptyList();
+        }
+
+        String newVersion = version != null ? version : getLatestVersion(ctx);
         List<SourceFile> sources = new ArrayList<>();
-        sources.add(createNewXml(GRADLE_ENTERPRISE_XML_PATH, gradleEnterpriseConfiguration(acc.isUseCRLFNewLines())));
+
+        if (versionComparator.compare(null, newVersion, "1.21") >= 0) {
+            BuildScanConfiguration buildScanConfiguration = buildScanConfiguration(true);
+            ServerConfiguration serverConfiguration = new ServerConfiguration(server, allowUntrustedServer);
+            DevelocityConfiguration develocityConfiguration = new DevelocityConfiguration(serverConfiguration, buildScanConfiguration);
+            sources.add(createNewXml(DEVELOCITY_XML_PATH, writeConfiguration(develocityConfiguration, acc.isUseCRLFNewLines())));
+        } else {
+            BuildScanConfiguration buildScanConfiguration = buildScanConfiguration(false);
+            ServerConfiguration serverConfiguration = new ServerConfiguration(server, allowUntrustedServer);
+            GradleEnterpriseConfiguration gradleEnterpriseConfiguration = new GradleEnterpriseConfiguration(serverConfiguration, buildScanConfiguration);
+            sources.add(createNewXml(GRADLE_ENTERPRISE_XML_PATH, writeConfiguration(gradleEnterpriseConfiguration, acc.isUseCRLFNewLines())));
+        }
 
         if (acc.getMatchingExtensionsXmlFile() == null) {
             Xml.Document extensionsXml = createNewXml(EXTENSIONS_XML_PATH, EXTENSIONS_XML_FORMAT);
-            extensionsXml = addEnterpriseExtension(extensionsXml, ctx);
+            extensionsXml = addExtension(extensionsXml, ctx);
             sources.add(extensionsXml);
         }
 
@@ -221,13 +242,13 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
                 if (sourceFile.getSourcePath().equals(acc.getMatchingExtensionsXmlFile())) {
                     Xml.Document extensionsXml = (Xml.Document) sourceFile;
 
-                    // find `gradle-enterprise-maven-extension` extension, do nothing if it already exists,
-                    boolean hasEnterpriseExtension = findExistingEnterpriseExtension(extensionsXml);
+                    // find extension, do nothing if it already exists,
+                    boolean hasEnterpriseExtension = findExistingExtension(extensionsXml);
                     if (hasEnterpriseExtension) {
                         return sourceFile;
                     }
 
-                    return addEnterpriseExtension(extensionsXml, ctx);
+                    return addExtension(extensionsXml, ctx);
                 }
                 return tree;
             }
@@ -237,6 +258,15 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
     @JacksonXmlRootElement(localName = "gradleEnterprise")
     @Value
     private static class GradleEnterpriseConfiguration {
+        ServerConfiguration server;
+
+        @Nullable
+        BuildScanConfiguration buildScan;
+    }
+
+    @JacksonXmlRootElement(localName = "develocity")
+    @Value
+    private static class DevelocityConfiguration {
         ServerConfiguration server;
 
         @Nullable
@@ -260,35 +290,71 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
         String publish;
 
         @Nullable
+        PublishingConfiguration publishing;
+
+        @Nullable
         Capture capture;
+    }
+
+    @Value
+    private static class PublishingConfiguration {
+        @Nullable
+        String onlyIf;
     }
 
     @Value
     private static class Capture {
         Boolean goalInputFiles;
+        Boolean fileFingerprints;
     }
 
-    private String gradleEnterpriseConfiguration(boolean useCRLFNewLines) {
-        BuildScanConfiguration buildScanConfiguration = buildScanConfiguration();
-        ServerConfiguration serverConfiguration = new ServerConfiguration(server, allowUntrustedServer);
+    private String writeConfiguration(Object config, boolean useCRLFNewLines) {
         try {
             ObjectMapper objectMapper = MavenXmlMapper.writeMapper();
             objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
             objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
             PrettyPrinter pp = new DefaultXmlPrettyPrinter().withCustomNewLine(useCRLFNewLines ? "\r\n" : "\n");
-            return objectMapper.writer(pp)
-                    .writeValueAsString(new GradleEnterpriseConfiguration(serverConfiguration, buildScanConfiguration));
+            return objectMapper.writer(pp).writeValueAsString(config);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
     }
 
     @Nullable
-    private BuildScanConfiguration buildScanConfiguration() {
-        if (uploadInBackground != null || publishCriteria != null || captureGoalInputFiles != null) {
-            return new BuildScanConfiguration(uploadInBackground,
-                    publishCriteria != null ? publishCriteria.xmlName : null,
-                    captureGoalInputFiles != null ? new Capture(captureGoalInputFiles) : null);
+    private BuildScanConfiguration buildScanConfiguration(boolean develocity) {
+        if (uploadInBackground != null || publishCriteria != null || fileFingerprints != null) {
+            if (develocity) {
+                PublishingConfiguration publishing = null;
+                if (publishCriteria != null) {
+                    String onlyIf;
+                    switch (publishCriteria) {
+                        case Always:
+                            onlyIf = "true";
+                            break;
+                        case Failure:
+                            onlyIf = "!buildResult.failures.empty";
+                            break;
+                        case Demand:
+                            onlyIf = "false";
+                            break;
+                        default:
+                            throw new IllegalStateException("All options exhausted");
+                    }
+                    publishing = new PublishingConfiguration(onlyIf);
+                }
+
+                return new BuildScanConfiguration(
+                        uploadInBackground,
+                        null,
+                        publishing,
+                        fileFingerprints != null ? new Capture(null, fileFingerprints) : null
+                );
+            } else {
+                return new BuildScanConfiguration(uploadInBackground,
+                        publishCriteria != null ? publishCriteria.xmlName : null,
+                        null,
+                        fileFingerprints != null ? new Capture(fileFingerprints, null) : null);
+            }
         }
         return null;
     }
@@ -304,7 +370,7 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
     /**
      * Return true if the `.mvn/extensions.xml` already includes `gradle-enterprise-maven-extension`
      */
-    private boolean findExistingEnterpriseExtension(Xml.Document extensionsXml) {
+    private boolean findExistingExtension(Xml.Document extensionsXml) {
         XPathMatcher xPathMatcher = new XPathMatcher("/extensions/extension/artifactId");
         return new XmlIsoVisitor<AtomicBoolean>() {
             @Override
@@ -315,7 +381,7 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
                 tag = super.visitTag(tag, found);
                 if (xPathMatcher.matches(getCursor())) {
                     Optional<String> maybeArtifactId = tag.getValue();
-                    if (maybeArtifactId.isPresent() && maybeArtifactId.get().equals(GRADLE_ENTERPRISE_MAVEN_EXTENSION_ARTIFACT_ID)) {
+                    if (maybeArtifactId.isPresent() && (maybeArtifactId.get().equals(GRADLE_ENTERPRISE_MAVEN_EXTENSION_ARTIFACT_ID) || maybeArtifactId.get().equals(DEVELOCITY_MAVEN_EXTENSION_ARTIFACT_ID))) {
                         found.set(true);
                     }
                 }
@@ -325,12 +391,25 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
     }
 
     /**
-     * Add `gradle-enterprise-maven-extension` to the file `.mvn/extensions.xml`,
-     * this method assumes that `gradle-enterprise-maven-extension` does not exist yet, and it should have been checked.
+     * Add `develocity-maven-extension` to the file `.mvn/extensions.xml`,
+     * this method assumes that `develocity-maven-extension` does not exist yet, and it should have been checked.
      */
-    private Xml.Document addEnterpriseExtension(Xml.Document extensionsXml, ExecutionContext ctx) {
+    private Xml.Document addExtension(Xml.Document extensionsXml, ExecutionContext ctx) {
+        VersionComparator versionComparator = Semver.validate("(,1.21)", null).getValue();
+        if (versionComparator == null) {
+            return extensionsXml;
+        }
+
+        String newVersion = version != null ? version : getLatestVersion(ctx);
+
+        String extension;
+        if (versionComparator.compare(null, newVersion, "1.21") >= 0) {
+            extension = "develocity-maven-extension";
+        } else {
+            extension = "gradle-enterprise-maven-extension";
+        }
         @Language("xml")
-        String tagSource = version != null ? String.format(ENTERPRISE_TAG_FORMAT, version) : String.format(ENTERPRISE_TAG_FORMAT, getLatestVersion(ctx));
+        String tagSource = String.format(EXTENSION_TAG_FORMAT, extension, newVersion);
         AddToTagVisitor<ExecutionContext> addToTagVisitor = new AddToTagVisitor<>(
                 extensionsXml.getRoot(),
                 Xml.Tag.build(tagSource));
@@ -341,15 +420,15 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
         MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
         MavenPomDownloader pomDownloader = new MavenPomDownloader(Collections.emptyMap(), ctx, mctx.getSettings(), mctx.getActiveProfiles());
         VersionComparator versionComparator = new LatestRelease(null);
-        GroupArtifact gradleEnterpriseExtension = new GroupArtifact("com.gradle", "gradle-enterprise-maven-extension");
+        GroupArtifact develocityExtension = new GroupArtifact("com.gradle", DEVELOCITY_MAVEN_EXTENSION_ARTIFACT_ID);
         try {
-            MavenMetadata extensionMetadata = pomDownloader.downloadMetadata(gradleEnterpriseExtension, null, Collections.singletonList(MavenRepository.MAVEN_CENTRAL));
-        return extensionMetadata.getVersioning()
-            .getVersions()
-            .stream()
-            .filter(v -> versionComparator.isValid(null, v))
-            .max((v1, v2) -> versionComparator.compare(null, v1, v2))
-            .orElseThrow(() -> new IllegalStateException("Expected to find at least one Gradle Enterprise Maven extension version to select from."));
+            MavenMetadata extensionMetadata = pomDownloader.downloadMetadata(develocityExtension, null, Collections.singletonList(MavenRepository.MAVEN_CENTRAL));
+            return extensionMetadata.getVersioning()
+                    .getVersions()
+                    .stream()
+                    .filter(v -> versionComparator.isValid(null, v))
+                    .max((v1, v2) -> versionComparator.compare(null, v1, v2))
+                    .orElseThrow(() -> new IllegalStateException("Expected to find at least one Gradle Enterprise Maven extension version to select from."));
         } catch (MavenDownloadingException e) {
             throw new IllegalStateException("Could not download Maven metadata", e);
         }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDevelocityMavenExtensionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDevelocityMavenExtensionTest.java
@@ -141,7 +141,7 @@ class AddDevelocityMavenExtensionTest implements RewriteTest {
                   <extensions>
                     <extension>
                       <groupId>com.gradle</groupId>
-                      <artifactId>gradle-enterprise-maven-extension</artifactId>
+                      <artifactId>develocity-maven-extension</artifactId>
                       <version>%s</version>
                     </extension>
                   </extensions>
@@ -151,13 +151,13 @@ class AddDevelocityMavenExtensionTest implements RewriteTest {
           xml(
             null,
             """
-              <gradleEnterprise>
+              <develocity>
                 <server>
                   <url>https://foo</url>
                 </server>
-              </gradleEnterprise>
+              </develocity>
               """,
-            spec -> spec.path(".mvn/gradle-enterprise.xml")
+            spec -> spec.path(".mvn/develocity.xml")
           )
         );
     }
@@ -179,7 +179,22 @@ class AddDevelocityMavenExtensionTest implements RewriteTest {
     }
 
     @Test
-    void allSettings() {
+    void noChangeIfDevelocityXmlExists() {
+        rewriteRun(
+          POM_XML_SOURCE_SPEC,
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+              <develocity>
+              </develocity>
+              """,
+            spec -> spec.path(".mvn/develocity.xml")
+          )
+        );
+    }
+
+    @Test
+    void allGradleEnterpriseSettings() {
         rewriteRun(
           spec -> spec.recipe(new AddDevelocityMavenExtension("1.17", "https://foo", true, true, false, AddDevelocityMavenExtension.PublishCriteria.Failure)),
           POM_XML_SOURCE_SPEC,
@@ -215,6 +230,49 @@ class AddDevelocityMavenExtensionTest implements RewriteTest {
               </gradleEnterprise>
               """,
             spec -> spec.path(".mvn/gradle-enterprise.xml")
+          )
+        );
+    }
+
+    @Test
+    void allDevelocitySettings() {
+        rewriteRun(
+          spec -> spec.recipe(new AddDevelocityMavenExtension("1.21", "https://foo", true, true, false, AddDevelocityMavenExtension.PublishCriteria.Failure)),
+          POM_XML_SOURCE_SPEC,
+          xml(
+            null,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <extensions>
+                <extension>
+                  <groupId>com.gradle</groupId>
+                  <artifactId>develocity-maven-extension</artifactId>
+                  <version>1.21</version>
+                </extension>
+              </extensions>
+              """,
+            spec -> spec.path(".mvn/extensions.xml")
+          ),
+          xml(
+            null,
+            """
+              <develocity>
+                <server>
+                  <url>https://foo</url>
+                  <allowUntrusted>true</allowUntrusted>
+                </server>
+                <buildScan>
+                  <backgroundBuildScanUpload>false</backgroundBuildScanUpload>
+                  <publishing>
+                    <onlyIf>!buildResult.failures.empty</onlyIf>
+                  </publishing>
+                  <capture>
+                    <fileFingerprints>true</fileFingerprints>
+                  </capture>
+                </buildScan>
+              </develocity>
+              """,
+            spec -> spec.path(".mvn/develocity.xml")
           )
         );
     }


### PR DESCRIPTION
## What's changed?
- [x] When adding Develocity to a new Gradle project make sure to use the new Develocity configuration names as of 3.17.x
- [x] When adding Develocity to a new Maven project make sure to use the new Develocity configuration names as of 3.17.x
- [ ] Migrate an existing Gradle project configured with Develocity or Gradle Enterprise < 3.17 to use the new configurations for 3.17.x and newer (moved to #4320)
- [ ] Migrate an existing Maven project configured with Develocity or Gradle Enterprise < 3.17 to use the new configurations for 3.17.x and newer

## What's your motivation?
Gradle Enterprise was renamed to Develocity and as such the Gradle plugin has been equally renamed including with a Maven POM relocation. Additionally changes to the configuration names have been introduced as part of the product rename and must be taken by end users.

## Anything in particular you'd like reviewers to focus on?
https://docs.gradle.com/enterprise/gradle-plugin/legacy/#develocity_migration
https://docs.gradle.com/enterprise/maven-extension/legacy/#develocity_migration

## Anyone you would like to review specifically?
Not in particular.

## Have you considered any alternatives or workarounds?
Do the migration manually

## Any additional context
* #4134 
* #4135

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
