### PR TITLE
feat: add shell executor interface for running shell commands during recipe execution

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/shell/exec/ShellExecutor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/shell/exec/ShellExecutor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.shell.exec;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.scheduling.WorkingDirectoryExecutionContextView;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Incubating(since = "8.30.0")
+@SuppressWarnings("unused")
+public interface ShellExecutor {
+
+    @SuppressWarnings("unused")
+    default void init() {
+    }
+
+    @SuppressWarnings("unused")
+    default Path exec(List<String> command, Path workingDirectory, Map<String, String> environment, ExecutionContext ctx) {
+        return exec(command, workingDirectory, environment, Duration.ofMinutes(5), ctx);
+    }
+
+    default Path exec(List<String> command, Path workingDirectory, Map<String, String> environment, Duration timeout, ExecutionContext ctx) {
+        Path stdOut = null, stdErr = null;
+        try {
+            ProcessBuilder builder = new ProcessBuilder();
+            builder.command(command);
+            builder.directory(workingDirectory.toFile());
+            builder.environment().putAll(environment);
+
+            stdOut = Files.createTempFile(WorkingDirectoryExecutionContextView.view(ctx).getWorkingDirectory(), "shell",
+                    null);
+            stdErr = Files.createTempFile(WorkingDirectoryExecutionContextView.view(ctx).getWorkingDirectory(), "shell",
+                    null);
+            builder.redirectOutput(ProcessBuilder.Redirect.to(stdOut.toFile()));
+            builder.redirectError(ProcessBuilder.Redirect.to(stdErr.toFile()));
+            Process process = builder.start();
+
+            process.waitFor(timeout.getSeconds(), TimeUnit.SECONDS);
+            if (process.exitValue() != 0) {
+                String error = "Command failed:" + String.join(" ", command);
+                if (Files.exists(stdErr)) {
+                    error += "\n" + new String(Files.readAllBytes(stdErr));
+                }
+                throw new RuntimeException(error);
+            }
+            return stdOut;
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (stdOut != null) {
+                // noinspection ResultOfMethodCallIgnored
+                stdOut.toFile().delete();
+            }
+            if (stdErr != null) {
+                // noinspection ResultOfMethodCallIgnored
+                stdErr.toFile().delete();
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    default void postExec() {
+    }
+}


### PR DESCRIPTION
## What's changed?
Adding a default executor for running npm commands in code mod recipes.

## What's your motivation?
Standardize execution of npm commands in codemod recipes and allow for customization of the environment the commands are running in. The moderne platform needs to be able to customize the environment when running codemods recipes on the moderne platform to allow custom registries.

Duplicate shell running code in these code mod repos. 
https://github.com/moderneinc/rewrite-codemods/blob/main/src/main/java/org/openrewrite/codemods/NodeBasedRecipe.java#L111 
https://github.com/moderneinc/rewrite-codemods-ng/blob/main/src/main/java/org/openrewrite/codemods/migrate/angular/NodeBasedRecipe.java#L150


### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
