### PR TITLE
Gradle UpgradeDependencyVersion visitor should override isAcceptable

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -301,6 +301,16 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     public TreeVisitor<?, ExecutionContext> getVisitor(DependencyVersionState acc) {
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
+            public boolean isAcceptable(SourceFile sf, ExecutionContext ctx) {
+                if (sf instanceof Properties) {
+                    return new UpdateProperties(acc).isAcceptable(sf, ctx);
+                } else if (sf instanceof G.CompilationUnit) {
+                    return new UpdateGroovy(acc).isAcceptable(sf, ctx);
+                }
+                return false;
+            }
+
+            @Override
             public @Nullable Tree visit(@Nullable Tree t, ExecutionContext ctx) {
                 if (t instanceof Properties) {
                     t = new UpdateProperties(acc).visitNonNull(t, ctx);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -300,22 +300,21 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(DependencyVersionState acc) {
         return new TreeVisitor<Tree, ExecutionContext>() {
+            private UpdateGroovy updateGroovy = new UpdateGroovy(acc);
+            private UpdateProperties updateProperties = new UpdateProperties(acc);
+
             @Override
             public boolean isAcceptable(SourceFile sf, ExecutionContext ctx) {
-                if (sf instanceof Properties) {
-                    return new UpdateProperties(acc).isAcceptable(sf, ctx);
-                } else if (sf instanceof G.CompilationUnit) {
-                    return new UpdateGroovy(acc).isAcceptable(sf, ctx);
-                }
-                return false;
+                return updateProperties.isAcceptable(sf, ctx) || updateGroovy.isAcceptable(sf, ctx);
             }
 
             @Override
             public @Nullable Tree visit(@Nullable Tree t, ExecutionContext ctx) {
-                if (t instanceof Properties) {
-                    t = new UpdateProperties(acc).visitNonNull(t, ctx);
-                } else if (t instanceof G.CompilationUnit) {
-                    t = new UpdateGroovy(acc).visitNonNull(t, ctx);
+                SourceFile sf = (SourceFile) t;
+                if (updateProperties.isAcceptable(sf, ctx)) {
+                    t = updateProperties.visitNonNull(t, ctx);
+                } else if (updateGroovy.isAcceptable(sf, ctx)) {
+                    t = updateGroovy.visitNonNull(t, ctx);
                 }
                 return t;
             }


### PR DESCRIPTION
## What's changed?
We returned a TreeVisitor from `getVisitor(Accumulator)`, which then implicitly returns true, meaning we incorrectly skipped the Maven visitor for `pom.xml` files, calling the Gradle visitor instead. https://github.com/openrewrite/rewrite-java-dependencies/blob/2e3f39c4863b943cdaacb39d0e788c9c73e3f949/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java#L128-L133

With this change we only return true for Groovy and Properties files, as we should.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-java-dependencies/pull/106
