### PR TITLE
Exclude Maven built-in property from circular placeholder reference check

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
@@ -17,6 +17,10 @@ package org.openrewrite.internal;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PropertyPlaceholderHelperTest {
@@ -30,5 +34,26 @@ class PropertyPlaceholderHelperTest {
             default -> throw new UnsupportedOperationException();
         });
         assertThat(s).isEqualTo("hi jon");
+    }
+
+    @Test
+    void testMavenBuiltInProperty() {
+        var helper = new PropertyPlaceholderHelper("${", "}", null);
+        final Set<String> visitedPlaceholders = new HashSet<>();
+        visitedPlaceholders.add("project.version");
+        visitedPlaceholders.add("pom.basedir");
+        visitedPlaceholders.add("maven.home");
+        visitedPlaceholders.add("env.PATH");
+        visitedPlaceholders.add("settings.localRepository");
+        assertThat(helper.parseStringValue("${project.version}", Function.identity(), visitedPlaceholders))
+          .isEqualTo("project.version");
+        assertThat(helper.parseStringValue("${pom.basedir}", Function.identity(), visitedPlaceholders))
+          .isEqualTo("pom.basedir");
+        assertThat(helper.parseStringValue("${maven.home}", Function.identity(), visitedPlaceholders))
+          .isEqualTo("maven.home");
+        assertThat(helper.parseStringValue("${env.PATH}", Function.identity(), visitedPlaceholders))
+          .isEqualTo("env.PATH");
+        assertThat(helper.parseStringValue("${settings.localRepository}", Function.identity(), visitedPlaceholders))
+          .isEqualTo("settings.localRepository");
     }
 }


### PR DESCRIPTION
## What's changed?
Exclude Maven built-in property from circular placeholder reference check

## What's your motivation?
Error `Circular placeholder reference 'XYZ' in property definitions` is thrown when a built-in property, such as `project.version`, is redefined in the root POM and used in a child in multi-module projects.
I would not expect running recipes to fail given that `mvn clean verify` succeeds.

Attached is a minimum project to reproduce the issue.
[Circular-placeholder-reference.zip](https://github.com/user-attachments/files/16256934/Circular-placeholder-reference.zip)
You can run any recipe to trigger it. I ran the one for SpringBoot
```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:RELEASE -Drewrite.activeRecipes=org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_2 
```


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek 


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
