### PR TITLE
Fixed maven multi module property version problem

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -152,7 +152,7 @@ public class MavenParser implements Parser {
                 if (parent != null &&
                     resolutionResult.getPom().getGroupId().equals(resolutionResult.getPom().getValue(parent.getGroupId())) &&
                     resolutionResult.getPom().getArtifactId().equals(resolutionResult.getPom().getValue(parent.getArtifactId())) &&
-                    resolutionResult.getPom().getVersion().equals(resolutionResult.getPom().getValue(parent.getVersion()))) {
+                    Objects.equals(resolutionResult.getPom().getValue(resolutionResult.getPom().getVersion()), resolutionResult.getPom().getValue(parent.getVersion()))) {
                     moduleResolutionResult.unsafeSetParent(resolutionResult);
                     modules.add(moduleResolutionResult);
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3159,6 +3159,7 @@ class MavenParserTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4319")
     void multiModulePropertyVersionShouldAddModules() {
         rewriteRun(
           mavenProject("root",
@@ -3183,7 +3184,7 @@ class MavenParserTest implements RewriteTest {
                 pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow()
                   .getModules()).isNotEmpty())
             ),
-            mavenProject("multiModule-example-child",
+            mavenProject("example-child",
               pomXml(
                 """
                   <project>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3157,4 +3157,48 @@ class MavenParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multiModulePropertyVersionShouldAddModules() {
+        rewriteRun(
+          mavenProject("root",
+            pomXml(
+              """
+                <project>
+                    <groupId>example</groupId>
+                    <artifactId>example-root</artifactId>
+                    <packaging>pom</packaging>
+                    <version>${revision}</version>
+
+                    <properties>
+                        <revision>1.0.1</revision>
+                    </properties>
+
+                    <modules>
+                        <module>example-child</module>
+                    </modules>
+                </project>
+                """,
+              spec -> spec.afterRecipe(pomXml -> assertThat(
+                pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow()
+                  .getModules()).isNotEmpty())
+            ),
+            mavenProject("multiModule-example-child",
+              pomXml(
+                """
+                  <project>
+                      <parent>
+                          <groupId>example</groupId>
+                          <artifactId>example-root</artifactId>
+                          <version>${revision}</version>
+                      </parent>
+
+                      <artifactId>example-child</artifactId>
+                  </project>
+                  """
+              )
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
A property resolver has also been added to the project version, not only to the parent version.

## What's your motivation?
As mentioned in the issue #4319 both poms do not change if there is a property inside the version. So I took the initiative and started looking for the error. It took me a while to figure it out, but now I get it.

- Fixes #4319