### PR TITLE
Allow JavaVisitors to operate on the J language island

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -33,7 +33,7 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
 
     @Override
     public boolean isAcceptable(SourceFile sourceFile, P p) {
-        return sourceFile instanceof JavaSourceFile;
+        return sourceFile instanceof J;
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
Allow JavaVisitor and JavaIsoVisitor to operate on any `SourceFile` in the `J` language grammar island (e.g. C# soon)

## What's your motivation?
To be able to run many of the existing recipes on C# files.

## Anything in particular you'd like reviewers to focus on?

Any potential risks of operating on all SourceFiles of type J as I'm not familiar with the havoc this could wreak.

## Anyone you would like to review specifically?

@sambsnyd @timtebeek 

## Have you considered any alternatives or workarounds?

No

## Any additional context

N/A

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
