### PR TITLE
Fix AddOrUpdateAnnotationAttribute for values of type Class

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -394,8 +394,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Test
     void implicitValueToExplicitValue() {
-        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null))
-            .expectedCyclesThatMakeChanges(2),
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null)),
           java(
             """
               package org.junit;
@@ -432,8 +431,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Test
     void implicitValueToExplicitValueClass() {
-        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null))
-            .expectedCyclesThatMakeChanges(2),
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null)),
           java(
             """
               package org.junit;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -54,6 +54,37 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     }
 
     @Test
+    void addValueAttributeClass() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  Class<? extends Number> value();
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.Foo;
+                            
+              @Foo
+              public class A {
+              }
+              """,
+            """
+              import org.example.Foo;
+                            
+              @Foo(Integer.class)
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void updateValueAttribute() {
         rewriteRun(
           spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", null)),
@@ -86,6 +117,38 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     }
 
     @Test
+    void updateValueAttributeClass() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  Class<? extends Number> value();
+              }
+              """
+          ),
+
+          java(
+            """
+              import org.example.Foo;
+                            
+              @Foo(Long.class)
+              public class A {
+              }
+              """,
+            """
+              import org.example.Foo;
+                            
+              @Foo(Integer.class)
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeValueAttribute() {
         rewriteRun(
           spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, null, null)),
@@ -103,6 +166,38 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               import org.example.Foo;
 
               @Foo("goodbye")
+              public class A {
+              }
+              """,
+            """
+              import org.example.Foo;
+
+              @Foo
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeValueAttributeClass() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, null, null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  Class<? extends Number> value();
+              }
+              """
+          ),
+
+          java(
+            """
+              import org.example.Foo;
+
+              @Foo(Long.class)
               public class A {
               }
               """,
@@ -296,6 +391,44 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               class SomeTest {
                             
                   @Test(other = 1, value = "foo")
+                  void foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void implicitValueToExplicitValueClass() {
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null))
+            .expectedCyclesThatMakeChanges(2),
+          java(
+            """
+              package org.junit;
+              public @interface Test {
+                  long other() default 0L;
+                  Class<? extends Number> value();
+              }
+              """
+          ),
+          java(
+            """
+              import org.junit.Test;
+                            
+              class SomeTest {
+                            
+                  @Test(Integer.class)
+                  void foo() {
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+                            
+              class SomeTest {
+                            
+                  @Test(other = 1, value = Integer.class)
                   void foo() {
                   }
               }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -37,14 +37,14 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.example.Foo;
-                            
+
               @Foo
               public class A {
               }
               """,
             """
               import org.example.Foo;
-                            
+
               @Foo("hello")
               public class A {
               }
@@ -68,15 +68,46 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.example.Foo;
-                            
+
               @Foo
               public class A {
               }
               """,
             """
               import org.example.Foo;
-                            
+
               @Foo(Integer.class)
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addValueAttributeFullyQualifiedClass() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "java.math.BigDecimal.class", null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  Class<? extends Number> value();
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.Foo;
+
+              @Foo
+              public class A {
+              }
+              """,
+            """
+              import org.example.Foo;
+
+              @Foo(java.math.BigDecimal.class)
               public class A {
               }
               """
@@ -100,14 +131,14 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.example.Foo;
-                            
+
               @Foo("goodbye")
               public class A {
               }
               """,
             """
               import org.example.Foo;
-                            
+
               @Foo("hello")
               public class A {
               }
@@ -132,14 +163,14 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.example.Foo;
-                            
+
               @Foo(Long.class)
               public class A {
               }
               """,
             """
               import org.example.Foo;
-                            
+
               @Foo(Integer.class)
               public class A {
               }
@@ -226,9 +257,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test
                   void foo() {
                   }
@@ -236,9 +267,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """,
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test(timeout = 500)
                   void foo() {
                   }
@@ -263,9 +294,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test(timeout = 1)
                   void foo() {
                   }
@@ -273,9 +304,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """,
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test(timeout = 500)
                   void foo() {
                   }
@@ -300,9 +331,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test(timeout = 1)
                   void foo() {
                   }
@@ -310,9 +341,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """,
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test
                   void foo() {
                   }
@@ -339,9 +370,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test(foo = "")
                   void foo() {
                   }
@@ -349,9 +380,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """,
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                  
+
                   @Test(timeout = 500, foo = "")
                   void foo() {
                   }
@@ -377,9 +408,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                            
+
                   @Test("foo")
                   void foo() {
                   }
@@ -387,9 +418,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """,
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                            
+
                   @Test(other = 1, value = "foo")
                   void foo() {
                   }
@@ -415,9 +446,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                            
+
                   @Test(Integer.class)
                   void foo() {
                   }
@@ -425,9 +456,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """,
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
-                            
+
                   @Test(other = 1, value = Integer.class)
                   void foo() {
                   }
@@ -453,7 +484,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                            
+
               class SomeTest {
                   @Test(other = 0)
                   void foo() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -43,7 +43,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                "or adds the argument if it is not already set.";
     }
 
-    @Option(displayName = "Annotation Type",
+    @Option(displayName = "Annotation type",
             description = "The fully qualified name of the annotation.",
             example = "org.junit.Test")
     String annotationType;
@@ -61,7 +61,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
     @Nullable
     String attributeValue;
 
-    @Option(displayName = "Add Only",
+    @Option(displayName = "Add only",
             description = "When set to `true` will not change existing annotation attribute values.")
     @Nullable
     Boolean addOnly;
@@ -144,22 +144,16 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                     foundAttributeWithDesiredValue.set(true);
                                     return it;
                                 }
-
-                                JavaType.ShallowClass newClass = JavaType.ShallowClass.build(newAttributeValue);
-                                Expression currentTarget = value.getTarget();
-                                Expression newTarget = ((J.Identifier) currentTarget)
-                                        .withType(newClass)
-                                        .withSimpleName(newClass.getOwningClass().getClassName());
-                                return value
-                                        .withType(newClass)
-                                        .withTarget(newTarget);
+                                //noinspection ConstantConditions
+                                return ((J.Annotation) JavaTemplate.apply(newAttributeValue, getCursor(), finalA.getCoordinates().replaceArguments()))
+                                        .getArguments().get(0);
                             } else {
                                 //noinspection ConstantConditions
-                                return ((J.Annotation) JavaTemplate.builder("value = #{any(java.lang.Class)}")
+                                return ((J.Annotation) JavaTemplate.builder("value = #{any()}")
                                         .contextSensitive()
                                         .build()
-                                        .apply(getCursor(), finalA.getCoordinates().replaceArguments(), it)
-                                ).getArguments().get(0);
+                                        .apply(getCursor(), finalA.getCoordinates().replaceArguments(), it))
+                                        .getArguments().get(0);
                             }
                         }
                         return it;

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -126,6 +126,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                 }
                                 return ((J.Literal) it).withValue(newAttributeValue).withValueSource(newAttributeValue);
                             } else {
+                                // Make the attribute name explicit, before we add the new value below
                                 //noinspection ConstantConditions
                                 return ((J.Annotation) JavaTemplate.builder("value = #{}")
                                         .contextSensitive()
@@ -148,6 +149,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                 return ((J.Annotation) JavaTemplate.apply(newAttributeValue, getCursor(), finalA.getCoordinates().replaceArguments()))
                                         .getArguments().get(0);
                             } else {
+                                // Make the attribute name explicit, before we add the new value below
                                 //noinspection ConstantConditions
                                 return ((J.Annotation) JavaTemplate.builder("value = #{any()}")
                                         .contextSensitive()


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Fixes AddOrUpdateAnnotationAttribute to work with values of type Class

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix a bug.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
No. 

## Anyone you would like to review specifically?
<!-- @mention them here -->
No. 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No. 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
No. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] ~~I've used the IntelliJ IDEA auto-formatter on affected files~~
