### PR TITLE
Avoid potential for StackOverflow on J#getWeight

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1528,11 +1528,9 @@ public interface J extends Tree {
                 };
 
                 @Override
-                public @Nullable J visit(@Nullable Tree tree, AtomicInteger n) {
-                    if (tree != null) {
-                        n.incrementAndGet();
-                    }
-                    return super.visit(tree, n);
+                public @Nullable J preVisit(J tree, AtomicInteger n) {
+                    n.incrementAndGet();
+                    return tree;
                 }
 
                 @Override


### PR DESCRIPTION
Sometimes, inexplicably we would get this StackOverflow. Using `preVisit` will avoid this.

<img width="527" alt="image" src="https://github.com/user-attachments/assets/c3bdd083-23c5-4b74-b5e0-c69c7626db0a">
