### PR TITLE
Do not wrap single active recipe & remove `activateAll()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -161,6 +161,9 @@ public class Environment {
                     String.join(", ", suggestions));
             throw new RecipeException(message);
         }
+        if (activatedRecipes.isEmpty()) {
+            return Recipe.noop();
+        }
         if (activatedRecipes.size() == 1) {
             return activatedRecipes.get(0);
         }

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -150,26 +150,25 @@ public class Environment {
             }
         }
         if (!recipesNotFound.isEmpty()) {
+            @SuppressWarnings("deprecation")
             List<String> suggestions = recipesNotFound.stream()
                     .map(r -> recipesByName.keySet().stream()
                             .min(comparingInt(a -> StringUtils.getLevenshteinDistance(a, r)))
                             .orElse(r))
                     .collect(toList());
-            String message = String.format("Recipes not found: %s\nDid you mean: %s",
+            String message = String.format("Recipe(s) not found: %s\nDid you mean: %s",
                     String.join(", ", recipesNotFound),
                     String.join(", ", suggestions));
             throw new RecipeException(message);
+        }
+        if (activatedRecipes.size() == 1) {
+            return activatedRecipes.get(0);
         }
         return new CompositeRecipe(activatedRecipes);
     }
 
     public Recipe activateRecipes(String... activeRecipes) {
         return activateRecipes(Arrays.asList(activeRecipes));
-    }
-
-    //TODO: Nothing uses this and in most cases it would be a bad idea anyway, should consider removing
-    public Recipe activateAll() {
-        return new CompositeRecipe(listRecipes());
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -280,6 +280,7 @@ class RecipeLifecycleTest implements RewriteTest {
             type: specs.openrewrite.org/v1beta/recipe
             name: test.recipe
             displayName: Test Recipe
+            description: Test Recipe.
             recipeList:
               - org.openrewrite.NoArgRecipe
             """,
@@ -295,6 +296,7 @@ class RecipeLifecycleTest implements RewriteTest {
             type: specs.openrewrite.org/v1beta/recipe
             name: test.recipe
             displayName: Test Recipe
+            description: Test Recipe.
             recipeList:
               - org.openrewrite.NoArgRecipe:
                   foo: bar
@@ -311,6 +313,7 @@ class RecipeLifecycleTest implements RewriteTest {
             type: specs.openrewrite.org/v1beta/recipe
             name: test.recipe
             displayName: Test Recipe
+            description: Test Recipe.
             recipeList:
               - org.openrewrite.DefaultConstructorRecipe
             """,
@@ -326,18 +329,21 @@ class RecipeLifecycleTest implements RewriteTest {
             type: specs.openrewrite.org/v1beta/recipe
             name: test.recipe.a
             displayName: Test Recipe
+            description: Test Recipe.
             recipeList:
               - test.recipe.b
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: test.recipe.b
             displayName: Test Recipe
+            description: Test Recipe.
             recipeList:
               - test.recipe.c
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: test.recipe.c
             displayName: Test Recipe
+            description: Test Recipe.
             recipeList:
               - org.openrewrite.NoArgRecipe
             """,
@@ -354,6 +360,7 @@ class RecipeLifecycleTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.recipe.c
                 displayName: Test Recipe
+                description: Test Recipe.
                 recipeList:
                   - org.openrewrite.NoArgRecipe
                 """.getBytes()),
@@ -363,6 +370,7 @@ class RecipeLifecycleTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.recipe.b
                 displayName: Test Recipe
+                description: Test Recipe.
                 recipeList:
                   - test.recipe.c
                 """.getBytes()),
@@ -372,6 +380,7 @@ class RecipeLifecycleTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.recipe.a
                 displayName: Test Recipe
+                description: Test Recipe.
                 recipeList:
                   - test.recipe.b
                 """.getBytes()),
@@ -391,7 +400,7 @@ class RecipeLifecycleTest implements RewriteTest {
     void declarativeRecipeChainFromResourcesIncludesImperativeRecipesInDescriptors() {
         rewriteRun(spec -> spec.recipeFromResources("test.declarative.sample.a")
             .afterRecipe(recipeRun -> assertThat(recipeRun.getChangeset().getAllResults().get(0)
-              .getRecipeDescriptorsThatMadeChanges().get(0).getRecipeList().get(0).getRecipeList().get(0)
+              .getRecipeDescriptorsThatMadeChanges().get(0).getRecipeList().get(0)
               .getDisplayName()).isEqualTo("Change text")),
           text("Hi", "after"));
     }

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -159,6 +159,7 @@ class DeclarativeRecipeTest implements RewriteTest {
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.PreconditionTest
+            description: Test.
             preconditions:
               - org.openrewrite.text.Find:
                   find: 1
@@ -180,6 +181,7 @@ class DeclarativeRecipeTest implements RewriteTest {
               ---
               type: specs.openrewrite.org/v1beta/recipe
               name: org.openrewrite.PreconditionTest
+              description: Test.
               preconditions:
                 - org.openrewrite.text.Find:
                     find: 1

--- a/rewrite-core/src/test/java/org/openrewrite/table/SourceFileResultsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/table/SourceFileResultsTest.java
@@ -31,8 +31,7 @@ class SourceFileResultsTest implements RewriteTest {
     void hierarchical() {
         rewriteRun(
           spec -> spec
-            .recipe(
-              new ByteArrayInputStream(
+            .recipeFromYaml(
                 //language=yml
                 """
                   type: specs.openrewrite.org/v1beta/recipe
@@ -40,17 +39,16 @@ class SourceFileResultsTest implements RewriteTest {
                   displayName: Change text to hello
                   description: Hello world.
                   recipeList:
-                      - org.openrewrite.text.ChangeText:
-                          toText: Hello!
-                  """.getBytes()
-              ),
+                    - org.openrewrite.text.ChangeText:
+                        toText: Hello!
+                  """,
               "test.ChangeTextToHello"
             ).dataTable(SourcesFileResults.Row.class, rows -> {
-                assertThat(rows).hasSize(2);
+                assertThat(rows).hasSize(1);
                 assertThat(rows.stream().map(SourcesFileResults.Row::getParentRecipe))
-                  .containsExactly("test.ChangeTextToHello", "");
+                  .containsExactly("test.ChangeTextToHello");
                 assertThat(rows.stream().map(SourcesFileResults.Row::getRecipe))
-                  .containsExactly("org.openrewrite.text.ChangeText", "test.ChangeTextToHello");
+                  .containsExactly("org.openrewrite.text.ChangeText");
             }),
           text(
             "Hi",

--- a/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-a.yml
+++ b/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-a.yml
@@ -18,5 +18,6 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: test.declarative.sample.a
 displayName: Test Recipe
+description: Test Recipe.
 recipeList:
   - test.declarative.sample.b

--- a/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-b.yml
+++ b/rewrite-core/src/test/resources/META-INF/rewrite/test-sample-b.yml
@@ -18,6 +18,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: test.declarative.sample.b
 displayName: Test Recipe
+description: Test Recipe.
 recipeList:
   - org.openrewrite.text.ChangeText:
       toText: after

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ReplaceStringLiteralWithConstantTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ReplaceStringLiteralWithConstantTest.java
@@ -193,6 +193,7 @@ class ReplaceStringLiteralWithConstantTest implements RewriteTest {
           spec -> spec.recipeFromYaml("""
               type: specs.openrewrite.org/v1beta/recipe
               name: org.openrewrite.ReplaceStringLiteralWithConstantList
+              description: Replace string literals with constants.
               recipeList:
                   - org.openrewrite.java.ReplaceStringLiteralWithConstant:
                       fullyQualifiedConstantName: %s
@@ -221,6 +222,7 @@ class ReplaceStringLiteralWithConstantTest implements RewriteTest {
           spec -> spec.recipeFromYaml("""
               type: specs.openrewrite.org/v1beta/recipe
               name: org.openrewrite.ReplaceStringLiteralWithConstantList
+              description: Replace string literals with constants.
               recipeList:
                   - org.openrewrite.java.ReplaceStringLiteralWithConstant:
                       literalValue: %s

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
@@ -68,6 +68,7 @@ class HasJavaVersionTest implements RewriteTest {
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.PreconditionTest
+            description: Test.
             preconditions:
               - org.openrewrite.java.search.HasJavaVersion:
                   version: 11
@@ -87,6 +88,7 @@ class HasJavaVersionTest implements RewriteTest {
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.PreconditionTest
+            description: Test.
             preconditions:
               - org.openrewrite.java.search.HasJavaVersion:
                   version: 11
@@ -105,6 +107,7 @@ class HasJavaVersionTest implements RewriteTest {
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.CombinedWithFindMethod
+            description: Test.
             recipeList:
               - org.openrewrite.java.search.HasJavaVersion:
                   version: 11
@@ -142,6 +145,7 @@ class HasJavaVersionTest implements RewriteTest {
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.CombinedWithFindMethod
+            description: Test.
             recipeList:
               - org.openrewrite.java.search.FindMethods:
                   methodPattern: java.util.List add(..)

--- a/rewrite-java-test/src/test/java/org/openrewrite/text/FindAndReplaceJavaTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/text/FindAndReplaceJavaTest.java
@@ -53,6 +53,7 @@ class FindAndReplaceJavaTest implements RewriteTest {
               type: specs.openrewrite.org/v1beta/recipe
               name: com.yourorg.FindAndReplaceExample
               displayName: Find and replace example
+              description: Test.
               recipeList:
                 - org.openrewrite.text.FindAndReplace:
                     find: blacklist

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RenamePropertyKeyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RenamePropertyKeyTest.java
@@ -15,16 +15,11 @@
  */
 package org.openrewrite.maven;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RenamePropertyKeyTest implements RewriteTest {
@@ -42,15 +37,15 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <guava.version>29.0-jre</guava.version>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -63,15 +58,15 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <version.com.google.guava>29.0-jre</version.com.google.guava>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -92,15 +87,15 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <guava.version>29.0-jre</guava.version>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencyManagement>
                   <dependencies>
                     <dependency>
@@ -115,15 +110,15 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <version.com.google.guava>29.0-jre</version.com.google.guava>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencyManagement>
                   <dependencies>
                     <dependency>
@@ -146,14 +141,14 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <guava.version>29.0-jre</guava.version>
                   <abc>${guava.version}</abc>
                   <def>prefix ${guava.version}</def>
                   <xyz>${guava.version} suffix ${abc}</xyz>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
@@ -162,14 +157,14 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <version.com.google.guava>29.0-jre</version.com.google.guava>
                   <abc>${version.com.google.guava}</abc>
                   <def>prefix ${version.com.google.guava}</def>
                   <xyz>${version.com.google.guava} suffix ${abc}</xyz>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
@@ -186,7 +181,7 @@ class RenamePropertyKeyTest implements RewriteTest {
           type: specs.openrewrite.org/v1beta/recipe
           name: org.openrewrite.RenamePropertyAndValue
           displayName: RenamePropertyAndValue
-          description: RenamePropertyAndValue description
+          description: RenamePropertyAndValue description.
           recipeList:
             - org.openrewrite.maven.RenamePropertyKey:
                   oldKey: "abc"
@@ -201,11 +196,11 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <abc>1.0</abc>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
@@ -214,11 +209,11 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <properties>
                   <def>2.0</def>
                 </properties>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
@@ -235,11 +230,11 @@ class RenamePropertyKeyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <a.version>a</a.version>
                   <bla.version>b</bla.version>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPluginTest.java
@@ -17,14 +17,9 @@ package org.openrewrite.maven.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.config.DeclarativeRecipe;
 import org.openrewrite.test.RewriteTest;
 
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -97,6 +92,7 @@ class FindPluginTest implements RewriteTest {
             ---
             type: specs.openrewrite.org/v1beta/recipe
             name: org.openrewrite.MultiModuleTest
+            description: Test.
             preconditions:
               - org.openrewrite.maven.search.FindPlugin:
                   groupId: org.apache.maven.plugins
@@ -115,7 +111,7 @@ class FindPluginTest implements RewriteTest {
                       <packaging>pom</packaging>
                       <modules>
                           <module>submodule</module>
-                      </modules>                
+                      </modules>
                       <build>
                           <plugins>
                               <plugin>
@@ -124,16 +120,16 @@ class FindPluginTest implements RewriteTest {
                                   <version>5.28.0</version>
                               </plugin>
                           </plugins>
-                      </build>                  
+                      </build>
                   </project>
-                  """,sourceSpecs -> sourceSpecs.path("pom.xml")),
+                  """, sourceSpecs -> sourceSpecs.path("pom.xml")),
           pomXml(
             """
                 <project>
                     <parent>
                         <groupId>org.example</groupId>
                         <artifactId>mvn_multi_module_test</artifactId>
-                        <version>1.0-SNAPSHOT</version>            
+                        <version>1.0-SNAPSHOT</version>
                     </parent>
                     <artifactId>submodule</artifactId>
                     <build>
@@ -146,7 +142,7 @@ class FindPluginTest implements RewriteTest {
                         </plugins>
                     </build>
                 </project>
-                    """,sourceSpecs -> sourceSpecs.path("submodule.pom.xml")
+                """, sourceSpecs -> sourceSpecs.path("submodule.pom.xml")
           )
         );
     }

--- a/rewrite-test/src/test/java/org/openrewrite/config/EnvironmentTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/config/EnvironmentTest.java
@@ -45,6 +45,7 @@ class EnvironmentTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.ChangeTextToHello
                 displayName: Change text to hello
+                description: Test.
                 recipeList:
                     - org.openrewrite.text.ChangeText:
                         toText: Hello
@@ -74,6 +75,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.ChangeTextToHello
                   displayName: Change text to hello
+                  description: Test.
                   recipeList:
                       - org.openrewrite.text.ChangeText:
                           toText: Hello
@@ -112,6 +114,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.ChangeTextToHello
                   displayName: Change text to hello
+                  description: Test.
                   recipeList:
                     - org.openrewrite.text.ChangeText:
                         toText: Hello
@@ -119,6 +122,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.ChangeTextToHelloWorld
                   displayName: Change text to hello world
+                  description: Test.
                   recipeList:
                     - org.openrewrite.text.ChangeText:
                         toText: Hello
@@ -147,6 +151,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.ChangeTextToHello
                   displayName: Change text to hello
+                  description: Test.
                   recipeList:
                       - org.openrewrite.text.ChangeText
                   """.getBytes()
@@ -172,12 +177,14 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.TextMigration
                   displayName: Text migration
+                  description: Test.
                   recipeList:
                       - test.ChangeTextToHello
                   ---
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.ChangeTextToHello
                   displayName: Change text to hello
+                  description: Test.
                   recipeList:
                       - org.openrewrite.text.ChangeText:
                           toText: Hello
@@ -213,6 +220,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.TextMigration
                   displayName: Text migration
+                  description: Test.
                   recipeList:
                       - test.ChangeTextToHello
                   """.getBytes()
@@ -262,6 +270,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.TextMigration
                   displayName: Text migration
+                  description: Test.
                   recipeList:
                       - test.DoesNotExist
                   """.getBytes()
@@ -286,7 +295,8 @@ class EnvironmentTest implements RewriteTest {
                 """
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.LicenseHeader
-                  displayName: License header.
+                  displayName: License header
+                  description: Test.
                   recipeList:
                     - org.openrewrite.java.AddLicenseHeader: |-
                         LicenseHeader
@@ -312,6 +322,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.ResultOfFileMkdirsIgnored
                   displayName: Test
+                  description: Test.
                   recipeList:
                     - org.openrewrite.java.ResultOfMethodCallIgnored:
                           methodPattern: 'java.io.File mkdir*()'
@@ -427,6 +438,7 @@ class EnvironmentTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.FooOne
                 displayName: Test
+                description: Test.
                 recipeList:
                   - org.openrewrite.config.RecipeAcceptingParameters:
                         foo: "foo"
@@ -459,6 +471,7 @@ class EnvironmentTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.OrderPreserved
                 displayName: Test
+                description: Test.
                 recipeList:
                   - org.openrewrite.config.RecipeNoParameters
                   - test.FooOne
@@ -474,7 +487,7 @@ class EnvironmentTest implements RewriteTest {
             new Properties()
           ))
           .build();
-        var recipeList = env.activateRecipes("test.OrderPreserved").getRecipeList().get(0).getRecipeList();
+        var recipeList = env.activateRecipes("test.OrderPreserved").getRecipeList();
         assertThat(recipeList.get(0).getName()).isEqualTo("org.openrewrite.config.RecipeNoParameters");
         assertThat(recipeList.get(1).getName()).isEqualTo("test.FooOne");
         assertThat(recipeList.get(2).getName()).isEqualTo("org.openrewrite.config.RecipeAcceptingParameters");
@@ -493,17 +506,18 @@ class EnvironmentTest implements RewriteTest {
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.Foo
                 displayName: Test
+                description: Test.
                 causesAnotherCycle: true
                 recipeList:
                   - org.openrewrite.config.RecipeNoParameters
-                                
+                
                 """.getBytes()
             ),
             URI.create("rewrite.yml"),
             new Properties()
           )).build();
         var recipe = env.activateRecipes("test.Foo");
-        assertThat(recipe.getRecipeList().get(0).causesAnotherCycle()).isTrue();
+        assertThat(recipe.causesAnotherCycle()).isTrue();
     }
 
     @Test
@@ -516,6 +530,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: test.Foo
                   displayName: Test
+                  description: Test.
                   recipeList:
                     - org.openrewrite.config.RecipeNoParameters
                   """.getBytes()
@@ -530,6 +545,7 @@ class EnvironmentTest implements RewriteTest {
                   type: specs.openrewrite.org/v1beta/recipe
                   name: org.openrewrite.config.RecipeNoParameters
                   displayName: Test
+                  description: Test.
                   recipeList:
                     - org.openrewrite.config.RecipeSomeParameters
                   """.getBytes()

--- a/rewrite-test/src/test/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-test/src/test/resources/META-INF/rewrite/rewrite.yml
@@ -17,7 +17,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.text.ChangeTextToJon
 displayName: Change Text To Jon
-description: Changes Text to "Hello Jon!"
+description: Changes Text to "Hello Jon!".
 tags:
   - testing
   - plain text


### PR DESCRIPTION
## What's changed?
Remove `activateAll()` and do not wrap single active recipe into a new `CompositeRecipe`.

## What's your motivation?
- Removes need for edge case handling unwrap in https://github.com/openrewrite/rewrite-maven-plugin/pull/816
- Closer to what folks would expect in the simplest case: the directly instantiated Recipe, not an indirection wrapper.

## Anything in particular you'd like reviewers to focus on?
The CompositeRecipe overrides a number of methods like the estimated time and data table descriptors. I think it's fine to skip this indirection, but an extra pair of eyes can't hurt.
https://github.com/openrewrite/rewrite/blob/03c458404073082275a752063887c188d213afbe/rewrite-core/src/main/java/org/openrewrite/config/CompositeRecipe.java#L25-L71

## Have you considered any alternatives or workarounds?
We can leave this indirection in for consistent handling no matter the number of active recipes.

## Any additional context
- As discovered on https://github.com/openrewrite/rewrite-maven-plugin/pull/816
