### PR TITLE
feat: Extend message on http sender response

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -903,7 +903,6 @@ public class MavenPomDownloader {
             this.body = body;
         }
 
-
         /**
          * All 400s are considered client-side exceptions, but we only want to cache ones that are unlikely to change
          * if requested again in order to save on time spent making HTTP calls.

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -374,7 +374,7 @@ public class MavenPomDownloader {
                 return new MavenMetadata(versioning);
             }
         } catch (HttpSenderResponseException e) {
-            if (e.isClientSideException() && e.getResponseCode() != null && e.getResponseCode() != 404) {
+            if (e.isClientSideException() && e.getResponseCode() != 404) {
                 // If access was denied, do not attempt to derive metadata from this repository in the future.
                 repo.setDeriveMetadataIfMissing(false);
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -911,9 +911,20 @@ public class MavenPomDownloader {
 
         @Override
         public String getMessage() {
-            return responseCode == null ?
-                    requireNonNull(getCause()).getMessage() :
-                    "HTTP " + responseCode;
+            String message = "";
+            if (responseCode != null) {
+                message += "HTTP " + responseCode;
+                if (responseCode < 0) {
+                    message += " - Connection failed";
+                } else if (responseCode > 399) {
+                    message += "\n" + body;
+                }
+            }
+            Throwable cause = getCause();
+            if (cause != null && cause.getMessage() != null) {
+                message += "\nCaused by: " + cause.getMessage();
+            }
+            return message;
         }
 
         public boolean isAccessDenied() {


### PR DESCRIPTION
Adding a body when it makes sense (server/client exceptions) and cause message if available (although this is unused in this repo).
