### PR TITLE
fix: Dont generate the same file multiple times & fix CreateTextFile

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryLargeSourceSet.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryLargeSourceSet.java
@@ -81,7 +81,8 @@ public class InMemoryLargeSourceSet implements LargeSourceSet {
             //noinspection ConstantConditions
             return this;
         } else if (ls.isEmpty()) {
-            return withChanges(deletions, new ArrayList<>(t));
+            //noinspection unchecked
+            return withChanges(deletions, (List<SourceFile>) t);
         }
 
         List<SourceFile> newLs = new ArrayList<>(ls);

--- a/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryLargeSourceSet.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryLargeSourceSet.java
@@ -44,8 +44,8 @@ public class InMemoryLargeSourceSet implements LargeSourceSet {
     }
 
     protected InMemoryLargeSourceSet(@Nullable InMemoryLargeSourceSet initialState,
-                                   @Nullable Map<SourceFile, List<Recipe>> deletions,
-                                   List<SourceFile> ls) {
+                                     @Nullable Map<SourceFile, List<Recipe>> deletions,
+                                     List<SourceFile> ls) {
         this.initialState = initialState;
         this.ls = ls;
         this.deletions = deletions;
@@ -81,8 +81,7 @@ public class InMemoryLargeSourceSet implements LargeSourceSet {
             //noinspection ConstantConditions
             return this;
         } else if (ls.isEmpty()) {
-            //noinspection unchecked
-            return withChanges(deletions, (List<SourceFile>) t);
+            return withChanges(deletions, new ArrayList<>(t));
         }
 
         List<SourceFile> newLs = new ArrayList<>(ls);

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -112,7 +112,11 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 ScanningRecipe<Object> scanningRecipe = (ScanningRecipe<Object>) recipe;
                 List<SourceFile> generated = new ArrayList<>(scanningRecipe.generate(scanningRecipe.getAccumulator(rootCursor, ctx), unmodifiableList(acc), ctx));
                 generated.replaceAll(source -> addRecipesThatMadeChanges(recipeStack, source));
-                acc.addAll(generated);
+                for (SourceFile source : generated) {
+                    if (acc.stream().noneMatch(s -> s.getSourcePath().equals(source.getSourcePath()))) {
+                        acc.add(source);
+                    }
+                }
                 if (!generated.isEmpty()) {
                     madeChangesInThisCycle.add(recipe);
                 }
@@ -238,7 +242,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     }
 
     private @Nullable SourceFile handleError(Recipe recipe, SourceFile sourceFile, @Nullable SourceFile after,
-                                   Throwable t) {
+                                             Throwable t) {
         ctx.getOnError().accept(t);
 
         if (t instanceof RecipeRunException) {

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -121,7 +121,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         }, new TreeSet<>(Comparator.comparing(SourceFile::getSourcePath)));
 
         // noinspection unchecked
-        return (LSS) sourceSet.generate(generatedInThisCycle);
+        return (LSS) sourceSet.generate(new ArrayList<>(generatedInThisCycle));
     }
 
     public LSS editSources(LSS sourceSet) {

--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -86,7 +86,7 @@ public class CreateTextFile extends ScanningRecipe<AtomicBoolean> {
             @Override
             public SourceFile visit(@Nullable Tree tree, ExecutionContext ctx) {
                 SourceFile sourceFile = (SourceFile) requireNonNull(tree);
-                if ((created.get() || Boolean.TRUE.equals(overwriteExisting)) && path.equals(sourceFile.getSourcePath())) {
+                if (Boolean.TRUE.equals(overwriteExisting) && path.equals(sourceFile.getSourcePath())) {
                     if (sourceFile instanceof PlainText) {
                         return ((PlainText) sourceFile).withText(fileContents);
                     }

--- a/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
@@ -135,24 +135,24 @@ class CreateTextFileTest implements RewriteTest {
     void shouldNotOverrideIfCreatedInSameRun() {
         rewriteRun(
           spec -> spec.recipeFromYaml("""
-                  ---
-                  type: specs.openrewrite.org/v1beta/recipe
-                  name: org.openrewrite.text.CreateTextFileDuplication
-                  displayName: Create Text File test recipe
-                  description: Create Text File test recipe.
-                  recipeList:
-                    - org.openrewrite.text.CreateTextFile:
-                        relativeFileName: duplicate.txt
-                        overwriteExisting: false
-                        fileContents: |
-                          hi
-                    - org.openrewrite.text.CreateTextFile:
-                        relativeFileName: duplicate.txt
-                        overwriteExisting: false
-                        fileContents: |
-                          hello
-                  """),
-          text(null,"hi", spec -> spec.path(Path.of("duplicate.txt")))
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.test.CreateTextFileDuplication
+            displayName: Create Text File test recipe
+            description: Create Text File test recipe.
+            recipeList:
+              - org.openrewrite.text.CreateTextFile:
+                  relativeFileName: duplicate.txt
+                  overwriteExisting: false
+                  fileContents: |
+                    hi
+              - org.openrewrite.text.CreateTextFile:
+                  relativeFileName: duplicate.txt
+                  overwriteExisting: false
+                  fileContents: |
+                    hello
+            """, "org.openrewrite.test.CreateTextFileDuplication"),
+          text(null, "hi", spec -> spec.path(Path.of("duplicate.txt")))
         );
     }
 }

--- a/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/text/CreateTextFileTest.java
@@ -21,6 +21,8 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
+import java.nio.file.Path;
+
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.test.SourceSpecs.text;
 
@@ -126,6 +128,31 @@ class CreateTextFileTest implements RewriteTest {
             after,
             spec -> spec.path("Jenkinsfile")
           )
+        );
+    }
+
+    @Test
+    void shouldNotOverrideIfCreatedInSameRun() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+                  ---
+                  type: specs.openrewrite.org/v1beta/recipe
+                  name: org.openrewrite.text.CreateTextFileDuplication
+                  displayName: Create Text File test recipe
+                  description: Create Text File test recipe.
+                  recipeList:
+                    - org.openrewrite.text.CreateTextFile:
+                        relativeFileName: duplicate.txt
+                        overwriteExisting: false
+                        fileContents: |
+                          hi
+                    - org.openrewrite.text.CreateTextFile:
+                        relativeFileName: duplicate.txt
+                        overwriteExisting: false
+                        fileContents: |
+                          hello
+                  """),
+          text(null,"hi", spec -> spec.path(Path.of("duplicate.txt")))
         );
     }
 }


### PR DESCRIPTION
## What's changed?
generate no longer creates files at the same path multiple times

## What's your motivation?
Currently the same file can be created multiple times, causing instabilities in recipe execution. For instance
running `CreateTextFile` twice in the same run causes multiple cycles changing back and forth from 1 text to the other, even if `overwriteExisting` is false

## Anything in particular you'd like reviewers to focus on?
This is a change in the core recipe running and might have unwanted side-effects

## Anyone you would like to review specifically?
@sambsnyd @timtebeek 

## Have you considered any alternatives or workarounds?
Fixing it on the recipe level alone, but this would require "rescanning" during the edit phase.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
