### PR TITLE
fix: `CreateYaml` does not work the same as `CreateTextFile` with precondition

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CreateYamlFile.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CreateYamlFile.java
@@ -87,7 +87,7 @@ public class CreateYamlFile extends ScanningRecipe<AtomicBoolean> {
     @Override
     public Collection<SourceFile> generate(AtomicBoolean shouldCreate, ExecutionContext ctx) {
         if (shouldCreate.get()) {
-            return YamlParser.builder().build().parse("")
+            return YamlParser.builder().build().parse(getYamlContents(ctx))
                     .map(brandNewFile -> (SourceFile) brandNewFile.withSourcePath(Paths.get(relativeFileName)))
                     .collect(Collectors.toList());
         }
@@ -98,13 +98,12 @@ public class CreateYamlFile extends ScanningRecipe<AtomicBoolean> {
     public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean created) {
         Path path = Paths.get(relativeFileName);
         return new YamlVisitor<ExecutionContext>() {
+
             @Override
             public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
-                if ((created.get() || Boolean.TRUE.equals(overwriteExisting)) && path.equals(documents.getSourcePath())) {
-                    @Language("yml") String yamlContents = fileContents;
-                    if (yamlContents == null && fileContentsUrl != null) {
-                        yamlContents = Remote.builder(path, URI.create(fileContentsUrl)).build().printAll(ctx);
-                    }
+                if (Boolean.TRUE.equals(overwriteExisting) && path.equals(documents.getSourcePath())) {
+                    @Language("yml")
+                    String yamlContents = getYamlContents(ctx);
                     if (StringUtils.isBlank(yamlContents)) {
                         return documents.withDocuments(emptyList());
                     }
@@ -124,5 +123,15 @@ public class CreateYamlFile extends ScanningRecipe<AtomicBoolean> {
                 return documents;
             }
         };
+    }
+
+    @Language("yml")
+    @Nullable
+    private String getYamlContents(ExecutionContext ctx) {
+        @Language("yml") String yamlContents = fileContents;
+        if (yamlContents == null && fileContentsUrl != null) {
+            yamlContents = Remote.builder(Paths.get(relativeFileName), URI.create(fileContentsUrl)).build().printAll(ctx);
+        }
+        return yamlContents;
     }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CreateYamlFile.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CreateYamlFile.java
@@ -126,12 +126,11 @@ public class CreateYamlFile extends ScanningRecipe<AtomicBoolean> {
     }
 
     @Language("yml")
-    @Nullable
     private String getYamlContents(ExecutionContext ctx) {
         @Language("yml") String yamlContents = fileContents;
         if (yamlContents == null && fileContentsUrl != null) {
             yamlContents = Remote.builder(Paths.get(relativeFileName), URI.create(fileContentsUrl)).build().printAll(ctx);
         }
-        return yamlContents;
+        return yamlContents == null ? "" : yamlContents;
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
@@ -208,4 +208,63 @@ class CreateYamlFileTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldCreateYamlFromYamlRecipe() {
+        rewriteRun(spec -> spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.CreateYamlPrecondition
+            displayName: Create yaml file with precondition
+            description: Create a yaml file with a precondition.
+            recipeList:
+              - org.openrewrite.yaml.CreateYamlFile:
+                  relativeFileName: created.yml
+                  overwriteExisting: false
+                  fileContents: |
+                    content: yes
+            """, "org.openrewrite.CreateYamlPrecondition"),
+          yaml("""
+            foo: bar
+            """, spec -> spec.path("precondition.yml")),
+          yaml(
+            null,
+            """
+                    content: yes
+                    """,
+            spec -> spec.path("created.yml")
+          )
+        );
+    }
+
+    @Test
+    void shouldCreateYamlFromYamlRecipeWithPrecondition() {
+        rewriteRun(spec -> spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.CreateYamlPrecondition
+            displayName: Create yaml file with precondition
+            description: Create a yaml file with a precondition.
+            preconditions:
+              - org.openrewrite.FindSourceFiles:
+                  filePattern: "**/precondition.yml"
+            recipeList:
+              - org.openrewrite.yaml.CreateYamlFile:
+                  relativeFileName: created.yml
+                  overwriteExisting: false
+                  fileContents: |
+                    content: yes
+            """, "org.openrewrite.CreateYamlPrecondition"),
+          yaml("""
+            foo: bar
+            """, spec -> spec.path("precondition.yml")),
+          yaml(
+            null,
+            """
+                    content: yes
+                    """,
+            spec -> spec.path("created.yml")
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
@@ -224,7 +224,8 @@ class CreateYamlFileTest implements RewriteTest {
                   fileContents: |
                     content: yes
             """, "org.openrewrite.CreateYamlPrecondition"),
-          yaml("""
+          yaml(
+                """
             foo: bar
             """, spec -> spec.path("precondition.yml")),
           yaml(

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
@@ -120,7 +120,7 @@ class CreateYamlFileTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new CreateYamlFile(
             "test/test-file-2.yaml",
-            null,
+            "",
             null,
             true
           )),

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
@@ -255,7 +255,8 @@ class CreateYamlFileTest implements RewriteTest {
                   fileContents: |
                     content: yes
             """, "org.openrewrite.CreateYamlPrecondition"),
-          yaml("""
+          yaml(
+                """
             foo: bar
             """, spec -> spec.path("precondition.yml")),
           yaml(


### PR DESCRIPTION
When a precondition is present and matched, an empty file is generated but the content is not added.

```
expected: "content: yes"
 but was: ""
```

## What's changed?
`CreateYamlFile` will add content in the generate phase to work "correctly" with preconditions.

## What's your motivation?
Just like CreateTextFile, CreateYaml should always add content if a file is created.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
-->