### PR TITLE
feat: Add GitProvenance support for Azure DevOps repositories

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -117,12 +117,11 @@ public class GitProvenance implements Marker {
 
     private static @Nullable String getOrganizationNameFromOrigin(String origin) {
         Matcher matcher = AZURE_DEVOPS_HTTP_REMOTE.matcher(origin);
-        if (matcher.matches()) {
-            return matcher.group(1);
+        if (!matcher.matches()) {
+            matcher = AZURE_DEVOPS_SSH_REMOTE.matcher(origin);
         }
-        matcher = AZURE_DEVOPS_SSH_REMOTE.matcher(origin);
         if (matcher.matches()) {
-            return matcher.group(1);
+            return matcher.group(1) + '/' + matcher.group(2);
         }
 
         try {
@@ -132,22 +131,6 @@ public class GitProvenance implements Marker {
             // Strip off any leading sub organization names
             return path.substring(path.lastIndexOf('/') + 1);
         } catch (URISyntaxException e) {
-        }
-        return null;
-    }
-
-    public @Nullable String getProjectName() {
-        return Optional.ofNullable(origin).map(GitProvenance::getProjectName).orElse(null);
-    }
-
-    private static @Nullable String getProjectName(String origin) {
-        Matcher matcher = AZURE_DEVOPS_HTTP_REMOTE.matcher(origin);
-        if (matcher.matches()) {
-            return matcher.group(2);
-        }
-        matcher = AZURE_DEVOPS_SSH_REMOTE.matcher(origin);
-        if (matcher.matches()) {
-            return matcher.group(2);
         }
         return null;
     }
@@ -169,10 +152,6 @@ public class GitProvenance implements Marker {
     public static String getRepositoryPath(String origin) {
         StringBuilder builder = new StringBuilder(64);
         builder.append(getOrganizationNameFromOrigin(origin));
-        String projectName = getProjectName(origin);
-        if (projectName != null) {
-            builder.append('/').append(projectName);
-        }
         String repositoryName = getRepositoryName(origin);
         if (repositoryName != null) {
             builder.append('/').append(repositoryName);

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -54,24 +54,21 @@ class GitProvenanceTest {
 
     private static Stream<Arguments> remotes() {
         return Stream.of(
-          Arguments.of("ssh://git@github.com/openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("https://github.com/openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("file:///openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("http://localhost:7990/scm/openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("http://localhost:7990/scm/some/openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("git@github.com:openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("org-12345678@github.com:openrewrite/rewrite.git", "openrewrite", null, "rewrite"),
-          Arguments.of("https://dev.azure.com/openrewrite/rewrite/_git/rewrite", "openrewrite", "rewrite", "rewrite"),
-          Arguments.of(
-            "https://openrewrite@dev.azure.com/openrewrite/rewrite/_git/rewrite",
-            "openrewrite",
-            "rewrite",
+          Arguments.of("ssh://git@github.com/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("https://github.com/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("file:///openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("http://localhost:7990/scm/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("http://localhost:7990/scm/some/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("git@github.com:openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("org-12345678@github.com:openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("https://dev.azure.com/openrewrite/rewrite/_git/rewrite", "openrewrite/rewrite", "rewrite"),
+          Arguments.of("https://openrewrite@dev.azure.com/openrewrite/rewrite/_git/rewrite",
+            "openrewrite/rewrite",
             "rewrite"),
-          Arguments.of("git@ssh.dev.azure.com:v3/openrewrite/rewrite/rewrite", "openrewrite", "rewrite", "rewrite"),
+          Arguments.of("git@ssh.dev.azure.com:v3/openrewrite/rewrite/rewrite", "openrewrite/rewrite", "rewrite"),
           Arguments.of(
             "ssh://git@ssh.dev.azure.com:v3/openrewrite/rewrite/rewrite",
-            "openrewrite",
-            "rewrite",
+            "openrewrite/rewrite",
             "rewrite")
         );
     }
@@ -79,24 +76,21 @@ class GitProvenanceTest {
     @SuppressWarnings("deprecation")
     @ParameterizedTest
     @MethodSource("remotes")
-    void getRepositoryPath(String origin, String expectedOrg, String expectedProject, String expectedRepo) {
+    void getRepositoryPath(String origin, String expectedOrg, String expectedRepo) {
         GitProvenance gitProvenance = new GitProvenance(randomId(), origin, "main", "123", null, null, List.of());
         assertThat(gitProvenance.getOrganizationName()).isEqualTo(expectedOrg);
-        assertThat(gitProvenance.getProjectName()).isEqualTo(expectedProject);
         assertThat(gitProvenance.getRepositoryName()).isEqualTo(expectedRepo);
-        String expectedPath = expectedProject != null ?
-          expectedOrg + '/' + expectedProject + '/' + expectedRepo :
-          expectedOrg + '/' + expectedRepo;
-        assertThat(gitProvenance.getRepositoryPath(origin)).isEqualTo(expectedPath);
+        String expectedPath = expectedOrg + '/' + expectedRepo;
+        assertThat(GitProvenance.getRepositoryPath(origin)).isEqualTo(expectedPath);
     }
 
     @ParameterizedTest
     @CsvSource({
       "git@gitlab.acme.com:organization/subgroup/repository.git, https://gitlab.acme.com, organization/subgroup",
       "git@gitlab.acme.com:organization/subgroup/repository.git, git@gitlab.acme.com, organization/subgroup",
-      "https://dev.azure.com/organization/project/_git/repository, https://dev.azure.com, organization",
-      "https://organization@dev.azure.com/organization/project/_git/repository, https://dev.azure.com, organization",
-      "git@ssh.dev.azure.com:v3/organization/project/repository, git@ssh.dev.azure.com, organization"
+      "https://dev.azure.com/organization/project/_git/repository, https://dev.azure.com, organization/project",
+      "https://organization@dev.azure.com/organization/project/_git/repository, https://dev.azure.com, organization/project",
+      "git@ssh.dev.azure.com:v3/organization/project/repository, git@ssh.dev.azure.com, organization/project"
 
     })
     void getOrganizationNameWithBaseUrl(String gitOrigin, String baseUrl, String organizationName) {


### PR DESCRIPTION
## What's changed?
Updated `GitProvenance` to support parsing Azure DevOps repositories.

## What's your motivation?
These changes are required to support Azure DevOps as an SCM.

## Anything in particular you'd like reviewers to focus on?
Let me know of other `rewrite` classes that may require similar updates.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
No.

## Any additional context
No.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
