### PR TITLE
Merge yaml test for inline comments retention

### DIFF
--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1135,4 +1135,36 @@ class MergeYamlTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/1598")
+    @Test
+    void mergePropertiesWithExistingComments() {
+        rewriteRun(
+          spec -> spec.recipe(new
+              MergeYaml(
+              "$",
+              //language=yaml
+              """
+                widget:
+                  list:
+                    currentCount: 3
+                """,
+              true, null, null
+            )
+          ),
+          yaml(
+            """
+              widget:
+                list:
+                  itemCount: 5 #number of existing items in the list
+              """,
+            """
+              widget:
+                list:
+                  itemCount: 5 #number of existing items in the list
+                  currentCount: 3
+              """
+          )
+        );
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1136,7 +1136,7 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1598")
+    @Issue("https://github.com/openrewrite/rewrite/issues/2218")
     @Test
     void mergePropertiesWithExistingComments() {
         rewriteRun(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added test case to test inline comment retention for mergeyaml recipe

## What's your motivation?
We have same issue as described here
- https://github.com/openrewrite/rewrite/issues/2218

## Anything in particular you'd like reviewers to focus on?
Nothing as of now.

## Anyone you would like to review specifically?
@timtebeek @pstreef to review this test case

## Have you considered any alternatives or workarounds?
There is no work around for this issue. Developers want to retain the comments in their yaml file.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
