### PR TITLE
Remove temporary JavaTemplate files

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -47,14 +47,26 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         if (TEMPLATE_CLASSPATH_DIR == null) {
             try {
                 TEMPLATE_CLASSPATH_DIR = Files.createTempDirectory("java-template");
+                TEMPLATE_CLASSPATH_DIR.toFile().deleteOnExit();
                 Path templateDir = Files.createDirectories(TEMPLATE_CLASSPATH_DIR.resolve("org/openrewrite/java/internal/template"));
+                for (Path subDir : new Path[] {
+                   TEMPLATE_CLASSPATH_DIR.resolve("org"),
+                   TEMPLATE_CLASSPATH_DIR.resolve("org/openrewrite"),
+                   TEMPLATE_CLASSPATH_DIR.resolve("org/openrewrite/java"),
+                   TEMPLATE_CLASSPATH_DIR.resolve("org/openrewrite/java/internal")
+                }) {
+                  subDir.toFile().deleteOnExit();
+                }
+                templateDir.toFile().deleteOnExit();
                 try (InputStream in = JavaTemplateParser.class.getClassLoader().getResourceAsStream("org/openrewrite/java/internal/template/__M__.class")) {
                     assert in != null;
                     Files.copy(in, templateDir.resolve("__M__.class"));
+                    templateDir.resolve("__M__.class").toFile().deleteOnExit();
                 }
                 try (InputStream in = JavaTemplateParser.class.getClassLoader().getResourceAsStream("org/openrewrite/java/internal/template/__P__.class")) {
                     assert in != null;
                     Files.copy(in, templateDir.resolve("__P__.class"));
+                    templateDir.resolve("__P__.class").toFile().deleteOnExit();
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
## What's changed?

Temporary directory created by `JavaTemplate`, subdirectories within, and files copied there were registered for deletion upon JVM shutdown.

## What's your motivation?
- Fixes #4369 

## Anything in particular you'd like reviewers to focus on?
- Tested only inside this project, ie. during the build. (Luckily tests for current `main` leave such directories already).
Specifically - didn't test it with maven plugin, rewrite-migrate-java, etc.
Don't know how this class is used across components.
#4369 was observed after maven ran many recipes on multi-module project.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
- wait for systemd-tmpfiles to reclaim temporary but no longer used space
- manually remove files left after rewrite executions

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
