### PR TITLE
Isolate JavaTemplate issue with generic type parameters

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -1222,14 +1222,15 @@ class JavaTemplateTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
                 @Override
-                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                     if (new MethodMatcher("batch.StepBuilder create()").matches(method)) {
                         return JavaTemplate.builder("new StepBuilder()")
+                          //.doBeforeParseTemplate(System.out::println)
                           .contextSensitive()
                           .build()
                           .apply(getCursor(), method.getCoordinates().replace());
                     }
-                    return super.visitMethodInvocation(method, executionContext);
+                    return super.visitMethodInvocation(method, ctx);
                 }
             }))
             .parser(JavaParser.fromJavaVersion().dependsOn(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -1229,7 +1229,6 @@ class JavaTemplateTest implements RewriteTest {
                         return JavaTemplate.builder("new StepBuilder()")
                           //.doBeforeParseTemplate(System.out::println)
                           .contextSensitive()
-                          .imports("batch.StepBuilder")
                           .build()
                           .apply(getCursor(), method.getCoordinates().replace());
                     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -298,7 +298,7 @@ class JavaTemplateTest implements RewriteTest {
                   void m() {
                       hashCode();
                   }
-                            
+
                   void m2() {
                       hashCode();
                   }
@@ -721,20 +721,20 @@ class JavaTemplateTest implements RewriteTest {
               class A {
                   public enum Type {
                       One;
-                            
+
                       public Type(String t) {
                       }
-                            
+
                       String t;
-                            
+
                       public static Type fromType(String type) {
                           return null;
                       }
                   }
-                            
+
                   public A(Type type) {}
                   public A() {}
-                            
+
                   public void method(Type type) {
                       new A(type);
                   }
@@ -744,20 +744,20 @@ class JavaTemplateTest implements RewriteTest {
               class A {
                   public enum Type {
                       One;
-                            
+
                       public Type(String t) {
                       }
-                            
+
                       String t;
-                            
+
                       public static Type fromType(String type) {
                           return null;
                       }
                   }
-                            
+
                   public A(Type type) {}
                   public A() {}
-                            
+
                   public void method(Type type) {
                       new A();
                   }
@@ -865,7 +865,7 @@ class JavaTemplateTest implements RewriteTest {
           java(
             """
               import java.util.Collection;
-                            
+
               class Test {
                   void doSomething(Collection<Object> c) {
                       assert c.size() > 0;
@@ -874,7 +874,7 @@ class JavaTemplateTest implements RewriteTest {
               """,
             """
               import java.util.Collection;
-                            
+
               class Test {
                   void doSomething(Collection<Object> c) {
                       assert !c.isEmpty();
@@ -1084,7 +1084,7 @@ class JavaTemplateTest implements RewriteTest {
             """
               import java.util.Map;
               import org.junit.jupiter.api.Assertions;
-                            
+
               class T {
                   void m(String one, Map<String, ?> map) {
                       Assertions.assertEquals(one, map.get("one"));
@@ -1093,9 +1093,9 @@ class JavaTemplateTest implements RewriteTest {
               """,
             """
               import java.util.Map;
-                            
+
               import static org.assertj.core.api.Assertions.assertThat;
-                            
+
               class T {
                   void m(String one, Map<String, ?> map) {
                       assertThat(map.get("one")).isEqualTo(one);
@@ -1140,7 +1140,7 @@ class JavaTemplateTest implements RewriteTest {
               import java.util.Objects;
               import java.util.Map;
               import java.util.HashMap;
-                            
+
               class T {
               	void m() {
               		Map<String, ?> map = new HashMap<>();
@@ -1151,10 +1151,10 @@ class JavaTemplateTest implements RewriteTest {
             """
               import java.util.Objects;
               import java.util.Map;
-                            
+
               import static java.util.Objects.requireNonNull;
               import java.util.HashMap;
-                            
+
               class T {
               	void m() {
               		Map<String, ?> map = new HashMap<>();
@@ -1182,13 +1182,11 @@ class JavaTemplateTest implements RewriteTest {
           java(
             """
               interface Test {
-                            
                   String a;
               }
               """,
             """
               interface Test {
-                            
                   String a();
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -1182,11 +1182,13 @@ class JavaTemplateTest implements RewriteTest {
           java(
             """
               interface Test {
+
                   String a;
               }
               """,
             """
               interface Test {
+
                   String a();
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TreeVisitingPrinter.java
@@ -17,14 +17,12 @@ package org.openrewrite.java;
 
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JLeftPadded;
-import org.openrewrite.java.tree.JRightPadded;
-import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.StreamSupport.stream;
 
 
@@ -174,7 +172,8 @@ public class TreeVisitingPrinter extends TreeVisitor<Tree, ExecutionContext> {
             return s != null ? s : "";
         }
 
-        String[] lines = tree.toString().split("\n");
+        String precedingComments = tree instanceof J ? printComments(((J) tree).getPrefix().getComments()) : "";
+        String[] lines = (precedingComments + tree).split("\n");
         StringBuilder output = new StringBuilder();
         for (int i = 0; i < lines.length; i++) {
             output.append(lines[i].trim());
@@ -197,9 +196,15 @@ public class TreeVisitingPrinter extends TreeVisitor<Tree, ExecutionContext> {
         sb.append(" whitespace=\"")
             .append(space.getWhitespace()).append("\"");
         sb.append(" comments=\"")
-            .append(String.join(",", space.getComments().stream().map(c -> c.printComment(new Cursor(null, "root"))).collect(Collectors.toList())))
-            .append("\"");;
+            .append(printComments(space.getComments()))
+            .append("\"");
         return sb.toString().replace("\n", "\\s\n");
+    }
+
+    private static String printComments(List<Comment> comments) {
+        return comments.stream()
+                .map(c -> c.printComment(new Cursor(null, "root")))
+                .collect(joining(","));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -67,9 +67,17 @@ public class BlockStatementTemplateGenerator {
                         after.append('}');
                     }
 
-                    template(next(cursor), cursor.getValue(), before, after, cursor.getValue(), mode);
+                    if (contextSensitive) {
+                        contextTemplate(next(cursor), cursor.getValue(), before, after, cursor.getValue(), mode);
+                    } else {
+                        contextFreeTemplate(next(cursor), cursor.getValue(), before, after);
+                    }
 
-                    return before.toString().trim() + "\n/*" + TEMPLATE_COMMENT + "*/" + template + "/*" + STOP_COMMENT + "*/" + "\n" + after.toString().trim();
+                    return before.toString().trim() +
+                           "\n/*" + TEMPLATE_COMMENT + "*/" +
+                           template +
+                           "/*" + STOP_COMMENT + "*/\n" +
+                           after.toString().trim();
                 });
     }
 
@@ -84,7 +92,8 @@ public class BlockStatementTemplateGenerator {
 
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, Integer integer) {
-                if (getCursor().getParentTreeCursor().getValue() instanceof SourceFile && (classDecl.getSimpleName().equals("__P__") || classDecl.getSimpleName().equals("__M__"))) {
+                if (getCursor().getParentTreeCursor().getValue() instanceof SourceFile &&
+                    (classDecl.getSimpleName().equals("__P__") || classDecl.getSimpleName().equals("__M__"))) {
                     // don't visit the __P__ and __M__ classes declaring stubs
                     return classDecl;
                 }
@@ -191,14 +200,6 @@ public class BlockStatementTemplateGenerator {
         }.visit(cu, 0);
 
         return js;
-    }
-
-    private void template(Cursor cursor, J prior, StringBuilder before, StringBuilder after, J insertionPoint, JavaCoordinates.Mode mode) {
-        if (contextSensitive) {
-            contextTemplate(cursor, prior, before, after, insertionPoint, mode);
-        } else {
-            contextFreeTemplate(cursor, prior, before, after);
-        }
     }
 
     @SuppressWarnings("DataFlowIssue")

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -775,11 +775,13 @@ public class BlockStatementTemplateGenerator {
 
         private static class TemplatedTreeTrimmerVisitor extends JavaVisitor<Integer> {
             private boolean stopCommentExists(@Nullable J j) {
-                if (j != null) {
-                    for (Comment comment : j.getComments()) {
-                        if (comment instanceof TextComment && ((TextComment) comment).getText().equals(STOP_COMMENT)) {
-                            return true;
-                        }
+                return j != null && stopCommentExists(j.getComments());
+            }
+
+            private static boolean stopCommentExists(List<Comment> comments) {
+                for (Comment comment : comments) {
+                    if (comment instanceof TextComment && ((TextComment) comment).getText().equals(STOP_COMMENT)) {
+                        return true;
                     }
                 }
                 return false;
@@ -803,6 +805,13 @@ public class BlockStatementTemplateGenerator {
                 if (stopCommentExists(mi.getName())) {
                     //noinspection ConstantConditions
                     return mi.getSelect();
+                }
+                if (method.getTypeParameters() != null) {
+                    // For method chains return `select` if `STOP_COMMENT` is found before `typeParameters`
+                    if (stopCommentExists(mi.getPadding().getTypeParameters().getBefore().getComments())) {
+                        //noinspection ConstantConditions
+                        return mi.getSelect();
+                    }
                 }
                 return mi;
             }


### PR DESCRIPTION
## What's changed?
Replicate generic type issue affecting a downstream PR.

```diff
diff --git a/Foo.java b/Foo.java
index c811849..2466f30 100644
--- a/Foo.java
+++ b/Foo.java
@@ -1,7 +1,8 @@ 
 import batch.StepBuilder;
 class Foo {
     void test() {
-        new StepBuilder()
+        new StepBuilder()/*__TEMPLATE_STOP__*/
+                ./*__TEMPLATE_STOP__*/<String>method()
             .<String>method();
     }
 }
```

## What's your motivation?
This is holding up
- https://github.com/openrewrite/rewrite-spring/pull/284

## Anything in particular you'd like reviewers to focus on?
Not yet explored the fix; figured log the issue first to document the problem in isolation. Any help welcome.

## Anyone you would like to review specifically?
@knutwannheden or @sambsnyd 