### PR TITLE
Added test property for FAIL_ON_UNKNOWN_PROPERTIES configuration

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -146,8 +146,12 @@ public class YamlResourceLoader implements ResourceLoader {
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModule(new ParameterNamesModule())
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                .registerModule(new ParameterNamesModule());
+
+        if (Boolean.FALSE.equals(properties.getOrDefault(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))) {
+            mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        }
+
         maybeAddKotlinModule(mapper);
 
         this.classLoader = classLoader;

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -131,6 +131,7 @@ public class YamlResourceLoader implements ResourceLoader {
      * @param source      Declarative recipe source
      * @param properties  Placeholder properties
      * @param classLoader Optional classloader to use with jackson. If not specified, the runtime classloader will be used.
+     * @param dependencyResourceLoaders Optional resource loaders for recipes from dependencies
      * @throws UncheckedIOException On unexpected IOException
      */
     public YamlResourceLoader(InputStream yamlInput,
@@ -138,6 +139,26 @@ public class YamlResourceLoader implements ResourceLoader {
                               Properties properties,
                               @Nullable ClassLoader classLoader,
                               Collection<? extends ResourceLoader> dependencyResourceLoaders) throws UncheckedIOException {
+        this(yamlInput, source, properties, classLoader, dependencyResourceLoaders, jsonMapper -> {
+        });
+    }
+
+    /**
+     * Load a declarative recipe, optionally using the specified classloader and optionally including resource loaders
+     * for recipes from dependencies.
+     *
+     * @param yamlInput                 Declarative recipe yaml input stream
+     * @param source                    Declarative recipe source
+     * @param properties                Placeholder properties
+     * @param classLoader               Optional classloader to use with jackson. If not specified, the runtime classloader will be used.
+     * @param dependencyResourceLoaders Optional resource loaders for recipes from dependencies
+     * @param mapperCustomizer          Customizer for the ObjectMapper
+     * @throws UncheckedIOException On unexpected IOException
+     */
+    public YamlResourceLoader(InputStream yamlInput, URI source, Properties properties,
+                              @Nullable ClassLoader classLoader,
+                              Collection<? extends ResourceLoader> dependencyResourceLoaders,
+                              Consumer<ObjectMapper> mapperCustomizer) {
         this.source = source;
         this.dependencyResourceLoaders = dependencyResourceLoaders;
 
@@ -146,12 +167,10 @@ public class YamlResourceLoader implements ResourceLoader {
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModule(new ParameterNamesModule());
+                .registerModule(new ParameterNamesModule())
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-        if (Boolean.FALSE.equals(properties.getOrDefault(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))) {
-            mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        }
-
+        mapperCustomizer.accept(mapper);
         maybeAddKotlinModule(mapper);
 
         this.classLoader = classLoader;
@@ -486,7 +505,7 @@ public class YamlResourceLoader implements ResourceLoader {
                     @Language("markdown")
                     String packageName = (String) c.get("packageName");
                     if (packageName.endsWith("." + CategoryTree.CORE) ||
-                            packageName.contains("." + CategoryTree.CORE + ".")) {
+                        packageName.contains("." + CategoryTree.CORE + ".")) {
                         throw new IllegalArgumentException("The package name 'core' is reserved.");
                     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -277,23 +277,23 @@ class RecipeLifecycleTest implements RewriteTest {
     @Test
     void canCallImperativeRecipeWithoutArgsFromDeclarative() {
         rewriteRun(spec -> spec.recipeFromYaml("""
-            ---
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.recipe
-            displayName: Test Recipe
-            description: Test Recipe.
-            recipeList:
-              - org.openrewrite.NoArgRecipe
-            """,
-          "test.recipe"
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - org.openrewrite.NoArgRecipe
+              """,
+            "test.recipe"
           ),
           text("Hi", "NoArgRecipeHi"));
     }
 
     @Test
-    void canCallImperativeRecipeWithUnnecessaryArgsWhenFailOnUnknownPropertiesFalse() {
-        rewriteRun(spec -> spec.failOnUnknownProperties(false)
-            .recipeFromYaml("""
+    void canNotCallImperativeRecipeWithUnnecessaryArgsFromDeclarativeInTests() {
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+          rewriteRun(spec -> spec.recipeFromYaml("""
                 ---
                 type: specs.openrewrite.org/v1beta/recipe
                 name: test.recipe
@@ -305,56 +305,20 @@ class RecipeLifecycleTest implements RewriteTest {
                 """,
               "test.recipe"
             ),
-          text("Hi", "NoArgRecipeHi"));
-    }
-
-    @Test
-    void cannotCallImperativeRecipeWithUnnecessaryArgsWhenFailOnUnknownPropertiesTrue() {
-        assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
-            rewriteRun(spec -> spec.failOnUnknownProperties(true)
-              .recipeFromYaml("""
-                  ---
-                  type: specs.openrewrite.org/v1beta/recipe
-                  name: test.recipe
-                  displayName: Test Recipe
-                  description: Test Recipe.
-                  recipeList:
-                    - org.openrewrite.NoArgRecipe:
-                        foo: bar
-                  """,
-                "test.recipe"
-              )))
-          .withMessageContaining("Unrecognized field \"foo\"");
-    }
-
-    @Test
-    void canCallImperativeRecipeWithUnnecessaryArgsFromDeclarative() {
-        rewriteRun(spec -> spec.recipeFromYaml("""
-            ---
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.recipe
-            displayName: Test Recipe
-            description: Test Recipe.
-            recipeList:
-              - org.openrewrite.NoArgRecipe:
-                  foo: bar
-            """,
-            "test.recipe"
-          ),
-          text("Hi", "NoArgRecipeHi"));
+            text("Hi", "NoArgRecipeHi")));
     }
 
     @Test
     void canCallRecipeWithNoExplicitConstructor() {
         rewriteRun(spec -> spec.recipeFromYaml("""
-            ---
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.recipe
-            displayName: Test Recipe
-            description: Test Recipe.
-            recipeList:
-              - org.openrewrite.DefaultConstructorRecipe
-            """,
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - org.openrewrite.DefaultConstructorRecipe
+              """,
             "test.recipe"
           ),
           text("Hi", "DefaultConstructorRecipeHi"));
@@ -363,28 +327,28 @@ class RecipeLifecycleTest implements RewriteTest {
     @Test
     void declarativeRecipeChain() {
         rewriteRun(spec -> spec.recipeFromYaml("""
-            ---
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.recipe.a
-            displayName: Test Recipe
-            description: Test Recipe.
-            recipeList:
-              - test.recipe.b
-            ---
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.recipe.b
-            displayName: Test Recipe
-            description: Test Recipe.
-            recipeList:
-              - test.recipe.c
-            ---
-            type: specs.openrewrite.org/v1beta/recipe
-            name: test.recipe.c
-            displayName: Test Recipe
-            description: Test Recipe.
-            recipeList:
-              - org.openrewrite.NoArgRecipe
-            """,
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe.a
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - test.recipe.b
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe.b
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - test.recipe.c
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe.c
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - org.openrewrite.NoArgRecipe
+              """,
             "test.recipe.a"
           ),
           text("Hi", "NoArgRecipeHi"));
@@ -394,34 +358,34 @@ class RecipeLifecycleTest implements RewriteTest {
     void declarativeRecipeChainAcrossFiles() {
         rewriteRun(spec -> spec.recipe(Environment.builder()
             .load(new YamlResourceLoader(new ByteArrayInputStream("""
-                ---
-                type: specs.openrewrite.org/v1beta/recipe
-                name: test.recipe.c
-                displayName: Test Recipe
-                description: Test Recipe.
-                recipeList:
-                  - org.openrewrite.NoArgRecipe
-                """.getBytes()),
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe.c
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - org.openrewrite.NoArgRecipe
+              """.getBytes()),
               URI.create("rewrite.yml"), new Properties()))
             .load(new YamlResourceLoader(new ByteArrayInputStream("""
-                ---
-                type: specs.openrewrite.org/v1beta/recipe
-                name: test.recipe.b
-                displayName: Test Recipe
-                description: Test Recipe.
-                recipeList:
-                  - test.recipe.c
-                """.getBytes()),
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe.b
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - test.recipe.c
+              """.getBytes()),
               URI.create("rewrite.yml"), new Properties()))
             .load(new YamlResourceLoader(new ByteArrayInputStream("""
-                ---
-                type: specs.openrewrite.org/v1beta/recipe
-                name: test.recipe.a
-                displayName: Test Recipe
-                description: Test Recipe.
-                recipeList:
-                  - test.recipe.b
-                """.getBytes()),
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.recipe.a
+              displayName: Test Recipe
+              description: Test Recipe.
+              recipeList:
+                - test.recipe.b
+              """.getBytes()),
               URI.create("rewrite.yml"), new Properties()))
             .build()
             .activateRecipes("test.recipe.a")),

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -43,6 +43,7 @@ import java.util.UUID;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.openrewrite.Recipe.noop;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -287,6 +288,43 @@ class RecipeLifecycleTest implements RewriteTest {
           "test.recipe"
           ),
           text("Hi", "NoArgRecipeHi"));
+    }
+
+    @Test
+    void canCallImperativeRecipeWithUnnecessaryArgsWhenFailOnUnknownPropertiesFalse() {
+        rewriteRun(spec -> spec.failOnUnknownProperties(false)
+            .recipeFromYaml("""
+                ---
+                type: specs.openrewrite.org/v1beta/recipe
+                name: test.recipe
+                displayName: Test Recipe
+                description: Test Recipe.
+                recipeList:
+                  - org.openrewrite.NoArgRecipe:
+                      foo: bar
+                """,
+              "test.recipe"
+            ),
+          text("Hi", "NoArgRecipeHi"));
+    }
+
+    @Test
+    void cannotCallImperativeRecipeWithUnnecessaryArgsWhenFailOnUnknownPropertiesTrue() {
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+            rewriteRun(spec -> spec.failOnUnknownProperties(true)
+              .recipeFromYaml("""
+                  ---
+                  type: specs.openrewrite.org/v1beta/recipe
+                  name: test.recipe
+                  displayName: Test Recipe
+                  description: Test Recipe.
+                  recipeList:
+                    - org.openrewrite.NoArgRecipe:
+                        foo: bar
+                  """,
+                "test.recipe"
+              )))
+          .withMessageContaining("Unrecognized field \"foo\"");
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeLifecycleTest.java
@@ -41,9 +41,7 @@ import java.util.Properties;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.openrewrite.Recipe.noop;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.text;


### PR DESCRIPTION
## What's changed?
I have changed the `new Properties()` used in test `RecipeSpec` to be a class field. This allows customization of logic deeper in rewrite-core. In this case I have changed the `JsonMapper` in `YamlResourceLoader` to allow `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` to be customized. The default is that `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` is disabled as that was the existing behavior.

Users can now make their tests fail if there are unknown properties present in the recipe using
`spec.failOnUnknownProperties(true)`

I also had to update the `RECIPE_CACHE` key as the properties set can change the recipe outcome - although typically the new part of the key will be `{}` as no existing code could be configuring any properties.

## What's your motivation?
This allows bugs for incorrectly specified recipe options to be more easily caught. E.g., the in below example both are valid recipes and will run but the second one is the true intent and it can be difficult to catch during code reviews:

Incorrect:
```
  - org.openrewrite.maven.RemoveRedundantDependencyVersions:
      groupId: org.apache.commons
```

Correct:
```
  - org.openrewrite.maven.RemoveRedundantDependencyVersions:
      groupPattern: org.apache.commons
```

## Anything in particular you'd like reviewers to focus on?
If there is a better/alternate approach - although it would seem that using the `Properties` object is the correct way to configure object.

## Anyone you would like to review specifically?
- As discussed here: https://github.com/openrewrite/rewrite/discussions/4375
@timtebeek 

## Any additional context
I made this change as we hit the exact issue describe above and it wasn't caught during PR review. If we had the option to fail tests when unnecessary arguments are specified we would likely enable it for every test case.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
