### PR TITLE
refactor: Azure devops refactoring

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsCloneUrl.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsCloneUrl.java
@@ -25,15 +25,16 @@ public class AzureDevOpsCloneUrl implements CloneUrl {
     String organization;
     String repositoryName;
 
-    public AzureDevOpsCloneUrl(String cloneUrl,
-                               String origin,
-                               String organization,
-                               String project,
-                               String repositoryName) {
+    public AzureDevOpsCloneUrl(String cloneUrl, String origin, String path) {
         this.cloneUrl = cloneUrl;
         this.origin = origin;
-        this.organization = organization + '/' + project;
-        this.repositoryName = repositoryName;
-        this.path = this.organization + '/' + repositoryName;
+        this.path = path;
+        if (!this.path.contains("/")) {
+            throw new IllegalArgumentException("Azure DevOps clone url path must contain organization, project and repository");
+        }
+        String azureDevOpsOrganization = path.substring(0, path.indexOf("/"));
+        String azureDevOpsProject = path.substring(path.indexOf("/") + 1, path.lastIndexOf("/"));
+        this.repositoryName = path.substring(path.lastIndexOf("/") + 1);
+        this.organization = azureDevOpsOrganization + '/' + azureDevOpsProject;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsCloneUrl.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsCloneUrl.java
@@ -18,23 +18,22 @@ package org.openrewrite.scm;
 import lombok.Value;
 
 @Value
-public class AzureDevopsCloneUrl implements CloneUrl {
+public class AzureDevOpsCloneUrl implements CloneUrl {
     String cloneUrl;
     String origin;
     String path;
     String organization;
-    String project;
     String repositoryName;
 
-    public AzureDevopsCloneUrl(String cloneUrl, String origin, String path) {
+    public AzureDevOpsCloneUrl(String cloneUrl,
+                               String origin,
+                               String organization,
+                               String project,
+                               String repositoryName) {
         this.cloneUrl = cloneUrl;
         this.origin = origin;
-        this.path = path;
-        if (!path.contains("/")) {
-            throw new IllegalArgumentException("Azure DevOps clone url path must contain organization, project and repository");
-        }
-        this.organization = path.substring(0, path.indexOf("/"));
-        this.project = path.substring(path.indexOf("/") + 1, path.lastIndexOf("/"));
-        this.repositoryName = path.substring(path.lastIndexOf("/") + 1);
+        this.organization = organization + '/' + project;
+        this.repositoryName = repositoryName;
+        this.path = this.organization + '/' + repositoryName;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsCloneUrl.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsCloneUrl.java
@@ -29,7 +29,7 @@ public class AzureDevOpsCloneUrl implements CloneUrl {
         this.cloneUrl = cloneUrl;
         this.origin = origin;
         this.path = path;
-        if (!this.path.contains("/")) {
+        if (!path.contains("/")) {
             throw new IllegalArgumentException("Azure DevOps clone url path must contain organization, project and repository");
         }
         String azureDevOpsOrganization = path.substring(0, path.indexOf("/"));

--- a/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsScm.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scm/AzureDevOpsScm.java
@@ -15,16 +15,7 @@
  */
 package org.openrewrite.scm;
 
-import org.openrewrite.internal.lang.Nullable;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class AzureDevOpsScm implements Scm {
-    private static final Pattern AZURE_DEVOPS_HTTP_REMOTE =
-            Pattern.compile("https://(?:[\\w-]+@)?dev\\.azure\\.com/([^/]+)/([^/]+)/_git/(.*)");
-    private static final Pattern AZURE_DEVOPS_SSH_REMOTE =
-            Pattern.compile("(?:ssh://)?git@ssh\\.dev\\.azure\\.com:v3/([^/]+)/([^/]+)/(.*)");
 
     @Override
     public String getOrigin() {
@@ -33,27 +24,23 @@ public class AzureDevOpsScm implements Scm {
 
     @Override
     public String cleanHostAndPath(String url) {
-        Matcher matcher = getUrlMatcher(url);
-        if (matcher != null) {
-            return getOrigin() + '/' + matcher.group(1) + '/' + matcher.group(2) + '/' + matcher.group(3);
+        UrlComponents uri = UrlComponents.parse(url);
+        String host = uri.getHost();
+        String path = uri.getPath();
+        if (uri.isSsh() && host.startsWith("ssh.")) {
+            host = host.substring(4);
+            path = path.replaceFirst("v3/", "");
+        } else {
+            path = path.replaceFirst("_git/", "");
         }
-        return url;
+        String hostAndPath = host + "/" + path
+                .replaceFirst("\\.git$", "");
+        return hostAndPath.replaceFirst("/$", "");
     }
 
     @Override
     public CloneUrl parseCloneUrl(String cloneUrl) {
-        Matcher matcher = getUrlMatcher(cloneUrl);
-        if (matcher == null) {
-            throw new IllegalArgumentException("Unable to parse Azure DevOps repository URL: " + cloneUrl);
-        }
-        return new AzureDevOpsCloneUrl(cloneUrl, getOrigin(), matcher.group(1), matcher.group(2), matcher.group(3));
-    }
-
-    private @Nullable Matcher getUrlMatcher(String cloneUrl) {
-        Matcher matcher = AZURE_DEVOPS_HTTP_REMOTE.matcher(cloneUrl);
-        if (!matcher.matches()) {
-            matcher = AZURE_DEVOPS_SSH_REMOTE.matcher(cloneUrl);
-        }
-        return matcher.matches() ? matcher : null;
+        CloneUrl parsed = Scm.super.parseCloneUrl(cloneUrl);
+        return new AzureDevOpsCloneUrl(cloneUrl, getOrigin(), parsed.getPath());
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.jgit.api.Git;
@@ -40,6 +41,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -53,30 +55,47 @@ import static org.openrewrite.jgit.lib.ConfigConstants.CONFIG_BRANCH_SECTION;
 @SuppressWarnings({"ConstantConditions", "HttpUrlsUsage"})
 class GitProvenanceTest {
 
-    private static Stream<String> remotes() {
+    private static Stream<Arguments> remotes() {
         return Stream.of(
-          "ssh://git@github.com/openrewrite/rewrite.git",
-          "https://github.com/openrewrite/rewrite.git",
-          "file:///openrewrite/rewrite.git",
-          "http://localhost:7990/scm/openrewrite/rewrite.git",
-          "http://localhost:7990/scm/some/openrewrite/rewrite.git",
-          "git@github.com:openrewrite/rewrite.git",
-          "org-12345678@github.com:openrewrite/rewrite.git"
+          Arguments.of("ssh://git@github.com/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("https://github.com/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("file:///openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("http://localhost:7990/scm/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("http://localhost:7990/scm/some/openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("git@github.com:openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("org-12345678@github.com:openrewrite/rewrite.git", "openrewrite", "rewrite"),
+          Arguments.of("https://dev.azure.com/openrewrite/rewrite/_git/rewrite", "openrewrite/rewrite", "rewrite"),
+          Arguments.of("https://openrewrite@dev.azure.com/openrewrite/rewrite/_git/rewrite",
+            "openrewrite/rewrite",
+            "rewrite"),
+          Arguments.of("git@ssh.dev.azure.com:v3/openrewrite/rewrite/rewrite", "openrewrite/rewrite", "rewrite"),
+          Arguments.of(
+            "ssh://git@ssh.dev.azure.com:v3/openrewrite/rewrite/rewrite",
+            "openrewrite/rewrite",
+            "rewrite")
         );
     }
 
     @SuppressWarnings("deprecation")
     @ParameterizedTest
     @MethodSource("remotes")
-    void getOrganizationName(String remote) {
-        assertThat(new GitProvenance(randomId(), remote, "main", "123", null, null, emptyList()).getOrganizationName())
-          .isEqualTo("openrewrite");
+    void getRepositoryPath(String origin, String expectedOrg, String expectedRepo) {
+        GitProvenance gitProvenance = new GitProvenance(randomId(), origin, "main", "123", null, null, List.of());
+        assertThat(gitProvenance.getOrganizationName()).isEqualTo(expectedOrg);
+        assertThat(gitProvenance.getRepositoryName()).isEqualTo(expectedRepo);
+        String expectedPath = expectedOrg + '/' + expectedRepo;
+        assertThat(GitProvenance.getRepositoryPath(origin)).isEqualTo(expectedPath);
     }
 
     @ParameterizedTest
     @CsvSource({
       "git@gitlab.acme.com:organization/subgroup/repository.git, https://gitlab.acme.com, organization/subgroup",
-      "git@gitlab.acme.com:organization/subgroup/repository.git, git@gitlab.acme.com, organization/subgroup"
+      "git@gitlab.acme.com:organization/subgroup/repository.git, git@gitlab.acme.com, organization/subgroup",
+      "git@gitlab.acme.com:organization/subgroup/repository.git, git@gitlab.acme.com, organization/subgroup",
+      "https://dev.azure.com/organization/project/_git/repository, https://dev.azure.com, organization/project",
+      "https://organization@dev.azure.com/organization/project/_git/repository, https://dev.azure.com, organization/project",
+      "git@ssh.dev.azure.com:v3/organization/project/repository, git@ssh.dev.azure.com, organization/project"
+
     })
     void getOrganizationNameWithBaseUrl(String gitOrigin, String baseUrl, String organizationName) {
         Scm.registerScm(new GitLabScm(baseUrl));

--- a/rewrite-core/src/test/java/org/openrewrite/scm/AzureDevOpsScmTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/scm/AzureDevOpsScmTest.java
@@ -29,6 +29,7 @@ class AzureDevOpsScmTest {
     @CsvSource(textBlock = """
       https://dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project
       git@ssh.dev.azure.com:v3/org/project/repo, dev.azure.com, org/project/repo, org/project
+      ssh://ssh.dev.azure.com:22/v3/org/project/repo, dev.azure.com, org/project/repo, org/project
       """)
     void splitOriginPathWithValidUrls(String cloneUrl,
                                       @Nullable String expectedOrigin,
@@ -51,7 +52,7 @@ class AzureDevOpsScmTest {
       "https://scm.company.com/scm/project/repo.git",
       "git@scm.company.com:context/path/scm/project/repo.git"
     })
-    void splitOriginPathWithInvalidUrls(String cloneUrl) {
+    void otherScmDoNotMatch(String cloneUrl) {
         assertThat(scm.belongsToScm(cloneUrl)).isFalse();
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/scm/AzureDevOpsScmTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/scm/AzureDevOpsScmTest.java
@@ -17,35 +17,41 @@ package org.openrewrite.scm;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.internal.lang.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AzureDevOpsScmTest {
+    Scm scm = new AzureDevOpsScm();
 
-    @CsvSource(textBlock = """
-      https://dev.azure.com/org/project/_git/repo.git, true, dev.azure.com, org/project/repo, project, org
-      git@ssh.dev.azure.com:v3/org/project/repo.git, true, dev.azure.com, org/project/repo, project, org
-                  
-      https://github.com/org/repo, false,,,,
-      https://gitlab.com/org/repo, false,,,,
-      https://scm.company.com/scm/project/repo.git, false,,,,
-      git@scm.company.com:context/path/scm/project/repo.git, false,,,,
-      """)
     @ParameterizedTest
-    void splitOriginPath(String cloneUrl, boolean matchesScm, @Nullable String expectedOrigin, @Nullable String expectedPath, @Nullable String expectedProject, @Nullable String expectedOrganization) {
-        Scm scm = new AzureDevOpsScm();
-        assertThat(scm.belongsToScm(cloneUrl)).isEqualTo(matchesScm);
-        if (matchesScm) {
-            assertThat(scm.getOrigin()).isEqualTo(expectedOrigin);
-            CloneUrl parsed = scm.parseCloneUrl(cloneUrl);
-            assertThat(parsed).isInstanceOf(AzureDevopsCloneUrl.class);
-            AzureDevopsCloneUrl azureDevopsCloneUrl = (AzureDevopsCloneUrl) parsed;
-            assertThat(azureDevopsCloneUrl.getOrigin()).isEqualTo(expectedOrigin);
-            assertThat(azureDevopsCloneUrl.getPath()).isEqualTo(expectedPath);
-            assertThat(azureDevopsCloneUrl.getProject()).isEqualTo(expectedProject);
-            assertThat(azureDevopsCloneUrl.getOrganization()).isEqualTo(expectedOrganization);
-        }
+    @CsvSource(textBlock = """
+      https://dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project
+      git@ssh.dev.azure.com:v3/org/project/repo, dev.azure.com, org/project/repo, org/project
+      """)
+    void splitOriginPathWithValidUrls(String cloneUrl,
+                                      @Nullable String expectedOrigin,
+                                      @Nullable String expectedPath,
+                                      @Nullable String expectedOrganization) {
+        assertThat(scm.belongsToScm(cloneUrl)).isTrue();
+        assertThat(scm.getOrigin()).isEqualTo(expectedOrigin);
+        CloneUrl parsed = scm.parseCloneUrl(cloneUrl);
+        assertThat(parsed).isInstanceOf(AzureDevOpsCloneUrl.class);
+        AzureDevOpsCloneUrl azureDevopsCloneUrl = (AzureDevOpsCloneUrl) parsed;
+        assertThat(azureDevopsCloneUrl.getOrigin()).isEqualTo(expectedOrigin);
+        assertThat(azureDevopsCloneUrl.getPath()).isEqualTo(expectedPath);
+        assertThat(azureDevopsCloneUrl.getOrganization()).isEqualTo(expectedOrganization);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "https://github.com/org/repo",
+      "https://gitlab.com/org/repo",
+      "https://scm.company.com/scm/project/repo.git",
+      "git@scm.company.com:context/path/scm/project/repo.git"
+    })
+    void splitOriginPathWithInvalidUrls(String cloneUrl) {
+        assertThat(scm.belongsToScm(cloneUrl)).isFalse();
+    }
 }


### PR DESCRIPTION
- built org name from organization and project a la gitlab
- use `Pattern`s to parse Azure DevOps urls
- additional tests
- additional changes to run with `moderne-cli`