### PR TITLE
Only add a Gradle wrapper if there is a Gradle project

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -41,6 +41,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_BATCH_LOCATION;
 import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_JAR_LOCATION;
 import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_PROPERTIES_LOCATION;
@@ -67,7 +69,8 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UpdateGradleWrapper("7.4.2", null, null, null));
+        spec.recipe(new UpdateGradleWrapper("7.4.2", null, null, null))
+          .beforeRecipe(withToolingApi());
     }
 
     @Test
@@ -95,7 +98,14 @@ class UpdateGradleWrapperTest implements RewriteTest {
               assertThat(gradleWrapperJar.getSourcePath()).isEqualTo(WRAPPER_JAR_LOCATION);
               assertThat(gradleWrapperJar.getUri()).isEqualTo(URI.create("https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"));
               assertThat(isValidWrapperJar(gradleWrapperJar)).as("Wrapper jar is not valid").isTrue();
-          })
+          }),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+              """
+          )
         );
     }
 
@@ -218,7 +228,10 @@ class UpdateGradleWrapperTest implements RewriteTest {
               zipStorePath=wrapper/dists
               """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
-          )
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
         );
     }
 
@@ -325,7 +338,10 @@ class UpdateGradleWrapperTest implements RewriteTest {
               distributionSha256Sum=1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d
               """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
-          )
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
         );
     }
 
@@ -383,7 +399,10 @@ class UpdateGradleWrapperTest implements RewriteTest {
               distributionSha256Sum=1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d
               """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
-          )
+          ),
+          gradlew,
+          gradlewBat,
+          gradleWrapperJarQuark
         );
     }
 


### PR DESCRIPTION
## What's changed?
Modify `UpdateGradleWrapper` to only generate a wrapper when it has deduced that there also exists a Gradle project within the source set.

## What's your motivation?
When running the recipe with either the default or an explicit `true` value for the `addIfMissing` parameter will result in a new Gradle wrapper being generated at the root of the project, even if one doesn't make sense for the repository at hand.

## Anything in particular you'd like reviewers to focus on?
Are there use cases where a Gradle wrapper may be desired and a Gradle project doesn't exist? 🤔

## Anyone you would like to review specifically?
Anyone

## Have you considered any alternatives or workarounds?
* Use a precondition to gate the generation within upstream recipes
* Be more selective when using the default or explicit `true` value for the `addIfMissing` parameter

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
