### PR TITLE
Ignore module-info.java files for now

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.openrewrite.java.Assertions.java;
 
 /**
@@ -156,5 +157,12 @@ class JavaParserTest implements RewriteTest {
             spec -> spec.afterRecipe(cu -> assertThat(cu.getSourcePath()).isEqualTo(Path.of("my","example","PublicClass.java")))
           )
         );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1895")
+    void moduleInfo(){
+        // Ignored until properly handled: https://github.com/openrewrite/rewrite/issues/4054#issuecomment-2267605739
+        assertFalse(JavaParser.fromJavaVersion().build().accept(Path.of("src/main/java/foo/module-info.java")));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -273,7 +273,7 @@ public interface JavaParser extends Parser {
 
     @Override
     default boolean accept(Path path) {
-        return path.toString().endsWith(".java");
+        return path.toString().endsWith(".java") && !path.endsWith("module-info.java");
     }
 
     /**


### PR DESCRIPTION
Pending proper support in https://github.com/openrewrite/rewrite/issues/4054#issuecomment-2267605739 this is the easiest way not to trip over these files, such that folks don't need other workarounds to get their projects to build and run recipes.