### PR TITLE
fix: CommentOutProperty to work with single keys

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
@@ -63,11 +63,16 @@ public class CommentOutProperty extends Recipe {
             private String indentation = "";
 
             @Override
-            public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext executionContext) {
-                Yaml.Document doc = super.visitDocument(document, executionContext);
+            public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
+                Yaml.Document doc = super.visitDocument(document, ctx);
                 // Add any leftover comment to the end of document
                 if (!comment.isEmpty()) {
-                    String newPrefix = indentation + "# " + commentText + (indentation.contains("\n") ? "" : "\n") + (indentation.contains("\n") ? comment : comment.replace("#", "# "));
+                    String newPrefix = String.format("%s# %s%s%s",
+                            indentation,
+                            commentText,
+                            indentation.contains("\n") ? "" : "\n",
+                            indentation.contains("\n") ? comment : comment.replace("#", "# "));
+                    comment = "";
                     return document.withEnd(doc.getEnd().withPrefix(newPrefix));
                 }
                 return doc;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
 
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class CommentOutProperty extends Recipe {
@@ -59,12 +58,19 @@ public class CommentOutProperty extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new YamlIsoVisitor<ExecutionContext>() {
+            private boolean nextDocNeedsNewline;
             private String comment = "";
             private String indentation = "";
 
             @Override
             public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
                 Yaml.Document doc = super.visitDocument(document, ctx);
+
+                if (nextDocNeedsNewline) {
+                    nextDocNeedsNewline = false;
+                    doc = doc.withPrefix("\n" + doc.getPrefix());
+                }
+
                 // Add any leftover comment to the end of document
                 if (!comment.isEmpty()) {
                     String newPrefix = String.format("%s# %s%s%s",
@@ -72,6 +78,7 @@ public class CommentOutProperty extends Recipe {
                             commentText,
                             indentation.contains("\n") ? "" : "\n",
                             indentation.contains("\n") ? comment : comment.replace("#", "# "));
+                    nextDocNeedsNewline = !newPrefix.endsWith("\n");
                     comment = "";
                     return document.withEnd(doc.getEnd().withPrefix(newPrefix));
                 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CommentOutProperty.java
@@ -63,6 +63,17 @@ public class CommentOutProperty extends Recipe {
             private String indentation = "";
 
             @Override
+            public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext executionContext) {
+                Yaml.Document doc = super.visitDocument(document, executionContext);
+                // Add any leftover comment to the end of document
+                if (!comment.isEmpty()) {
+                    String newPrefix = indentation + "# " + commentText + (indentation.contains("\n") ? "" : "\n") + (indentation.contains("\n") ? comment : comment.replace("#", "# "));
+                    return document.withEnd(doc.getEnd().withPrefix(newPrefix));
+                }
+                return doc;
+            }
+
+            @Override
             public Yaml.Sequence.Entry visitSequenceEntry(Yaml.Sequence.Entry entry,
                                                           ExecutionContext ctx) {
                 indentation = entry.getPrefix();

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.yaml;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -24,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.yaml.Assertions.yaml;
 
 class CommentOutPropertyTest implements RewriteTest {
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new CommentOutProperty("management.metrics.binders.files.enabled", "some comments"));
@@ -96,18 +96,18 @@ class CommentOutPropertyTest implements RewriteTest {
             "Some comments")),
           yaml(
             """
-                with:
-                  java-cache: 'maven'
-                  java-version: 11
-                  test: 'bar'
-                """,
+              with:
+                java-cache: 'maven'
+                java-version: 11
+                test: 'bar'
+              """,
             """
-                with:
-                  java-cache: 'maven'
-                  # Some comments
-                  # java-version: 11
-                  test: 'bar'
-                """
+              with:
+                java-cache: 'maven'
+                # Some comments
+                # java-version: 11
+                test: 'bar'
+              """
           )
         );
     }
@@ -119,40 +119,39 @@ class CommentOutPropertyTest implements RewriteTest {
             "Some comments")),
           yaml(
             """
-                with:
-                  java-cache: 'maven'
-                  java-version: 11
-                """,
+              with:
+                java-cache: 'maven'
+                java-version: 11
+              """,
             """
-                with:
-                  java-cache: 'maven'
-                  # Some comments
-                  # java-version: 11
-                """
+              with:
+                java-cache: 'maven'
+                # Some comments
+                # java-version: 11
+              """
           )
         );
     }
 
     @Test
-    @Disabled("Still needs to be fixed")
     void commentLastPropertyOfFirstDocument() {
         rewriteRun(
           spec -> spec.recipe(new CommentOutProperty("with.java-version",
             "Some comments")),
           yaml(
             """
-                with:
-                  java-cache: 'maven'
-                  java-version: 11
-                ---
-                """,
+              with:
+                java-cache: 'maven'
+                java-version: 11
+              ---
+              """,
             """
-                with:
-                  java-cache: 'maven'
-                  # Some comments
-                  # java-version: 11
-                ---
-                """
+              with:
+                java-cache: 'maven'
+                # Some comments
+                # java-version: 11
+              ---
+              """
           )
         );
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
@@ -87,4 +87,49 @@ class CommentOutPropertyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void commentSingleProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentOutProperty("with.java-version",
+            "Some comments")),
+          yaml(
+            """
+                with:
+                  java-cache: 'maven'
+                  java-version: 11
+                  test: 'bar'
+              """,
+            """
+                with:
+                  java-cache: 'maven'
+                  # Some comments
+                  # java-version: 11
+                  test: 'bar'
+              """
+          )
+        );
+    }
+
+    @Test
+    void commentLastProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentOutProperty("with.java-version",
+            "Some comments")),
+          yaml(
+            """
+                with:
+                  java-cache: 'maven'
+                  java-version: 11
+              """,
+            """
+                with:
+                  java-cache: 'maven'
+                  # Some comments
+                  # java-version: 11
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -99,14 +100,14 @@ class CommentOutPropertyTest implements RewriteTest {
                   java-cache: 'maven'
                   java-version: 11
                   test: 'bar'
-              """,
+                """,
             """
                 with:
                   java-cache: 'maven'
                   # Some comments
                   # java-version: 11
                   test: 'bar'
-              """
+                """
           )
         );
     }
@@ -121,13 +122,37 @@ class CommentOutPropertyTest implements RewriteTest {
                 with:
                   java-cache: 'maven'
                   java-version: 11
-              """,
+                """,
             """
                 with:
                   java-cache: 'maven'
                   # Some comments
                   # java-version: 11
-              """
+                """
+          )
+        );
+    }
+
+    @Test
+    @Disabled("Still needs to be fixed")
+    void commentLastPropertyOfFirstDocument() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentOutProperty("with.java-version",
+            "Some comments")),
+          yaml(
+            """
+                with:
+                  java-cache: 'maven'
+                  java-version: 11
+                ---
+                """,
+            """
+                with:
+                  java-cache: 'maven'
+                  # Some comments
+                  # java-version: 11
+                ---
+                """
           )
         );
     }
@@ -139,14 +164,13 @@ class CommentOutPropertyTest implements RewriteTest {
             "Some comments")),
           yaml(
             """
-                test: foo
+              test: foo
               """,
             """
-                # Some comments
-                # test: foo
+              # Some comments
+              # test: foo
               """
           )
         );
     }
-
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CommentOutPropertyTest.java
@@ -112,7 +112,7 @@ class CommentOutPropertyTest implements RewriteTest {
     }
 
     @Test
-    void commentLastProperty() {
+    void commentLastPropertyWithIndent() {
         rewriteRun(
           spec -> spec.recipe(new CommentOutProperty("with.java-version",
             "Some comments")),
@@ -127,6 +127,23 @@ class CommentOutPropertyTest implements RewriteTest {
                   java-cache: 'maven'
                   # Some comments
                   # java-version: 11
+              """
+          )
+        );
+    }
+
+    @Test
+    void commentLastProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new CommentOutProperty("test",
+            "Some comments")),
+          yaml(
+            """
+                test: foo
+              """,
+            """
+                # Some comments
+                # test: foo
               """
           )
         );


### PR DESCRIPTION
Just demonstrate it doesn't works as expected (or I didn't understood the recipe).

Instead of commenting out the property it's removed.

![issue](https://github.com/user-attachments/assets/43e9e42c-d539-4a2a-94b9-8498ed54d0b2)


## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
