### PR TITLE
fix: Include port in GitRemote origin

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -132,6 +132,7 @@ public class GitRemote {
         private static class HostAndPath {
             String scheme;
             String host;
+            int port;
             String path;
 
             public HostAndPath(String url) {
@@ -139,6 +140,7 @@ public class GitRemote {
                     URIish uri = new URIish(url);
                     scheme = uri.getScheme();
                     host = uri.getHost();
+                    port = uri.getPort();
                     if (host == null && !"file".equals(scheme)) {
                         throw new IllegalStateException("No host in url: " + url);
                     }
@@ -151,14 +153,20 @@ public class GitRemote {
             }
 
             private String concat() {
-                String hostAndPath = host == null ? "" : host;
-                if (!path.isEmpty()) {
-                    if (!hostAndPath.isEmpty()) {
-                        hostAndPath += "/";
-                    }
-                    hostAndPath += path;
+                StringBuilder builder = new StringBuilder(64);
+                if (host != null) {
+                    builder.append(host);
                 }
-                return hostAndPath;
+                if (port > 0) {
+                    builder.append(':').append(port);
+                }
+                if (!path.isEmpty()) {
+                    if (builder.length() != 0) {
+                        builder.append('/');
+                    }
+                    builder.append(path);
+                }
+                return builder.toString();
             }
 
             private String repositoryPath(@Nullable String origin) {
@@ -170,6 +178,7 @@ public class GitRemote {
                     throw new IllegalArgumentException("Unable to find origin '" + origin + "' in '" + hostAndPath + "'");
                 }
                 return hostAndPath.substring(origin.length())
+                        .replaceFirst("^:\\d+", "")
                         .replaceFirst("^/", "");
             }
         }

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -53,6 +53,7 @@ public class GitRemote {
             origins = new LinkedHashMap<>();
             origins.put("github.com", Service.GitHub);
             origins.put("gitlab.com", Service.GitLab);
+            origins.put("gitlab.com:22", Service.GitLab);
             origins.put("bitbucket.org", Service.BitbucketCloud);
             origins.put("dev.azure.com", Service.AzureDevOps);
             origins.put("ssh.dev.azure.com", Service.AzureDevOps);
@@ -78,6 +79,9 @@ public class GitRemote {
             Parser.HostAndPath hostAndPath = new Parser.HostAndPath(url);
 
             String origin = hostAndPath.host;
+            if (hostAndPath.port > 0) {
+                origin = origin + ':' + hostAndPath.port;
+            }
             Service service = origins.get(origin);
             if (service == null) {
                 for (String maybeOrigin : origins.keySet()) {
@@ -177,9 +181,7 @@ public class GitRemote {
                 if (!hostAndPath.startsWith(origin)) {
                     throw new IllegalArgumentException("Unable to find origin '" + origin + "' in '" + hostAndPath + "'");
                 }
-                return hostAndPath.substring(origin.length())
-                        .replaceFirst("^:\\d+", "")
-                        .replaceFirst("^/", "");
+                return hostAndPath.substring(origin.length()).replaceFirst("^/", "");
             }
         }
     }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -31,7 +31,7 @@ public class GitRemoteTest {
       https://gitlab.com/group/repo.git, gitlab.com, group/repo, group, repo
       https://gitlab.com/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@gitlab.com:group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com:22, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
 
       https://bitbucket.org/PRJ/repo, bitbucket.org, PRJ/repo, PRJ, repo
       git@bitbucket.org:PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
@@ -83,7 +83,7 @@ public class GitRemoteTest {
       https://scm.company.com/group/subgroup/subergroup/subestgroup/repo, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       https://scm.company.com:1234/group/subgroup/subergroup/subestgroup/repo, scm.company.com:1234, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@scm.company.com:group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com:22, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
 
       https://scm.company.com/very/long/context/path/group/subgroup/subergroup/subestgroup/repo, scm.company.com/very/long/context/path, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       """)

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -27,19 +27,19 @@ public class GitRemoteTest {
       https://github.com/org/repo, github.com, org/repo, org, repo
       git@github.com:org/repo.git, github.com, org/repo, org, repo
       ssh://github.com/org/repo.git, github.com, org/repo, org, repo
-                
+
       https://gitlab.com/group/repo.git, gitlab.com, group/repo, group, repo
       https://gitlab.com/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@gitlab.com:group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-                
+
       https://bitbucket.org/PRJ/repo, bitbucket.org, PRJ/repo, PRJ, repo
       git@bitbucket.org:PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
       ssh://bitbucket.org/PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
-                
+
+      https://org@dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project, repo
       https://dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project, repo
       git@ssh.dev.azure.com:v3/org/project/repo, dev.azure.com, org/project/repo, org/project, repo
-      ssh://ssh.dev.azure.com:22/v3/org/project/repo, dev.azure.com, org/project/repo, org/project, repo
       """)
     void parseKnownRemotes(String cloneUrl, String expectedOrigin, String expectedPath, String expectedOrganization, String expectedRepositoryName) {
         GitRemote.Parser parser = new GitRemote.Parser();
@@ -53,9 +53,11 @@ public class GitRemoteTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
       https://scm.company.com/stash/scm/org/repo.git, scm.company.com/stash/scm, org/repo, org, repo
+      https://scm.company.com:1234/stash/scm/org/repo.git, scm.company.com:1234/stash/scm, org/repo, org, repo
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, org/repo, org, repo
       ssh://scm.company.com/stash/org/repo, scm.company.com/stash, org/repo, org, repo
-                
+
+      https://scm.company.com:1234/very/long/context/path/org/repo.git, scm.company.com:1234/very/long/context/path, org/repo, org, repo
       git@scm.company.com:very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, org/repo, org, repo
       """)
     void parseUnknownRemote(String cloneUrl, String expectedOrigin, String expectedPath, String expectedOrganization, String expectedRepositoryName) {
@@ -70,15 +72,19 @@ public class GitRemoteTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
       https://scm.company.com/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
+      https://scm.company.com:1234/stash/scm/org/repo.git, scm.company.com:1234/stash, Bitbucket, org/repo, org, repo
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
-                
+
+      https://scm.company.com/very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo
+      https://scm.company.com:1234/very/long/context/path/org/repo.git, scm.company.com:1234/very/long/context/path, Bitbucket, org/repo, org, repo
       git@scm.company.com:very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo
-                
+  
       https://scm.company.com/group/subgroup/subergroup/subestgroup/repo, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      https://scm.company.com:1234/group/subgroup/subergroup/subestgroup/repo, scm.company.com:1234, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@scm.company.com:group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-                
+
       https://scm.company.com/very/long/context/path/group/subgroup/subergroup/subestgroup/repo, scm.company.com/very/long/context/path, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       """)
     void parseRegisteredRemote(String cloneUrl, String origin, GitRemote.Service service, String expectedPath, String expectedOrganization, String expectedRepositoryName) {


### PR DESCRIPTION

## What's changed?
Update `GitRemote` to include port in origin.

## What's your motivation?
Host port is required to avoid ambiguity between origins.

## Anything in particular you'd like reviewers to focus on?
No

## Anyone you would like to review specifically?
@pstreef 

## Have you considered any alternatives or workarounds?
No

## Any additional context
No

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
