### PR TITLE
feat: Do not add explicit default ports to origin

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -142,10 +142,9 @@ public class GitRemote {
             public HostAndPath(String url) {
                 try {
                     URIish uri = new URIish(url);
-                    host = uri.getHost();
                     scheme = uri.getScheme();
+                    host = uri.getHost();
                     port = uri.getPort();
-
                     if (host == null && !"file".equals(scheme)) {
                         throw new IllegalStateException("No host in url: " + url);
                     }

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -142,9 +142,10 @@ public class GitRemote {
             public HostAndPath(String url) {
                 try {
                     URIish uri = new URIish(url);
-                    scheme = uri.getScheme();
                     host = uri.getHost();
+                    scheme = uri.getScheme();
                     port = uri.getPort();
+
                     if (host == null && !"file".equals(scheme)) {
                         throw new IllegalStateException("No host in url: " + url);
                     }
@@ -161,7 +162,7 @@ public class GitRemote {
                 if (host != null) {
                     builder.append(host);
                 }
-                if (port > 0) {
+                if (!isDefaultPort()) {
                     builder.append(':').append(port);
                 }
                 if (!path.isEmpty()) {
@@ -171,6 +172,13 @@ public class GitRemote {
                     builder.append(path);
                 }
                 return builder.toString();
+            }
+
+            private boolean isDefaultPort() {
+                return port < 1 ||
+                       ("https".equals(scheme) && port == 443) ||
+                       ("http".equals(scheme) && port == 80) ||
+                       ("ssh".equals(scheme) && port == 22);
             }
 
             private String repositoryPath(@Nullable String origin) {

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -31,7 +31,7 @@ public class GitRemoteTest {
       https://gitlab.com/group/repo.git, gitlab.com, group/repo, group, repo
       https://gitlab.com/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@gitlab.com:group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com:22, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
 
       https://bitbucket.org/PRJ/repo, bitbucket.org, PRJ/repo, PRJ, repo
       git@bitbucket.org:PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
@@ -72,18 +72,24 @@ public class GitRemoteTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
       https://scm.company.com/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
+      http://scm.company.com:80/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
+      http://scm.company.com:8080/stash/scm/org/repo.git, scm.company.com:8080/stash, Bitbucket, org/repo, org, repo
+      https://scm.company.com:443/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
       https://scm.company.com:1234/stash/scm/org/repo.git, scm.company.com:1234/stash, Bitbucket, org/repo, org, repo
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
+      ssh://scm.company.com:22/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
+      ssh://scm.company.com:7999/stash/org/repo, scm.company.com:7999/stash, Bitbucket, org/repo, org, repo
 
       https://scm.company.com/very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo
       https://scm.company.com:1234/very/long/context/path/org/repo.git, scm.company.com:1234/very/long/context/path, Bitbucket, org/repo, org, repo
       git@scm.company.com:very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo
-  
+        
       https://scm.company.com/group/subgroup/subergroup/subestgroup/repo, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       https://scm.company.com:1234/group/subgroup/subergroup/subestgroup/repo, scm.company.com:1234, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@scm.company.com:group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com:22, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://scm.company.com:222/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com:222, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
 
       https://scm.company.com/very/long/context/path/group/subgroup/subergroup/subestgroup/repo, scm.company.com/very/long/context/path, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       """)


### PR DESCRIPTION
## What's changed?
When a default port is explicitly added to a url it is not considered as part of the origin. Only if the port deviates from the protocols default port do we add it.

## What's your motivation?
This would avoid having 2 different origins for the same protocol and port.

## Anything in particular you'd like reviewers to focus on?
no

## Anyone you would like to review specifically?
@timtebeek  for review
@bryceatmoderne @shanman190 for reference

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
