### PR TITLE
fix: Allow deserialization of GitProvenance

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -17,7 +17,6 @@ package org.openrewrite.marker;
 
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import lombok.experimental.NonFinal;
 import org.openrewrite.GitRemote;

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -77,8 +77,7 @@ public class GitProvenance implements Marker {
     @Incubating(since = "8.33.0")
     @NonFinal
     @Nullable
-    @JsonIgnore
-    transient GitRemote gitRemote;
+    GitRemote gitRemote;
 
     public @Nullable GitRemote getGitRemote() {
         if (gitRemote == null && origin != null) {

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -17,7 +17,10 @@ package org.openrewrite.marker;
 
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import lombok.With;
 import lombok.experimental.NonFinal;
 import org.openrewrite.GitRemote;
 import org.openrewrite.Incubating;
@@ -45,7 +48,6 @@ import static org.openrewrite.Tree.randomId;
 
 @Value
 @AllArgsConstructor(access = AccessLevel.PACKAGE) // required for @With and tests
-@RequiredArgsConstructor(onConstructor_ = @JsonCreator)
 @With
 public class GitProvenance implements Marker {
     UUID id;
@@ -77,6 +79,24 @@ public class GitProvenance implements Marker {
     @NonFinal
     @Nullable
     GitRemote gitRemote;
+
+    // javadoc does not like @RequiredArgsConstructor(onConstructor_ = { @JsonCreator })
+    @JsonCreator
+    public GitProvenance(UUID id,
+                         @Nullable String origin,
+                         @Nullable String branch,
+                         @Nullable String change,
+                         @Nullable AutoCRLF autocrlf,
+                         @Nullable EOL eol,
+                         @Nullable List<Committer> committers) {
+        this.id = id;
+        this.origin = origin;
+        this.branch = branch;
+        this.change = change;
+        this.autocrlf = autocrlf;
+        this.eol = eol;
+        this.committers = committers;
+    }
 
     public @Nullable GitRemote getGitRemote() {
         if (gitRemote == null && origin != null) {

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -45,7 +45,7 @@ import static org.openrewrite.Tree.randomId;
 
 @Value
 @AllArgsConstructor(access = AccessLevel.PACKAGE) // required for @With and tests
-@RequiredArgsConstructor(onConstructor_ = @__({@JsonCreator}))
+@RequiredArgsConstructor(onConstructor_ = @JsonCreator)
 @With
 public class GitProvenance implements Marker {
     UUID id;

--- a/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marker/GitProvenance.java
@@ -16,6 +16,8 @@
 package org.openrewrite.marker;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import lombok.experimental.NonFinal;
 import org.openrewrite.GitRemote;
@@ -44,7 +46,7 @@ import static org.openrewrite.Tree.randomId;
 
 @Value
 @AllArgsConstructor(access = AccessLevel.PACKAGE) // required for @With and tests
-@RequiredArgsConstructor
+@RequiredArgsConstructor(onConstructor_ = @__({@JsonCreator}))
 @With
 public class GitProvenance implements Marker {
     UUID id;
@@ -75,7 +77,8 @@ public class GitProvenance implements Marker {
     @Incubating(since = "8.33.0")
     @NonFinal
     @Nullable
-    GitRemote gitRemote;
+    @JsonIgnore
+    transient GitRemote gitRemote;
 
     public @Nullable GitRemote getGitRemote() {
         if (gitRemote == null && origin != null) {


### PR DESCRIPTION
## What's changed?
Fixes a deserialization issue caused by the new constructor on `GitProvenance`

## Anything in particular you'd like reviewers to focus on?
Is there another way to achieve this on a value class with 2 constructors without the `.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)` ?

## Anyone you would like to review specifically?
no

## Have you considered any alternatives or workarounds?
Changing this to an `@Data`. But losing immutability would be bad.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
