### PR TITLE
Tolerate weird class names, as seen in functionaljava

### DIFF
--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     testRuntimeOnly("org.mapstruct:mapstruct:latest.release")
     testRuntimeOnly("org.projectlombok:lombok:latest.release")
     testRuntimeOnly("org.apache.commons:commons-lang3:latest.release")
-    testRuntimeOnly("org.functionaljava:functionaljava:5.0") // Contains `fj.data.$`
     testRuntimeOnly(project(":rewrite-yaml"))
     testImplementation(project(":rewrite-maven"))
 }

--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     testRuntimeOnly("org.mapstruct:mapstruct:latest.release")
     testRuntimeOnly("org.projectlombok:lombok:latest.release")
     testRuntimeOnly("org.apache.commons:commons-lang3:latest.release")
+    testRuntimeOnly("org.functionaljava:functionaljava:5.0") // Contains `fj.data.$`
     testRuntimeOnly(project(":rewrite-yaml"))
     testImplementation(project(":rewrite-maven"))
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
@@ -70,4 +70,10 @@ class JavaSourceSetTest {
         assertThat(gavFromPath(Paths.get("C:/Users/Sam/.m2/repository/org/openrewrite/rewrite-core/8.32.0/rewrite-core-8.32.0.jar")))
           .isEqualTo("org.openrewrite:rewrite-core:8.32.0");
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/4401")
+    void tolerateWeirdClassNames(){
+        JavaSourceSet.build("main", JavaParser.dependenciesFromClasspath("functionaljava"));
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/marker/JavaSourceSetTest.java
@@ -74,6 +74,6 @@ class JavaSourceSetTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite/pull/4401")
     void tolerateWeirdClassNames(){
-        JavaSourceSet.build("main", JavaParser.dependenciesFromClasspath("functionaljava"));
+        assertThat(JavaSourceSet.isDeclarable("fj.data.$")).isFalse();
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -327,7 +327,7 @@ public class JavaSourceSet implements SourceSet {
                 .replace('/', '.');
     }
 
-    private static boolean isDeclarable(String className) {
+    static boolean isDeclarable(String className) {
         int dotIndex = Math.max(className.lastIndexOf("."), className.lastIndexOf('$'));
         className = className.substring(dotIndex + 1);
         return !className.isEmpty() &&

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -330,7 +330,8 @@ public class JavaSourceSet implements SourceSet {
     private static boolean isDeclarable(String className) {
         int dotIndex = Math.max(className.lastIndexOf("."), className.lastIndexOf('$'));
         className = className.substring(dotIndex + 1);
-        char firstChar = className.charAt(0);
-        return Character.isJavaIdentifierPart(firstChar) && !Character.isDigit(firstChar);
+        return !className.isEmpty() &&
+               Character.isJavaIdentifierPart(className.charAt(0)) &&
+               !Character.isDigit(className.charAt(0));
     }
 }


### PR DESCRIPTION
They are using `fj.data.$`, which then leads to an empty String.

![image](https://github.com/user-attachments/assets/a458f294-e3e2-432b-80fc-285a79990abe)

First noticed on recipe runs against [rewrite-migrate-java](https://github.com/openrewrite/rewrite-migrate-java), where the previous lead to:
```
Caused by: java.lang.StringIndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
        at org.openrewrite.java.marker.JavaSourceSet.isDeclarable(JavaSourceSet.java:333)
        at org.openrewrite.java.marker.JavaSourceSet.typesFromPath(JavaSourceSet.java:281)
        at org.openrewrite.java.marker.JavaSourceSet.build(JavaSourceSet.java:210)
        at org.openrewrite.gradle.isolated.DefaultProjectParser.parse(DefaultProjectParser.java:836)
        ... 125 more
```