### PR TITLE
fix: Remove JavaSourceSet.typeToGav field to ensure Jackson serialization

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -233,6 +233,6 @@ public class Assertions {
 
     private static JavaSourceSet javaSourceSet(String sourceSet) {
         return javaSourceSets.computeIfAbsent(sourceSet, name ->
-                new JavaSourceSet(Tree.randomId(), name, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap()));
+                new JavaSourceSet(Tree.randomId(), name, Collections.emptyList(), Collections.emptyMap()));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -55,13 +55,6 @@ public class JavaSourceSet implements SourceSet {
     Map<String, List<JavaType.FullyQualified>> gavToTypes;
 
     /**
-     * Mapping of the name of a fully qualified JavaType to the String "group:artifact:version" of the artifact that
-     * provides that type.
-     * Does not include java standard library types.
-     */
-    Map<String, String> typeToGav;
-
-    /**
      * Extract type information from the provided classpath.
      * Uses ClassGraph to compute the classpath.
 
@@ -102,7 +95,7 @@ public class JavaSourceSet implements SourceSet {
 
         // Peculiarly, Classgraph will not return a ClassInfo for java.lang.Object, although it does for all other java.lang types
         typeNames.add("java.lang.Object");
-        return new JavaSourceSet(randomId(), sourceSetName, typesFrom(typeNames), null, null);
+        return new JavaSourceSet(randomId(), sourceSetName, typesFrom(typeNames), null);
     }
 
 
@@ -206,20 +199,16 @@ public class JavaSourceSet implements SourceSet {
     public static JavaSourceSet build(String sourceSetName, Collection<Path> classpath) {
         List<JavaType.FullyQualified> types = getJavaStandardLibraryTypes();
         Map<String, List<JavaType.FullyQualified>> gavToTypes = new LinkedHashMap<>();
-        Map<String, String> typeToGav = new LinkedHashMap<>();
         for (Path path : classpath) {
             List<JavaType.FullyQualified> typesFromPath = typesFromPath(path, null);
 
             types.addAll(typesFromPath);
             String gav = gavFromPath(path);
-            if(gav != null) {
+            if (gav != null) {
                 gavToTypes.put(gav, typesFromPath);
-                for(JavaType.FullyQualified type : typesFromPath) {
-                    typeToGav.put(type.getFullyQualifiedName(), gav);
-                }
             }
         }
-        return new JavaSourceSet(randomId(), sourceSetName, types, gavToTypes, typeToGav);
+        return new JavaSourceSet(randomId(), sourceSetName, types, gavToTypes);
     }
 
     /**

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/JavaSourceSet.java
@@ -55,10 +55,11 @@ public class JavaSourceSet implements SourceSet {
     Map<String, List<JavaType.FullyQualified>> gavToTypes;
 
     /**
-     * Mapping of a JavaType to the String "group:artifact:version" of the artifact that provides that type.
+     * Mapping of the name of a fully qualified JavaType to the String "group:artifact:version" of the artifact that
+     * provides that type.
      * Does not include java standard library types.
      */
-    Map<JavaType.FullyQualified, String> typeToGav;
+    Map<String, String> typeToGav;
 
     /**
      * Extract type information from the provided classpath.
@@ -205,7 +206,7 @@ public class JavaSourceSet implements SourceSet {
     public static JavaSourceSet build(String sourceSetName, Collection<Path> classpath) {
         List<JavaType.FullyQualified> types = getJavaStandardLibraryTypes();
         Map<String, List<JavaType.FullyQualified>> gavToTypes = new LinkedHashMap<>();
-        Map<JavaType.FullyQualified, String> typeToGav = new LinkedHashMap<>();
+        Map<String, String> typeToGav = new LinkedHashMap<>();
         for (Path path : classpath) {
             List<JavaType.FullyQualified> typesFromPath = typesFromPath(path, null);
 
@@ -214,7 +215,7 @@ public class JavaSourceSet implements SourceSet {
             if(gav != null) {
                 gavToTypes.put(gav, typesFromPath);
                 for(JavaType.FullyQualified type : typesFromPath) {
-                    typeToGav.put(type, gav);
+                    typeToGav.put(type.getFullyQualifiedName(), gav);
                 }
             }
         }


### PR DESCRIPTION

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
