### PR TITLE
Better ignore blank wrapperUri when determining whether to use existing Gradle wrapper URI

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -135,7 +135,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                         throw new IllegalArgumentException(
                                 "wrapperUri contains a ${version} interpolation specifier but no version parameter was specified.", e);
                     }
-                    if(!version.matches("[0-9.]+")) {
+                    if (!version.matches("[0-9.]+")) {
                         throw new IllegalArgumentException(
                                 "Version selectors like \"" + version + "\" are unavailable when services.gradle.org cannot be reached. " +
                                 "Specify an exact, literal version number.", e);
@@ -472,7 +472,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                 String currentUrl = value.getText();
                 // Prefer wrapperUri specified directly in the recipe over other options
                 // If that isn't set, prefer the existing artifact repository URL over changing to services.gradle.org
-                if (wrapperUri != null) {
+                if (!StringUtils.isBlank(wrapperUri)) {
                     String effectiveWrapperUri = formatUriForPropertiesFile(wrapperUri
                             .replace("${version}", gradleWrapper.getVersion())
                             .replace("${distribution}", distribution == null ? "bin" : distribution));


### PR DESCRIPTION
<img width="940" alt="image" src="https://github.com/user-attachments/assets/0dd3260f-8f38-448d-8b20-0f4eb766e79c">
