### PR TITLE
Parse packages.config as XML for C#

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -97,7 +97,9 @@ public class XmlParser implements Parser {
                p.endsWith(".stp") ||
                p.endsWith(".dcn") ||
                p.endsWith(".pst") ||
-               p.endsWith(".csproj");
+               // C# project files
+               p.endsWith(".csproj") ||
+               p.equals("packages.config");
     }
 
     @Override


### PR DESCRIPTION
https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files
https://learn.microsoft.com/en-us/nuget/reference/packages-config

Alternatively we could have picked these up from PlainText and parsed them as XML there, but that just seems needless extra steps.

There's a small risk of any non-XML `packages.config` files being picked up. I'd say that's unlikely and tolerable.