### PR TITLE
Build `GitRemote` url from it's parts

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -47,6 +47,10 @@ public class GitRemote {
         Unknown
     }
 
+    public URI toUri(boolean ssh) {
+        return buildRemoteUrl(service, ssh, origin, path);
+    }
+
     public static URI buildRemoteUrl(Service service, boolean ssh, String origin, String path) {
         StringBuilder url = new StringBuilder();
         path = path.replaceFirst("^/", "").replaceFirst("/$", "");

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -61,6 +61,7 @@ public class GitRemote {
         if (service == Service.AzureDevOps) {
             if (ssh) {
                 origin = "ssh." + origin;
+                path = "v3/" + path;
             } else {
                 path = path.replaceFirst("([^/]+)/([^/]+)/(.*)", "$1/$2/_git/$3");
             }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -122,7 +122,7 @@ public class GitRemoteTest {
       Bitbucket, false, scm.company.com/context/path, org/repo, https://scm.company.com/context/path/scm/org/repo
       Bitbucket, true, scm.company.com/context/path, org/repo, ssh://git@scm.company.com/context/path/org/repo.git
       AzureDevOps, false, dev.azure.com, org/repo, https://dev.azure.com/org/repo
-      AzureDevOps, true, dev.azure.com, org/repo, ssh://git@ssh.dev.azure.com/org/repo
+      AzureDevOps, true, dev.azure.com, org/repo, ssh://git@ssh.dev.azure.com/v3/org/repo
       """)
     void buildRemoteUrl(GitRemote.Service service, boolean ssh, String origin, String path, String expectedUrl) {
         URI url = GitRemote.buildRemoteUrl(service, ssh, origin, path);

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -18,6 +18,8 @@ package org.openrewrite;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.net.URI;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitRemoteTest {
@@ -101,5 +103,29 @@ public class GitRemoteTest {
         assertThat(remote.getPath()).isEqualTo(expectedPath);
         assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);
         assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+      GitHub, false, github.com, org/repo, https://github.com/org/repo
+      GitHub, true, github.com, org/repo, ssh://git@github.com/org/repo.git
+      GitHub, false, https://github.com, org/repo, https://github.com/org/repo
+      GitHub, true, https://github.com, org/repo, ssh://git@github.com/org/repo.git
+      GitHub, false, scm.company.com/context/path, org/repo, https://scm.company.com/context/path/org/repo
+      GitHub, true, scm.company.com/context/path, org/repo, ssh://git@scm.company.com/context/path/org/repo.git
+      GitLab, false, gitlab.com, group/subgroup/repo, https://gitlab.com/group/subgroup/repo.git
+      GitLab, true, gitlab.com, group/subgroup/repo, ssh://git@gitlab.com/group/subgroup/repo.git
+      GitLab, false, scm.company.com/context/path, group/subgroup/repo, https://scm.company.com/context/path/group/subgroup/repo.git
+      GitLab, true, scm.company.com/context/path, group/subgroup/repo, ssh://git@scm.company.com/context/path/group/subgroup/repo.git
+      BitbucketCloud, false, bitbucket.org, org/repo, https://bitbucket.org/org/repo
+      BitbucketCloud, true, bitbucket.org, org/repo, ssh://git@bitbucket.org/org/repo.git
+      Bitbucket, false, scm.company.com/context/path, org/repo, https://scm.company.com/context/path/scm/org/repo
+      Bitbucket, true, scm.company.com/context/path, org/repo, ssh://git@scm.company.com/context/path/org/repo.git
+      AzureDevOps, false, dev.azure.com, org/repo, https://dev.azure.com/org/repo
+      AzureDevOps, true, dev.azure.com, org/repo, ssh://git@ssh.dev.azure.com/org/repo
+      """)
+    void buildRemoteUrl(GitRemote.Service service, boolean ssh, String origin, String path, String expectedUrl) {
+        URI url = GitRemote.buildRemoteUrl(service, ssh, origin, path);
+        assertThat(url.toString()).isEqualTo(expectedUrl);
     }
 }


### PR DESCRIPTION
## What's changed?

Adds a static method on `GitRemote` that can be used to create a `URI` from the required parts:
```
URI buildRemoteUrl(Service service, boolean ssh, String origin, String path)
```

## What's your motivation?
A single place to put this logic, which is the reverse of the URL parser that is already in `GitRemote`

## Anything in particular you'd like reviewers to focus on?
Are all these URI's (in the test) correct

## Anyone you would like to review specifically?
@bryceatmoderne 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
