### PR TITLE
Use 7999 as Bitbucket DC default port

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -79,6 +79,8 @@ public class GitRemoteTest {
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com:22/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
+      ssh://scm.company.com:22/stash/org/repo, scm.company.com:22/stash, Bitbucket, org/repo, org, repo
+      ssh://scm.company.com:7999/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com:7999/stash/org/repo, scm.company.com:7999/stash, Bitbucket, org/repo, org, repo
 
       https://scm.company.com/very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo


### PR DESCRIPTION
## What's changed?
Assume 7999 as a default SSH port for Bitbucket and strip it off. This way we can match the origin to the https origin (without port)

## What's your motivation?
Currently when using the default port, we need to register 2 origins to make them both work. This can cause conflicts when switching between protocols.

## Anyone you would like to review specifically?
@bryceatmoderne  @kmccarp 

## Have you considered any alternatives or workarounds?
Not doing this

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
