### PR TITLE
Migrate to JSpecify

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("net.java.dev.jna:jna-platform:latest.release")
 
+    implementation("org.jspecify:jspecify:latest.release")
+
     // Pinning okhttp while waiting on 5.0.0
     // https://github.com/openrewrite/rewrite/issues/1479
     compileOnly("com.squareup.okhttp3:okhttp:4.9.3")

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNull.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNull.java
@@ -32,11 +32,13 @@ import java.lang.annotation.*;
  * @see NonNullApi
  * @see NonNullFields
  * @see Nullable
+ * @deprecated Use {@link org.jspecify.annotations.NonNull} instead.
  */
 @Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Nonnull
 @TypeQualifierNickname
+@Deprecated
 public @interface NonNull {
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNullApi.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNullApi.java
@@ -15,26 +15,29 @@
  */
 package org.openrewrite.internal.lang;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NullMarked;
+
 import javax.annotation.meta.TypeQualifierDefault;
 import java.lang.annotation.*;
 
 /**
  * A common annotation to declare that parameters and return values
  * are to be considered as non-nullable by default for a given package.
- * <p>Leverages JSR-305 meta-annotations to indicate nullability in Java to common
- * tools with JSR-305 support and used by Kotlin to infer nullability of the API.
+ * <p>Leverages JSpecify meta-annotations to indicate nullability in Java to common
+ * tools with JSpecify support and used by Kotlin to infer nullability of the API.
  * <p>Should be used at package level in association with {@link Nullable}
  * annotations at parameter and return value level.
  *
  * @see NonNullFields
  * @see Nullable
  * @see NonNull
+ * @deprecated Use {@link org.jspecify.annotations.NullMarked} instead.
  */
 @Target({ElementType.PACKAGE, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Nonnull
+@NullMarked
 @TypeQualifierDefault({ElementType.METHOD, ElementType.PARAMETER})
+@Deprecated
 public @interface NonNullApi {
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNullFields.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNullFields.java
@@ -15,26 +15,25 @@
  */
 package org.openrewrite.internal.lang;
 
-import javax.annotation.Nonnull;
 import javax.annotation.meta.TypeQualifierDefault;
 import java.lang.annotation.*;
 
 /**
  * A common annotation to declare that fields are to be considered as
  * non-nullable by default for a given package.
- * <p>Leverages JSR-305 meta-annotations to indicate nullability in Java to common
- * tools with JSR-305 support and used by Kotlin to infer nullability of the API.
- * <p>Should be used at package level in association with {@link Nullable}
+ * <p>Leverages JSpecify meta-annotations to indicate nullability in Java to common
+ * tools with JSpecify support and used by Kotlin to infer nullability of the API.
+ * <p>Should be used at package level in association with {@link org.jspecify.annotations.Nullable}
  * annotations at field level.
  *
  * @see NonNullFields
- * @see Nullable
- * @see NonNull
+ * @see org.jspecify.annotations.NonNull
+ * @see org.jspecify.annotations.Nullable
  */
 @Target({ElementType.PACKAGE, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Nonnull
+@org.jspecify.annotations.NonNull
 @TypeQualifierDefault(ElementType.FIELD)
 public @interface NonNullFields {
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullFields.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NullFields.java
@@ -21,19 +21,19 @@ import java.lang.annotation.*;
 /**
  * A common annotation to declare that fields are to be considered as
  * non-nullable by default for a given package.
- * <p>Leverages JSR-305 meta-annotations to indicate nullability in Java to common
- * tools with JSR-305 support and used by Kotlin to infer nullability of the API.
+ * <p>Leverages JSpecify meta-annotations to indicate nullability in Java to common
+ * tools with JSpecify support and used by Kotlin to infer nullability of the API.
  * <p>Should be used at package level in association with {@link Nullable}
  * annotations at field level.
  *
  * @see NullFields
- * @see Nullable
- * @see NonNull
+ * @see org.jspecify.annotations.Nullable
+ * @see org.jspecify.annotations.NonNull
  */
 @Target({ElementType.PACKAGE, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@javax.annotation.Nullable
+@org.jspecify.annotations.Nullable
 @TypeQualifierDefault(ElementType.FIELD)
 public @interface NullFields {
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/Nullable.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/Nullable.java
@@ -15,9 +15,7 @@
  */
 package org.openrewrite.internal.lang;
 
-import javax.annotation.Nonnull;
 import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
 import java.lang.annotation.*;
 
 /**
@@ -32,11 +30,13 @@ import java.lang.annotation.*;
  * @see NonNullApi
  * @see NonNullFields
  * @see NonNull
+ * @deprecated Use {@link org.jspecify.annotations.Nullable} instead.
  */
 @Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Nonnull(when = When.MAYBE)
+@org.jspecify.annotations.Nullable
 @TypeQualifierNickname
+@Deprecated
 public @interface Nullable {
 }


### PR DESCRIPTION
## What's changed?
This sets the groundwork to mass migrate OpenRewrite to JSpecify.

## What's your motivation?
Since JSpecify went GA there is now no longer any need for OpenRewrite to maintain its own meta-annotations.