### PR TITLE
Restore newArtifactId property in ChangePluginGroupIdAndArtifactId

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
@@ -56,6 +56,18 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
             example = "my-new-maven-plugin",
             required = false)
     @Nullable
+    String newArtifactId;
+
+    /**
+     * Mistakenly introduced, we restored newArtifactId but let's not break recipes abruptly.
+     */
+    @Option(displayName = "New artifact ID",
+        description = "The new artifact ID to use. Defaults to the existing artifact ID. This property is deprecated, use newArtifactId instead.",
+        example = "my-new-maven-plugin",
+        required = false)
+    @Nullable
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
     String newArtifact;
 
     @Override
@@ -65,7 +77,7 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
 
     @Override
     public String getInstanceNameSuffix() {
-        return String.format("`%s:%s`", newGroupId, newArtifact);
+        return String.format("`%s:%s`", newGroupId, newArtifactId);
     }
 
     @Override
@@ -84,7 +96,9 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
                     if (newGroupId != null) {
                         t = changeChildTagValue(t, "groupId", newGroupId, ctx);
                     }
-                    if (newArtifact != null) {
+                    if (newArtifactId != null) {
+                        t = changeChildTagValue(t, "artifactId", newArtifactId, ctx);
+                    } else if (newArtifact != null) {
                         t = changeChildTagValue(t, "artifactId", newArtifact, ctx);
                     }
                     if (t != tag) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
@@ -31,6 +31,85 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
+            "quarkus-extension-maven-plugin",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                              <version>3.0.0.Beta1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+                  <profiles>
+                      <profile>
+                          <id>profile</id>
+                          <build>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>io.quarkus</groupId>
+                                      <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                                      <version>3.0.0.Beta1</version>
+                                  </plugin>
+                              </plugins>
+                          </build>
+                      </profile>
+                  </profiles>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-extension-maven-plugin</artifactId>
+                              <version>3.0.0.Beta1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+                  <profiles>
+                      <profile>
+                          <id>profile</id>
+                          <build>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>io.quarkus</groupId>
+                                      <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                      <version>3.0.0.Beta1</version>
+                                  </plugin>
+                              </plugins>
+                          </build>
+                      </profile>
+                  </profiles>
+              </project>
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void changePluginGroupIdAndArtifactIdDeprecatedNewArtifact() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
+            "io.quarkus",
+            "quarkus-bootstrap-maven-plugin",
+            null,
+            null,
             "quarkus-extension-maven-plugin"
           )),
           pomXml(
@@ -107,7 +186,8 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
           )),
           pomXml(
             """
@@ -152,7 +232,8 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
           )),
           pomXml(
             """
@@ -262,7 +343,8 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
           )),
           pomXml(
             """


### PR DESCRIPTION
It was mistakenly changed here:
https://github.com/openrewrite/rewrite/pull/3843/files#diff-a3496299541c5119d2fd48e331f97b62173789f41a9ec4f5f25f9e8454ab7518R59

I made sure we don't break people who are using `newArtifact`.

- Fixes #4420
