### PR TITLE
Check for annotations on qualified type

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AnnotationService.java
@@ -41,7 +41,7 @@ public class AnnotationService {
     public List<J.Annotation> getAllAnnotations(Cursor cursor) {
         J j = cursor.getValue();
         if (j instanceof J.VariableDeclarations) {
-            return ((J.VariableDeclarations) j).getAllAnnotations();
+            return getAllAnnotations((J.VariableDeclarations) j);
         } else if (j instanceof J.MethodDeclaration) {
             return ((J.MethodDeclaration) j).getAllAnnotations();
         } else if (j instanceof J.ClassDeclaration) {
@@ -73,8 +73,21 @@ public class AnnotationService {
             return getAllAnnotations((J.Identifier) j);
         } else if (j instanceof J.FieldAccess) {
             return getAllAnnotations((J.FieldAccess) j);
+        } else if (j instanceof J.VariableDeclarations) {
+            return getAllAnnotations((J.VariableDeclarations) j);
         }
         return emptyList();
+    }
+
+    private List<J.Annotation> getAllAnnotations(J.VariableDeclarations variableDeclarations) {
+        List<J.Annotation> allAnnotations = new ArrayList<>(variableDeclarations.getLeadingAnnotations());
+        for (J.Modifier modifier : variableDeclarations.getModifiers()) {
+            allAnnotations.addAll(modifier.getAnnotations());
+        }
+        if (variableDeclarations.getTypeExpression() instanceof J.AnnotatedType) {
+            allAnnotations.addAll(getAllAnnotations(((J.AnnotatedType) variableDeclarations.getTypeExpression())));
+        }
+        return allAnnotations;
     }
 
     private List<J.Annotation> getAllAnnotations(J.AnnotatedType annotatedType) {
@@ -100,6 +113,6 @@ public class AnnotationService {
     }
 
     private List<J.Annotation> getAllAnnotations(J.Identifier identifier) {
-        return identifier.getAnnotations() == null ? emptyList() : identifier.getAnnotations();
+        return identifier.getAnnotations();
     }
 }


### PR DESCRIPTION
The `AnnotationService` will now also return any type use annotation that is on the type of a variable is in `J.@Nullable Identifier label`.

At some point the `AnnotationService` should probably offer more precise methods, which allow checking for annotations with a given target (e.g. type use), so that the expected annotations are returned / matched.
