### PR TITLE
Support multiple protocols and ports for a single `GitRemote` server and build URIs

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -57,9 +57,9 @@ public class GitRemote {
             servers.add(new RemoteServer(Service.AzureDevOps, "dev.azure.com", URI.create("https://dev.azure.com"), URI.create("ssh://ssh.dev.azure.com")));
         }
 
-        // todo test
-
         /**
+         * Register a remote git server with multiple protocols and ports all matching the same server/origin.
+         *
          * @param service       the type of SCM service
          * @param remoteUri     the (main) origin of the server
          * @param alternateUris the alternate origins of the server
@@ -77,12 +77,13 @@ public class GitRemote {
         }
 
         /**
+         * Register a remote git server with a single origin with a single (supplied or guessed) protocol.
+         * If multiple protocols and/or ports should be supported use {@link #registerRemote(Service, URI, Collection)}
+         *
          * @param service the type of SCM service
          * @param origin  the origin of the server
          * @return this
-         * @deprecated Use {@link #registerRemote(Service, URI, Collection)} instead to configure multiple uris for a single remote server
          */
-        @Deprecated
         public Parser registerRemote(Service service, String origin) {
             add(new RemoteServer(service, origin, normalize(origin)));
             return this;

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -62,6 +62,9 @@ public class GitRemote {
             URI selectedBaseUrl;
 
             if (remote.service == Service.Unknown) {
+                if (PORT_PATTERN.matcher(remote.origin).find()) {
+                    throw new IllegalArgumentException("Unable to guess protocol port combination for an unregistered origin with a port: " + remote.origin);
+                }
                 selectedBaseUrl = URI.create((ssh ? "ssh://" : "https://") + stripProtocol(remote.origin));
             } else {
                 selectedBaseUrl = servers.stream()

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -58,18 +58,19 @@ public class GitRemote {
         }
 
         // todo test
+
         /**
          * @param service       the type of SCM service
-         * @param uri           the (main) origin of the server
+         * @param remoteUri     the (main) origin of the server
          * @param alternateUris the alternate origins of the server
          * @return this
          */
-        public Parser registerRemote(Service service, URI uri, Collection<URI> alternateUris) {
-            URI normalizedUri = normalize(uri.toString());
-            String maybePort = maybePort(uri.getPort(), uri.getScheme());
+        public Parser registerRemote(Service service, URI remoteUri, Collection<URI> alternateUris) {
+            URI normalizedUri = normalize(remoteUri.toString());
+            String maybePort = maybePort(remoteUri.getPort(), remoteUri.getScheme());
             String origin = normalizedUri.getHost() + maybePort + normalizedUri.getPath();
             List<URI> allUris = new ArrayList<>();
-            allUris.add(uri);
+            allUris.add(remoteUri);
             allUris.addAll(alternateUris);
             add(new RemoteServer(service, origin, allUris));
             return this;

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -153,7 +153,6 @@ public class GitRemote {
             URI normalizedUri = normalize(url);
 
             RemoteServerMatch match = matchRemoteServer(normalizedUri);
-
             String repositoryPath = repositoryPath(match, normalizedUri);
 
             switch (match.service) {

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -19,10 +19,10 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.jgit.transport.URIish;
 
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Value
@@ -47,69 +47,73 @@ public class GitRemote {
     }
 
     public static class Parser {
-        private final Map<String, Service> origins;
+        private final List<RemoteServer> servers;
 
         public Parser() {
-            origins = new LinkedHashMap<>();
-            origins.put("github.com", Service.GitHub);
-            origins.put("gitlab.com", Service.GitLab);
-            origins.put("bitbucket.org", Service.BitbucketCloud);
-            origins.put("dev.azure.com", Service.AzureDevOps);
-            origins.put("ssh.dev.azure.com", Service.AzureDevOps);
+            servers = new ArrayList<>();
+            servers.add(new RemoteServer(Service.GitHub, "github.com", URI.create("https://github.com"), URI.create("ssh://github.com")));
+            servers.add(new RemoteServer(Service.GitLab, "gitlab.com", URI.create("https://gitlab.com"), URI.create("ssh://gitlab.com")));
+            servers.add(new RemoteServer(Service.BitbucketCloud, "bitbucket.org", URI.create("https://bitbucket.org"), URI.create("ssh://bitbucket.org")));
+            servers.add(new RemoteServer(Service.AzureDevOps, "dev.azure.com", URI.create("https://dev.azure.com"), URI.create("ssh://ssh.dev.azure.com")));
         }
 
-        public Parser registerRemote(Service service, String origin) {
-            if (origin.startsWith("https://") || origin.startsWith("http://") || origin.startsWith("ssh://")) {
-                origin = new Parser.HostAndPath(origin).concat();
-            }
-            if (origin.contains("@")) {
-                origin = new Parser.HostAndPath("https://" + origin).concat();
-            }
-            if (service == Service.Unknown) {
-                // Do not override a known with an unknown service
-                origins.putIfAbsent(origin, service);
-            } else {
-                origins.put(origin, service);
-            }
+        // todo test
+        /**
+         * @param service       the type of SCM service
+         * @param uri           the (main) origin of the server
+         * @param alternateUris the alternate origins of the server
+         * @return this
+         */
+        public Parser registerRemote(Service service, URI uri, Collection<URI> alternateUris) {
+            URI normalizedUri = normalize(uri.toString());
+            String maybePort = maybePort(uri.getPort(), uri.getScheme());
+            String origin = normalizedUri.getHost() + maybePort + normalizedUri.getPath();
+            List<URI> allUris = new ArrayList<>();
+            allUris.add(uri);
+            allUris.addAll(alternateUris);
+            add(new RemoteServer(service, origin, allUris));
             return this;
         }
 
+        /**
+         * @param service the type of SCM service
+         * @param origin  the origin of the server
+         * @return this
+         * @deprecated Use {@link #registerRemote(Service, URI, Collection)} instead to configure multiple uris for a single remote server
+         */
+        @Deprecated
+        public Parser registerRemote(Service service, String origin) {
+            add(new RemoteServer(service, origin, normalize(origin)));
+            return this;
+        }
+
+        private void add(RemoteServer server) {
+            if (server.service != Service.Unknown || servers.stream().noneMatch(s -> s.origin.equals(server.origin))) {
+                servers.add(server);
+            }
+        }
+
         public GitRemote parse(String url) {
-            Parser.HostAndPath hostAndPath = new Parser.HostAndPath(url);
+            URI normalizedUri = normalize(url);
 
-            String origin = hostAndPath.host;
-            if (hostAndPath.port > 0) {
-                origin = origin + ':' + hostAndPath.port;
-            }
-            Service service = origins.get(origin);
-            if (service == null) {
-                for (String maybeOrigin : origins.keySet()) {
-                    if (hostAndPath.concat().startsWith(maybeOrigin)) {
-                        service = origins.get(maybeOrigin);
-                        origin = maybeOrigin;
-                        break;
-                    }
-                }
-            }
+            RemoteServerMatch match = servers.stream()
+                    .map(server -> server.match(normalizedUri))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseGet(() -> {
+                        String[] segments = normalizedUri.getPath().split("/");
+                        String origin = normalizedUri.getHost() + maybePort(normalizedUri.getPort(), normalizedUri.getScheme());
+                        if (segments.length > 2) {
+                            origin += Arrays.stream(segments, 0, segments.length - 2).collect(Collectors.joining("/"));
+                        }
+                        return new RemoteServerMatch(Service.Unknown, origin, URI.create(normalizedUri.getScheme() + "://" + origin));
+                    });
 
-            if (service == null) {
-                // If we cannot find a service, we assume the last 2 path segments are the organization and repository name
-                service = Service.Unknown;
-                String hostPath = hostAndPath.concat();
-                String[] segments = hostPath.split("/");
-                if (segments.length <= 2) {
-                    origin = null;
-                } else {
-                    origin = Arrays.stream(segments, 0, segments.length - 2).collect(Collectors.joining("/"));
-                }
-            }
+            String repositoryPath = repositoryPath(match, normalizedUri);
 
-            String repositoryPath = hostAndPath.repositoryPath(origin);
-
-            switch (service) {
+            switch (match.service) {
                 case AzureDevOps:
-                    if (origin.equals("ssh.dev.azure.com")) {
-                        origin = "dev.azure.com";
+                    if (match.matchedUri.getHost().equals("ssh.dev.azure.com")) {
                         repositoryPath = repositoryPath.replaceFirst("v3/", "");
                     } else {
                         repositoryPath = repositoryPath.replaceFirst("/_git/", "/");
@@ -129,66 +133,106 @@ public class GitRemote {
             } else {
                 repositoryName = repositoryPath;
             }
-            return new GitRemote(service, url, origin, repositoryPath, organization, repositoryName);
+            return new GitRemote(match.service, url, match.origin, repositoryPath, organization, repositoryName);
         }
 
-        private static class HostAndPath {
-            String scheme;
-            String host;
-            int port;
-            String path;
+        private String repositoryPath(RemoteServerMatch match, URI normalizedUri) {
+            String origin = match.matchedUri.toString();
+            String uri = normalizedUri.toString();
+            if (!uri.startsWith(origin)) {
+                throw new IllegalArgumentException("Unable to find origin '" + origin + "' in '" + uri + "'");
+            }
+            return uri.substring(origin.length()).replaceFirst("^/", "");
+        }
 
-            public HostAndPath(String url) {
-                try {
-                    URIish uri = new URIish(url);
-                    scheme = uri.getScheme();
-                    host = uri.getHost();
-                    port = uri.getPort();
-                    if (host == null && !"file".equals(scheme)) {
+        private static final Pattern PORT_PATTERN = Pattern.compile(":\\d+");
+
+        static URI normalize(String url) {
+            try {
+                URIish uri = new URIish(url);
+                String scheme = uri.getScheme();
+                String host = uri.getHost();
+                if (host == null) {
+                    if (scheme == null) {
+                        if (url.contains(":")) {
+                            // Looks like SCP style url
+                            scheme = "ssh";
+                        } else {
+                            scheme = "https";
+                        }
+                        uri = new URIish(scheme + "://" + url);
+                        host = uri.getHost();
+                    } else if (!"file".equals(scheme)) {
                         throw new IllegalStateException("No host in url: " + url);
                     }
-                    path = uri.getPath().replaceFirst("/$", "")
-                            .replaceFirst(".git$", "")
-                            .replaceFirst("^/", "");
-                } catch (URISyntaxException e) {
-                    throw new IllegalStateException("Unable to parse origin from: " + url, e);
                 }
-            }
-
-            private String concat() {
-                StringBuilder builder = new StringBuilder(64);
-                if (host != null) {
-                    builder.append(host);
-                }
-                if (!isDefaultPort()) {
-                    builder.append(':').append(port);
-                }
-                if (!path.isEmpty()) {
-                    if (builder.length() != 0) {
-                        builder.append('/');
+                if (scheme == null) {
+                    if (PORT_PATTERN.matcher(url).find()) {
+                        throw new IllegalArgumentException("Unable to normalize URI. Port without a scheme is not supported: " + url);
                     }
-                    builder.append(path);
+                    if (url.contains(":")) {
+                        // Looks like SCP style url
+                        scheme = "ssh";
+                    } else {
+                        scheme = "https";
+                    }
                 }
-                return builder.toString();
+                String maybePort = maybePort(uri.getPort(), scheme);
+
+                String path = uri.getPath().replaceFirst("/$", "")
+                        .replaceFirst(".git$", "")
+                        .replaceFirst("^/", "");
+                return URI.create(scheme + "://" + host + maybePort + "/" + path);
+            } catch (URISyntaxException e) {
+                throw new IllegalStateException("Unable to parse origin from: " + url, e);
+            }
+        }
+
+        @Value
+        private static class RemoteServer {
+            Service service;
+            String origin;
+            List<URI> uris = new ArrayList<>();
+
+            public RemoteServer(Service service, String origin, URI... uris) {
+                this(service, origin, Arrays.asList(uris));
             }
 
-            private boolean isDefaultPort() {
-                return port < 1 ||
-                       ("https".equals(scheme) && port == 443) ||
-                       ("http".equals(scheme) && port == 80) ||
-                       ("ssh".equals(scheme) && port == 22);
+            public RemoteServer(Service service, String origin, Collection<URI> uris) {
+                this.service = service;
+                this.origin = origin;
+                this.uris.addAll(uris);
             }
 
-            private String repositoryPath(@Nullable String origin) {
-                if (origin == null) {
-                    origin = "";
+            @Nullable
+            private RemoteServerMatch match(URI normalizedUri) {
+                for (URI uri : uris) {
+                    if (normalizedUri.toString().startsWith(uri.toString())) {
+                        return new RemoteServerMatch(service, origin, uri);
+                    }
                 }
-                String hostAndPath = concat();
-                if (!hostAndPath.startsWith(origin)) {
-                    throw new IllegalArgumentException("Unable to find origin '" + origin + "' in '" + hostAndPath + "'");
-                }
-                return hostAndPath.substring(origin.length()).replaceFirst("^/", "");
+                return null;
             }
+        }
+
+        @Value
+        private static class RemoteServerMatch {
+            Service service;
+            String origin;
+            URI matchedUri;
+        }
+
+        private static String maybePort(int port, String scheme) {
+            if (isDefaultPort(port, scheme))
+                return "";
+            return ":" + port;
+        }
+
+        private static boolean isDefaultPort(int port, String scheme) {
+            return port < 1 ||
+                   ("https".equals(scheme) && port == 443) ||
+                   ("http".equals(scheme) && port == 80) ||
+                   ("ssh".equals(scheme) && port == 22);
         }
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -221,7 +221,7 @@ public class GitRemote {
                         uri = new URIish(scheme + "://" + url);
                         host = uri.getHost();
                     } else if (!"file".equals(scheme)) {
-                        throw new IllegalStateException("No host in url: " + url);
+                        throw new IllegalStateException("No host found in URL " + url);
                     }
                 }
                 if (scheme == null) {

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -71,7 +71,7 @@ public class GitRemote {
             String origin = normalizedUri.getHost() + maybePort + normalizedUri.getPath();
             List<URI> allUris = new ArrayList<>();
             allUris.add(remoteUri);
-            allUris.addAll(alternateUris);
+            alternateUris.stream().map(URI::toString).map(Parser::normalize).forEach(allUris::add);
             add(new RemoteServer(service, origin, allUris));
             return this;
         }

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -61,7 +61,7 @@ public class GitRemote {
         private static final Set<String> ALLOWED_PROTOCOLS = new HashSet<>(Arrays.asList("ssh", "http", "https"));
 
         /**
-         * Transform a {@link GitRemote} into a clone url in the form of an{@link URI}
+         * Transform a {@link GitRemote} into a clone url in the form of an {@link URI}
          * @param remote the previously parsed GitRemote
          * @param protocol the protocol to use. Supported protocols: ssh, http, https
          * @return the clone url

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -63,7 +63,7 @@ public class GitRemote {
 
             if (remote.service == Service.Unknown) {
                 if (PORT_PATTERN.matcher(remote.origin).find()) {
-                    throw new IllegalArgumentException("Unable to guess protocol port combination for an unregistered origin with a port: " + remote.origin);
+                    throw new IllegalArgumentException("Unable to determine protocol/port combination for an unregistered origin with a port: " + remote.origin);
                 }
                 selectedBaseUrl = URI.create((ssh ? "ssh://" : "https://") + stripProtocol(remote.origin));
             } else {
@@ -104,11 +104,7 @@ public class GitRemote {
         }
 
         private static String stripProtocol(String origin) {
-            int idx = origin.indexOf("://");
-            if (idx < 0) {
-                return origin;
-            }
-            return origin.substring(idx + 3);
+            return origin.replaceFirst("^\\w+://", "");
         }
 
         /**
@@ -230,7 +226,7 @@ public class GitRemote {
                 }
                 if (scheme == null) {
                     if (PORT_PATTERN.matcher(url).find()) {
-                        throw new IllegalArgumentException("Unable to normalize URI. Port without a scheme is not supported: " + url);
+                        throw new IllegalArgumentException("Unable to normalize URL: Specifying a port without a scheme is not supported for URL : " + url);
                     }
                     if (url.contains(":")) {
                         // Looks like SCP style url

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -215,6 +215,6 @@ public class GitRemoteTest {
     void buildUriUnregisteredOriginWithPortNotSupported() {
         GitRemote remote = new GitRemote(GitRemote.Service.Unknown, null, "scm.unregistered.com:8443/context/path", "org/repo", null, null);
         IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> new GitRemote.Parser().toUri(remote, true));
-        assertThat(ex).isNotNull().hasMessageContaining("Unable to guess protocol port combination for an unregistered origin with a port");
+        assertThat(ex).isNotNull().hasMessageContaining("Unable to determine protocol/port combination for an unregistered origin with a port");
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -190,14 +190,20 @@ public class GitRemoteTest {
       GitHub, scm.company.com/context/github, org/repo, false, https://scm.company.com/context/github/org/repo.git
       GitHub, scm.company.com/context/github, org/repo, true, ssh://git@scm.company.com/context/github/org/repo.git
       GitLab, scm.company.com/context/gitlab, group/subgroup/repo, false, https://scm.company.com/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com:8443/context/gitlab, group/subgroup/repo, false, https://scm.company.com:8443/context/gitlab/group/subgroup/repo.git
       GitLab, scm.company.com/context/gitlab, group/subgroup/repo, true, ssh://git@scm.company.com:8022/context/gitlab/group/subgroup/repo.git
+      
+      Bitbucket, scm.company.com:12345/context/bitbucket, org/repo, false, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
+      Bitbucket, scm.company.com:12346/context/bitbucket, org/repo, false, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
       """)
     void buildUri(GitRemote.Service service, String origin, String path, boolean ssh, String expectedUri) {
         GitRemote remote = new GitRemote(service, null, origin, path, null, null);
         URI uri = new GitRemote.Parser()
-          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket"), List.of(URI.create("ssh://git@scm.company.com:7999/context/bitbucket")))
-          .registerRemote(GitRemote.Service.GitHub, URI.create("https://scm.company.com/context/github"), List.of(URI.create("ssh://git@scm.company.com/context/github")))
-          .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com/context/gitlab"), List.of(URI.create("ssh://git@scm.company.com:8022/context/gitlab")))
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket/"), List.of(URI.create("ssh://git@scm.company.com:7999/context/bitbucket")))
+          .registerRemote(GitRemote.Service.GitHub, URI.create("https://scm.company.com/context/github"), List.of(URI.create("ssh://git@scm.company.com/context/github/")))
+          .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com/context/gitlab/"), List.of(URI.create("ssh://git@scm.company.com:8022/context/gitlab")))
+          .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com:8443/context/gitlab"), List.of(URI.create("https://scm.company.com/context/gitlab/")))
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com:12345/context/bitbucket"), List.of(URI.create("https://scm.company.com:12346/context/bitbucket/")))
           .toUri(remote, ssh);
         assertThat(uri).isEqualTo(URI.create(expectedUri));
     }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -170,4 +170,35 @@ public class GitRemoteTest {
         IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> GitRemote.Parser.normalize("github.com:443/org/repo.git"));
         assertThat(ex).isNotNull().hasMessageContaining("Unable to normalize URI. Port without a scheme is not supported");
     }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+      GitHub, github.com, org/repo, false, https://github.com/org/repo.git
+      GitHub, github.com, org/repo, true, ssh://git@github.com/org/repo.git
+      GitHub, https://github.com, org/repo, false, https://github.com/org/repo.git
+      GitHub, https://github.com, org/repo, true, ssh://git@github.com/org/repo.git
+      
+      GitLab, gitlab.com, group/subgroup/repo, false, https://gitlab.com/group/subgroup/repo.git
+      GitLab, gitlab.com, group/subgroup/repo, true, ssh://git@gitlab.com/group/subgroup/repo.git
+      AzureDevOps, dev.azure.com, org/project/repo, false, https://dev.azure.com/org/project/_git/repo
+      AzureDevOps, dev.azure.com, org/project/repo, true, ssh://git@ssh.dev.azure.com/v3/org/project/repo
+      BitbucketCloud, bitbucket.org, org/repo, false, https://bitbucket.org/org/repo.git
+      BitbucketCloud, bitbucket.org, org/repo, true, ssh://git@bitbucket.org/org/repo.git
+     
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, false, https://scm.company.com/context/bitbucket/scm/org/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, true, ssh://git@scm.company.com/context/bitbucket/org/repo.git
+      GitHub, scm.company.com/context/github, org/repo, false, https://scm.company.com/context/github/org/repo.git
+      GitHub, scm.company.com/context/github, org/repo, true, ssh://git@scm.company.com/context/github/org/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, false, https://scm.company.com/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, true, ssh://git@scm.company.com/context/gitlab/group/subgroup/repo.git
+      """)
+    void buildUri(GitRemote.Service service, String origin, String path, boolean ssh, String expectedUri) {
+        GitRemote remote = new GitRemote(service, null, origin, path, null, null);
+        URI uri = new GitRemote.Parser()
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket"), List.of(URI.create("ssh://git@scm.company.com/context/bitbucket")))
+          .registerRemote(GitRemote.Service.GitHub, URI.create("https://scm.company.com/context/github"), List.of(URI.create("ssh://git@scm.company.com/context/github")))
+          .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com/context/gitlab"), List.of(URI.create("ssh://git@scm.company.com/context/gitlab")))
+          .toUri(remote, ssh);
+        assertThat(uri).isEqualTo(URI.create(expectedUri));
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -210,4 +210,11 @@ public class GitRemoteTest {
           .toUri(remote, ssh);
         assertThat(uri).isEqualTo(URI.create(expectedUri));
     }
+
+    @Test
+    void buildUriUnregisteredOriginWithPortNotSupported() {
+        GitRemote remote = new GitRemote(GitRemote.Service.Unknown, null, "scm.unregistered.com:8443/context/path", "org/repo", null, null);
+        IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> new GitRemote.Parser().toUri(remote, true));
+        assertThat(ex).isNotNull().hasMessageContaining("Unable to guess protocol port combination for an unregistered origin with a port");
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -168,53 +168,54 @@ public class GitRemoteTest {
     @Test
     void normalizePortWithoutSchemaNotSupported() {
         IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> GitRemote.Parser.normalize("github.com:443/org/repo.git"));
-        assertThat(ex).isNotNull().hasMessageContaining("Unable to normalize URI. Port without a scheme is not supported");
+        assertThat(ex).isNotNull().hasMessageContaining("Unable to normalize URL: Specifying a port without a scheme is not supported for URL");
     }
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-      GitHub, github.com, org/repo, false, https://github.com/org/repo.git
-      GitHub, github.com, org/repo, true, ssh://git@github.com/org/repo.git
-      GitHub, https://github.com, org/repo, false, https://github.com/org/repo.git
-      GitHub, https://github.com, org/repo, true, ssh://git@github.com/org/repo.git
+      GitHub, github.com, org/repo, https, https://github.com/org/repo.git
+      GitHub, github.com, org/repo, ssh, ssh://git@github.com/org/repo.git
+      GitHub, https://github.com, org/repo, https, https://github.com/org/repo.git
+      GitHub, https://github.com, org/repo, ssh, ssh://git@github.com/org/repo.git
       
-      GitLab, gitlab.com, group/subgroup/repo, false, https://gitlab.com/group/subgroup/repo.git
-      GitLab, gitlab.com, group/subgroup/repo, true, ssh://git@gitlab.com/group/subgroup/repo.git
-      AzureDevOps, dev.azure.com, org/project/repo, false, https://dev.azure.com/org/project/_git/repo
-      AzureDevOps, dev.azure.com, org/project/repo, true, ssh://git@ssh.dev.azure.com/v3/org/project/repo
-      BitbucketCloud, bitbucket.org, org/repo, false, https://bitbucket.org/org/repo.git
-      BitbucketCloud, bitbucket.org, org/repo, true, ssh://git@bitbucket.org/org/repo.git
+      GitLab, gitlab.com, group/subgroup/repo, https, https://gitlab.com/group/subgroup/repo.git
+      GitLab, gitlab.com, group/subgroup/repo, ssh, ssh://git@gitlab.com/group/subgroup/repo.git
+      AzureDevOps, dev.azure.com, org/project/repo, https, https://dev.azure.com/org/project/_git/repo
+      AzureDevOps, dev.azure.com, org/project/repo, ssh, ssh://git@ssh.dev.azure.com/v3/org/project/repo
+      BitbucketCloud, bitbucket.org, org/repo, https, https://bitbucket.org/org/repo.git
+      BitbucketCloud, bitbucket.org, org/repo, ssh, ssh://git@bitbucket.org/org/repo.git
       
-      Bitbucket, scm.company.com/context/bitbucket, org/repo, false, https://scm.company.com/context/bitbucket/scm/org/repo.git
-      Bitbucket, scm.company.com/context/bitbucket, org/repo, true, ssh://git@scm.company.com:7999/context/bitbucket/org/repo.git
-      GitHub, scm.company.com/context/github, org/repo, false, https://scm.company.com/context/github/org/repo.git
-      GitHub, scm.company.com/context/github, org/repo, true, ssh://git@scm.company.com/context/github/org/repo.git
-      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, false, https://scm.company.com/context/gitlab/group/subgroup/repo.git
-      GitLab, scm.company.com:8443/context/gitlab, group/subgroup/repo, false, https://scm.company.com:8443/context/gitlab/group/subgroup/repo.git
-      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, true, ssh://git@scm.company.com:8022/context/gitlab/group/subgroup/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, https, https://scm.company.com/context/bitbucket/scm/org/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, http, http://scm.company.com/context/bitbucket/scm/org/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, ssh, ssh://git@scm.company.com:7999/context/bitbucket/org/repo.git
+      GitHub, scm.company.com/context/github, org/repo, https, https://scm.company.com/context/github/org/repo.git
+      GitHub, scm.company.com/context/github, org/repo, ssh, ssh://git@scm.company.com/context/github/org/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, https, https://scm.company.com/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com:8443/context/gitlab, group/subgroup/repo, https, https://scm.company.com:8443/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, ssh, ssh://git@scm.company.com:8022/context/gitlab/group/subgroup/repo.git
       
-      Bitbucket, scm.company.com:12345/context/bitbucket, org/repo, false, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
-      Bitbucket, scm.company.com:12346/context/bitbucket, org/repo, false, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
+      Bitbucket, scm.company.com:12345/context/bitbucket, org/repo, https, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
+      Bitbucket, scm.company.com:12346/context/bitbucket, org/repo, https, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
       
-      Unknown, scm.unregistered.com/context/path/, org/repo, false, https://scm.unregistered.com/context/path/org/repo.git
-      Unknown, scm.unregistered.com/context/path/, org/repo, true, ssh://scm.unregistered.com/context/path/org/repo.git
+      Unknown, scm.unregistered.com/context/path/, org/repo, https, https://scm.unregistered.com/context/path/org/repo.git
+      Unknown, scm.unregistered.com/context/path/, org/repo, ssh, ssh://scm.unregistered.com/context/path/org/repo.git
       """)
-    void buildUri(GitRemote.Service service, String origin, String path, boolean ssh, String expectedUri) {
+    void buildUri(GitRemote.Service service, String origin, String path, String protocol, String expectedUri) {
         GitRemote remote = new GitRemote(service, null, origin, path, null, null);
         URI uri = new GitRemote.Parser()
-          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket/"), List.of(URI.create("ssh://git@scm.company.com:7999/context/bitbucket")))
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket/"), List.of( URI.create("http://scm.company.com/context/bitbucket/"),URI.create("ssh://git@scm.company.com:7999/context/bitbucket")))
           .registerRemote(GitRemote.Service.GitHub, URI.create("https://scm.company.com/context/github"), List.of(URI.create("ssh://git@scm.company.com/context/github/")))
           .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com/context/gitlab/"), List.of(URI.create("ssh://git@scm.company.com:8022/context/gitlab")))
           .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com:8443/context/gitlab"), List.of(URI.create("https://scm.company.com/context/gitlab/")))
           .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com:12345/context/bitbucket"), List.of(URI.create("https://scm.company.com:12346/context/bitbucket/")))
-          .toUri(remote, ssh);
+          .toUri(remote, protocol);
         assertThat(uri).isEqualTo(URI.create(expectedUri));
     }
 
     @Test
     void buildUriUnregisteredOriginWithPortNotSupported() {
         GitRemote remote = new GitRemote(GitRemote.Service.Unknown, null, "scm.unregistered.com:8443/context/path", "org/repo", null, null);
-        IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> new GitRemote.Parser().toUri(remote, true));
+        IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> new GitRemote.Parser().toUri(remote, "ssh"));
         assertThat(ex).isNotNull().hasMessageContaining("Unable to determine protocol/port combination for an unregistered origin with a port");
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -103,6 +104,36 @@ public class GitRemoteTest {
         GitRemote.Parser parser = new GitRemote.Parser();
         parser.registerRemote(service, origin);
         GitRemote remote = parser.parse(cloneUrl);
+        assertThat(remote.getOrigin()).isEqualTo(origin);
+        assertThat(remote.getPath()).isEqualTo(expectedPath);
+        assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);
+        assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+    https://scm.company.com/very/long/context/path/org/repo.git,
+    https://scm.company.com:8443/very/long/context/path/org/repo.git
+    http://scm.company.com/very/long/context/path/org/repo.git
+    ssh://scm.company.com:7999/very/long/context/path/org/repo.git
+    ssh://scm.company.com:222/very/long/context/path/org/repo.git
+    ssh://scm.company.com/very/long/context/path/org/repo.git
+    scm.company.com:very/long/context/path/org/repo.git
+    """)
+    void parseRegisteredRemoteServer(String cloneUrl) {
+        GitRemote.Parser parser = new GitRemote.Parser();
+        parser.registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/very/long/context/path"), List.of(
+          URI.create("https://scm.company.com:8443/very/long/context/path"),
+          URI.create("http://scm.company.com/very/long/context/path"),
+          URI.create("ssh://scm.company.com:7999/very/long/context/path"),
+          URI.create("ssh://scm.company.com:222/very/long/context/path"),
+          URI.create("ssh://scm.company.com/very/long/context/path")
+        ));
+        GitRemote remote = parser.parse(cloneUrl);
+        String origin = "scm.company.com/very/long/context/path";
+        String expectedPath = "org/repo";
+        String expectedOrganization = "org";
+        String expectedRepositoryName = "repo";
         assertThat(remote.getOrigin()).isEqualTo(origin);
         assertThat(remote.getPath()).isEqualTo(expectedPath);
         assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -121,9 +121,9 @@ public class GitRemoteTest {
       """)
     void parseRegisteredRemoteServer(String cloneUrl) {
         GitRemote.Parser parser = new GitRemote.Parser()
-          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/very/long/context/path"), List.of(
-            URI.create("https://scm.company.com:8443/very/long/context/path"),
-            URI.create("http://scm.company.com/very/long/context/path"),
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/very/long/context/path/"), List.of(
+            URI.create("https://scm.company.com:8443/very/long/context/path/"),
+            URI.create("http://scm.company.com/very/long/context/path/"),
             URI.create("ssh://scm.company.com:7999/very/long/context/path"),
             URI.create("ssh://scm.company.com:222/very/long/context/path"),
             URI.create("ssh://scm.company.com/very/long/context/path")

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -15,10 +15,14 @@
  */
 package org.openrewrite;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.net.URI;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 public class GitRemoteTest {
 
@@ -27,16 +31,16 @@ public class GitRemoteTest {
       https://github.com/org/repo, github.com, org/repo, org, repo
       git@github.com:org/repo.git, github.com, org/repo, org, repo
       ssh://github.com/org/repo.git, github.com, org/repo, org, repo
-
+      
       https://gitlab.com/group/repo.git, gitlab.com, group/repo, group, repo
       https://gitlab.com/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       git@gitlab.com:group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-
+      
       https://bitbucket.org/PRJ/repo, bitbucket.org, PRJ/repo, PRJ, repo
       git@bitbucket.org:PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
       ssh://bitbucket.org/PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
-
+      
       https://org@dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project, repo
       https://dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project, repo
       git@ssh.dev.azure.com:v3/org/project/repo, dev.azure.com, org/project/repo, org/project, repo
@@ -56,7 +60,7 @@ public class GitRemoteTest {
       https://scm.company.com:1234/stash/scm/org/repo.git, scm.company.com:1234/stash/scm, org/repo, org, repo
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, org/repo, org, repo
       ssh://scm.company.com/stash/org/repo, scm.company.com/stash, org/repo, org, repo
-
+      
       https://scm.company.com:1234/very/long/context/path/org/repo.git, scm.company.com:1234/very/long/context/path, org/repo, org, repo
       git@scm.company.com:very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, org/repo, org, repo
       """)
@@ -72,25 +76,27 @@ public class GitRemoteTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
       https://scm.company.com/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
-      http://scm.company.com:80/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
-      http://scm.company.com:8080/stash/scm/org/repo.git, scm.company.com:8080/stash, Bitbucket, org/repo, org, repo
+      http://scm.company.com:80/stash/scm/org/repo.git, http://scm.company.com/stash, Bitbucket, org/repo, org, repo
+      http://scm.company.com:8080/stash/scm/org/repo.git, http://scm.company.com:8080/stash, Bitbucket, org/repo, org, repo
       https://scm.company.com:443/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
-      https://scm.company.com:1234/stash/scm/org/repo.git, scm.company.com:1234/stash, Bitbucket, org/repo, org, repo
+      https://scm.company.com:1234/stash/scm/org/repo.git, https://scm.company.com:1234/stash, Bitbucket, org/repo, org, repo
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
       ssh://scm.company.com:22/stash/org/repo, scm.company.com/stash, Bitbucket, org/repo, org, repo
-      ssh://scm.company.com:7999/stash/org/repo, scm.company.com:7999/stash, Bitbucket, org/repo, org, repo
-
+      ssh://scm.company.com:7999/stash/org/repo, ssh://scm.company.com:7999/stash, Bitbucket, org/repo, org, repo
+      
       https://scm.company.com/very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo
-      https://scm.company.com:1234/very/long/context/path/org/repo.git, scm.company.com:1234/very/long/context/path, Bitbucket, org/repo, org, repo
+      https://scm.company.com:1234/very/long/context/path/org/repo.git, https://scm.company.com:1234/very/long/context/path, Bitbucket, org/repo, org, repo
       git@scm.company.com:very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, org/repo, org, repo
-        
+      
       https://scm.company.com/group/subgroup/subergroup/subestgroup/repo, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      https://scm.company.com:1234/group/subgroup/subergroup/subestgroup/repo, scm.company.com:1234, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      git@scm.company.com:group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://scm.company.com:222/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com:222, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-
+      https://scm.company.com:1234/group/subgroup/subergroup/subestgroup/repo, https://scm.company.com:1234, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      git@scm.company.com/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      git@scm.company.com:group/subgroup/subergroup/subestgroup/repo.git, ssh://scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      https://scm.company.com:443/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, ssh://scm.company.com, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://scm.company.com:222/group/subgroup/subergroup/subestgroup/repo.git, ssh://scm.company.com:222, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      
       https://scm.company.com/very/long/context/path/group/subgroup/subergroup/subestgroup/repo, scm.company.com/very/long/context/path, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       """)
     void parseRegisteredRemote(String cloneUrl, String origin, GitRemote.Service service, String expectedPath, String expectedOrganization, String expectedRepositoryName) {
@@ -101,5 +107,37 @@ public class GitRemoteTest {
         assertThat(remote.getPath()).isEqualTo(expectedPath);
         assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);
         assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+      https://github.com/org/repo.git, https://github.com/org/repo
+      ssh://github.com/org/repo.git, ssh://github.com/org/repo
+      github.com:org/repo.git, ssh://github.com/org/repo
+      github.com/org/repo.git, https://github.com/org/repo
+      
+      https://github.com/org/repo/, https://github.com/org/repo
+      ssh://github.com/org/repo/, ssh://github.com/org/repo
+      
+      https://github.com:443/org/repo.git, https://github.com/org/repo
+      ssh://github.com:22/org/repo.git, ssh://github.com/org/repo
+      github.com:org/repo.git, ssh://github.com/org/repo
+      
+      https://github.com:8443/org/repo, https://github.com:8443/org/repo
+      ssh://github.com:8022/org/repo, ssh://github.com:8022/org/repo
+      
+      https://scm.company.com/very/long/context/path/org/repo.git, https://scm.company.com/very/long/context/path/org/repo
+      ssh://scm.company.com/very/long/context/path/org/repo.git, ssh://scm.company.com/very/long/context/path/org/repo
+      scm.company.com:very/long/context/path/org/repo.git, ssh://scm.company.com/very/long/context/path/org/repo
+      """)
+    void normalizeUri(String input, String expected) {
+        URI result = GitRemote.Parser.normalize(input);
+        assertThat(result).isEqualTo(URI.create(expected));
+    }
+
+    @Test
+    void normalizePortWithoutSchemaNotSupported() {
+        IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> GitRemote.Parser.normalize("github.com:443/org/repo.git"));
+        assertThat(ex).isNotNull().hasMessageContaining("Unable to normalize URI. Port without a scheme is not supported");
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -186,18 +186,18 @@ public class GitRemoteTest {
       BitbucketCloud, bitbucket.org, org/repo, true, ssh://git@bitbucket.org/org/repo.git
      
       Bitbucket, scm.company.com/context/bitbucket, org/repo, false, https://scm.company.com/context/bitbucket/scm/org/repo.git
-      Bitbucket, scm.company.com/context/bitbucket, org/repo, true, ssh://git@scm.company.com/context/bitbucket/org/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, true, ssh://git@scm.company.com:7999/context/bitbucket/org/repo.git
       GitHub, scm.company.com/context/github, org/repo, false, https://scm.company.com/context/github/org/repo.git
       GitHub, scm.company.com/context/github, org/repo, true, ssh://git@scm.company.com/context/github/org/repo.git
       GitLab, scm.company.com/context/gitlab, group/subgroup/repo, false, https://scm.company.com/context/gitlab/group/subgroup/repo.git
-      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, true, ssh://git@scm.company.com/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, true, ssh://git@scm.company.com:8022/context/gitlab/group/subgroup/repo.git
       """)
     void buildUri(GitRemote.Service service, String origin, String path, boolean ssh, String expectedUri) {
         GitRemote remote = new GitRemote(service, null, origin, path, null, null);
         URI uri = new GitRemote.Parser()
-          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket"), List.of(URI.create("ssh://git@scm.company.com/context/bitbucket")))
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/context/bitbucket"), List.of(URI.create("ssh://git@scm.company.com:7999/context/bitbucket")))
           .registerRemote(GitRemote.Service.GitHub, URI.create("https://scm.company.com/context/github"), List.of(URI.create("ssh://git@scm.company.com/context/github")))
-          .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com/context/gitlab"), List.of(URI.create("ssh://git@scm.company.com/context/gitlab")))
+          .registerRemote(GitRemote.Service.GitLab, URI.create("https://scm.company.com/context/gitlab"), List.of(URI.create("ssh://git@scm.company.com:8022/context/gitlab")))
           .toUri(remote, ssh);
         assertThat(uri).isEqualTo(URI.create(expectedUri));
     }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -101,8 +101,7 @@ public class GitRemoteTest {
       https://scm.company.com/very/long/context/path/group/subgroup/subergroup/subestgroup/repo, scm.company.com/very/long/context/path, GitLab, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       """)
     void parseRegisteredRemote(String cloneUrl, String origin, GitRemote.Service service, String expectedPath, String expectedOrganization, String expectedRepositoryName) {
-        GitRemote.Parser parser = new GitRemote.Parser();
-        parser.registerRemote(service, origin);
+        GitRemote.Parser parser = new GitRemote.Parser().registerRemote(service, origin);
         GitRemote remote = parser.parse(cloneUrl);
         assertThat(remote.getOrigin()).isEqualTo(origin);
         assertThat(remote.getPath()).isEqualTo(expectedPath);
@@ -112,23 +111,23 @@ public class GitRemoteTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-    https://scm.company.com/very/long/context/path/org/repo.git,
-    https://scm.company.com:8443/very/long/context/path/org/repo.git
-    http://scm.company.com/very/long/context/path/org/repo.git
-    ssh://scm.company.com:7999/very/long/context/path/org/repo.git
-    ssh://scm.company.com:222/very/long/context/path/org/repo.git
-    ssh://scm.company.com/very/long/context/path/org/repo.git
-    scm.company.com:very/long/context/path/org/repo.git
-    """)
+      https://scm.company.com/very/long/context/path/org/repo.git,
+      https://scm.company.com:8443/very/long/context/path/org/repo.git
+      http://scm.company.com/very/long/context/path/org/repo.git
+      ssh://scm.company.com:7999/very/long/context/path/org/repo.git
+      ssh://scm.company.com:222/very/long/context/path/org/repo.git
+      ssh://scm.company.com/very/long/context/path/org/repo.git
+      scm.company.com:very/long/context/path/org/repo.git
+      """)
     void parseRegisteredRemoteServer(String cloneUrl) {
-        GitRemote.Parser parser = new GitRemote.Parser();
-        parser.registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/very/long/context/path"), List.of(
-          URI.create("https://scm.company.com:8443/very/long/context/path"),
-          URI.create("http://scm.company.com/very/long/context/path"),
-          URI.create("ssh://scm.company.com:7999/very/long/context/path"),
-          URI.create("ssh://scm.company.com:222/very/long/context/path"),
-          URI.create("ssh://scm.company.com/very/long/context/path")
-        ));
+        GitRemote.Parser parser = new GitRemote.Parser()
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("https://scm.company.com/very/long/context/path"), List.of(
+            URI.create("https://scm.company.com:8443/very/long/context/path"),
+            URI.create("http://scm.company.com/very/long/context/path"),
+            URI.create("ssh://scm.company.com:7999/very/long/context/path"),
+            URI.create("ssh://scm.company.com:222/very/long/context/path"),
+            URI.create("ssh://scm.company.com/very/long/context/path")
+          ));
         GitRemote remote = parser.parse(cloneUrl);
         String origin = "scm.company.com/very/long/context/path";
         String expectedPath = "org/repo";

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -184,7 +184,7 @@ public class GitRemoteTest {
       AzureDevOps, dev.azure.com, org/project/repo, true, ssh://git@ssh.dev.azure.com/v3/org/project/repo
       BitbucketCloud, bitbucket.org, org/repo, false, https://bitbucket.org/org/repo.git
       BitbucketCloud, bitbucket.org, org/repo, true, ssh://git@bitbucket.org/org/repo.git
-     
+      
       Bitbucket, scm.company.com/context/bitbucket, org/repo, false, https://scm.company.com/context/bitbucket/scm/org/repo.git
       Bitbucket, scm.company.com/context/bitbucket, org/repo, true, ssh://git@scm.company.com:7999/context/bitbucket/org/repo.git
       GitHub, scm.company.com/context/github, org/repo, false, https://scm.company.com/context/github/org/repo.git
@@ -195,6 +195,9 @@ public class GitRemoteTest {
       
       Bitbucket, scm.company.com:12345/context/bitbucket, org/repo, false, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
       Bitbucket, scm.company.com:12346/context/bitbucket, org/repo, false, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
+      
+      Unknown, scm.unregistered.com/context/path/, org/repo, false, https://scm.unregistered.com/context/path/org/repo.git
+      Unknown, scm.unregistered.com/context/path/, org/repo, true, ssh://scm.unregistered.com/context/path/org/repo.git
       """)
     void buildUri(GitRemote.Service service, String origin, String path, boolean ssh, String expectedUri) {
         GitRemote remote = new GitRemote(service, null, origin, path, null, null);

--- a/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marker/GitProvenanceTest.java
@@ -98,9 +98,10 @@ class GitProvenanceTest {
 
     @ParameterizedTest
     @CsvSource({
-      "git@gitlab.acme.com:organization/subgroup/repository.git, https://gitlab.acme.com, GitLab, organization/subgroup",
-      "git@gitlab.acme.com:organization/subgroup/repository.git, git@gitlab.acme.com, GitLab, organization/subgroup",
-      "git@gitlab.acme.com:organization/subgroup/repository.git, git@gitlab.acme.com, GitLab, organization/subgroup",
+      "https://github.com/organization/repository, https://github.com, GitHub, organization",
+      "git@gitlab.acme.com/organization/subgroup/repository.git, https://gitlab.acme.com, GitLab, organization/subgroup",
+      "git@gitlab.acme.com/organization/subgroup/repository.git, git@gitlab.acme.com, GitLab, organization/subgroup",
+      "git@gitlab.acme.com:organization/subgroup/repository.git, ssh://git@gitlab.acme.com, GitLab, organization/subgroup",
       "https://dev.azure.com/organization/project/_git/repository, https://dev.azure.com, AzureDevOps, organization/project",
       "https://organization@dev.azure.com/organization/project/_git/repository, https://dev.azure.com, AzureDevOps, organization/project",
       "git@ssh.dev.azure.com:v3/organization/project/repository, git@ssh.dev.azure.com, AzureDevOps, organization/project"


### PR DESCRIPTION
## What's changed?
In stead of manipulating URIs and matching on a simple origin, we now register multiple URIs for a remote git server. This way we can indicate the multiple protocols/ports indeed point to the same server.

## What's your motivation?
We can currently get multiple origins for the same server which means we could fail to match.

## Anything in particular you'd like reviewers to focus on?
the `normalizeUri` method

## Anyone you would like to review specifically?
@bryceatmoderne

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
