### PR TITLE
Use correct length for GString substrings

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1457,7 +1457,7 @@ public class GroovyParserVisitor {
                     // The sub-strings within a GString have no delimiters of their own, confusing visitConstantExpression()
                     // ConstantExpression.getValue() cannot be trusted for strings as its values don't match source code because sequences like "\\" have already been replaced with a single "\"
                     // Use the AST element's line/column positions to figure out its extent, but those numbers need tweaks to be correct
-                    int length = sourceLengthOfString(cs);
+                    int length = lengthAccordingToAst(cs);
                     if (i == 0 || i == rawExprs.size() - 1) {
                         // The first and last constants within a GString have line/column position which incorrectly include the GString's delimiters
                         length -= delimiter.length();


### PR DESCRIPTION
## What's changed?
For GString substrings restore the length calculations we saw before https://github.com/openrewrite/rewrite/commit/b1cb4708f9d4acb1ad89c47d8b6d6e8d112b2f52, as this negatively affected projects using Groovy 2.5, or by extension Gradle 5 or 6.

## What's your motivation?
Restore successful parsing for Gradle 5 and 6 projects that use GStrings.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
This was a bit tricky to test, since we use the latest Groovy in rewrite-groovy. I was able to unit test this by adding a quick sample project:
```kts
plugins {
    id("org.openrewrite.build.language-library")
}

dependencies {
    implementation(project(":rewrite-groovy"))
    implementation(project(":rewrite-test"))
    implementation('org.codehaus.groovy:groovy:2.5.23')
}
```
And adding some unit tests there:
```java
package org.openrewrite.groovy.test;

import org.junit.jupiter.api.Test;
import org.openrewrite.FindParseFailures;
import org.openrewrite.groovy.GroovyParser;
import org.openrewrite.test.RecipeSpec;
import org.openrewrite.test.RewriteTest;

import static org.openrewrite.groovy.Assertions.groovy;

class StringOffByOneTest implements RewriteTest {

    @Override
    public void defaults(RecipeSpec spec) {
        spec
          .parser(GroovyParser.builder())
          .recipe(new FindParseFailures(null, null, null));
    }

    @Test
    void plain() {
        rewriteRun(
          groovy(
            """
              def projectDir = "project"
              def location = "src/main/webapp"
              """
          )
        );
    }

    @Test
    void curlyBraced() {
        rewriteRun(
          groovy(
            """
              def projectDir = "project"
              def location = "${projectDir}-src/main/webapp"
              """
          )
        );
    }

    @Test
    void omittedCurlyBraces() {
        rewriteRun(
          groovy(
            """
              def projectDir = "project"
              def location = "$projectDir-src/main/webapp"
              """
          )
        );
    }


    @Test
    void slashyStringStartCharInRegularString() {
        rewriteRun(
          groovy(
            """
              def projectDir = "project"
              def location = "$projectDir/src/main/webapp"
              """
          )
        );
    }

    @Test
    void slashyString() { // Fails still
        rewriteRun(
          groovy(
            """
              def projectDir = "project"
              def location = /\\/folder/
              """
          )
        );
    }
}
```
We might want to consider adding  a separate module using Groovy 2.5.+ for the purpose of catching these regressions.