### PR TITLE
fix: do not replace jgit in clone url (regex issue)

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -250,7 +250,7 @@ public class GitRemote {
                 String maybePort = maybePort(uri.getPort(), scheme);
 
                 String path = uri.getPath().replaceFirst("/$", "")
-                        .replaceFirst(".git$", "")
+                        .replaceFirst("\\.git$", "")
                         .replaceFirst("^/", "");
                 return URI.create((scheme + "://" + host + maybePort + "/" + path).replaceFirst("/$", ""));
             } catch (URISyntaxException e) {

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -218,4 +218,11 @@ public class GitRemoteTest {
         IllegalArgumentException ex = catchThrowableOfType(IllegalArgumentException.class, () -> new GitRemote.Parser().toUri(remote, "ssh"));
         assertThat(ex).isNotNull().hasMessageContaining("Unable to determine protocol/port combination for an unregistered origin with a port");
     }
+
+    @Test
+    void shouldNotStripJgit(){
+        GitRemote.Parser parser = new GitRemote.Parser();
+        GitRemote remote = parser.parse("https://github.com/openrewrite/jgit");
+        assertThat(remote.getPath()).isEqualTo("openrewrite/jgit");
+    }
 }


### PR DESCRIPTION
the `.replaceFirst(".git$", "")` is supposed to strip off `.git` at the end of a clone url, but in the following clone url `https://github.com/openrewrite/jgit` it also matches the regex because `.` is not escaped