### PR TITLE
Add method to find a `GitRemote.RemoteServer` registered to the `GitRemote.Parser`

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -224,5 +225,19 @@ public class GitRemoteTest {
         GitRemote.Parser parser = new GitRemote.Parser();
         GitRemote remote = parser.parse("https://github.com/openrewrite/jgit");
         assertThat(remote.getPath()).isEqualTo("openrewrite/jgit");
+    }
+
+    @Test
+    void findRemote() {
+        GitRemote.Parser parser = new GitRemote.Parser()
+          .registerRemote(GitRemote.Service.Bitbucket, URI.create("scm.company.com/stash"), Collections.emptyList());
+        assertThat(parser.findRemoteServer("github.com").getService()).isEqualTo(GitRemote.Service.GitHub);
+        assertThat(parser.findRemoteServer("gitlab.com").getService()).isEqualTo(GitRemote.Service.GitLab);
+        assertThat(parser.findRemoteServer("bitbucket.org").getService()).isEqualTo(GitRemote.Service.BitbucketCloud);
+        assertThat(parser.findRemoteServer("dev.azure.com").getService()).isEqualTo(GitRemote.Service.AzureDevOps);
+        assertThat(parser.findRemoteServer("scm.company.com/stash").getService()).isEqualTo(GitRemote.Service.Bitbucket);
+        assertThat(parser.findRemoteServer("scm.unregistered.com").getService()).isEqualTo(GitRemote.Service.Unknown);
+        assertThat(parser.findRemoteServer("scm.unregistered.com").getOrigin()).isEqualTo("scm.unregistered.com");
+        assertThat(parser.findRemoteServer("https://scm.unregistered.com").getOrigin()).isEqualTo("scm.unregistered.com");
     }
 }


### PR DESCRIPTION
## What's changed?
Add a method to find out if a remote server is registered by (possibly not normalized) origin

## What's your motivation?
Knowledge is power

## Anything in particular you'd like reviewers to focus on?
Am I using `@Nullable` like the cool kids do?

## Anyone you would like to review specifically?
@timtebeek @bryceatmoderne 

## Have you considered any alternatives or workarounds?
guessing if a server is registered by random dice roll

## Any additional context
no

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
