### PR TITLE
Only extract annotations with template comment

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -101,12 +101,13 @@ public class AnnotationTemplateGenerator {
 
             @Override
             public J.Annotation visitAnnotation(J.Annotation annotation, Integer integer) {
-                J.Annotation withoutTemplateComment = annotation.withComments(
-                        ListUtils.concatAll(
-                                ListUtils.map(getCursor().getParentOrThrow().<J>getValue().getComments(), this::filterTemplateComment),
-                                ListUtils.map(annotation.getComments(), this::filterTemplateComment)
-                        ));
-                annotations.add(withoutTemplateComment);
+                List<Comment> combinedComments = ListUtils.concatAll(
+                        getCursor().getParentOrThrow().<J>getValue().getComments(),
+                        annotation.getComments());
+                List<Comment> filteredComments = ListUtils.map(combinedComments, this::filterTemplateComment);
+                if (combinedComments != filteredComments) {
+                    annotations.add(annotation.withComments(filteredComments));
+                }
                 return annotation;
             }
         }.visit(cu, 0);

--- a/rewrite-java/src/test/java/org/openrewrite/java/ReplaceAnnotationTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ReplaceAnnotationTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -39,7 +40,7 @@ class ReplaceAnnotationTest implements RewriteTest {
                       String testMethod() {}
                   }
                   """,
-                  """
+                """
                   import lombok.NonNull;
 
                   class A {
@@ -65,7 +66,7 @@ class ReplaceAnnotationTest implements RewriteTest {
                       String testMethod() {}
                   }
                   """,
-                  """
+                """
                   import lombok.NonNull;
 
                   class A {
@@ -96,6 +97,38 @@ class ReplaceAnnotationTest implements RewriteTest {
                   class A {
                       @NotNull("Test")
                       String testMethod() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite/issues/4441")
+        void methodWithAnnotatedParameter() {
+            rewriteRun(
+              spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull", "@lombok.NonNull", null)),
+              java(
+                """
+                  import org.jetbrains.annotations.NotNull;
+                  import org.jetbrains.annotations.Nullable;
+
+                  class A {
+                      void methodName(
+                          @Nullable final boolean valueVar) {
+                          @NotNull final String nullableVar = "test";
+                      }
+                  }
+                  """,
+                """
+                  import lombok.NonNull;
+                  import org.jetbrains.annotations.Nullable;
+
+                  class A {
+                      void methodName(
+                          @Nullable final boolean valueVar) {
+                          @NonNull final String nullableVar = "test";
+                      }
                   }
                   """
               )


### PR DESCRIPTION
Before we extracted all annotations; now only annotations with the template comment, avoiding confusion as to what annotation gets replaced.

- Fixes https://github.com/openrewrite/rewrite/issues/4441