### PR TITLE
Do not change package when non-recursive

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -71,6 +71,15 @@ class ChangePackageTest implements RewriteTest {
               class Test {
               }
               """
+          ),
+          java(
+            """
+              package org.openrewrite.internal.one;
+              import org.openrewrite.internal.two.*;
+              class Test {
+              
+              }
+              """
           )
         );
     }
@@ -338,7 +347,7 @@ class ChangePackageTest implements RewriteTest {
     }
 
     @Test
-    void renamePackageRecursive() {
+    void renamePackageRecursiveByDefault() {
         rewriteRun(
           java(
             """
@@ -1156,7 +1165,7 @@ class ChangePackageTest implements RewriteTest {
     @Test
     void typeInNestedPackageInheritingFromTypeInBasePackage() {
         rewriteRun(
-          spec -> spec.recipe(new ChangePackage("java.util", "util", null)),
+          spec -> spec.recipe(new ChangePackage("java.util", "util", false)),
           java(
             """
               import java.util.concurrent.ConcurrentHashMap;

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -88,14 +88,14 @@ public class ChangePackage extends Recipe {
             public @Nullable J preVisit(J tree, ExecutionContext ctx) {
                 if (tree instanceof JavaSourceFile) {
                     JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+                    boolean recursive = ChangePackage.this.recursive == null || ChangePackage.this.recursive;
                     if (cu.getPackageDeclaration() != null) {
                         String original = cu.getPackageDeclaration().getExpression()
                                 .printTrimmed(getCursor()).replaceAll("\\s", "");
-                        if (original.startsWith(oldPackageName)) {
+                        if (original.equals(oldPackageName) || recursive && original.startsWith(oldPackageName)) {
                             return SearchResult.found(cu);
                         }
                     }
-                    boolean recursive = Boolean.TRUE.equals(ChangePackage.this.recursive);
                     String recursivePackageNamePrefix = oldPackageName + ".";
                     for (J.Import anImport : cu.getImports()) {
                         String importedPackage = anImport.getPackageName();


### PR DESCRIPTION
Add unit test as reported via Slack by @BhavanaPidapa; update precondition to evaluate recursive boolean for package declaration too.