### PR TITLE
Force lowercase urls and origins in `GitRemote`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -266,7 +266,7 @@ public class GitRemote {
                 String path = uri.getPath().replaceFirst("/$", "")
                         .replaceFirst("\\.git$", "")
                         .replaceFirst("^/", "");
-                return URI.create((scheme + "://" + host + maybePort + "/" + path).replaceFirst("/$", ""));
+                return URI.create((scheme + "://" + host + maybePort + "/" + path).replaceFirst("/$", "").toLowerCase());
             } catch (URISyntaxException e) {
                 throw new IllegalStateException("Unable to parse origin from: " + url, e);
             }
@@ -305,8 +305,12 @@ public class GitRemote {
 
         public RemoteServer(Service service, String origin, Collection<URI> uris) {
             this.service = service;
-            this.origin = origin;
-            this.uris.addAll(uris);
+            this.origin = origin.toLowerCase();
+            this.uris.addAll(uris.stream()
+                    .map(URI::toString)
+                    .map(String::toLowerCase)
+                    .map(URI::create)
+                    .collect(Collectors.toList()));
         }
 
         private GitRemote.Parser.@Nullable RemoteServerMatch match(URI normalizedUri) {

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -231,7 +231,8 @@ public class GitRemote {
 
         private static final Pattern PORT_PATTERN = Pattern.compile(":\\d+");
 
-        static URI normalize(String url) {
+        static URI normalize(String original) {
+            String url = original.toLowerCase(Locale.ENGLISH);
             try {
                 URIish uri = new URIish(url);
                 String scheme = uri.getScheme();

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -266,7 +266,7 @@ public class GitRemote {
                 String path = uri.getPath().replaceFirst("/$", "")
                         .replaceFirst("\\.git$", "")
                         .replaceFirst("^/", "");
-                return URI.create((scheme + "://" + host + maybePort + "/" + path).replaceFirst("/$", "").toLowerCase());
+                return URI.create((scheme + "://" + host + maybePort + "/" + path).replaceFirst("/$", "").toLowerCase(Locale.ENGLISH));
             } catch (URISyntaxException e) {
                 throw new IllegalStateException("Unable to parse origin from: " + url, e);
             }
@@ -305,10 +305,10 @@ public class GitRemote {
 
         public RemoteServer(Service service, String origin, Collection<URI> uris) {
             this.service = service;
-            this.origin = origin.toLowerCase();
+            this.origin = origin.toLowerCase(Locale.ENGLISH);
             this.uris.addAll(uris.stream()
                     .map(URI::toString)
-                    .map(String::toLowerCase)
+                    .map(urlString -> urlString.toLowerCase(Locale.ENGLISH))
                     .map(URI::create)
                     .collect(Collectors.toList()));
         }

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -86,9 +86,9 @@ public class GitRemoteTest {
       https://scm.company.com:443/stash/scm/org/repo.git, scm.company.com/stash, Bitbucket, scm.company.com/stash, org/repo,  org, repo
       https://scm.company.com:1234/stash/scm/org/repo.git, https://scm.company.com:1234/stash, Bitbucket, scm.company.com:1234/stash, org/repo, org, repo
       git@scm.company.com:stash/org/repo.git, scm.company.com/stash, Bitbucket, scm.company.com/stash, org/repo, org, repo
-      ssh://scm.company.com/stash/org/repo, scm.company.com/stash, Bitbucket, scm.company.com/stash, org/repo, org, repo
+      ssh://scm.CompanY.com/stash/org/repo, scm.cOMpAnY.com/stash, Bitbucket, scm.company.com/stash, org/repo, org, repo
       ssh://scm.company.com:22/stash/org/repo, scm.company.com/stash, Bitbucket, scm.company.com/stash, org/repo, org, repo
-      ssh://scm.company.com:7999/stash/org/repo, ssh://scm.company.com:7999/stash, Bitbucket, scm.company.com:7999/stash, org/repo, org, repo
+      ssh://scm.company.com:7999/stash/org/repo, ssh://sCm.company.com:7999/stash, Bitbucket, scm.company.com:7999/stash, org/repo, org, repo
       
       https://scm.company.com/very/long/context/path/org/repo.git, scm.company.com/very/long/context/path, Bitbucket, scm.company.com/very/long/context/path, org/repo, org, repo
       https://scm.company.com:1234/very/long/context/path/org/repo.git, https://scm.company.com:1234/very/long/context/path, Bitbucket, scm.company.com:1234/very/long/context/path, org/repo, org, repo
@@ -100,7 +100,7 @@ public class GitRemoteTest {
       git@scm.company.com:group/subgroup/subergroup/subestgroup/repo.git, ssh://scm.company.com, GitLab, scm.company.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       https://scm.company.com:443/group/subgroup/subergroup/subestgroup/repo.git, scm.company.com, GitLab, scm.company.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       ssh://scm.company.com:22/group/subgroup/subergroup/subestgroup/repo.git, ssh://scm.company.com, GitLab, scm.company.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
-      ssh://scm.company.com:222/group/subgroup/subergroup/subestgroup/repo.git, ssh://scm.company.com:222, GitLab, scm.company.com:222, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
+      ssh://SCM.COMPANY.COM:222/group/subgroup/subergroup/subestgroup/repo.git, ssh://SCM.CoMpAnY.cOm:222, GitLab, scm.company.com:222, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       
       https://scm.company.com/very/long/context/path/group/subgroup/subergroup/subestgroup/repo, scm.company.com/very/long/context/path, GitLab, scm.company.com/very/long/context/path, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       """)

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -39,13 +39,16 @@ public class GitRemoteTest {
       git@gitlab.com:group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       ssh://git@gitlab.com:22/group/subgroup/subergroup/subestgroup/repo.git, gitlab.com, group/subgroup/subergroup/subestgroup/repo, group/subgroup/subergroup/subestgroup, repo
       
-      https://bitbucket.org/PRJ/repo, bitbucket.org, PRJ/repo, PRJ, repo
-      git@bitbucket.org:PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
-      ssh://bitbucket.org/PRJ/repo.git, bitbucket.org, PRJ/repo, PRJ, repo
+      https://bitbucket.org/PRJ/repo, bitbucket.org, prj/repo, prj, repo
+      git@bitbucket.org:PRJ/repo.git, bitbucket.org, prj/repo, prj, repo
+      ssh://bitbucket.org/PRJ/repo.git, bitbucket.org, prj/repo, prj, repo
       
       https://org@dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project, repo
       https://dev.azure.com/org/project/_git/repo, dev.azure.com, org/project/repo, org/project, repo
       git@ssh.dev.azure.com:v3/org/project/repo, dev.azure.com, org/project/repo, org/project, repo
+      
+      HTTPS://GITHUB.COM/ORG/REPO.GIT, github.com, org/repo, org, repo
+      HtTpS://GitHub.CoM/OrG/R3P0.GIT, github.com, org/r3p0, org, r3p0
       """)
     void parseKnownRemotes(String cloneUrl, String expectedOrigin, String expectedPath, String expectedOrganization, String expectedRepositoryName) {
         GitRemote.Parser parser = new GitRemote.Parser();


### PR DESCRIPTION
## What's changed?
Forcing lowercase on all URLs (and origins) registered to GitRemote

## What's your motivation?
This improves the matching by being case insensitive

## Anything in particular you'd like reviewers to focus on?
Should we force the locale?

## Anyone you would like to review specifically?
@bryceatmoderne 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
