### PR TITLE
Fix `ChangeType` issue introduced in #4458

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -1971,4 +1971,52 @@ class ChangeTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldNotFullyQualifyWhenNewTypeIsAlreadyUsed() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType(
+            "org.a.A",
+            "org.ab.AB",
+            true)),
+          java(
+            """
+            package org.a;
+
+            public class A {
+              public static String A = "A";
+            }
+            """),
+          java(
+            """
+            package org.ab;
+
+            public class AB {
+              public static String A = "A";
+              public static String B = "B";
+            }
+            """),
+          // language=java
+          java(
+            """
+              import org.a.A;
+              import org.ab.AB;
+
+              class Letters {
+                String a = A.A;
+                String b = AB.B;
+              }
+              """,
+            """
+              import org.ab.AB;
+
+              class Letters {
+                String a = AB.A;
+                String b = AB.B;
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -518,6 +518,7 @@ public class ChangeType extends Recipe {
                 JavaType.FullyQualified currType = TypeUtils.asFullyQualified(anImport.getQualid().getType());
                 if (currType != null &&
                     !TypeUtils.isOfType(currType, oldType) &&
+                    !TypeUtils.isOfType(currType, newType) &&
                     currType.getClassName().equals(newType.getClassName())) {
                     return false;
                 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Theoretically the `newType` can already be used and therefore we should exclude it from checking ambiguity

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
https://ge.openrewrite.org/s/fyq3wpbm56qgk/tests/task/:test/details/org.openrewrite.apache.httpclient4.CookieConstantsTest/cookieConstantsMapping()?top-execution=1

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
