### PR TITLE
Also exclude omitted dependencies

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ExcludeDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ExcludeDependencyTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.maven;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -232,6 +233,70 @@ class ExcludeDependencyTest implements RewriteTest {
             </dependencies>
           </project>
           """)
+        );
+    }
+
+    @Test
+    void excludeAlsoWhereConflictOmitted() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new ExcludeDependency("org.apache.logging.log4j", "log4j-api", null)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter</artifactId>
+                    <version>2.7.18</version>
+                  </dependency>
+                  <dependency>
+                    <!-- (org.apache.logging.log4j:log4j-api:jar:2.20.0:compile - omitted for conflict with 2.17.2) -->
+                    <groupId>org.opensearch.client</groupId>
+                    <artifactId>spring-data-opensearch-starter</artifactId>
+                    <version>1.3.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter</artifactId>
+                    <version>2.7.18</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                  <dependency>
+                    <!-- (org.apache.logging.log4j:log4j-api:jar:2.20.0:compile - omitted for conflict with 2.17.2) -->
+                    <groupId>org.opensearch.client</groupId>
+                    <artifactId>spring-data-opensearch-starter</artifactId>
+                    <version>1.3.0</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
         );
     }
 }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
When conflicts occur dependencies are omitted; when we then exclude from the conflict, the omitted dependency can resurface. The goal of ExcludeDependency is to fully exclude a dependency, not to see the omitted conflict being used. We should then also add `<exclusion>` where dependencies are omitted.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
