### PR TITLE
Retain default `ChangeType` behavior when dependency conflict cannot be determined

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -307,7 +307,7 @@ public class ChangeType extends Recipe {
                                     .withType(null)
                                     .withPrefix(ident.getPrefix()));
                         } else {
-                            if (sf != null && hasNoConflictingImport(sf)) {
+                            if (hasNoConflictingImport(sf)) {
                                 ident = ident.withSimpleName(((JavaType.FullyQualified) targetType).getClassName());
                             } else {
                                 ident = ident.withSimpleName(((JavaType.FullyQualified) targetType).getFullyQualifiedName());
@@ -508,11 +508,11 @@ public class ChangeType extends Recipe {
             return fq != null && TypeUtils.isOfClassType(fq, originalType.getFullyQualifiedName()) && targetType instanceof JavaType.FullyQualified;
         }
 
-        private boolean hasNoConflictingImport(JavaSourceFile sf) {
+        private boolean hasNoConflictingImport(@Nullable JavaSourceFile sf) {
             JavaType.FullyQualified oldType = TypeUtils.asFullyQualified(originalType);
             JavaType.FullyQualified newType = TypeUtils.asFullyQualified(targetType);
-            if (oldType == null || newType == null) {
-                return false; // No way to be sure
+            if (sf == null || oldType == null || newType == null) {
+                return true; // No way to be sure so we retain previous behaviour
             }
             for (J.Import anImport : sf.getImports()) {
                 JavaType.FullyQualified currType = TypeUtils.asFullyQualified(anImport.getQualid().getType());


### PR DESCRIPTION

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
https://ge.openrewrite.org/s/7acywy46uorxi/tests/task/:test/details/org.openrewrite.java.migrate.javax.UseJoinColumnForMappingTest/useJoinColumnForManyToOneNoAttr()?top-execution=1

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
