### PR TITLE
Case insensitive origin matching

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -240,4 +240,21 @@ public class GitRemoteTest {
         assertThat(parser.findRemoteServer("scm.unregistered.com").getOrigin()).isEqualTo("scm.unregistered.com");
         assertThat(parser.findRemoteServer("https://scm.unregistered.com").getOrigin()).isEqualTo("scm.unregistered.com");
     }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+      https://github.com/org/repo, github.com, org/repo, org, repo
+      https://GITHUB.COM/ORG/REPO, github.com, ORG/REPO, ORG, REPO
+      ssh://GITHUB.COM/ORG/REPO.GIT, github.com, ORG/REPO, ORG, REPO
+      https://DEV.AZURE.COM/ORG/PROJECT/_GIT/REPO, dev.azure.com, ORG/PROJECT/REPO, ORG/PROJECT, REPO
+      GIT@SSH.DEV.AZURE.COM:V3/ORG/PROJECT/REPO, dev.azure.com, ORG/PROJECT/REPO, ORG/PROJECT, REPO
+      """)
+    void parseOriginCaseInsensitive(String cloneUrl, String expectedOrigin, String expectedPath, String expectedOrganization, String expectedRepositoryName) {
+        GitRemote.Parser parser = new GitRemote.Parser();
+        GitRemote remote = parser.parse(cloneUrl);
+        assertThat(remote.getOrigin()).isEqualTo(expectedOrigin);
+        assertThat(remote.getPath()).isEqualTo(expectedPath);
+        assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);
+        assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
+    }
 }


### PR DESCRIPTION
## What's changed?
update `GitRemote` origin matching to be case insensitive

## What's your motivation?
When a clone url has an incorrect or different case we still want to be able to match it against a registered origin.

## Anything in particular you'd like reviewers to focus on?
We're comparing everything case-insensitive except for the protocol. Since the URI parsers do not like that.

## Have you considered any alternatives or workarounds?
We went with lowercasing everything before, but that has more implications and impacts UX

## Any additional context
Lowercasing was released and reverted before.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
