### PR TITLE
Ignore case on GitRemote equals

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -58,7 +58,8 @@ public class GitRemote {
 
     @Override
     public int hashCode() {
-        return Objects.hash(service, url,
+        return Objects.hash(service,
+                url == null ? null : url.toLowerCase(Locale.ENGLISH),
                 origin == null ? null : origin.toLowerCase(Locale.ENGLISH),
                 path == null ? null : path.toLowerCase(Locale.ENGLISH),
                 organization == null ? null : organization.toLowerCase(Locale.ENGLISH),

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -16,6 +16,7 @@
 package org.openrewrite;
 
 import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.jgit.transport.URIish;
@@ -37,6 +38,32 @@ public class GitRemote {
     String organization;
 
     String repositoryName;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GitRemote gitRemote = (GitRemote) o;
+        return service == gitRemote.service &&
+               StringUtils.equalsIgnoreCase(url, gitRemote.url) &&
+               StringUtils.equalsIgnoreCase(origin, gitRemote.origin) &&
+               StringUtils.equalsIgnoreCase(path, gitRemote.path) &&
+               StringUtils.equalsIgnoreCase(organization, gitRemote.organization) &&
+               StringUtils.equalsIgnoreCase(repositoryName, gitRemote.repositoryName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(service, url,
+                origin == null ? null : origin.toLowerCase(Locale.ENGLISH),
+                path == null ? null : path.toLowerCase(Locale.ENGLISH),
+                organization == null ? null : organization.toLowerCase(Locale.ENGLISH),
+                repositoryName == null ? null : repositoryName.toLowerCase(Locale.ENGLISH));
+    }
 
     public enum Service {
         GitHub,

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -257,4 +257,16 @@ public class GitRemoteTest {
         assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);
         assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
     }
+
+    @Test
+    void equalsIgnoresCase() {
+        assertThat(new GitRemote(GitRemote.Service.GitHub, "https://github.com/org/repo", "github.com", "org/repo", "org", "repo"))
+          .isEqualTo(new GitRemote(GitRemote.Service.GitHub, "https://GITHUB.COM/ORG/REPO", "GITHUB.COM", "ORG/REPO", "ORG", "REPO"));
+    }
+
+    @Test
+    void hashCodeIgnoresCase() {
+        assertThat(new GitRemote(GitRemote.Service.GitHub, "https://github.com/org/repo", "github.com", "org/repo", "org", "repo"))
+          .hasSameHashCodeAs(new GitRemote(GitRemote.Service.GitHub, "https://GITHUB.COM/ORG/REPO", "GITHUB.COM", "ORG/REPO", "ORG", "REPO"));
+    }
 }


### PR DESCRIPTION
## What's changed?
Ignore case on `GitRemote` string fields

## What's your motivation?
A git clone URL should be compared case insensivive. All fields (except service) are derivatives

## Have you considered any alternatives or workarounds?
no

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
