### PR TITLE
Add static constructor for `GitRemote.Service` from any previously used name formats

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -44,7 +44,24 @@ public class GitRemote {
         Bitbucket,
         BitbucketCloud,
         AzureDevOps,
-        Unknown
+        Unknown;
+
+        public static Service forName(String serviceName) {
+            switch (serviceName.toLowerCase(Locale.ENGLISH).replaceAll("[-_ ]", "")) {
+                case "github":
+                    return GitHub;
+                case "gitlab":
+                    return GitLab;
+                case "bitbucket":
+                    return Bitbucket;
+                case "bitbucketcloud":
+                    return BitbucketCloud;
+                case "azuredevops":
+                    return AzureDevOps;
+                default:
+                    return Unknown;
+            }
+        }
     }
 
     public static class Parser {

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -257,4 +257,21 @@ public class GitRemoteTest {
         assertThat(remote.getOrganization()).isEqualTo(expectedOrganization);
         assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
     }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+      GitHub, GitHub
+      GITLAB, GitLab
+      bitbucket, Bitbucket
+      BitbucketCloud, BitbucketCloud
+      Bitbucket Cloud, BitbucketCloud
+      BITBUCKET_CLOUD, BitbucketCloud
+      AzureDevOps, AzureDevOps
+      AZURE_DEVOPS, AzureDevOps
+      Azure DevOps, AzureDevOps
+      idontknow, Unknown
+    """)
+    void findServiceForName(String name, GitRemote.Service service){
+        assertThat(GitRemote.Service.forName(name)).isEqualTo(service);
+    }
 }


### PR DESCRIPTION
## What's changed?
Add a static constructor for `GitRemote.Service`

## What's your motivation?
There are a few different places where different cases have been used in configurations like BITBUCKET_CLOUD or BitbucketCloud and it would be nice to have a single helper method to initiate a service.

## Have you considered any alternatives or workarounds?
Doing this on the consuming side

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
