### PR TITLE
Make CreateFileVisitor less opaque by returning if it changed the value

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CreateFileVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CreateFileVisitor.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.marker.SearchResult;
 
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,6 +39,7 @@ public class CreateFileVisitor extends TreeVisitor<Tree, ExecutionContext> {
         SourceFile sourceFile = (SourceFile) requireNonNull(tree);
         if (relativeFileName.equals(sourceFile.getSourcePath())) {
             shouldCreate.set(false);
+            SearchResult.found(sourceFile);
         }
         return sourceFile;
     }


### PR DESCRIPTION
## What's changed?
Changed `CreateFileVisitor` to return `SearchResult.found(sourceFile)` rather than `sourceFile` if it updates the `shouldCreate` boolean.

## What's your motivation?
To allow the visitor to be more easily used in precondition checks - it is currently used as a type of precondition in scanner recipes but is currently alway alone - e.g., when doing an `.and` it will return if any visitor returns the `tree` unchanged which this visitor always does. Currently you don't know if the visitor found the file or not without checking an external variable. 

## Have you considered any alternatives or workarounds?
Yes, I could wrap the visitor, but I don't see any downside to the visitor exposing if it made a change or not.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
