### PR TITLE
`RemoveUnusedImports` should not remove imports for used nested classes

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1907,6 +1907,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3283")
     @Test
     void nestedImport() {
         rewriteRun(
@@ -1947,6 +1948,7 @@ class RemoveUnusedImportsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3283")
     @Test
     void nestedImportStaticInnerClass() {
         rewriteRun(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1906,4 +1906,79 @@ class RemoveUnusedImportsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void nestedImport() {
+        rewriteRun(
+          java(
+            """
+              package foo;
+
+              public interface J {
+                  final class One implements J {}
+                  final class Two implements J {}
+                  final class Three implements J {}
+                  final class Four implements J {}
+                  final class Five implements J {}
+                  final class Six implements J {}
+              }
+              """
+          ),
+          java(
+            """
+              package bar;
+
+              import foo.J;
+              import foo.J.*;
+
+              class Quz {
+                void test() {
+                  J j = null;
+                  One one = null;
+                  Two two = null;
+                  Three three = null;
+                  Four four = null;
+                  Five five = null;
+                  Six six = null;
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedImportStaticInnerClass() {
+        rewriteRun(
+          java(
+            """
+              package com.a.b.c;
+              public final class ParentBaseClass {
+                public static abstract class BaseImplClass {
+                   void foo() {
+                    }
+                }
+              }
+              """
+          ),
+          java(
+            """
+              import com.a.b.c.ParentBaseClass.*;
+              public class MyClass extends BaseImplClass {
+                 @Override
+                 public void foo() {
+                 }
+              }
+              """,
+            """
+              import com.a.b.c.ParentBaseClass.BaseImplClass;
+              public class MyClass extends BaseImplClass {
+                 @Override
+                 public void foo() {
+                 }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -236,7 +236,7 @@ public class RemoveUnusedImports extends Recipe {
 
                             changed = true;
                         } else {
-                            usedWildcardImports.add(((J.FieldAccess) elem.getQualid().getTarget()).toString());
+                            usedWildcardImports.add(elem.getQualid().getTarget().toString());
                         }
                     } else if (combinedTypes.stream().noneMatch(c -> {
                         if ("*".equals(elem.getQualid().getSimpleName())) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -226,7 +226,7 @@ public class RemoveUnusedImports extends Recipe {
                             // add each unfolded import
                             combinedTypes.stream().map(JavaType.FullyQualified::getClassName).sorted().distinct().forEach(type ->
                                     anImport.imports.add(new JRightPadded<>(elem
-                                            .withQualid(qualid.withName(name.withSimpleName(type)))
+                                            .withQualid(qualid.withName(name.withSimpleName(type.substring(type.lastIndexOf('.') + 1))))
                                             .withPrefix(Space.format("\n")), Space.EMPTY, Markers.EMPTY))
                             );
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -236,7 +236,7 @@ public class RemoveUnusedImports extends Recipe {
 
                             changed = true;
                         } else {
-                            usedWildcardImports.add(elem.getPackageName());
+                            usedWildcardImports.add(((J.FieldAccess) elem.getQualid().getTarget()).toString());
                         }
                     } else if (combinedTypes.stream().noneMatch(c -> {
                         if ("*".equals(elem.getQualid().getSimpleName())) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -310,9 +310,7 @@ public interface JavaType {
         public abstract @Nullable FullyQualified getSupertype();
 
         /**
-         * @return The class name without package qualification.
-         * If an inner class, outer/inner classes are separated by '.'.
-         * If a static inner class, outer/inner classes are separated by '$'.
+         * @return The class name without package qualification. If an inner class, outer/inner classes are separated by '.'.
          */
         public String getClassName() {
             String fqn = getFullyQualifiedName();

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -310,11 +310,14 @@ public interface JavaType {
         public abstract @Nullable FullyQualified getSupertype();
 
         /**
-         * @return The class name without package qualification. If an inner class, outer/inner classes are separated by '.'.
+         * @return The class name without package qualification.
+         * If an inner class, outer/inner classes are separated by '.'.
+         * If a static inner class, outer/inner classes are separated by '$'.
          */
         public String getClassName() {
             String fqn = getFullyQualifiedName();
             String className = fqn.substring(fqn.lastIndexOf('.') + 1);
+            className = className.substring(className.lastIndexOf('$') + 1);
             return TypeUtils.toFullyQualifiedName(className);
         }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -317,7 +317,6 @@ public interface JavaType {
         public String getClassName() {
             String fqn = getFullyQualifiedName();
             String className = fqn.substring(fqn.lastIndexOf('.') + 1);
-            className = className.substring(className.lastIndexOf('$') + 1);
             return TypeUtils.toFullyQualifiedName(className);
         }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Some improvements to handling nested inner class imports

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- Fixes https://github.com/openrewrite/rewrite/issues/3283

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
