### PR TITLE
Adding gradle wrapper through distribution is now possible

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -22,16 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.FileAttributes;
-import org.openrewrite.Option;
-import org.openrewrite.PathUtils;
-import org.openrewrite.Preconditions;
-import org.openrewrite.ScanningRecipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.Validated;
+import org.openrewrite.*;
 import org.openrewrite.gradle.search.FindGradleProject;
 import org.openrewrite.gradle.util.DistributionInfos;
 import org.openrewrite.gradle.util.GradleWrapper;
@@ -52,25 +43,11 @@ import org.openrewrite.text.PlainText;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.PathUtils.equalIgnoringSeparators;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_BATCH_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_BATCH_LOCATION_RELATIVE_PATH;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_JAR_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_JAR_LOCATION_RELATIVE_PATH;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_PROPERTIES_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_PROPERTIES_LOCATION_RELATIVE_PATH;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_SCRIPT_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_SCRIPT_LOCATION_RELATIVE_PATH;
+import static org.openrewrite.gradle.util.GradleWrapper.*;
 import static org.openrewrite.internal.StringUtils.isBlank;
 
 @RequiredArgsConstructor
@@ -247,19 +224,19 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
 
                         GradleWrapper gradleWrpr = getGradleWrapper(ctx);
                         if (StringUtils.isBlank(gradleWrpr.getDistributionUrl()) && !StringUtils.isBlank(version) && Semver.validate(version, null)
-                                                                                                                           .getValue() instanceof ExactVersion) {
+                                .getValue() instanceof ExactVersion) {
                             String newDownloadUrl = currentDistributionUrl.replace("\\", "")
-                                                                          .replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-(?:bin|all).zip)",
-                                                                                      "$1" + gradleWrapper.getVersion() + "$3");
+                                    .replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-(?:bin|all).zip)",
+                                            "$1" + gradleWrapper.getVersion() + "$3");
                             gradleWrapper = new GradleWrapper(version, new DistributionInfos(newDownloadUrl, null, null));
                         }
                         String wrapperHost = currentDistributionUrl.substring(0, currentDistributionUrl.lastIndexOf("/")) + "/gradle-";
                         if (StringUtils.isBlank(wrapperUri) && !StringUtils.isBlank(gradleWrpr.getDistributionUrl()) && !gradleWrpr.getPropertiesFormattedUrl().startsWith(wrapperHost)) {
 
                             String newDownloadUrl = gradleWrpr.getDistributionUrl()
-                                                              .replace("\\", "")
-                                                              .replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-(?:bin|all).zip)",
-                                                                          wrapperHost + gradleWrapper.getVersion() + "$3");
+                                    .replace("\\", "")
+                                    .replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-(?:bin|all).zip)",
+                                            wrapperHost + gradleWrapper.getVersion() + "$3");
                             gradleWrapper = new GradleWrapper(gradleWrpr.getVersion(), new DistributionInfos(newDownloadUrl, null, null));
                         }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -223,16 +223,16 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                         String currentDistributionUrl = entry.getValue().getText();
 
                         GradleWrapper gradleWrpr = getGradleWrapper(ctx);
-                        if (StringUtils.isBlank(gradleWrpr.getDistributionUrl()) && !StringUtils.isBlank(version) && Semver.validate(version, null)
-                                .getValue() instanceof ExactVersion) {
+                        if (StringUtils.isBlank(gradleWrpr.getDistributionUrl()) && !StringUtils.isBlank(version) &&
+                            Semver.validate(version, null).getValue() instanceof ExactVersion) {
                             String newDownloadUrl = currentDistributionUrl.replace("\\", "")
                                     .replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-(?:bin|all).zip)",
                                             "$1" + gradleWrapper.getVersion() + "$3");
                             gradleWrapper = new GradleWrapper(version, new DistributionInfos(newDownloadUrl, null, null));
                         }
                         String wrapperHost = currentDistributionUrl.substring(0, currentDistributionUrl.lastIndexOf("/")) + "/gradle-";
-                        if (StringUtils.isBlank(wrapperUri) && !StringUtils.isBlank(gradleWrpr.getDistributionUrl()) && !gradleWrpr.getPropertiesFormattedUrl().startsWith(wrapperHost)) {
-
+                        if (StringUtils.isBlank(wrapperUri) && !StringUtils.isBlank(gradleWrpr.getDistributionUrl()) &&
+                            !gradleWrpr.getPropertiesFormattedUrl().startsWith(wrapperHost)) {
                             String newDownloadUrl = gradleWrpr.getDistributionUrl()
                                     .replace("\\", "")
                                     .replaceAll("(.*gradle-)(\\d+\\.\\d+(?:\\.\\d+)?)(.*-(?:bin|all).zip)",

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -17,15 +17,7 @@ package org.openrewrite.gradle;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.HttpSenderExecutionContextView;
-import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.PathUtils;
-import org.openrewrite.RecipeRun;
-import org.openrewrite.Result;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
+import org.openrewrite.*;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
@@ -41,12 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.*;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
@@ -56,14 +43,9 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_BATCH_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_JAR_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_PROPERTIES_LOCATION;
-import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_SCRIPT_LOCATION;
+import static org.openrewrite.gradle.util.GradleWrapper.*;
 import static org.openrewrite.properties.Assertions.properties;
-import static org.openrewrite.test.SourceSpecs.dir;
-import static org.openrewrite.test.SourceSpecs.other;
-import static org.openrewrite.test.SourceSpecs.text;
+import static org.openrewrite.test.SourceSpecs.*;
 
 @SuppressWarnings("UnusedProperty")
 class UpdateGradleWrapperTest implements RewriteTest {
@@ -631,13 +613,14 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void addWrapperWithCustomDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
-                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {});
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
             }
             return new HttpUrlConnectionSender().send(request);
         };
         HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-                                                                           .setHttpSender(customDistributionHost)
-                                                                           .setLargeFileHttpSender(customDistributionHost);
+          .setHttpSender(customDistributionHost)
+          .setLargeFileHttpSender(customDistributionHost);
         rewriteRun(
           spec -> spec
             .recipe(new UpdateGradleWrapper(null, null, null, "https://company.com/repo/gradle-8.0.2-bin.zip", null))
@@ -677,13 +660,14 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void addWrapperWithCustomDistributionUriAndDistributionChecksum() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
-                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {});
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
             }
             return new HttpUrlConnectionSender().send(request);
         };
         HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-                                                                           .setHttpSender(customDistributionHost)
-                                                                           .setLargeFileHttpSender(customDistributionHost);
+          .setHttpSender(customDistributionHost)
+          .setLargeFileHttpSender(customDistributionHost);
         rewriteRun(
           spec -> spec
             .recipe(new UpdateGradleWrapper(null, null, null, "https://company.com/repo/gradle-8.0.2-bin.zip", wrapperJarChecksum))
@@ -693,9 +677,9 @@ class UpdateGradleWrapperTest implements RewriteTest {
                 var gradleWrapperProperties = result(run, Properties.File.class, "gradle-wrapper.properties");
                 assertThat(gradleWrapperProperties.getSourcePath()).isEqualTo(WRAPPER_PROPERTIES_LOCATION);
                 assertThat(gradleWrapperProperties.getContent().stream()
-                                       .filter(Properties.Entry.class::isInstance)
-                                       .map(Properties.Entry.class::cast)
-                                       .anyMatch(prop -> "distributionSha256Sum".equals(prop.getKey()) && wrapperJarChecksum.equals(prop.getValue().getText()))).isTrue();
+                  .filter(Properties.Entry.class::isInstance)
+                  .map(Properties.Entry.class::cast)
+                  .anyMatch(prop -> "distributionSha256Sum".equals(prop.getKey()) && wrapperJarChecksum.equals(prop.getValue().getText()))).isTrue();
             }),
           buildGradle(
             """
@@ -711,13 +695,14 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void migrateToCustomDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
-                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {});
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
             }
             return new HttpUrlConnectionSender().send(request);
         };
         HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-                                                                           .setHttpSender(customDistributionHost)
-                                                                           .setLargeFileHttpSender(customDistributionHost);
+          .setHttpSender(customDistributionHost)
+          .setLargeFileHttpSender(customDistributionHost);
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper(null, null, null, "https://company.com/repo/gradle-8.10-bin.zip", null))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -749,17 +734,18 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void removeShaDuringMigrationToCustomDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
-                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {});
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
             }
             return new HttpUrlConnectionSender().send(request);
         };
         HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-                                                                           .setHttpSender(customDistributionHost)
-                                                                           .setLargeFileHttpSender(customDistributionHost);
+          .setHttpSender(customDistributionHost)
+          .setLargeFileHttpSender(customDistributionHost);
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper(null, null, null, "https://company.com/repo/gradle-8.10-bin.zip", null))
-                      .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
-                      .executionContext(ctx),
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
+            .executionContext(ctx),
           properties(
             """
               distributionBase=GRADLE_USER_HOME
@@ -788,17 +774,18 @@ class UpdateGradleWrapperTest implements RewriteTest {
     void updateWithCustomDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
-                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {});
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
             }
             return new HttpUrlConnectionSender().send(request);
         };
         HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-                                                                           .setHttpSender(customDistributionHost)
-                                                                           .setLargeFileHttpSender(customDistributionHost);
+          .setHttpSender(customDistributionHost)
+          .setLargeFileHttpSender(customDistributionHost);
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("8.10", null, null, null, null))
-                      .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
-                      .executionContext(ctx),
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
+            .executionContext(ctx),
           properties(
             """
               distributionBase=GRADLE_USER_HOME
@@ -867,17 +854,18 @@ class UpdateGradleWrapperTest implements RewriteTest {
                 throw new RuntimeException("I'm sorry Dave, I'm afraid I can't do that.");
             }
             if (request.getUrl().toString().contains("company.com")) {
-                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {});
+                return new HttpSender.Response(200, UpdateGradleWrapperTest.class.getClassLoader().getResourceAsStream("gradle-8.10-bin.zip"), () -> {
+                });
             }
             return new HttpUrlConnectionSender().send(request);
         };
         HttpSenderExecutionContextView ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-                                                                           .setHttpSender(unhelpfulSender)
-                                                                           .setLargeFileHttpSender(unhelpfulSender);
+          .setHttpSender(unhelpfulSender)
+          .setLargeFileHttpSender(unhelpfulSender);
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("8.10", null, null, null, null))
-                      .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
-                      .executionContext(ctx),
+            .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
+            .executionContext(ctx),
           properties(
             """
               distributionBase=GRADLE_USER_HOME

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -16,8 +16,18 @@
 package org.openrewrite.gradle;
 
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.*;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.HttpSenderExecutionContextView;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.PathUtils;
+import org.openrewrite.RecipeRun;
+import org.openrewrite.Result;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
@@ -33,7 +43,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
@@ -76,6 +91,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
     @Test
     @DocumentExample("Add a new Gradle wrapper")
+    @Disabled
     void addGradleWrapper() {
         rewriteRun(
           spec -> spec.expectedCyclesThatMakeChanges(1).afterRecipe(run -> {
@@ -112,6 +128,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
     @Test
     @DocumentExample("Update existing Gradle wrapper")
+    @Disabled
     void updateWrapper() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -162,6 +179,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void updateVersionAndDistribution() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -202,6 +220,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void updateChecksumAlreadySet() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -246,6 +265,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void updateMultipleWrappers() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -367,6 +387,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void allowUpdatingDistributionTypeWhenSameVersion() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("5.6.x", "bin", null, null, null))
@@ -408,6 +429,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void defaultsToLatestRelease() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper(null, null, null, null, null))
@@ -469,6 +491,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void skipWorkIfUpdatedEarlier() {
         rewriteRun(
           spec -> spec.recipeFromYaml(
@@ -696,6 +719,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void customDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
@@ -765,13 +789,14 @@ class UpdateGradleWrapperTest implements RewriteTest {
               """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
           ),
-          gradlew,
-          gradlewBat,
+          text(GRADLEW_TEXT, spec -> spec.path(WRAPPER_SCRIPT_LOCATION)),
+          text(GRADLEW_BAT_TEXT, spec -> spec.path(WRAPPER_BATCH_LOCATION)),
           gradleWrapperJarQuark
         );
     }
 
     @Test
+    @Disabled
     void updateWrapperInSubDirectory() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -825,6 +850,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
     void failRecipeIfBothVersionAndDistributionUriAreProvided() {
         assertThat(new UpdateGradleWrapper("7.4.2", "bin", false, "https://company.com/repo/gradle-7.4.2-bin.zip", null).validate().isInvalid()).isTrue();
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -529,7 +529,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    void preferExistingDistributionSource() {
+    void getExactVersionWithPatternFromGradleServices() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("8.0.x", null, null, null, null))
             .allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4"))),
@@ -770,6 +770,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2651")
     void updateWithCustomDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.gradle;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
@@ -91,7 +90,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
     @Test
     @DocumentExample("Add a new Gradle wrapper")
-    @Disabled
     void addGradleWrapper() {
         rewriteRun(
           spec -> spec.expectedCyclesThatMakeChanges(1).afterRecipe(run -> {
@@ -128,7 +126,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
     @Test
     @DocumentExample("Update existing Gradle wrapper")
-    @Disabled
     void updateWrapper() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -179,7 +176,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void updateVersionAndDistribution() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -220,7 +216,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void updateChecksumAlreadySet() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -265,7 +260,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void updateMultipleWrappers() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -387,7 +381,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void allowUpdatingDistributionTypeWhenSameVersion() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper("5.6.x", "bin", null, null, null))
@@ -429,7 +422,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void defaultsToLatestRelease() {
         rewriteRun(
           spec -> spec.recipe(new UpdateGradleWrapper(null, null, null, null, null))
@@ -491,7 +483,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void skipWorkIfUpdatedEarlier() {
         rewriteRun(
           spec -> spec.recipeFromYaml(
@@ -719,7 +710,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void customDistributionUri() {
         HttpSender customDistributionHost = request -> {
             if (request.getUrl().toString().contains("company.com")) {
@@ -796,7 +786,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void updateWrapperInSubDirectory() {
         rewriteRun(
           spec -> spec.allSources(source -> source.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Gradle, "7.4")))
@@ -850,7 +839,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
     void failRecipeIfBothVersionAndDistributionUriAreProvided() {
         assertThat(new UpdateGradleWrapper("7.4.2", "bin", false, "https://company.com/repo/gradle-7.4.2-bin.zip", null).validate().isInvalid()).isTrue();
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -58,7 +58,6 @@ class UpdateGradleWrapperTest implements RewriteTest {
     private static final String GRADLEW_TEXT = StringUtils.readFully(UpdateGradleWrapperTest.class.getResourceAsStream("gradlew-7.4.2"));
     private static final String GRADLEW_BAT_TEXT = StringUtils.readFully(UpdateGradleWrapperTest.class.getResourceAsStream("gradlew-7.4.2.bat"));
 
-
     private final SourceSpecs gradlew = text("", spec -> spec.path(WRAPPER_SCRIPT_LOCATION).after(notEmpty));
     private final SourceSpecs gradlewBat = text("", spec -> spec.path(WRAPPER_BATCH_LOCATION).after(notEmpty));
     private final SourceSpecs gradleWrapperJarQuark = other("", spec -> spec.path(WRAPPER_JAR_LOCATION));

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -854,8 +854,8 @@ class UpdateGradleWrapperTest implements RewriteTest {
               """,
             spec -> spec.path("gradle/wrapper/gradle-wrapper.properties")
           ),
-          gradlew,
-          gradlewBat,
+          text(GRADLEW_TEXT, spec -> spec.path(WRAPPER_SCRIPT_LOCATION)),
+          text(GRADLEW_BAT_TEXT, spec -> spec.path(WRAPPER_BATCH_LOCATION)),
           gradleWrapperJarQuark
         );
     }


### PR DESCRIPTION
- Fixes #4490

By allowing only distributionUri OR version/distribution, we also no longer use gradle services to determine the version which could not be available on the distributionUrl

Follow up from
- https://github.com/openrewrite/rewrite/pull/4445