### PR TITLE
RemoveRedundantDependencyVersions handles pluginManagement incorrectly

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -42,9 +42,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     static final XPathMatcher PROFILE_MANAGED_DEPENDENCY_MATCHER = new XPathMatcher("/project/profiles/profile/dependencyManagement/dependencies/dependency");
     static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
     static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("//plugins/plugin");
-    static final XPathMatcher MANAGED_PLUGIN_MATCHER = new XPathMatcher("///pluginManagement/plugins/plugin");
+    static final XPathMatcher MANAGED_PLUGIN_MATCHER = new XPathMatcher("//pluginManagement/plugins/plugin");
     static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
-
 
     private transient Xml.@Nullable Document document;
 
@@ -408,10 +407,9 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     public @Nullable Plugin findManagedPlugin(Xml.Tag tag) {
         for (Plugin resolvedPlugin : getResolutionResult().getPom().getPluginManagement()) {
             String reqGroup = resolvedPlugin.getGroupId();
-            String artifactId = resolvedPlugin.getArtifactId();
             String reqVersion = resolvedPlugin.getVersion();
             if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                (artifactId == null || artifactId.equals(tag.getChildValue("artifactId").orElse(null)) )&&
+                resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
                 (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
                 return resolvedPlugin;
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -399,8 +399,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         return findPlugin(tag, getResolutionResult().getPom().getPluginManagement());
     }
 
-    private static @Nullable Plugin findPlugin(Xml.Tag tag, List<Plugin> pluginManagement) {
-        for (Plugin resolvedPlugin : pluginManagement) {
+    private static @Nullable Plugin findPlugin(Xml.Tag tag, List<Plugin> plugins) {
+        for (Plugin resolvedPlugin : plugins) {
             String reqGroup = resolvedPlugin.getGroupId();
             String reqVersion = resolvedPlugin.getVersion();
             if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -42,6 +42,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     static final XPathMatcher PROFILE_MANAGED_DEPENDENCY_MATCHER = new XPathMatcher("/project/profiles/profile/dependencyManagement/dependencies/dependency");
     static final XPathMatcher PROPERTY_MATCHER = new XPathMatcher("/project/properties/*");
     static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("//plugins/plugin");
+    static final XPathMatcher MANAGED_PLUGIN_MATCHER = new XPathMatcher("///pluginManagement/plugins/plugin");
     static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
 
 
@@ -221,6 +222,10 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         return isPluginTag() && hasPluginGroupId(groupId) && hasPluginArtifactId(artifactId);
     }
 
+    public boolean isManagedPluginTag() {
+        return isTag("plugin") && MANAGED_PLUGIN_MATCHER.matches(getCursor());
+    }
+
     private boolean hasPluginGroupId(String groupId) {
         Xml.Tag tag = getCursor().getValue();
         boolean isGroupIdFound = matchesGlob(tag.getChildValue("groupId").orElse("org.apache.maven.plugins"), groupId);
@@ -388,16 +393,27 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     }
 
     public @Nullable Plugin findPlugin(Xml.Tag tag) {
-        List<Plugin> plugins = getResolutionResult().getPom().getPlugins();
-        if (plugins != null) {
-            for (Plugin resolvedPlugin : plugins) {
-                String reqGroup = resolvedPlugin.getGroupId();
-                String reqVersion = resolvedPlugin.getVersion();
-                if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                    resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                    (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
-                    return resolvedPlugin;
-                }
+        for (Plugin resolvedPlugin : getResolutionResult().getPom().getPlugins()) {
+            String reqGroup = resolvedPlugin.getGroupId();
+            String reqVersion = resolvedPlugin.getVersion();
+            if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
+                resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
+                return resolvedPlugin;
+            }
+        }
+        return null;
+    }
+
+    public @Nullable Plugin findManagedPlugin(Xml.Tag tag) {
+        for (Plugin resolvedPlugin : getResolutionResult().getPom().getPluginManagement()) {
+            String reqGroup = resolvedPlugin.getGroupId();
+            String artifactId = resolvedPlugin.getArtifactId();
+            String reqVersion = resolvedPlugin.getVersion();
+            if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
+                (artifactId == null || artifactId.equals(tag.getChildValue("artifactId").orElse(null)) )&&
+                (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
+                return resolvedPlugin;
             }
         }
         return null;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -392,20 +392,15 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     }
 
     public @Nullable Plugin findPlugin(Xml.Tag tag) {
-        for (Plugin resolvedPlugin : getResolutionResult().getPom().getPlugins()) {
-            String reqGroup = resolvedPlugin.getGroupId();
-            String reqVersion = resolvedPlugin.getVersion();
-            if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
-                return resolvedPlugin;
-            }
-        }
-        return null;
+        return findPlugin(tag, getResolutionResult().getPom().getPlugins());
     }
 
     public @Nullable Plugin findManagedPlugin(Xml.Tag tag) {
-        for (Plugin resolvedPlugin : getResolutionResult().getPom().getPluginManagement()) {
+        return findPlugin(tag, getResolutionResult().getPom().getPluginManagement());
+    }
+
+    private static @Nullable Plugin findPlugin(Xml.Tag tag, List<Plugin> pluginManagement) {
+        for (Plugin resolvedPlugin : pluginManagement) {
             String reqGroup = resolvedPlugin.getGroupId();
             String reqVersion = resolvedPlugin.getVersion();
             if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -39,7 +39,7 @@ import static org.openrewrite.internal.StringUtils.matchesGlob;
 public class RemoveRedundantDependencyVersions extends Recipe {
     @Option(displayName = "Group",
             description = "Group glob expression pattern used to match dependencies that should be managed." +
-                    "Group is the first part of a dependency coordinate `com.google.guava:guava:VERSION`.",
+                          "Group is the first part of a dependency coordinate `com.google.guava:guava:VERSION`.",
             example = "com.google.*",
             required = false)
     @Nullable
@@ -47,7 +47,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
 
     @Option(displayName = "Artifact",
             description = "Artifact glob expression pattern used to match dependencies that should be managed." +
-                    "Artifact is the second part of a dependency coordinate `com.google.guava:guava:VERSION`.",
+                          "Artifact is the second part of a dependency coordinate `com.google.guava:guava:VERSION`.",
             example = "guava*",
             required = false)
     @Nullable
@@ -55,8 +55,8 @@ public class RemoveRedundantDependencyVersions extends Recipe {
 
     @Option(displayName = "Only if versions match",
             description = "Only remove the explicit version if it exactly matches the managed dependency version. " +
-                    "When `false` explicit versions will be removed if they are older than or equal to the managed dependency version. " +
-                    "Default `true`.",
+                          "When `false` explicit versions will be removed if they are older than or equal to the managed dependency version. " +
+                          "Default `true`.",
             required = false)
     @Nullable
     @Deprecated
@@ -65,8 +65,8 @@ public class RemoveRedundantDependencyVersions extends Recipe {
 
     @Option(displayName = "Only if managed version is ...",
             description = "Only remove the explicit version if the managed version has the specified comparative relationship to the explicit version. " +
-                    "For example, `gte` will only remove the explicit version if the managed version is the same or newer. " +
-                    "Default `eq`.",
+                          "For example, `gte` will only remove the explicit version if the managed version is the same or newer. " +
+                          "Default `eq`.",
             valid = {"any", "eq", "lt", "lte", "gt", "gte"},
             required = false)
     @Nullable
@@ -74,7 +74,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
 
     @Option(displayName = "Except",
             description = "Accepts a list of GAVs. Dependencies matching a GAV will be ignored by this recipe."
-                    + " GAV versions are ignored if provided.",
+                          + " GAV versions are ignored if provided.",
             example = "com.jcraft:jsch",
             required = false)
     @Nullable
@@ -121,7 +121,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
     @Override
     public String getDescription() {
         return "Remove explicitly-specified dependency/plugin versions when a parent POM's `dependencyManagement`/`pluginManagement` " +
-                "specifies the version.";
+               "specifies the version.";
     }
 
     @Override
@@ -353,8 +353,8 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                     final String[] split = gav.split(":");
                     final String exceptedGroupId = split[0];
                     final String exceptedArtifactId = split[1];
-                    if (matchesGlob(d.getGroupId(), exceptedGroupId)
-                            && matchesGlob(d.getArtifactId(), exceptedArtifactId)) {
+                    if (matchesGlob(d.getGroupId(), exceptedGroupId) &&
+                        matchesGlob(d.getArtifactId(), exceptedArtifactId)) {
                         return false;
                     }
                 }
@@ -368,7 +368,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
             if (Objects.equals(
                     Optional.ofNullable(p.getGroupId()).orElse("org.apache.maven.plugins"),
                     Optional.ofNullable(groupId).orElse("org.apache.maven.plugins")) &&
-                    Objects.equals(p.getArtifactId(), artifactId)) {
+                Objects.equals(p.getArtifactId(), artifactId)) {
                 return resolvedPom.getValue(p.getVersion());
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -365,7 +365,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
     }
 
     private static @Nullable String getManagedPluginVersion(ResolvedPom resolvedPom, @Nullable String groupId, String artifactId) {
-        for (Plugin p : resolvedPom.getPluginManagement()) {
+        for (Plugin p : ListUtils.concatAll(resolvedPom.getPluginManagement(), resolvedPom.getRequested().getPluginManagement())) {
             if (Objects.equals(
                     Optional.ofNullable(p.getGroupId()).orElse("org.apache.maven.plugins"),
                     Optional.ofNullable(groupId).orElse("org.apache.maven.plugins")) &&

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
@@ -1116,6 +1116,65 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
+    void removeRedundantVersionsFromManagedPlugins() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>pl.project13.maven</groupId>
+                              <artifactId>git-commit-id-plugin</artifactId>
+                              <version>4.9.10</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>pl.project13.maven</groupId>
+                              <artifactId>git-commit-id-plugin</artifactId>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3932")
     void removeRedundantVersionsFromPluginsManagedByParent() {
         rewriteRun(
@@ -1163,6 +1222,116 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                               <artifactId>git-commit-id-plugin</artifactId>
                           </plugin>
                       </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantManagedVersionFromPluginsManagedByParentAndKeepOtherElements() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencyVersions(null, null, RemoveRedundantDependencyVersions.Comparator.GTE, null)),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.18</version>
+                      <relativePath/>
+                  </parent>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                                  <configuration><whatever /></configuration>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.18</version>
+                      <relativePath/>
+                  </parent>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <configuration><whatever /></configuration>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantManagedPluginWhenPluginManagedByParentAndNoOtherElement() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencyVersions(null, null, RemoveRedundantDependencyVersions.Comparator.GTE, null)),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.18</version>
+                      <relativePath/>
+                  </parent>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.18</version>
+                      <relativePath/>
+                  </parent>
+                  <build>
                   </build>
               </project>
               """

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
@@ -1175,6 +1175,67 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
+    void removeRedundantVersionsFromManagedButNonInheritedPlugins() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                                  <inherited>false</inherited>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>pl.project13.maven</groupId>
+                              <artifactId>git-commit-id-plugin</artifactId>
+                              <version>4.9.10</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0.0</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                                  <inherited>false</inherited>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>pl.project13.maven</groupId>
+                              <artifactId>git-commit-id-plugin</artifactId>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3932")
     void removeRedundantVersionsFromPluginsManagedByParent() {
         rewriteRun(
@@ -1225,6 +1286,85 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                   </build>
               </project>
               """
+          )
+        );
+    }
+
+    @Test
+    void keepPluginIfParentInheritanceDisabled() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <modules>
+                      <module>child-with-pluginManagement</module>
+                      <module>child-with-plugin-execution</module>
+                  </modules>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>pl.project13.maven</groupId>
+                                  <artifactId>git-commit-id-plugin</artifactId>
+                                  <version>4.9.10</version>
+                                  <inherited>false</inherited>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                  </build>
+              </project>
+              """
+          ),
+          mavenProject("child-with-pluginManagement",
+            pomXml(
+              """
+                <project>
+                    <parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>child-with-pluginManagement</artifactId>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <groupId>pl.project13.maven</groupId>
+                                    <artifactId>git-commit-id-plugin</artifactId>
+                                    <version>4.9.10</version>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """
+            )
+          ),
+          mavenProject("child-with-plugin-execution",
+            pomXml(
+              """
+                <project>
+                    <parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>child-with-plugin-execution</artifactId>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>pl.project13.maven</groupId>
+                                <artifactId>git-commit-id-plugin</artifactId>
+                                <version>4.9.10</version>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """
+            )
           )
         );
     }


### PR DESCRIPTION
I noticed several issues with `RemoveRedundantDependencyVersions` and plugins

- version shouldn't be removed from plugin in `pluginManagement` when no parent already defines it – probably a regression from #4156, the current logic finds the plugin in `pluginManagement` and removes the version since it is managed!
- version should be removed from `pluginManagement` when it matches the parent’s `pluginManagement`
- plugin should be removed from `pluginManagement` when nothing else is left (like for `dependencyManagement`) – need to keep it if there is configuration, executions or anything other than `groupId`, `artifactId` and `version`.

## What's changed?
For now these are just failing unit tests to show the problems.

## What's your motivation?
I would like proper management of plugins by `RemoveRedundantDependencyVersions` :)

## Anything in particular you'd like reviewers to focus on?
In #4156, the definition of `isPluginTag()` was changed to match plugins in `pluginManagement` as well as in profiles. As mentioned there, this breaks any recipe that is not handling that properly.
Moreover, it is inconsistent with `isDependencyTag()` which only matches `/project/dependencies/dependency` (no `dependencyManagement` or `profiles`)

## Anyone you would like to review specifically?
Maybe @timtebeek as he is the one who initiated that change of the base method. It seems the change was much broader than #3962 which inspired it.

## Have you considered any alternatives or workarounds?
I’m not sure what’s the best approach here. We certainly need the `isManagedPluginTag()` that was removed by #4156, and an `isPluginTag()` that does not match managed ones, like `isDependencyTag()`.

#4156 may need to be reverted or altered quite a bit.

## Any additional context
There seems to be more inconsistency between methods in `MavenVisitor`. For example, `isDependencyTag()` does not match managed or profile dependencies, but `isDependencyTag(String, String)` can match profile dependencies.

- #3962
- #4156

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
