### PR TITLE
Use a `HEAD` request to check if a maven server is reachable

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -750,7 +750,7 @@ public class MavenPomDownloader {
                     httpsUri += "/";
                 }
 
-                HttpSender.Request.Builder request = applyAuthenticationToRequest(repository, httpSender.get(httpsUri));
+                HttpSender.Request.Builder request = applyAuthenticationToRequest(repository, httpSender.head(httpsUri));
                 MavenRepository normalized = null;
                 try {
                     sendRequest(request.build());
@@ -792,8 +792,7 @@ public class MavenPomDownloader {
                             }
                         }
                     }
-                    if (normalized == null && !(t instanceof HttpSenderResponseException &&
-                                                ((HttpSenderResponseException) t).getBody().contains("Directory listing forbidden"))) {
+                    if (normalized == null) {
                         ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), t);
                     }
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -889,8 +889,9 @@ class MavenParserTest implements RewriteTest {
                                        it.getSecond().equals("Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes())))) {
                         return resp.setResponseCode(401);
                     } else {
-                        //language=xml
-                        resp.setBody("""
+                        if(!"HEAD".equalsIgnoreCase(request.getMethod())){
+                            //language=xml
+                            resp.setBody("""
                           <project>
                             <modelVersion>4.0.0</modelVersion>
                                                     
@@ -900,7 +901,8 @@ class MavenParserTest implements RewriteTest {
                                                     
                           </project>
                           """
-                        );
+                            );
+                        }
                         return resp.setResponseCode(200);
                     }
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -45,10 +45,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -443,17 +440,21 @@ class MavenPomDownloaderTest {
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    return recordedRequest.getHeaders().get("Authorization") == null ?
-                      new MockResponse().setResponseCode(200).setBody(
-                        //language=xml
-                        """
-                          <project>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dataflow-build</artifactId>
-                              <version>2.10.0-SNAPSHOT</version>
-                          </project>
-                          """) :
-                      new MockResponse().setResponseCode(401).setBody("");
+                    MockResponse response = new MockResponse();
+                    if (recordedRequest.getHeaders().get("Authorization") != null) {
+                        response.setResponseCode(401);
+                    } else if (recordedRequest.getMethod() == null || !recordedRequest.getMethod().equalsIgnoreCase("HEAD")) {
+                        response.setBody(
+                          //language=xml
+                          """
+                            <project>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dataflow-build</artifactId>
+                                <version>2.10.0-SNAPSHOT</version>
+                            </project>
+                            """);
+                    }
+                    return response;
                 }
             });
             mockRepo.start();
@@ -540,11 +541,11 @@ class MavenPomDownloaderTest {
               """
                     <project>
                         <modelVersion>4.0.0</modelVersion>
-                    
+                
                         <groupId>org.openrewrite.test</groupId>
                         <artifactId>foo</artifactId>
                         <version>0.1.0-SNAPSHOT</version>
-                        
+                
                         <repositories>
                           <repository>
                             <id>snapshot</id>
@@ -561,7 +562,7 @@ class MavenPomDownloaderTest {
                             <url>http://%s:%d</url>
                           </repository>
                         </repositories>
-                        
+                
                         <dependencies>
                             <dependency>
                                 <groupId>org.springframework.cloud</groupId>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -403,17 +403,24 @@ class MavenPomDownloaderTest {
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    return recordedRequest.getHeaders().get("Authorization") != null ?
-                      new MockResponse().setResponseCode(200).setBody(
-                        //language=xml
-                        """
-                          <project>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dataflow-build</artifactId>
-                              <version>2.10.0-SNAPSHOT</version>
-                          </project>
-                          """) :
-                      new MockResponse().setResponseCode(401).setBody("");
+                    MockResponse response = new MockResponse();
+                    if (recordedRequest.getHeaders().get("Authorization") != null) {
+                        response.setResponseCode(200);
+                        if (!"HEAD".equalsIgnoreCase(recordedRequest.getMethod())) {
+                            response.setBody(
+                              //language=xml
+                              """
+                                <project>
+                                    <groupId>org.springframework.cloud</groupId>
+                                    <artifactId>spring-cloud-dataflow-build</artifactId>
+                                    <version>2.10.0-SNAPSHOT</version>
+                                </project>
+                                """);
+                        }
+                    } else {
+                        response.setResponseCode(401);
+                    }
+                    return response;
                 }
             });
             mockRepo.start();


### PR DESCRIPTION
## What's changed?
Use `HEAD` in stead of `GET` request to determine if a maven server exists

## What's your motivation?
If a maven server does not block directory listing the listing itself might be very slow causing read timeouts.

## Anything in particular you'd like reviewers to focus on?
The removed check looks redundant to me

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Do nothing

## Any additional context
no

### Checklist
~- [ ] I've added unit tests to cover both positive and negative cases~ (already exist)
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
