### PR TITLE
Add declarative Gradle upgrade recipes

### DIFF
--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-5.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-5.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.gradle.UpgradeGradle5
+displayName: Upgrade Gradle to 5.x
+description: Upgrade to version 5.x. See the Gradle upgrade guide from [version 4.x to 5.0](https://docs.gradle.org/current/userguide/upgrading_version_4.html) for more information.
+recipeList:
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: 5.x
+      addIfMissing: false

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-5.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-5.yml
@@ -15,9 +15,9 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.gradle.UpgradeGradle5
-displayName: Upgrade Gradle to 5.x
-description: Upgrade to version 5.x. See the Gradle upgrade guide from [version 4.x to 5.0](https://docs.gradle.org/current/userguide/upgrading_version_4.html) for more information.
+name: org.openrewrite.gradle.MigrateToGradle5
+displayName: Migrate to Gradle 5 from Gradle 4
+description: Migrate to version 5.x. See the Gradle upgrade guide from [version 4.x to 5.0](https://docs.gradle.org/current/userguide/upgrading_version_4.html) for more information.
 recipeList:
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: 5.x

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-6.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-6.yml
@@ -15,10 +15,11 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.gradle.UpgradeGradle6
-displayName: Upgrade Gradle to 6.x
-description: Upgrade to version 6.x. See the Gradle upgrade guide from [version 5.x to 6.0](https://docs.gradle.org/current/userguide/upgrading_version_5.html) for more information.
+name: org.openrewrite.gradle.MigrateToGradle6
+displayName: Migrate to Gradle 6 from Gradle 5
+description: Migrate to version 6.x. See the Gradle upgrade guide from [version 5.x to 6.0](https://docs.gradle.org/current/userguide/upgrading_version_5.html) for more information.
 recipeList:
+  - org.openrewrite.gradle.MigrateToGradle5
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: 6.x
       addIfMissing: false

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-6.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-6.yml
@@ -1,0 +1,50 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.gradle.UpgradeGradle6
+displayName: Upgrade Gradle to 6.x
+description: Upgrade to version 6.x. See the Gradle upgrade guide from [version 5.x to 6.0](https://docs.gradle.org/current/userguide/upgrading_version_5.html) for more information.
+recipeList:
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: 6.x
+      addIfMissing: false
+  # We can't easily convert `compile` to either `api` or `implementation`, because transitive requirements are unclear
+  # https://github.com/openrewrite/rewrite/issues/4194
+  - org.openrewrite.gradle.ChangeDependencyConfiguration:
+      groupId: "*"
+      artifactId: "*"
+      configuration: testCompile
+      newConfiguration: testImplementation
+  - org.openrewrite.gradle.ChangeDependencyConfiguration:
+      groupId: "*"
+      artifactId: "*"
+      configuration: runtime
+      newConfiguration: runtimeOnly
+  - org.openrewrite.gradle.ChangeDependencyConfiguration:
+      groupId: "*"
+      artifactId: "*"
+      configuration: testRuntime
+      newConfiguration: testRuntimeOnly
+
+  # https://github.com/gradle/gradle/blob/v5.6.4/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+  # https://github.com/gradle/gradle/blob/v6.9.4/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: IMPROVED_POM_SUPPORT
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: STABLE_PUBLISHING
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: INCREMENTAL_ARTIFACT_TRANSFORMATIONS

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-6.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-6.yml
@@ -28,13 +28,13 @@ recipeList:
   - org.openrewrite.gradle.ChangeDependencyConfiguration:
       groupId: "*"
       artifactId: "*"
-      configuration: testCompile
-      newConfiguration: testImplementation
+      configuration: runtime
+      newConfiguration: runtimeOnly
   - org.openrewrite.gradle.ChangeDependencyConfiguration:
       groupId: "*"
       artifactId: "*"
-      configuration: runtime
-      newConfiguration: runtimeOnly
+      configuration: testCompile
+      newConfiguration: testImplementation
   - org.openrewrite.gradle.ChangeDependencyConfiguration:
       groupId: "*"
       artifactId: "*"

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-7.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-7.yml
@@ -1,0 +1,29 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.gradle.UpgradeGradle7
+displayName: Upgrade Gradle to 7.x
+description: Upgrade to version 7.x. See the Gradle upgrade guide from [version 6.x to 7.0](https://docs.gradle.org/current/userguide/upgrading_version_6.html) for more information.
+recipeList:
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: 7.x
+      addIfMissing: false
+
+  # https://github.com/gradle/gradle/blob/v6.9.4/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+  # https://github.com/gradle/gradle/blob/v7.6.4/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: GRADLE_METADATA

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-7.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-7.yml
@@ -15,10 +15,11 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.gradle.UpgradeGradle7
-displayName: Upgrade Gradle to 7.x
-description: Upgrade to version 7.x. See the Gradle upgrade guide from [version 6.x to 7.0](https://docs.gradle.org/current/userguide/upgrading_version_6.html) for more information.
+name: org.openrewrite.gradle.MigrateToGradle7
+displayName: Migrate to Gradle 7 from Gradle 6
+description: Migrate to version 7.x. See the Gradle upgrade guide from [version 6.x to 7.0](https://docs.gradle.org/current/userguide/upgrading_version_6.html) for more information.
 recipeList:
+  - org.openrewrite.gradle.MigrateToGradle6
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: 7.x
       addIfMissing: false

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-8.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-8.yml
@@ -15,10 +15,11 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.gradle.UpgradeGradle8
-displayName: Upgrade Gradle to 8.x
-description: Upgrade to version 8.x. See the Gradle upgrade guide from [version 7.x to 8.0](https://docs.gradle.org/current/userguide/upgrading_version_7.html) and [version 8.x to latest](https://docs.gradle.org/current/userguide/upgrading_version_8.html) for more information.
+name: org.openrewrite.gradle.MigrateToGradle8
+displayName: Migrate to Gradle 8 from Gradle 7
+description: Migrate to version 8.x. See the Gradle upgrade guide from [version 7.x to 8.0](https://docs.gradle.org/current/userguide/upgrading_version_7.html) and [version 8.x to latest](https://docs.gradle.org/current/userguide/upgrading_version_8.html) for more information.
 recipeList:
+  - org.openrewrite.gradle.MigrateToGradle7
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: 8.x
       addIfMissing: false

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-8.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-8.yml
@@ -1,0 +1,33 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.gradle.UpgradeGradle8
+displayName: Upgrade Gradle to 8.x
+description: Upgrade to version 8.x. See the Gradle upgrade guide from [version 7.x to 8.0](https://docs.gradle.org/current/userguide/upgrading_version_7.html) and [version 8.x to latest](https://docs.gradle.org/current/userguide/upgrading_version_8.html) for more information.
+recipeList:
+  - org.openrewrite.gradle.UpdateGradleWrapper:
+      version: 8.x
+      addIfMissing: false
+
+  # https://github.com/gradle/gradle/blob/v7.6.4/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+  # https://github.com/gradle/gradle/blob/v8.10.1/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: ONE_LOCKFILE_PER_PROJECT
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: VERSION_ORDERING_V2
+  - org.openrewrite.gradle.RemoveEnableFeaturePreview:
+      previewFeatureName: VERSION_CATALOGS


### PR DESCRIPTION
## What's your motivation?
When upgrading Java versions folks also need to upgrade older Gradle versions. While upgrading the wrapper is one part of that upgrade, at times there's required changes as well, in particular going from 4.x to 5.0. Some of these changes we can already automate, others might still follow now that the framework for these migrations is there.

## Anything in particular you'd like reviewers to focus on?
- For the `RemoveEnableFeaturePreview` record I went by when those keys were dropped from the enum, going by latest.patch; seemed ok, but could be double checked as documentation was hard to find.
- Intentionally left out `compile` -> `api/implementation`, although that'll be a bigger pain point. Anything we can do for reasonable coverage here? Perhaps look if `java-library` plugin is defined and base our behavior on that? Or at worst merely post a comment on the first case?

## Have you considered any alternatives or workarounds?
The components here were already available. We could document the steps and considerations for `compile` -> `api/implementation`, and how they could be achieved with recipes.

## Any additional context
- https://github.com/openrewrite/rewrite/issues/4194