### PR TITLE
Fixing duplicate search markers in javaDocs

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
@@ -425,4 +425,36 @@ class FindTypesTest implements RewriteTest {
           java(a1)
         );
     }
+
+    @Test
+    void javadocComment() {
+
+        rewriteRun(
+          spec -> spec.recipe(new FindTypes("java.lang.String", true)),
+          java(
+            """
+                    public class A {               
+                      /** 
+                        * JavaDoc comment with {{@link String#trim()}}
+                        * JavaDoc comment with String#trim()
+                        */
+                      public static String replaceFoo(String string) {
+                        return string.replaceAll("foo", "bar");
+                      }
+                    }
+                    """,
+            """
+                    public class A {               
+                      /**
+                        * JavaDoc comment with {{@link ~~>String#trim()}}
+                        * JavaDoc comment with String#trim()
+                        */
+                      public static /*~~>*/String replaceFoo(/*~~>*/String string) {
+                        return string.replaceAll("foo", "bar");
+                      }
+                    }
+                    """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
@@ -464,18 +464,6 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
             return space;
         }
 
-        @Override
-        public <M extends Marker> M visitMarker(Marker marker, PrintOutputCapture<P> p) {
-            if (marker instanceof SearchResult) {
-                String description = ((SearchResult) marker).getDescription();
-                p.append("~~")
-                        .append(description == null ? "" : "(" + description + ")~~")
-                        .append(">");
-            }
-            //noinspection unchecked
-            return (M) marker;
-        }
-
         private void visitLineBreak(Javadoc.LineBreak lineBreak, PrintOutputCapture<P> p) {
             beforeSyntax(Space.EMPTY, lineBreak.getMarkers(), null, p);
             p.append(lineBreak.getMargin());


### PR DESCRIPTION
## What's changed?
When running the "FindTypes" recipe we are getting duplicate search markers being added to the result. 

## What's your motivation?
Having 2 search parameters printed in the search results is confusing
