### PR TITLE
Handle bom import in RemoveDuplicateDependencies

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
@@ -125,6 +125,9 @@ public class RemoveDuplicateDependencies extends Recipe {
             }
 
             private @Nullable DependencyKey getManagedDependencyKey(Xml.Tag tag) {
+                if (tag.getChildValue("scope").map("import"::equalsIgnoreCase).orElse(false)) {
+                    return DependencyKey.from(tag);
+                }
                 ResolvedManagedDependency resolvedDependency = findManagedDependency(tag);
                 return resolvedDependency != null ? DependencyKey.from(resolvedDependency) : null;
             }
@@ -150,6 +153,17 @@ public class RemoveDuplicateDependencies extends Recipe {
 
         public static DependencyKey from(ResolvedManagedDependency dependency) {
             return new DependencyKey(dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), dependency.getClassifier(), Scope.Compile);
+        }
+
+        public static @Nullable DependencyKey from(Xml.Tag tag) {
+            return tag.getChildValue("artifactId").map(artifactId ->
+                    new DependencyKey(
+                            tag.getChildValue("groupId").orElse(null),
+                            artifactId,
+                            tag.getChildValue("type").orElse("jar"),
+                            tag.getChildValue("classifier").orElse(null),
+                            tag.getChildValue("scope").map(Scope::fromName).orElse(Scope.Compile)
+                    )).orElse(null);
         }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDuplicateDependencies.java
@@ -125,7 +125,7 @@ public class RemoveDuplicateDependencies extends Recipe {
             }
 
             private @Nullable DependencyKey getManagedDependencyKey(Xml.Tag tag) {
-                if (tag.getChildValue("scope").map("import"::equalsIgnoreCase).orElse(false)) {
+                if (tag.getChildValue("scope").filter("import"::equalsIgnoreCase).isPresent()) {
                     return DependencyKey.from(tag);
                 }
                 ResolvedManagedDependency resolvedDependency = findManagedDependency(tag);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -411,6 +411,63 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
     }
 
     @Test
+    void removeDuplicatedDependencyWithImportScope() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+              
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+              
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.apache.logging.log4j</groupId>
+                              <artifactId>log4j-bom</artifactId>
+                              <version>2.24.0</version>
+                              <scope>import</scope>
+                              <type>pom</type>
+                          </dependency>
+                          <dependency>
+                              <groupId>org.apache.logging.log4j</groupId>
+                              <artifactId>log4j-bom</artifactId>
+                              <version>2.24.0</version>
+                              <scope>import</scope>
+                              <type>pom</type>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+              
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+              
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.apache.logging.log4j</groupId>
+                              <artifactId>log4j-bom</artifactId>
+                              <version>2.24.0</version>
+                              <scope>import</scope>
+                              <type>pom</type>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void removeDependencyWithDefaultType() {
         rewriteRun(
           pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -37,7 +37,7 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
@@ -55,11 +55,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -83,11 +83,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -114,11 +114,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <!-- comment 1 -->
                   <dependency>
@@ -145,11 +145,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <!-- comment 1 -->
                   <dependency>
@@ -179,11 +179,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -212,11 +212,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -243,11 +243,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.inject</groupId>
@@ -264,11 +264,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
               """, """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.inject</groupId>
@@ -289,11 +289,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.inject</groupId>
@@ -313,7 +313,6 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
         );
     }
 
-    @Disabled("Unsure if this is a valid use case or not")
     @Test
     void keepDependencyWithType() {
         rewriteRun(
@@ -321,11 +320,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -345,38 +344,38 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
         );
     }
 
-	@Test
-	void keepDependencyManagementWithType() {
-		rewriteRun(
-		  pomXml(
-			"""
- 			  <project>
-				<modelVersion>4.0.0</modelVersion>
-				
-				<groupId>com.mycompany.app</groupId>
-				<artifactId>my-app</artifactId>
-				<version>1</version>
-				
-				<dependencyManagement>
-				  <dependencies>
-					<dependency>
-					  <groupId>com.acme</groupId>
-					  <artifactId>example-dependency</artifactId>
-				      <version>1.0.0</version>
-					</dependency>
-					<dependency>
-				      <groupId>com.acme</groupId>
-				      <artifactId>example-dependency</artifactId>
-				      <version>1.0.0</version>
-				      <type>test-jar</type>
-					</dependency>
-				  </dependencies>
-				</dependencyManagement>
-			  </project>
-			  """
-		  )
-		);
-	}
+    @Test
+    void keepDependencyManagementWithType() {
+        rewriteRun(
+          pomXml(
+            """
+                <project>
+              <modelVersion>4.0.0</modelVersion>
+              
+              <groupId>com.mycompany.app</groupId>
+              <artifactId>my-app</artifactId>
+              <version>1</version>
+              
+              <dependencyManagement>
+                <dependencies>
+              	<dependency>
+              	  <groupId>com.acme</groupId>
+              	  <artifactId>example-dependency</artifactId>
+                    <version>1.0.0</version>
+              	</dependency>
+              	<dependency>
+                    <groupId>com.acme</groupId>
+                    <artifactId>example-dependency</artifactId>
+                    <version>1.0.0</version>
+                    <type>test-jar</type>
+              	</dependency>
+                </dependencies>
+              </dependencyManagement>
+               </project>
+              """
+          )
+        );
+    }
 
     @Test
     void keepDependencyWithDifferentScope() {
@@ -385,11 +384,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -474,11 +473,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -497,11 +496,11 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -523,15 +522,15 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <version.chromedriver>94.0.4606.61</version.chromedriver>
                 </properties>
-                
+              
                 <dependencyManagement>
                   <dependencies>
                     <dependency>


### PR DESCRIPTION
## What's changed?
Added support for `<scope>import</scope>` in `RemoveDuplicateDependencies`

## What's your motivation?
It seems we have duplicate imports in our poms 😏

## Have you considered any alternatives or workarounds?
I don’t really see any.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
