### PR TITLE
Creating "OR" preconditions instead of "AND" (#4003) does not actually work

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -175,6 +175,62 @@ class DeclarativeRecipeTest implements RewriteTest {
     }
 
     @Test
+    void yamlDeclarativeRecipeAsPrecondition() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.PreconditionTest
+            description: Test.
+            preconditions:
+              - org.openrewrite.DeclarativePrecondition
+            recipeList:
+              - org.openrewrite.text.ChangeText:
+                 toText: 2
+              - org.openrewrite.text.ChangeText:
+                 toText: 3
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.DeclarativePrecondition
+            recipeList:
+              - org.openrewrite.text.Find:
+                  find: 1
+            """, "org.openrewrite.PreconditionTest"),
+          text("1", "3"),
+          text("2")
+        );
+    }
+
+    @Test
+    void orPreconditions() {
+        // example from https://docs.openrewrite.org/reference/yaml-format-reference#creating-or-preconditions-instead-of-and
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.sample.DoSomething
+            description: Test.
+            preconditions:
+              - org.sample.FindAnyJson
+            recipeList:
+              - org.openrewrite.text.ChangeText:
+                 toText: 2
+            ---
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.sample.FindAnyJson
+            recipeList:
+              - org.openrewrite.FindSourceFiles:
+                  filePattern: "**/my.json"
+              - org.openrewrite.FindSourceFiles:
+                  filePattern: "**/your.json"
+              - org.openrewrite.FindSourceFiles:
+                  filePattern: "**/our.json"
+            """, "org.sample.DoSomething"),
+          text("1", "2", spec -> spec.path("a/my.json")),
+          text("a", spec -> spec.path("a/not-my.json"))
+        );
+    }
+
+    @Test
     void yamlPreconditionWithScanningRecipe() {
         rewriteRun(
           spec -> spec.recipeFromYaml("""


### PR DESCRIPTION
## What's changed?
Adds 2 failing tests using declarative recipes as preconditions.

Based on [Creating "OR" preconditions instead of "AND"](https://docs.openrewrite.org/reference/yaml-format-reference#creating-or-preconditions-instead-of-and), you should be able to use a declarative recipe as a precondition to combine recipes into an “or” clause, but it does not actually work.

Upon debugging, it appears that `DeclarativeRecipe` does not actually override `getVisitor()`, so when [`DeclarativeRecipe.getRecipeList()` calls `getVisitor()`](https://github.com/openrewrite/rewrite/blob/956fa7a820f1a520499165d5a2d1126033d12791/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java#L273) on the declarative recipe used as precondition, it just returns `noop()`.

## What's your motivation?
Be able to re-use a configured recipe as precondition for other recipes.

## Anything in particular you'd like reviewers to focus on?
In #4003 this use-case was documented and later reported as not working.

## Anyone you would like to review specifically?
#4003 involved a discussion mostly between @timtebeek and @nmck257 who might be interested.

## Have you considered any alternatives or workarounds?
Currently the only alternative is to repeat the predicate configuration, using only imperative recipes. If you need a disjunction of conditions, you will have to duplicate the whole recipe, but it may not always work.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
