### PR TITLE
Use `OPTIONS` request before falling back to `HEAD` request when trying to connect to repositories during normalization.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -779,21 +779,20 @@ public class MavenPomDownloader {
 
         ReachabilityResult reachability = reachable(repository, applyAuthenticationToRequest(repository, request));
         if (reachability.isSuccess()) {
-            return repository.withUri(httpsUri).withKnownToExist(true);
+            return repository.withUri(httpsUri);
         }
         reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(httpsUri)));
         if (reachability.isReachable()) {
-            return repository.withUri(httpsUri).withKnownToExist(reachability.isSuccess());
+            return repository.withUri(httpsUri);
         }
-
         if (!originalUrl.equals(httpsUri)) {
             reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.OPTIONS).url(originalUrl)));
             if (reachability.isSuccess()) {
-                return MavenRepository.from(repository, originalUrl).withKnownToExist(true);
+                return MavenRepository.from(repository, originalUrl);
             }
             reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(originalUrl)));
             if (reachability.isReachable()) {
-                return MavenRepository.from(repository, originalUrl).withKnownToExist(reachability.isSuccess());
+                return MavenRepository.from(repository, originalUrl);
             }
         }
         // Won't be null if server is unreachable

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -777,20 +777,20 @@ public class MavenPomDownloader {
                     .withReadTimeout(repository.getTimeout());
         }
 
-        ReachabilityResult reachability = reachable(repository, applyAuthenticationToRequest(repository, request));
+        ReachabilityResult reachability = reachable(applyAuthenticationToRequest(repository, request));
         if (reachability.isSuccess()) {
             return repository.withUri(httpsUri);
         }
-        reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(httpsUri)));
+        reachability = reachable(applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(httpsUri)));
         if (reachability.isReachable()) {
             return repository.withUri(httpsUri);
         }
         if (!originalUrl.equals(httpsUri)) {
-            reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.OPTIONS).url(originalUrl)));
+            reachability = reachable(applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.OPTIONS).url(originalUrl)));
             if (reachability.isSuccess()) {
                 return repository.withUri(originalUrl);
             }
-            reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(originalUrl)));
+            reachability = reachable(applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(originalUrl)));
             if (reachability.isReachable()) {
                 return repository.withUri(originalUrl);
             }
@@ -824,8 +824,7 @@ public class MavenPomDownloader {
         UNREACHABLE;
     }
 
-    private ReachabilityResult reachable(MavenRepository repository, HttpSender.Request.Builder requestBuilder) {
-        HttpSender.Request.Builder request = applyAuthenticationToRequest(repository, requestBuilder);
+    private ReachabilityResult reachable(HttpSender.Request.Builder request) {
         try {
             sendRequest(request.build());
             return ReachabilityResult.success();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -788,11 +788,11 @@ public class MavenPomDownloader {
         if (!originalUrl.equals(httpsUri)) {
             reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.OPTIONS).url(originalUrl)));
             if (reachability.isSuccess()) {
-                return MavenRepository.from(repository, originalUrl);
+                return repository.withUri(originalUrl);
             }
             reachability = reachable(repository, applyAuthenticationToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(originalUrl)));
             if (reachability.isReachable()) {
-                return MavenRepository.from(repository, originalUrl);
+                return repository.withUri(originalUrl);
             }
         }
         // Won't be null if server is unreachable

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -133,17 +133,6 @@ public class MavenRepository implements Serializable {
         this.deriveMetadataIfMissing = deriveMetadataIfMissing;
     }
 
-    public static MavenRepository from(MavenRepository repository, String url) {
-        return new MavenRepository(
-                repository.getId(),
-                url,
-                repository.getReleases(),
-                repository.getSnapshots(),
-                repository.getUsername(),
-                repository.getPassword(),
-                repository.getTimeout());
-    }
-
     public static Builder builder() {
         return new Builder();
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenRepository.java
@@ -133,6 +133,17 @@ public class MavenRepository implements Serializable {
         this.deriveMetadataIfMissing = deriveMetadataIfMissing;
     }
 
+    public static MavenRepository from(MavenRepository repository, String url) {
+        return new MavenRepository(
+                repository.getId(),
+                url,
+                repository.getReleases(),
+                repository.getSnapshots(),
+                repository.getUsername(),
+                repository.getPassword(),
+                repository.getTimeout());
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -766,23 +766,22 @@ class MavenPomDownloaderTest {
     }
 
     @CsvSource(textBlock = """
-      https://repo1.maven.org/maven2/, https://repo1.maven.org/maven2/, true
-      https://repo1.maven.org/maven2, https://repo1.maven.org/maven2/, true
-      http://repo1.maven.org/maven2/, https://repo1.maven.org/maven2/, true
+      https://repo1.maven.org/maven2/, https://repo1.maven.org/maven2/
+      https://repo1.maven.org/maven2, https://repo1.maven.org/maven2/
+      http://repo1.maven.org/maven2/, https://repo1.maven.org/maven2/
       
-      https://oss.sonatype.org/content/repositories/snapshots/, https://oss.sonatype.org/content/repositories/snapshots/, true
-      https://artifactory.moderne.ninja/artifactory/moderne-public/, https://artifactory.moderne.ninja/artifactory/moderne-public/, true
-      https://repo.maven.apache.org/maven2/, https://repo.maven.apache.org/maven2/, true
-      https://jitpack.io/, https://jitpack.io/, true
+      https://oss.sonatype.org/content/repositories/snapshots/, https://oss.sonatype.org/content/repositories/snapshots/
+      https://artifactory.moderne.ninja/artifactory/moderne-public/, https://artifactory.moderne.ninja/artifactory/moderne-public/
+      https://repo.maven.apache.org/maven2/, https://repo.maven.apache.org/maven2/
+      https://jitpack.io/, https://jitpack.io/
       """)
     @ParameterizedTest
-    void normalizeRepository(String originalUrl, String expectedUrl, boolean knownToExist) throws Throwable {
+    void normalizeRepository(String originalUrl, String expectedUrl) throws Throwable {
         MavenPomDownloader downloader = new MavenPomDownloader(new InMemoryExecutionContext());
         MavenRepository repository = new MavenRepository("id", originalUrl, null, null, null, null, null);
         MavenRepository normalized = downloader.normalizeRepository(repository);
         assertThat(normalized).isNotNull();
         assertThat(normalized.getUri()).isEqualTo(expectedUrl);
-        assertThat(normalized.isKnownToExist()).isEqualTo(knownToExist);
     }
 
     private static GroupArtifactVersion createArtifact(Path repository) throws IOException {


### PR DESCRIPTION
## What's changed?

To test if a repository is reachable we currently do a HEAD request. Unfortunately a HEAD request is just as slow as a GET on artifactory. `OPTIONS` is much faster, but it does not take authentication into account and is not always supported (thinking about reverse-proxies)

With this PR we now try an OPTIONS request first, if that returns 200 we accept that the server is reachable. If an error is returned we first try a HEAD request to see if that returns a 200 (in case of maven central OPTIONS gives an error, while HEAD returns 200)
If that is OK we set `knownToExist` to true.

We still first try https before (maybe) trying the original url.

## What's your motivation?
Some artifactory repositories are VERY slow at directory listing. 

## Anything in particular you'd like reviewers to focus on?
`knownToExist` is now true in most cases, even if the authentication would fail. This might not work as expected, but I'm not entirely sure what that is used for. Technically a 200 response from OPTIONS would mean it exists.

## Anyone you would like to review specifically?
@sambsnyd @timtebeek 

## Have you considered any alternatives or workarounds?
Increasing the timeout (which seems to not yet be used in this part of the code) but that leaves this to be very slow.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
