### PR TITLE
Handle plugins without groupId

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -404,9 +404,9 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         for (Plugin resolvedPlugin : plugins) {
             String reqGroup = resolvedPlugin.getGroupId();
             String reqVersion = resolvedPlugin.getVersion();
-            if (reqGroup.equals(tag.getChildValue("groupId").orElse(PLUGIN_DEFAULT_GROUPID))
-                    && resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null))
-                    && (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
+            if (reqGroup.equals(tag.getChildValue("groupId").orElse(PLUGIN_DEFAULT_GROUPID)) &&
+                resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
+                (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
                 return resolvedPlugin;
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -31,6 +31,7 @@ import java.util.function.Predicate;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
+import static org.openrewrite.maven.tree.Plugin.PLUGIN_DEFAULT_GROUPID;
 
 public class MavenVisitor<P> extends XmlVisitor<P> {
 
@@ -403,9 +404,9 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         for (Plugin resolvedPlugin : plugins) {
             String reqGroup = resolvedPlugin.getGroupId();
             String reqVersion = resolvedPlugin.getVersion();
-            if ((reqGroup == null || reqGroup.equals(tag.getChildValue("groupId").orElse(null))) &&
-                resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null)) &&
-                (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
+            if (reqGroup.equals(tag.getChildValue("groupId").orElse(PLUGIN_DEFAULT_GROUPID))
+                    && resolvedPlugin.getArtifactId().equals(tag.getChildValue("artifactId").orElse(null))
+                    && (reqVersion == null || reqVersion.equals(tag.getChildValue("version").orElse(null)))) {
                 return resolvedPlugin;
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.openrewrite.maven.tree.Plugin.PLUGIN_DEFAULT_GROUPID;
 
 /**
  * A value object deserialized directly from POM XML
@@ -249,6 +250,7 @@ public class RawPom {
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @Data
     public static class Plugin {
+        @Nullable
         String groupId;
         String artifactId;
 
@@ -510,9 +512,9 @@ public class RawPom {
         if (rawPlugins != null) {
             plugins = new ArrayList<>(rawPlugins.size());
             for (Plugin rawPlugin : rawPlugins) {
-
+                String pluginGroupId = rawPlugin.getGroupId();
                 plugins.add(new org.openrewrite.maven.tree.Plugin(
-                        rawPlugin.getGroupId(),
+                        pluginGroupId == null ? PLUGIN_DEFAULT_GROUPID : pluginGroupId,
                         rawPlugin.getArtifactId(),
                         rawPlugin.getVersion(),
                         rawPlugin.getExtensions(),

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Plugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Plugin.java
@@ -30,6 +30,8 @@ import java.util.List;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @Value
 public class Plugin {
+    // default value as per https://maven.apache.org/xsd/maven-4.0.0.xsd
+    public static final String PLUGIN_DEFAULT_GROUPID = "org.apache.maven.plugins";
 
     String groupId;
     String artifactId;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
 
 import java.util.Collections;
 
@@ -1286,6 +1287,170 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                   </build>
               </project>
               """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantVersionsFromPluginsManagedByParentNotSpecifyingGroupId() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencyVersions(null, null, RemoveRedundantDependencyVersions.Comparator.GTE, null)),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.18</version>
+                      <relativePath/>
+                  </parent>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <artifactId>maven-resources-plugin</artifactId>
+                                  <configuration><whatever/></configuration>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                  </build>
+              </project>
+              """, SourceSpec::skip),
+          mavenProject("child", pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.sample</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0.0</version>
+                        <relativePath/>
+                    </parent>
+                    <artifactId>sample</artifactId>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <artifactId>maven-resources-plugin</artifactId>
+                                <version>3.0.0</version>
+                                <configuration>
+                                    <something-else/>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.sample</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0.0</version>
+                        <relativePath/>
+                    </parent>
+                    <artifactId>sample</artifactId>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <artifactId>maven-resources-plugin</artifactId>
+                                <configuration>
+                                    <something-else/>
+                                </configuration>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantDmVersionsFromPluginsManagedByParentNotSpecifyingGroupId() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencyVersions(null, null, RemoveRedundantDependencyVersions.Comparator.GTE, null)),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.sample</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.18</version>
+                      <relativePath/>
+                  </parent>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <artifactId>maven-resources-plugin</artifactId>
+                                  <configuration><whatever/></configuration>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                  </build>
+              </project>
+              """, SourceSpec::skip),
+          mavenProject("child", pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.sample</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0.0</version>
+                        <relativePath/>
+                    </parent>
+                    <artifactId>sample</artifactId>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-resources-plugin</artifactId>
+                                    <version>3.0.0</version>
+                                    <configuration>
+                                        <something-else/>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.sample</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0.0</version>
+                        <relativePath/>
+                    </parent>
+                    <artifactId>sample</artifactId>
+                    <build>
+                        <pluginManagement>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-resources-plugin</artifactId>
+                                    <configuration>
+                                        <something-else/>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </pluginManagement>
+                    </build>
+                </project>
+                """
+            )
           )
         );
     }


### PR DESCRIPTION
## What's changed?
Handle the default value of plugin `groupId` as per https://maven.apache.org/xsd/maven-4.0.0.xsd

- Found after #4493 was merged and released 🙄

See also [is groupId required for plugins in Maven pom.xml?](https://stackoverflow.com/questions/65527291/is-groupid-required-for-plugins-in-maven-pom-xml) on Stack Overflow.

## What's your motivation?
Someone declared a plugin without groupId…

## Have you considered any alternatives or workarounds?
It would be possible to fix just `RemoveRedundantDependencyVersions`, but since this default value is defined in the xsd, I thought it would be better to fix the parsing/resolution.

## Any additional context
It was causing an invisible NPE in `RemoveRedundantDependencyVersions` for the `pluginManagement` case. I’m not sure how such exceptions should be handled.

Theoretically the `artifactId` is optional as well, but I don’t see why anyone wouldn’t provide it. Moreover there isn’t a default for it.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files