### PR TITLE
Parse `MavenMetadata.Versioning.lastUpdated` as `ZonedDateTime`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -42,6 +42,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -392,7 +393,7 @@ public class MavenPomDownloader {
                         versions.add(path.getFileName().toString());
                     }
                 }
-                return new MavenMetadata.Versioning(versions, null, null);
+                return new MavenMetadata.Versioning(versions, null, null, null);
             } catch (IOException e) {
                 throw new MavenDownloadingException("Unable to derive metadata from file repository. " + e.getMessage(), null, gav);
             }
@@ -422,7 +423,7 @@ public class MavenPomDownloader {
             return null;
         }
 
-        return new MavenMetadata.Versioning(versions, null, null);
+        return new MavenMetadata.Versioning(versions, null, null, null);
     }
 
     String hrefToVersion(String href, String rootUri) {
@@ -446,8 +447,13 @@ public class MavenPomDownloader {
                 mergeVersions(m1.getVersioning().getVersions(), m2.getVersioning().getVersions()),
                 Stream.concat(m1.getVersioning().getSnapshotVersions() == null ? Stream.empty() : m1.getVersioning().getSnapshotVersions().stream(),
                         m2.getVersioning().getSnapshotVersions() == null ? Stream.empty() : m2.getVersioning().getSnapshotVersions().stream()).collect(toList()),
-                maxSnapshot(m1.getVersioning().getSnapshot(), m2.getVersioning().getSnapshot())
+                maxSnapshot(m1.getVersioning().getSnapshot(), m2.getVersioning().getSnapshot()),
+                maxLastUpdated(m1.getVersioning().getLastUpdated(), m2.getVersioning().getLastUpdated())
         ));
+    }
+
+    private @Nullable ZonedDateTime maxLastUpdated(@Nullable ZonedDateTime left, @Nullable ZonedDateTime right) {
+        return left == null ? right : right == null ? left : left.compareTo(right) >= 0 ? left : right;
     }
 
     private List<String> mergeVersions(List<String> versions1, List<String> versions2) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenXmlMapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenXmlMapper.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
@@ -63,6 +64,7 @@ public class MavenXmlMapper {
                         .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
                         .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                         .withCreatorVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY))
+                .registerModule(new JavaTimeModule())
                 .registerModule(new StringTrimModule());
 
         writeMapper = XmlMapper.builder(xmlFactory)

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenMetadata.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenMetadata.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.maven.tree;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,12 +23,11 @@ import lombok.Value;
 import lombok.experimental.FieldDefaults;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.maven.internal.MavenXmlMapper;
-import org.openrewrite.xml.XmlParser;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -35,14 +35,7 @@ import static java.util.Collections.emptyList;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @Getter
 public class MavenMetadata {
-    private static final XmlParser xmlParser = new XmlParser() {
-        @Override
-        public boolean accept(Path path) {
-            return super.accept(path) || path.toString().endsWith(".pom");
-        }
-    };
-
-    public static final MavenMetadata EMPTY = new MavenMetadata(new MavenMetadata.Versioning(emptyList(), emptyList(), null));
+    public static final MavenMetadata EMPTY = new MavenMetadata(new MavenMetadata.Versioning(emptyList(), emptyList(), null, null));
 
     Versioning versioning;
 
@@ -62,10 +55,15 @@ public class MavenMetadata {
         @Nullable
         Snapshot snapshot;
 
+        @Nullable
+        ZonedDateTime lastUpdated;
+
         public Versioning(
                 @JacksonXmlElementWrapper(localName = "versions") List<String> versions,
                 @JacksonXmlElementWrapper(localName = "snapshotVersions") @Nullable List<SnapshotVersion> snapshotVersions,
-                @Nullable Snapshot snapshot) {
+                @Nullable Snapshot snapshot,
+                @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMddHHmmss", timezone = "UTC") @Nullable ZonedDateTime lastUpdated) {
+            this.lastUpdated = lastUpdated;
             this.versions = versions;
             this.snapshotVersions = snapshotVersions;
             this.snapshot = snapshot;
@@ -83,7 +81,11 @@ public class MavenMetadata {
     public static @Nullable MavenMetadata parse(byte[] document) throws IOException {
         MavenMetadata metadata = MavenXmlMapper.readMapper().readValue(document, MavenMetadata.class);
         if (metadata != null && metadata.getVersioning() != null && metadata.getVersioning().getVersions() == null) {
-            return new MavenMetadata(new Versioning(emptyList(), metadata.getVersioning().getSnapshotVersions(), metadata.getVersioning().getSnapshot()));
+            return new MavenMetadata(new Versioning(
+                    emptyList(),
+                    metadata.getVersioning().getSnapshotVersions(),
+                    metadata.getVersioning().getSnapshot(),
+                    metadata.getVersioning().getLastUpdated()));
         }
         return metadata;
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenMetadataTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenMetadataTest.java
@@ -21,7 +21,9 @@ import org.openrewrite.Issue;
 import org.openrewrite.maven.tree.MavenMetadata;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MavenMetadataTest {
@@ -46,6 +48,7 @@ class MavenMetadataTest {
 
         MavenMetadata parsed = MavenMetadata.parse(metadata.getBytes());
         assertThat(parsed.getVersioning().getVersions()).hasSize(2);
+        assertThat(parsed.getVersioning().getLastUpdated()).isEqualTo(ZonedDateTime.of(2021, 1, 15, 4, 27, 54, 0, UTC));
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -80,6 +83,7 @@ class MavenMetadataTest {
         MavenMetadata parsed = MavenMetadata.parse(metadata.getBytes());
         MavenMetadata.Versioning versioning = parsed.getVersioning();
 
+        assertThat(versioning.getLastUpdated()).isNull();
         assertThat(versioning.getSnapshot().getTimestamp()).isEqualTo("20220927.033510");
         assertThat(versioning.getSnapshot().getBuildNumber()).isEqualTo("223");
         assertThat(versioning.getVersions()).isNotNull();


### PR DESCRIPTION
## What's changed?
Added `MavenMetadata.Versioning.lastUpdated` and parse that using `@JsonFormat` and `JavaTimeModule`.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/4325

Unlocks a new type of analysis, looking at when dependencies were last maintained.

## Anything in particular you'd like reviewers to focus on?
Ok to add that `JavaTimeModule`?
Ok to drop that `MavenMetadata.xmlParser`?

## Have you considered any alternatives or workarounds?
Could have kept the time as String, but then that would have just passed the burden onto consumers.

## Any additional context
Inspired by https://github.com/Giovds/outdated-maven-plugin