### PR TITLE
Use `maven-metadata-local.xml` for `file://` paths

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -256,15 +256,14 @@ public class MavenPomDownloader {
                 boolean cacheEmptyResult = false;
                 try {
                     String scheme = URI.create(repo.getUri()).getScheme();
-                    String uri = repo.getUri() + (repo.getUri().endsWith("/") ? "" : "/") +
+                    String baseUri = repo.getUri() + (repo.getUri().endsWith("/") ? "" : "/") +
                                  requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
                                  gav.getArtifactId() + '/' +
-                                 (gav.getVersion() == null ? "" : gav.getVersion() + '/') +
-                                 "maven-metadata.xml";
+                                 (gav.getVersion() == null ? "" : gav.getVersion() + '/');
 
                     if ("file".equals(scheme)) {
                         // A maven repository can be expressed as a URI with a file scheme
-                        Path path = Paths.get(URI.create(uri));
+                        Path path = Paths.get(URI.create(baseUri + "maven-metadata-local.xml"));
                         if (Files.exists(path)) {
                             MavenMetadata parsed = MavenMetadata.parse(Files.readAllBytes(path));
                             if (parsed != null) {
@@ -272,7 +271,7 @@ public class MavenPomDownloader {
                             }
                         }
                     } else {
-                        byte[] responseBody = requestAsAuthenticatedOrAnonymous(repo, uri);
+                        byte[] responseBody = requestAsAuthenticatedOrAnonymous(repo, baseUri + "maven-metadata.xml");
                         MavenMetadata parsed = MavenMetadata.parse(responseBody);
                         if (parsed != null) {
                             result = Optional.of(parsed);


### PR DESCRIPTION
## What's changed?
Use `maven-metadata-local.xml` when accessing `file://` URIs, as documented on
- https://maven.apache.org/ref/3.9.9/maven-repository-metadata/

## What's your motivation?
Improve odds of picking up an existing local file, as opposed to downloading metadata remotely.

## Anything in particular you'd like reviewers to focus on?
Presumably the local metadata might be outdated; should we guard against that somehow?

## Anyone you would like to review specifically?
@DidierLoiseau

## Have you considered any alternatives or workarounds?
Locally I also see `maven-metadata-central.xml` as well as a few other repo-ids; Should we account for those?

## Any additional context
- https://github.com/openrewrite/rewrite/issues/4508