### PR TITLE
Accommodate Java 23 in ReloadableJava21ParserVisitor

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.isolated;
 
 
+import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.tree.*;
 import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Flags;
@@ -2136,7 +2137,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         return annotations;
     }
 
-    Space formatWithCommentTree(String prefix, JCTree tree, DCTree.@Nullable DCDocComment commentTree) {
+    Space formatWithCommentTree(String prefix, JCTree tree, @Nullable DocCommentTree commentTree) {
         Space fmt = format(prefix);
         if (commentTree != null) {
             List<Comment> comments = fmt.getComments();


### PR DESCRIPTION
## What's changed?

`com.sun.tools.javac.tree.DocCommentTable#getCommentTree` used to return `com.sun.tools.javac.tree.DCTree.DCDocComment` in Java 21.
As of Java 23 it returns `com.sun.source.doctree.DocCommentTree`, an interface that was already present and implemented by `DCDocComment`.

https://github.com/openrewrite/rewrite/blob/a98d83d698dda9971c93a0767b7f85d5866f306d/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java#L1666

This PR changes the usage downstream in `formatWithCommentTree` to use the interface instead.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/4513

## Have you considered any alternatives or workarounds?
A separate Java 23 parser; decided against for now as we still have work to do on our Java 21 parser, and will likely only target LST releases going forward. That said if support is easy to add, as seen here, we will try to do so.

## Any additional context
- https://github.com/openrewrite/rewrite/issues/4513#issuecomment-2367966854
