### PR TITLE
Only bump Maven plugin version property when needed

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -182,8 +182,10 @@ public class UpgradePluginVersion extends Recipe {
                 if (versionTag.isPresent()) {
                     String version = versionTag.get().getValue().orElse(null);
                     if (version != null) {
-                        if (version.trim().startsWith("${") && !newVersion.equals(getResolutionResult().getPom().getValue(version.trim()))) {
-                            doAfterVisit(new ChangePropertyValue(version, newVersion, false, false).getVisitor());
+                        if (version.trim().startsWith("${")) {
+                            if (!newVersion.equals(getResolutionResult().getPom().getValue(version.trim()))) {
+                                doAfterVisit(new ChangePropertyValue(version, newVersion, false, false).getVisitor());
+                            }
                         } else if (!newVersion.equals(version)) {
                             doAfterVisit(new ChangeTagValueVisitor<>(versionTag.get(), newVersion));
                         }


### PR DESCRIPTION
## Any additional context
As pointed out via Slack: https://rewriteoss.slack.com/archives/C01A843MWG5/p1726844234112149?thread_ts=1725959799.580249&cid=C01A843MWG5

> it seems that the issue is due to the tag being visited again after updating the property. I added some logs in the if-elseif check that you mentioned earlier and got the output after running the test with profiles.
> ```java
> if (version.trim().startsWith("${") && !newVersion.equals(getResolutionResult().getPom().getValue(version.trim()))) {
>     System.out.println("IF: Updating property: " + version);
>     doAfterVisit(new ChangePropertyValue(version, newVersion, false, false).getVisitor());
> } else if (!newVersion.equals(version)) {
>     System.out.printf("ELSEIF: version: %s, new-version: %s, resolved: %s\n", version, newVersion, getResolutionResult().getPom().getValue(version.trim()));
>     doAfterVisit(new ChangeTagValueVisitor<>(versionTag.get(), newVersion));
> }
> ```
> I couldn't understand why it is being visited twice, but a simple fix would be to move newVersion.equals(getResolutionResult().getPom().getValue(version.trim())) inside  if instead of &&.
It'd be great if you can confirm this. (edited) 
