### PR TITLE
Parse .NET .vbproj and .fsproj files as XML

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -111,7 +111,7 @@ public class XmlParser implements Parser {
     public boolean accept(Path path) {
         String p = path.toString();
         int dot = p.lastIndexOf('.');
-        if (dot > 0 && dot < (p.length() - 1)) {
+        if (0 < dot && dot < (p.length() - 1)) {
             if (ACCEPTED_FILE_EXTENSIONS.contains(p.substring(dot + 1))) {
                 return true;
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XmlParser.java
@@ -32,9 +32,43 @@ import org.openrewrite.xml.internal.grammar.XMLParser;
 import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class XmlParser implements Parser {
+    private static final Set<String> ACCEPTED_FILE_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "xml",
+            "wsdl",
+            "xhtml",
+            "xsd",
+            "xsl",
+            "xslt",
+            "xmi",
+            "tld",
+            "xjb",
+            "jsp",
+            // Datastage file formats that are all xml under the hood
+            "det",
+            "pjb",
+            "qjb",
+            "sjb",
+            "prt",
+            "srt",
+            "psc",
+            "ssc",
+            "tbd",
+            "tfm",
+            "dqs",
+            "stp",
+            "dcn",
+            "pst",
+            // .NET project files
+            "csproj",
+            "vbproj",
+            "fsproj"));
+
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
@@ -76,34 +110,13 @@ public class XmlParser implements Parser {
     @Override
     public boolean accept(Path path) {
         String p = path.toString();
-        return p.endsWith(".xml") ||
-               p.endsWith(".wsdl") ||
-               p.endsWith(".xhtml") ||
-               p.endsWith(".xsd") ||
-               p.endsWith(".xsl") ||
-               p.endsWith(".xslt") ||
-               p.endsWith(".xmi") ||
-               p.endsWith(".tld") ||
-               p.endsWith(".xjb") ||
-               p.endsWith(".jsp") ||
-               // Datastage file formats that are all xml under the hood
-               p.endsWith(".det") ||
-               p.endsWith(".pjb") ||
-               p.endsWith(".qjb") ||
-               p.endsWith(".sjb") ||
-               p.endsWith(".prt") ||
-               p.endsWith(".srt") ||
-               p.endsWith(".psc") ||
-               p.endsWith(".ssc") ||
-               p.endsWith(".tbd") ||
-               p.endsWith(".tfm") ||
-               p.endsWith(".dqs") ||
-               p.endsWith(".stp") ||
-               p.endsWith(".dcn") ||
-               p.endsWith(".pst") ||
-               // C# project files
-               p.endsWith(".csproj") ||
-               path.endsWith("packages.config");
+        int dot = p.lastIndexOf('.');
+        if (dot > 0 && dot < (p.length() - 1)) {
+            if (ACCEPTED_FILE_EXTENSIONS.contains(p.substring(dot + 1))) {
+                return true;
+            }
+        }
+        return path.endsWith("packages.config");
     }
 
     @Override

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -16,12 +16,19 @@
 package org.openrewrite.xml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.xml.tree.Xml;
 
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.xml.Assertions.xml;
@@ -371,5 +378,19 @@ class XmlParserTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @ParameterizedTest
+    @ValueSource(strings={"foo.xml", "proj.csproj", "/foo/bar/baz.jsp"})
+    void acceptWithValidPaths(String path) {
+        assertThat(new XmlParser().accept(Paths.get(path))).isTrue();
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @ParameterizedTest
+    @ValueSource(strings={".xml", "file.cpp", "/foo/bar/baz.xml.txt"})
+    void acceptWithInvalidPaths(String path) {
+        assertThat(new XmlParser().accept(Paths.get(path))).isFalse();
     }
 }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -236,7 +236,7 @@ class XmlParserTest implements RewriteTest {
             """
               <?xml version="1.0" encoding="UTF-8"?>
               <!DOCTYPE configuration >
-
+              
               <configuration scan="true">
                   <root>
                       <level>WARN</level>
@@ -382,14 +382,24 @@ class XmlParserTest implements RewriteTest {
 
     @DisabledOnOs(OS.WINDOWS)
     @ParameterizedTest
-    @ValueSource(strings={"foo.xml", "proj.csproj", "/foo/bar/baz.jsp"})
+    @ValueSource(strings = {
+      "foo.xml",
+      "proj.csproj",
+      "/foo/bar/baz.jsp",
+      "packages.config"
+    })
     void acceptWithValidPaths(String path) {
         assertThat(new XmlParser().accept(Paths.get(path))).isTrue();
     }
 
     @DisabledOnOs(OS.WINDOWS)
     @ParameterizedTest
-    @ValueSource(strings={".xml", "file.cpp", "/foo/bar/baz.xml.txt"})
+    @ValueSource(strings = {
+      ".xml",
+      "foo.xml.",
+      "file.cpp",
+      "/foo/bar/baz.xml.txt"
+    })
     void acceptWithInvalidPaths(String path) {
         assertThat(new XmlParser().accept(Paths.get(path))).isFalse();
     }


### PR DESCRIPTION

## What's changed?
`.vbproj` and `.fsproj` are .NET project XML files and need to be parsed as such.

## What's your motivation?
Prior to these changes these file types were being parsed as `PlainText`.

## Anything in particular you'd like reviewers to focus on?
No.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
No.

## Any additional context
No.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
