### PR TITLE
Fix a very minor typo in RemoveManagedDependency doc

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
@@ -38,7 +38,7 @@ public class RemoveManagedDependency extends Recipe {
     String artifactId;
 
     @Option(displayName = "Scope",
-            description = "Only remove managed dependencies if they are in this scope. If `runtime`, this will" +
+            description = "Only remove managed dependencies if they are in this scope. If `runtime`, this will " +
                           "also remove managed dependencies in the 'compile' scope because `compile` dependencies are part of the runtime dependency set.",
             valid = {"compile", "test", "runtime", "provided"},
             example = "compile",


### PR DESCRIPTION
This one is not exactly rocket science but I noticed it while reading the doc so I might as well fix it.

See https://docs.openrewrite.org/recipes/maven/removemanageddependency .