### PR TITLE
Make Plugin.getGroupId() NonNull

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -364,12 +364,9 @@ public class RemoveRedundantDependencyVersions extends Recipe {
         };
     }
 
-    private static @Nullable String getManagedPluginVersion(ResolvedPom resolvedPom, @Nullable String groupId, String artifactId) {
+    private static @Nullable String getManagedPluginVersion(ResolvedPom resolvedPom, String groupId, String artifactId) {
         for (Plugin p : ListUtils.concatAll(resolvedPom.getPluginManagement(), resolvedPom.getRequested().getPluginManagement())) {
-            if (Objects.equals(
-                    Optional.ofNullable(p.getGroupId()).orElse("org.apache.maven.plugins"),
-                    Optional.ofNullable(groupId).orElse("org.apache.maven.plugins")) &&
-                Objects.equals(p.getArtifactId(), artifactId)) {
+            if (Objects.equals(p.getGroupId(), groupId) && Objects.equals(p.getArtifactId(), artifactId)) {
                 return resolvedPom.getValue(p.getVersion());
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Plugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Plugin.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AccessLevel;
 import lombok.Value;
 import lombok.experimental.FieldDefaults;
+
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.maven.internal.MavenXmlMapper;
 
@@ -33,6 +35,7 @@ public class Plugin {
     // default value as per https://maven.apache.org/xsd/maven-4.0.0.xsd
     public static final String PLUGIN_DEFAULT_GROUPID = "org.apache.maven.plugins";
 
+    @Nullable
     String groupId;
     String artifactId;
 
@@ -50,6 +53,11 @@ public class Plugin {
 
     List<Dependency> dependencies;
     List<Execution> executions;
+
+    @NonNull
+    public String getGroupId() {
+        return groupId == null ? PLUGIN_DEFAULT_GROUPID : groupId;
+    }
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @Value


### PR DESCRIPTION
## What's changed?
`org.openrewrite.maven.tree.Plugin.getGroupId()` is now non-null, defaulting to `org.openrewrite.maven.tree.Plugin.PLUGIN_DEFAULT_GROUPID`. 

## What's your motivation?
closes #4526 

This ensures no more NullPointerExceptions can occur. Plugins can have a `null` `groupId` but not all places of the code take that situation into account. By automatically defaulting to `org.apache.maven.plugins` in the getter itself, there is no more need in the code to duplicate the nullability _branching_, and potentially forgetting it. 

## Anything in particular you'd like reviewers to focus on?
**I was not able to provide a test** for this case because the project being tested needs to use a parent pom that uses plugin management with plugins not explicitly setting `<groupId>org.apache.maven.plugins</groupId>`. I could not find a public pom file that I could use as a parent in the tests.

Locally there was 1, on first sight, non related test (`MavenPomDownloaderTest.mirrorsOverrideRepositoriesInPom()`) failing. I verified the changes by running our failing recipes again and now the NPE is gone. 

## Have you considered any alternatives or workarounds?
We bump into this issue because we use jgitver to manage out Maven versions. I tried to fix the issue in jgitver itself but it is using _native_ maven to write the built pom file and it is in that _native_ Maven code that the `groupId` for all plugins of org.apache.maven.plugins is not written to the new pom.xml file
