### PR TITLE
Expose AddOrUpdateChild as a recipe using XPath + child XML

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddOrUpdateChildTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddOrUpdateChildTag.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.intellij.lang.annotations.Language;
+import org.openrewrite.*;
+import org.openrewrite.xml.tree.Xml;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class AddOrUpdateChildTag extends Recipe {
+
+    @Option(displayName = "Parent XPath",
+            description = "XPath identifying the parent to which a child tag must be added",
+            example = "/project//plugin//configuration")
+    @Language("xpath")
+    String parentXPath;
+
+    @Option(displayName = "New child tag",
+            description = "The XML of the new child to add or update on the parent tag.",
+            example = "<skip>true</skip>")
+    @Language("xml")
+    String newChildTag;
+
+    @Override
+    public String getDisplayName() {
+        return "Add or update child tag";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds or updates a child element below the parent(s) matching the provided `parentXPath` expression. " +
+               "If a child with the same name exists, it will be replaced, otherwise a new child will be added. " +
+               "This ensures idempotent behaviour.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate()
+                .and(Validated.notBlank("parentXPath", parentXPath))
+                .and(Validated.notBlank("newChildTag", newChildTag));
+        try {
+            Xml.Tag.build(newChildTag);
+        } catch (Exception e) {
+            validated = validated.and(Validated.invalid("newChildTag", newChildTag, "Invalid XML for child tag", e));
+        }
+        return validated;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlVisitor<ExecutionContext>() {
+            private final XPathMatcher xPathMatcher = new XPathMatcher(parentXPath);
+
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                if (xPathMatcher.matches(getCursor())) {
+                    Xml.Tag newChild = Xml.Tag.build(newChildTag);
+                    return AddOrUpdateChild.addOrUpdateChild(tag, newChild, getCursor().getParentOrThrow());
+                }
+                return super.visitTag(tag, ctx);
+            }
+        };
+    }
+}

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddOrUpdateChildTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddOrUpdateChildTag.java
@@ -18,6 +18,7 @@ package org.openrewrite.xml;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.xml.tree.Xml;
 
@@ -37,6 +38,12 @@ public class AddOrUpdateChildTag extends Recipe {
     @Language("xml")
     String newChildTag;
 
+    @Option(displayName = "Replace existing child",
+            description = "Set to `false` to not replace the child tag if it already exists. Defaults to true.",
+            required = false)
+    @Nullable
+    Boolean replaceExisting;
+
     @Override
     public String getDisplayName() {
         return "Add or update child tag";
@@ -45,7 +52,7 @@ public class AddOrUpdateChildTag extends Recipe {
     @Override
     public String getDescription() {
         return "Adds or updates a child element below the parent(s) matching the provided `parentXPath` expression. " +
-               "If a child with the same name exists, it will be replaced, otherwise a new child will be added. " +
+               "If a child with the same name already exists, it will be replaced by default. Otherwise, a new child will be added. " +
                "This ensures idempotent behaviour.";
     }
 
@@ -71,7 +78,9 @@ public class AddOrUpdateChildTag extends Recipe {
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 if (xPathMatcher.matches(getCursor())) {
                     Xml.Tag newChild = Xml.Tag.build(newChildTag);
-                    return AddOrUpdateChild.addOrUpdateChild(tag, newChild, getCursor().getParentOrThrow());
+                    if (replaceExisting == null || replaceExisting || !tag.getChild(newChild.getName()).isPresent()) {
+                        return AddOrUpdateChild.addOrUpdateChild(tag, newChild, getCursor().getParentOrThrow());
+                    }
                 }
                 return super.visitTag(tag, ctx);
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -92,18 +92,8 @@ public class XPathMatcher {
                     if (index < 0) {
                         return false;
                     }
-                    if (part.startsWith("@")) { // is attribute selector
-                        partWithCondition = part;
-                        tagForCondition = i > 0 ? path.get(i - 1) : path.get(i);
-                    } else { // is element selector
-                        if (part.charAt(index + 1) == '@') { // is Attribute condition
-                            partWithCondition = part;
-                            tagForCondition = path.get(i);
-                        } else if (part.contains("(") && part.contains(")")) { // is function condition
-                            partWithCondition = part;
-                            tagForCondition = path.get(i);
-                        }
-                    }
+                    partWithCondition = part;
+                    tagForCondition = path.get(pathIndex);
                 } else if (i < path.size() && i > 0 && parts[i - 1].endsWith("]")) {
                     String partBefore = parts[i - 1];
                     int index = partBefore.indexOf("[");
@@ -117,6 +107,7 @@ public class XPathMatcher {
                     }
                 } else if (part.endsWith(")")) { // is xpath method
                     // TODO: implement other xpath methods
+                    throw new UnsupportedOperationException("XPath methods are not supported");
                 }
 
                 String partName;
@@ -164,31 +155,41 @@ public class XPathMatcher {
                 }
             }
 
-            return startsWithSlash || path.size() - pathIndex <= 1;
+            // we have matched the whole XPath, and it does not start with the root
+            return true;
         } else {
             Collections.reverse(path);
 
             // Deal with the two forward slashes in the expression; works, but I'm not proud of it.
-            if (expression.contains("//") && !expression.contains("://") && Arrays.stream(parts).anyMatch(StringUtils::isBlank)) {
+            if (expression.contains("//") && Arrays.stream(parts).anyMatch(StringUtils::isBlank)) {
                 int blankPartIndex = Arrays.asList(parts).indexOf("");
                 int doubleSlashIndex = expression.indexOf("//");
 
-                if (path.size() > blankPartIndex && path.size() >= parts.length - 1) {
+                if (path.size() > blankPartIndex && path.size() >= parts.length - (parts[parts.length - 1].startsWith("@") ? 2 : 1)) {
                     String newExpression;
-                    if (Objects.equals(path.get(blankPartIndex).getName(), parts[blankPartIndex + 1])) {
+                    Xml.Tag blankPartTag = path.get(blankPartIndex);
+                    String part = parts[blankPartIndex + 1];
+                    Matcher matcher = ELEMENT_WITH_CONDITION_PATTERN.matcher(part);
+                    if (matcher.matches() ?
+                            matchesElementWithConditionFunction(matcher, blankPartTag, cursor) != null :
+                            Objects.equals(blankPartTag.getName(), part)) {
                         newExpression = String.format(
                                 "%s/%s",
                                 expression.substring(0, doubleSlashIndex),
                                 expression.substring(doubleSlashIndex + 2)
                         );
-                    } else {
-                        newExpression = String.format(
-                                "%s/%s/%s",
-                                expression.substring(0, doubleSlashIndex),
-                                path.get(blankPartIndex).getName(),
-                                expression.substring(doubleSlashIndex + 2)
-                        );
+                        if (new XPathMatcher(newExpression).matches(cursor)) {
+                            return true;
+                        }
+                        // fall-through: maybe we can skip this element and match further down
                     }
+                    newExpression = String.format(
+                            // the // here allows to skip several levels of nested elements
+                            "%s/%s//%s",
+                            expression.substring(0, doubleSlashIndex),
+                            blankPartTag.getName(),
+                            expression.substring(doubleSlashIndex + 2)
+                    );
                     return new XPathMatcher(newExpression).matches(cursor);
                 }
             }
@@ -235,6 +236,15 @@ public class XPathMatcher {
         }
     }
 
+    /**
+     * Checks that the given {@code tag} matches the XPath part represented by {@code matcher}.
+     *
+     * @param matcher an XPath part matcher for {@link #ELEMENT_WITH_CONDITION_PATTERN}
+     * @param tag     a tag to match
+     * @param cursor  the cursor we are trying to match
+     * @return the element name specified before the condition of the part
+     * (either {@code tag.getName()}, {@code "*"} or an attribute name) or {@code null} if the tag did not match
+     */
     private @Nullable String matchesElementWithConditionFunction(Matcher matcher, Xml.Tag tag, Cursor cursor) {
         boolean isAttributeElement = matcher.group(1) != null;
         String element = matcher.group(2);

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/AddOrUpdateChildTagTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/AddOrUpdateChildTagTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class AddOrUpdateChildTagTest implements RewriteTest {
+    @Test
+    void addsTagEverywhereWhenAbsent() {
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateChildTag(
+                        "/project//plugin[groupId='org.apache.maven.plugins' and artifactId='maven-resources-plugin']" +
+                        "//configuration",
+                        "<skip>true</skip>")),
+                xml(
+                        """
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                                    <modelVersion>4.0.0</modelVersion>
+                                    <groupId>com.example</groupId>
+                                    <artifactId>my-project</artifactId>
+                                    <version>1.0</version>
+                                
+                                    <build>
+                                        <pluginManagement>
+                                            <plugins>
+                                                <plugin>
+                                                    <groupId>org.apache.maven.plugins</groupId>
+                                                    <artifactId>maven-resources-plugin</artifactId>
+                                                    <version>3.3.1</version>
+                                                    <configuration>
+                                                        <encoding>UTF-8</encoding>
+                                                    </configuration>
+                                                </plugin>
+                                            </plugins>
+                                        </pluginManagement>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-resources-plugin</artifactId>
+                                                <version>3.3.1</version>
+                                                <executions>
+                                                    <execution>
+                                                        <configuration>
+                                                            <encoding>UTF-8</encoding>
+                                                        </configuration>
+                                                    </execution>
+                                                </executions>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                    <profiles>
+                                        <profile>
+                                            <id>profile1</id>
+                                            <build>
+                                                <pluginManagement>
+                                                    <plugins>
+                                                        <plugin>
+                                                            <groupId>org.apache.maven.plugins</groupId>
+                                                            <artifactId>maven-resources-plugin</artifactId>
+                                                            <version>3.3.1</version>
+                                                            <executions>
+                                                                <execution>
+                                                                    <configuration>
+                                                                        <encoding>UTF-8</encoding>
+                                                                    </configuration>
+                                                                </execution>
+                                                            </executions>
+                                                        </plugin>
+                                                    </plugins>
+                                                </pluginManagement>
+                                                <plugins>
+                                                    <plugin>
+                                                        <groupId>org.apache.maven.plugins</groupId>
+                                                        <artifactId>maven-resources-plugin</artifactId>
+                                                        <version>3.3.1</version>
+                                                        <configuration>
+                                                            <encoding>UTF-8</encoding>
+                                                        </configuration>
+                                                    </plugin>
+                                                </plugins>
+                                            </build>
+                                        </profile>
+                                    </profiles>
+                                </project>
+                                """,
+                        """
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                                    <modelVersion>4.0.0</modelVersion>
+                                    <groupId>com.example</groupId>
+                                    <artifactId>my-project</artifactId>
+                                    <version>1.0</version>
+                                
+                                    <build>
+                                        <pluginManagement>
+                                            <plugins>
+                                                <plugin>
+                                                    <groupId>org.apache.maven.plugins</groupId>
+                                                    <artifactId>maven-resources-plugin</artifactId>
+                                                    <version>3.3.1</version>
+                                                    <configuration>
+                                                        <encoding>UTF-8</encoding>
+                                                        <skip>true</skip>
+                                                    </configuration>
+                                                </plugin>
+                                            </plugins>
+                                        </pluginManagement>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-resources-plugin</artifactId>
+                                                <version>3.3.1</version>
+                                                <executions>
+                                                    <execution>
+                                                        <configuration>
+                                                            <encoding>UTF-8</encoding>
+                                                            <skip>true</skip>
+                                                        </configuration>
+                                                    </execution>
+                                                </executions>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                    <profiles>
+                                        <profile>
+                                            <id>profile1</id>
+                                            <build>
+                                                <pluginManagement>
+                                                    <plugins>
+                                                        <plugin>
+                                                            <groupId>org.apache.maven.plugins</groupId>
+                                                            <artifactId>maven-resources-plugin</artifactId>
+                                                            <version>3.3.1</version>
+                                                            <executions>
+                                                                <execution>
+                                                                    <configuration>
+                                                                        <encoding>UTF-8</encoding>
+                                                                        <skip>true</skip>
+                                                                    </configuration>
+                                                                </execution>
+                                                            </executions>
+                                                        </plugin>
+                                                    </plugins>
+                                                </pluginManagement>
+                                                <plugins>
+                                                    <plugin>
+                                                        <groupId>org.apache.maven.plugins</groupId>
+                                                        <artifactId>maven-resources-plugin</artifactId>
+                                                        <version>3.3.1</version>
+                                                        <configuration>
+                                                            <encoding>UTF-8</encoding>
+                                                            <skip>true</skip>
+                                                        </configuration>
+                                                    </plugin>
+                                                </plugins>
+                                            </build>
+                                        </profile>
+                                    </profiles>
+                                </project>
+                                """
+                )
+        );
+    }
+
+    @Test
+    void updateTagEverywhere() {
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateChildTag(
+                        "/project//plugin[groupId='org.apache.maven.plugins' and artifactId='maven-resources-plugin']" +
+                        "//configuration",
+                        "<skip>true</skip>")),
+                xml(
+                        """
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                                    <modelVersion>4.0.0</modelVersion>
+                                    <groupId>com.example</groupId>
+                                    <artifactId>my-project</artifactId>
+                                    <version>1.0</version>
+                                
+                                    <build>
+                                        <pluginManagement>
+                                            <plugins>
+                                                <plugin>
+                                                    <groupId>org.apache.maven.plugins</groupId>
+                                                    <artifactId>maven-resources-plugin</artifactId>
+                                                    <version>3.3.1</version>
+                                                    <configuration>
+                                                        <encoding>UTF-8</encoding>
+                                                        <skip>false</skip>
+                                                    </configuration>
+                                                </plugin>
+                                            </plugins>
+                                        </pluginManagement>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-resources-plugin</artifactId>
+                                                <version>3.3.1</version>
+                                                <configuration>
+                                                    <encoding>UTF-8</encoding>
+                                                    <skip>false</skip>
+                                                </configuration>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                    <profiles>
+                                        <profile>
+                                            <id>profile1</id>
+                                            <build>
+                                                <pluginManagement>
+                                                    <plugins>
+                                                        <plugin>
+                                                            <groupId>org.apache.maven.plugins</groupId>
+                                                            <artifactId>maven-resources-plugin</artifactId>
+                                                            <version>3.3.1</version>
+                                                            <configuration>
+                                                                <encoding>UTF-8</encoding>
+                                                                <skip>false</skip>
+                                                            </configuration>
+                                                        </plugin>
+                                                    </plugins>
+                                                </pluginManagement>
+                                                <plugins>
+                                                    <plugin>
+                                                        <groupId>org.apache.maven.plugins</groupId>
+                                                        <artifactId>maven-resources-plugin</artifactId>
+                                                        <version>3.3.1</version>
+                                                        <configuration>
+                                                            <encoding>UTF-8</encoding>
+                                                            <skip>false</skip>
+                                                        </configuration>
+                                                    </plugin>
+                                                </plugins>
+                                            </build>
+                                        </profile>
+                                    </profiles>
+                                </project>
+                                """,
+                        """
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                                    <modelVersion>4.0.0</modelVersion>
+                                    <groupId>com.example</groupId>
+                                    <artifactId>my-project</artifactId>
+                                    <version>1.0</version>
+                                
+                                    <build>
+                                        <pluginManagement>
+                                            <plugins>
+                                                <plugin>
+                                                    <groupId>org.apache.maven.plugins</groupId>
+                                                    <artifactId>maven-resources-plugin</artifactId>
+                                                    <version>3.3.1</version>
+                                                    <configuration>
+                                                        <encoding>UTF-8</encoding>
+                                                        <skip>true</skip>
+                                                    </configuration>
+                                                </plugin>
+                                            </plugins>
+                                        </pluginManagement>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-resources-plugin</artifactId>
+                                                <version>3.3.1</version>
+                                                <configuration>
+                                                    <encoding>UTF-8</encoding>
+                                                    <skip>true</skip>
+                                                </configuration>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                    <profiles>
+                                        <profile>
+                                            <id>profile1</id>
+                                            <build>
+                                                <pluginManagement>
+                                                    <plugins>
+                                                        <plugin>
+                                                            <groupId>org.apache.maven.plugins</groupId>
+                                                            <artifactId>maven-resources-plugin</artifactId>
+                                                            <version>3.3.1</version>
+                                                            <configuration>
+                                                                <encoding>UTF-8</encoding>
+                                                                <skip>true</skip>
+                                                            </configuration>
+                                                        </plugin>
+                                                    </plugins>
+                                                </pluginManagement>
+                                                <plugins>
+                                                    <plugin>
+                                                        <groupId>org.apache.maven.plugins</groupId>
+                                                        <artifactId>maven-resources-plugin</artifactId>
+                                                        <version>3.3.1</version>
+                                                        <configuration>
+                                                            <encoding>UTF-8</encoding>
+                                                            <skip>true</skip>
+                                                        </configuration>
+                                                    </plugin>
+                                                </plugins>
+                                            </build>
+                                        </profile>
+                                    </profiles>
+                                </project>
+                                """
+                )
+        );
+    }
+
+    @Test
+    void dontTouchAnythingElse() {
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateChildTag(
+                        "/project//plugin[groupId='org.apache.maven.plugins' and artifactId='maven-resources-plugin']" +
+                        "//configuration",
+                        "<skip>true</skip>")),
+                xml(
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>com.example</groupId>
+                            <artifactId>my-project</artifactId>
+                            <version>1.0</version>
+                        
+                            <build>
+                                <pluginManagement>
+                                    <plugins>
+                                        <plugin>
+                                            <groupId>org.apache.maven.plugins</groupId>
+                                            <artifactId>maven-other-plugin</artifactId>
+                                            <version>3.3.1</version>
+                                            <configuration>
+                                                <encoding>UTF-8</encoding>
+                                                <skip>false</skip>
+                                            </configuration>
+                                        </plugin>
+                                    </plugins>
+                                </pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.other.plugins</groupId>
+                                        <artifactId>maven-resources-plugin</artifactId>
+                                        <version>3.3.1</version>
+                                        <configuration>
+                                            <encoding>UTF-8</encoding>
+                                            <skip>false</skip>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                            <profiles>
+                                <profile>
+                                    <id>profile1</id>
+                                    <build>
+                                        <pluginManagement>
+                                            <plugins>
+                                                <plugin>
+                                                    <groupId>org.apache.maven.plugins</groupId>
+                                                    <artifactId>maven-resources-plugin</artifactId>
+                                                    <version>3.3.1</version>
+                                                </plugin>
+                                            </plugins>
+                                        </pluginManagement>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-other-plugin</artifactId>
+                                                <version>3.3.1</version>
+                                                <configuration>
+                                                    <encoding>UTF-8</encoding>
+                                                    <skip>false</skip>
+                                                </configuration>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                </profile>
+                            </profiles>
+                        </project>
+                        """
+                )
+        );
+    }
+}

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XPathMatcherTest.java
@@ -118,7 +118,13 @@ class XPathMatcherTest {
         assertThat(match("/dependencies/dependency", xmlDoc)).isTrue();
         assertThat(match("/dependencies/*/artifactId", xmlDoc)).isTrue();
         assertThat(match("/dependencies/*", xmlDoc)).isTrue();
+        assertThat(match("/dependencies//dependency", xmlDoc)).isTrue();
+        assertThat(match("/dependencies//dependency//groupId", xmlDoc)).isTrue();
+
+        // negative matches
         assertThat(match("/dependencies/dne", xmlDoc)).isFalse();
+        assertThat(match("/dependencies//dne", xmlDoc)).isFalse();
+        assertThat(match("/dependencies//dependency//dne", xmlDoc)).isFalse();
     }
 
     @Test
@@ -127,6 +133,17 @@ class XPathMatcherTest {
         assertThat(match("/dependencies/dependency/artifactId/@scope", xmlDoc)).isTrue();
         assertThat(match("/dependencies/dependency/artifactId/@*", xmlDoc)).isTrue();
         assertThat(match("/dependencies/dependency/groupId/@*", xmlDoc)).isFalse();
+        assertThat(match("/dependencies//dependency//@scope", xmlDoc)).isTrue();
+        assertThat(match("/dependencies//dependency//artifactId//@scope", xmlDoc)).isTrue();
+        assertThat(match("/dependencies//dependency//@*", xmlDoc)).isTrue();
+        assertThat(match("/dependencies//dependency//artifactId//@*", xmlDoc)).isTrue();
+
+        // negative matches
+        assertThat(match("/dependencies/dependency/artifactId/@dne", xmlDoc)).isFalse();
+        assertThat(match("/dependencies/dependency/artifactId/@dne", xmlDoc)).isFalse();
+        assertThat(match("/dependencies//dependency//@dne", xmlDoc)).isFalse();
+        assertThat(match("/dependencies//dependency//artifactId//@dne", xmlDoc)).isFalse();
+
     }
 
     @Test
@@ -136,8 +153,6 @@ class XPathMatcherTest {
         assertThat(match("//dependency", xmlDoc)).isTrue();
         assertThat(match("dependency/*", xmlDoc)).isTrue();
         assertThat(match("dne", xmlDoc)).isFalse();
-        assertThat(match("/dependencies//dependency", xmlDoc)).isTrue();
-        assertThat(match("/dependencies//dependency/groupId", xmlDoc)).isTrue();
     }
 
     @Test
@@ -211,6 +226,7 @@ class XPathMatcherTest {
         // skip 2+ levels with //
         assertThat(match("/project/build//plugin/configuration/source", pomXml2)).isTrue();
         assertThat(match("/project//configuration/source", pomXml2)).isTrue();
+        assertThat(match("/project//plugin//source", pomXml2)).isTrue();
     }
 
     private final SourceFile attributeXml = new XmlParser().parse(


### PR DESCRIPTION
## What's changed?
Simple XML recipe that can add or update a child below the element(s) selected by XPath.

## What's your motivation?
Provide more flexible ways of updating XML/pom files. In our specific case we need to configure `openapi-generator-maven-plugin` with `<useJakartaEe>true</useJakartaEe>` when it matches `<generatorName>spring</generatorName>`, following `JavaxMigrationToJakarta` (once this PR is merged, maybe it could be included there).

## Anything in particular you'd like reviewers to focus on?
I had considered offering the option to add the child even when it already exists, but that wouldn’t be idempotent. I implemented an option to not replace the child in such a case, disabled by default.

I based this branch on top of #4532 so the former should be merged first and it’s not needed to review the changes on XPath implementation. I just wanted to use the XPath fixes in the tests of this new recipe.

## Have you considered any alternatives or workarounds?
I don’t think any other equivalent recipe exists. `ChangePluginConfiguration` only allows to override the whole configuration.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
