### PR TITLE
Add `@JsonProperty` to `JavaType#getManagedReference()`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Tree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Tree.java
@@ -15,9 +15,6 @@
  */
 package org.openrewrite;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.StringUtils;
@@ -25,15 +22,8 @@ import org.openrewrite.marker.Markers;
 
 import java.util.UUID;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
-@JsonPropertyOrder({"@c"}) // serialize type info first
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c", include = JsonTypeInfo.As.PROPERTY)
 public interface Tree {
-    @SuppressWarnings("unused")
-    @JsonProperty("@c")
-    default String getJacksonPolymorphicTypeTag() {
-        return getClass().getName();
-    }
 
     static UUID randomId() {
         //noinspection ConstantConditions

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -37,8 +37,7 @@ import static org.openrewrite.java.tree.TypeUtils.unknownIfNull;
 
 @SuppressWarnings("unused")
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c", include = JsonTypeInfo.As.PROPERTY)
 public interface JavaType {
 
     FullyQualified[] EMPTY_FULLY_QUALIFIED_ARRAY = new FullyQualified[0];
@@ -47,12 +46,8 @@ public interface JavaType {
     String[] EMPTY_STRING_ARRAY = new String[0];
     JavaType[] EMPTY_JAVA_TYPE_ARRAY = new JavaType[0];
 
-    @JsonProperty("@c")
-    default String getJacksonPolymorphicTypeTag() {
-        return getClass().getName();
-    }
-
     // TODO: To be removed with OpenRewrite 9
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     default @Nullable Integer getManagedReference() {
         return null;
     }


### PR DESCRIPTION
As the property will be phased out, mark it as write-only for serialization purposes. Also clean up some of the Jackson annotations.
