### PR TITLE
Nullability cleanups in `TreeVisitor`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -18,6 +18,7 @@ package org.openrewrite;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.RecipeRunException;
@@ -35,6 +36,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Abstract {@link TreeVisitor} for processing {@link Tree elements}
@@ -48,7 +50,7 @@ import static java.util.Collections.emptyList;
  * @param <T> The type of tree.
  * @param <P> An input object that is passed to every visit method.
  */
-public abstract class TreeVisitor<T extends Tree, P> {
+public abstract class TreeVisitor<T extends @Nullable Tree, P> {
     private static final String STOP_AFTER_PRE_VISIT = "__org.openrewrite.stopVisitor__";
 
     Cursor cursor = new Cursor(null, Cursor.ROOT_VALUE);
@@ -69,7 +71,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
         };
     }
 
-    private List<TreeVisitor<?, P>> afterVisit;
+    private @Nullable List<TreeVisitor<?, P>> afterVisit;
 
     private int visitCount;
     private final DistributionSummary visitCountSummary = DistributionSummary.builder("rewrite.visitor.visit.method.count").description("Visit methods called per source file visited.").tag("visitor.class", getClass().getName()).register(Metrics.globalRegistry);
@@ -79,6 +81,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
     }
 
     public void setCursor(@Nullable Cursor cursor) {
+        assert cursor != null;
         this.cursor = cursor;
     }
 
@@ -126,7 +129,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
         if (!(old instanceof Tree)) {
             throw new IllegalArgumentException("To update the cursor, it must currently be positioned at a Tree instance");
         }
-        if (!((Tree) old).getId().equals(currentValue.getId())) {
+        if (!((Tree) old).getId().equals(requireNonNull(currentValue).getId())) {
             throw new IllegalArgumentException("Updating the cursor in place is only supported for mutations on a Tree instance " +
                                                "that maintain the same ID after the mutation.");
         }
@@ -134,11 +137,11 @@ public abstract class TreeVisitor<T extends Tree, P> {
         return cursor;
     }
 
-    public @Nullable T preVisit(T tree, P p) {
+    public @Nullable T preVisit(@NonNull T tree, P p) {
         return defaultValue(tree, p);
     }
 
-    public @Nullable T postVisit(T tree, P p) {
+    public @Nullable T postVisit(@NonNull T tree, P p) {
         return defaultValue(tree, p);
     }
 
@@ -156,7 +159,7 @@ public abstract class TreeVisitor<T extends Tree, P> {
      * @param p    A state object that passes through the visitor.
      * @return A non-null tree.
      */
-    public T visitNonNull(Tree tree, P p) {
+    public @NonNull T visitNonNull(Tree tree, P p) {
         T t = visit(tree, p);
         assert t != null;
         return t;
@@ -266,11 +269,9 @@ public abstract class TreeVisitor<T extends Tree, P> {
 
                 if (t != null && afterVisit != null) {
                     for (TreeVisitor<?, P> v : afterVisit) {
-                        if (v != null) {
-                             v.setCursor(getCursor());
-                            //noinspection unchecked
-                            t = (T) v.visit(t, p);
-                        }
+                         v.setCursor(getCursor());
+                        //noinspection unchecked
+                        t = (T) v.visit(t, p);
                     }
                 }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddOrUpdateChild.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddOrUpdateChild.java
@@ -78,6 +78,6 @@ public class AddOrUpdateChild<P> extends XmlVisitor<P> {
      */
     public static Xml.Tag addOrUpdateChild(Xml.Tag parentScope, Xml.Tag parent, Xml.Tag child, Cursor parentCursor) {
         //noinspection ConstantConditions
-        return (Xml.Tag) new AddOrUpdateChild<Void>(parent, child).visitNonNull(parentScope, null, parentCursor);
+        return (Xml.Tag) new AddOrUpdateChild<Integer>(parent, child).visitNonNull(parentScope, 0, parentCursor);
     }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/AddToTagVisitor.java
@@ -111,7 +111,7 @@ public class AddToTagVisitor<P> extends XmlVisitor<P> {
      */
     public static Xml.Tag addToTag(Xml.Tag parentScope, Xml.Tag parent, Xml.Tag newChild, Cursor parentCursor) {
         //noinspection ConstantConditions
-        return (Xml.Tag) new AddToTagVisitor<Void>(parent, newChild)
-                .visitNonNull(parentScope, null, parentCursor);
+        return (Xml.Tag) new AddToTagVisitor<Integer>(parent, newChild)
+                .visitNonNull(parentScope, 0, parentCursor);
     }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/FilterTagChildrenVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/FilterTagChildrenVisitor.java
@@ -67,8 +67,8 @@ public class FilterTagChildrenVisitor<T> extends XmlVisitor<T> {
      */
     public static Xml.Tag filterChildren(Xml.Tag parentScope, Xml.Tag parent, Predicate<Content> childTest) {
         //noinspection ConstantConditions
-        return (Xml.Tag) new FilterTagChildrenVisitor<Void>(parent, childTest)
-                .visitNonNull(parentScope, null);
+        return (Xml.Tag) new FilterTagChildrenVisitor<Integer>(parent, childTest)
+                .visitNonNull(parentScope, 0);
     }
 
     /**

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/MapTagChildrenVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/MapTagChildrenVisitor.java
@@ -65,7 +65,7 @@ public class MapTagChildrenVisitor<T> extends XmlVisitor<T> {
      */
     public static Xml.Tag mapChildren(Xml.Tag parentScope, Xml.Tag parent, UnaryOperator<Content> map) {
         //noinspection ConstantConditions
-        return (Xml.Tag) new MapTagChildrenVisitor<Void>(parent, map).visitNonNull(parentScope, null);
+        return (Xml.Tag) new MapTagChildrenVisitor<Integer>(parent, map).visitNonNull(parentScope, 0);
     }
 
     public static Xml.Tag mapTagChildren(Xml.Tag parent, UnaryOperator<Xml.Tag> map) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
@@ -24,10 +24,10 @@ import org.openrewrite.yaml.tree.Yaml;
 
 public class Autodetect {
     public static IndentsStyle tabsAndIndents(Yaml yaml, IndentsStyle orElse) {
-        FindIndentYamlVisitor<Void> findIndent = new FindIndentYamlVisitor<>(0);
+        FindIndentYamlVisitor<Integer> findIndent = new FindIndentYamlVisitor<>(0);
 
         //noinspection ConstantConditions
-        findIndent.visit(yaml, null);
+        findIndent.visit(yaml, 0);
 
         return findIndent.nonZeroIndents() > 0 ?
                 new IndentsStyle(findIndent.getMostCommonIndent()) :
@@ -35,10 +35,10 @@ public class Autodetect {
     }
 
     public static GeneralFormatStyle generalFormat(Yaml yaml) {
-        FindLineFormatJavaVisitor<Void> findLineFormat = new FindLineFormatJavaVisitor<>();
+        FindLineFormatJavaVisitor<Integer> findLineFormat = new FindLineFormatJavaVisitor<>();
 
         //noinspection ConstantConditions
-        findLineFormat.visit(yaml, null);
+        findLineFormat.visit(yaml, 0);
 
         return new GeneralFormatStyle(!findLineFormat.isIndentedWithLFNewLines());
     }


### PR DESCRIPTION
Adjust some of the `@Nullable` and `@NonNull` annotations in `TreeVisitor` to reduce the number of warnings in code using the API as well as in `TreeVisitor` itself.
