### PR TITLE
add test case to illustrate issue with unsolicited indentation.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
@@ -19,9 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.java.style.ImportLayoutStyle;
+import org.openrewrite.java.style.TabsAndIndentsStyle;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.Arrays;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
@@ -711,8 +714,9 @@ class OrderImportsTest implements RewriteTest {
     }
 
     /**
-     * This style should only reorder the imports but it indents the `extends` keyword as well.
-     * Context is: I'm trying to enforce a custom order of imports, so I don't want this style to do anything else.
+     * With only an ImportLayoutStyle and no TabAndIndentsStyle the recipe indents the `extends` keyword as well.
+     * This test verifies that TabAndIndentsStyle can be configured (with continuationIndent <= -2) so that it leaves
+     * the code following the imports as it is.
      */
     @Issue("https://github.com/openrewrite/rewrite/issues/4165")
     @Test
@@ -722,16 +726,17 @@ class OrderImportsTest implements RewriteTest {
             singletonList(
               new NamedStyles(
                 randomId(),
-                "it.does.more.than.JustOrderImports",
-                "custom style",
-                null,
+                "it.will.only.OrderImports",
+                "Order imports by custom style",
+                "This style defines the order of imports and nothing else",
                 emptySet(),
-                singletonList(
+                Arrays.asList(
                   ImportLayoutStyle.builder()
                     .importAllOthers()
                     .blankLine()
                     .importStaticAllOthers()
-                    .build()
+                    .build(),
+                  new TabsAndIndentsStyle(false, -2, -2, -2, false, null)
                 )
               )
             ))),
@@ -743,6 +748,10 @@ class OrderImportsTest implements RewriteTest {
               import java.io.*;
               class Test
                   extends BaseClass {
+
+                   int foo;//nonstandard indentation
+
+              \tint ba;//tabbed indentation
               }
               """,
             """
@@ -752,6 +761,10 @@ class OrderImportsTest implements RewriteTest {
               
               class Test
                   extends BaseClass {
+
+                   int foo;//nonstandard indentation
+
+              \tint ba;//tabbed indentation
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
@@ -742,7 +742,7 @@ class OrderImportsTest implements RewriteTest {
             ))),
           java("class BaseClass {}"),
           java(
-            """              
+            """
               import static org.junit.jupiter.api.Assertions.*;
 
               import java.io.*;
@@ -756,15 +756,48 @@ class OrderImportsTest implements RewriteTest {
               """,
             """
               import java.io.*;
-              
+
               import static org.junit.jupiter.api.Assertions.*;
-              
+
               class Test
                   extends BaseClass {
 
                    int foo;//nonstandard indentation
 
               \tint ba;//tabbed indentation
+              }
+              """
+          ),
+          java(
+            """
+              import com.fasterxml.jackson.core.*;
+              
+              import com.fasterxml.jackson.databind.*;
+              
+              public class CollectionDeserializer {
+    
+                  void a()
+                  {
+                  }    
+                  /**
+                   * JavaDoc without a gap.
+                   */
+                  class B {}
+              }
+              """,
+            """
+              import com.fasterxml.jackson.core.*;
+              import com.fasterxml.jackson.databind.*;
+              
+              public class CollectionDeserializer {
+    
+                  void a()
+                  {
+                  }    
+                  /**
+                   * JavaDoc without a gap.
+                   */
+                  class B {}
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
@@ -709,4 +709,52 @@ class OrderImportsTest implements RewriteTest {
           )
         );
     }
+
+    /**
+     * This style should only reorder the imports but it indents the `extends` keyword as well.
+     * Context is: I'm trying to enforce a custom order of imports, so I don't want this style to do anything else.
+     */
+    @Issue("https://github.com/openrewrite/rewrite/issues/4165")
+    @Test
+    void shouldNotIndentExtends() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().styles(
+            singletonList(
+              new NamedStyles(
+                randomId(),
+                "it.does.more.than.JustOrderImports",
+                "custom style",
+                null,
+                emptySet(),
+                singletonList(
+                  ImportLayoutStyle.builder()
+                    .importAllOthers()
+                    .blankLine()
+                    .importStaticAllOthers()
+                    .build()
+                )
+              )
+            ))),
+          java("class BaseClass {}"),
+          java(
+            """              
+              import static org.junit.jupiter.api.Assertions.*;
+
+              import java.io.*;
+              class Test
+                  extends BaseClass {
+              }
+              """,
+            """
+              import java.io.*;
+              
+              import static org.junit.jupiter.api.Assertions.*;
+              
+              class Test
+                  extends BaseClass {
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
@@ -800,6 +800,25 @@ class OrderImportsTest implements RewriteTest {
                   class B {}
               }
               """
+          ),
+          java(
+            """
+              import java.lang.annotation.Target;
+              
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.ser.VirtualBeanPropertyWriter;
+              
+              @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE })
+              public @interface JsonAppend {}
+              """,
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.ser.VirtualBeanPropertyWriter;
+              import java.lang.annotation.Target;
+              
+              @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE })
+              public @interface JsonAppend {}
+              """
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/OrderImportsTest.java
@@ -715,7 +715,7 @@ class OrderImportsTest implements RewriteTest {
 
     /**
      * With only an ImportLayoutStyle and no TabAndIndentsStyle the recipe indents the `extends` keyword as well.
-     * This test verifies that TabAndIndentsStyle can be configured (with continuationIndent <= -2) so that it leaves
+     * This test verifies that TabAndIndentsStyle can be configured (with continuationIndent ≤ -2) so that it leaves
      * the code following the imports as it is.
      */
     @Issue("https://github.com/openrewrite/rewrite/issues/4165")
@@ -736,7 +736,7 @@ class OrderImportsTest implements RewriteTest {
                     .blankLine()
                     .importStaticAllOthers()
                     .build(),
-                  new TabsAndIndentsStyle(false, -2, -2, -2, false, null)
+                  new TabsAndIndentsStyle(false, -2, -2, null, false, null)
                 )
               )
             ))),


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR adds a test to illustrate a bug.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
I want to enforce a custom order of imports on new PRs through a custom style.
As I report in "observation 2" of https://github.com/openrewrite/rewrite/issues/4165 custom styles also change indentation. I don't think they should do that.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
I've marked this PR ready for review in he hope of triggering a build, but it seems a manual approval is necessary.
I won't be available to work on a fix.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
