### PR TITLE
Remove maven properties should remove comment

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProfile.java
@@ -101,7 +101,7 @@ public class AddProfile extends Recipe {
                 if (maybeProfile.isPresent()) {
                     Xml.Tag profile = maybeProfile.get();
 
-                    t = (Xml.Tag) new RemoveContentVisitor(profile, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
+                    t = (Xml.Tag) new RemoveContentVisitor(profile, false, false).visitNonNull(t, ctx, getCursor().getParentOrThrow());
 
                 }
                 Xml.Tag profileTag = Xml.Tag.build("<profile>\n" +

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddRepository.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddRepository.java
@@ -170,7 +170,7 @@ public class AddRepository extends Recipe {
                                 repositories = (Xml.Tag) new AddToTagVisitor<>(repo, Xml.Tag.build(assembleReleases()))
                                         .visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                             } else {
-                                repositories = (Xml.Tag) new RemoveContentVisitor<>(releases, true)
+                                repositories = (Xml.Tag) new RemoveContentVisitor<>(releases, true, true)
                                         .visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                                 if (!isNoSnapshots()) {
                                     repositories = (Xml.Tag) new AddToTagVisitor<>(repo, Xml.Tag.build(assembleReleases()))
@@ -184,7 +184,7 @@ public class AddRepository extends Recipe {
                             if (snapshots == null) {
                                 repositories = (Xml.Tag) new AddToTagVisitor<>(repo, Xml.Tag.build(assembleSnapshots())).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                             } else {
-                                repositories = (Xml.Tag) new RemoveContentVisitor<>(snapshots, true).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
+                                repositories = (Xml.Tag) new RemoveContentVisitor<>(snapshots, true, true).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                                 if (!isNoSnapshots()) {
                                     repositories = (Xml.Tag) new AddToTagVisitor<>(repo, Xml.Tag.build(assembleSnapshots())).visitNonNull(repositories, ctx, getCursor().getParentOrThrow());
                                 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyClassifier.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyClassifier.java
@@ -86,7 +86,7 @@ public class ChangeDependencyClassifier extends Recipe {
                     Optional<Xml.Tag> classifier = tag.getChild("classifier");
                     if (classifier.isPresent()) {
                         if (newClassifier == null) {
-                            doAfterVisit(new RemoveContentVisitor<>(classifier.get(), false));
+                            doAfterVisit(new RemoveContentVisitor<>(classifier.get(), false, true));
                         } else if (!newClassifier.equals(classifier.get().getValue().orElse(null))) {
                             doAfterVisit(new ChangeTagValueVisitor<>(classifier.get(), newClassifier));
                         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -200,7 +200,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                             if (versionTagPresent) {
                                 // If the previous dependency had a version but the new artifact is managed, removed the version tag.
                                 if (!configuredToOverrideManageVersion && newDependencyManaged || (oldDependencyManaged && configuredToChangeManagedDependency)) {
-                                    t = (Xml.Tag) new RemoveContentVisitor<>(versionTag.get(), false).visit(t, ctx);
+                                    t = (Xml.Tag) new RemoveContentVisitor<>(versionTag.get(), false, true).visit(t, ctx);
                                 } else {
                                     // Otherwise, change the version to the new value.
                                     t = changeChildTagValue(t, "version", resolvedNewVersion, ctx);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyScope.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyScope.java
@@ -81,7 +81,7 @@ public class ChangeDependencyScope extends Recipe {
                         Optional<Xml.Tag> scope = tag.getChild("scope");
                         if (scope.isPresent()) {
                             if (newScope == null) {
-                                doAfterVisit(new RemoveContentVisitor<>(scope.get(), false));
+                                doAfterVisit(new RemoveContentVisitor<>(scope.get(), false, true));
                             } else if (!newScope.equals(scope.get().getValue().orElse(null))) {
                                 doAfterVisit(new ChangeTagValueVisitor<>(scope.get(), newScope));
                             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ManageDependencies.java
@@ -169,7 +169,7 @@ public class ManageDependencies extends ScanningRecipe<Map<GroupArtifactVersion,
         @Override
         public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
             if (isDependencyTag() && isDependencyTag(groupPattern, artifactPattern)) {
-                tag.getChild("version").ifPresent(versionTag -> doAfterVisit(new RemoveContentVisitor<>(versionTag, false)));
+                tag.getChild("version").ifPresent(versionTag -> doAfterVisit(new RemoveContentVisitor<>(versionTag, false, true)));
                 return tag;
             }
             return super.visitTag(tag, ctx);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveDependency.java
@@ -80,7 +80,7 @@ public class RemoveDependency extends Recipe {
                 Scope checkScope = scope != null ? Scope.fromName(scope) : null;
                 ResolvedDependency dependency = findDependency(tag, checkScope);
                 if (dependency != null) {
-                    doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                    doAfterVisit(new RemoveContentVisitor<>(tag, true, true));
                     maybeUpdateModel();
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveManagedDependency.java
@@ -79,7 +79,7 @@ public class RemoveManagedDependency extends Recipe {
                 Scope checkScope = scope != null ? Scope.fromName(scope) : null;
                 boolean isBomImport = tag.getChildValue("scope").map("import"::equalsIgnoreCase).orElse(false);
                 if (isBomImport || findManagedDependency(tag, checkScope) != null) {
-                    doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                    doAfterVisit(new RemoveContentVisitor<>(tag, true, true));
                     maybeUpdateModel();
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemovePlugin.java
@@ -60,7 +60,7 @@ public class RemovePlugin extends Recipe {
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
                 for (Xml.Tag plugin : FindPlugin.find(document, groupId, artifactId)) {
-                    doAfterVisit(new RemoveContentVisitor<>(plugin, true));
+                    doAfterVisit(new RemoveContentVisitor<>(plugin, true, true));
                 }
                 return super.visitDocument(document, ctx);
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveProperty.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveProperty.java
@@ -52,7 +52,7 @@ public class RemoveProperty extends Recipe {
         @Override
         public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
             if (isPropertyTag() && propertyName.equals(tag.getName())) {
-                doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                doAfterVisit(new RemoveContentVisitor<>(tag, true, true));
                 maybeUpdateModel();
             }
             return super.visitTag(tag, ctx);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cleanup/DependencyManagementDependencyRequiresVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cleanup/DependencyManagementDependencyRequiresVersion.java
@@ -40,7 +40,7 @@ public class DependencyManagementDependencyRequiresVersion extends Recipe {
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 if (isManagedDependencyTag() && tag.getChildValue("version").orElse(null) == null) {
-                    doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                    doAfterVisit(new RemoveContentVisitor<>(tag, true, true));
                 }
                 return super.visitTag(tag, ctx);
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddProfileTest.java
@@ -131,6 +131,7 @@ class AddProfileTest implements RewriteTest {
                 <artifactId>artifact</artifactId>
                 <version>1</version>
                 <profiles>
+                  <!-- retained comment -->
                   <profile>
                     <id>myprofile</id>
                     <activation>
@@ -146,6 +147,7 @@ class AddProfileTest implements RewriteTest {
                 <artifactId>artifact</artifactId>
                 <version>1</version>
                 <profiles>
+                  <!-- retained comment -->
                   <profile>
                     <id>myprofile</id>
                     <activation>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemovePropertyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemovePropertyTest.java
@@ -41,11 +41,11 @@ class RemovePropertyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <a.version>a</a.version>
                   <bla.version>b</bla.version>
@@ -55,11 +55,11 @@ class RemovePropertyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <a.version>a</a.version>
                 </properties>
@@ -83,11 +83,11 @@ class RemovePropertyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <bla.version>b</bla.version>
                 </properties>
@@ -96,7 +96,7 @@ class RemovePropertyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
@@ -119,11 +119,11 @@ class RemovePropertyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <a.version>a</a.version>
                   <!-- I should remove this property -->
@@ -134,11 +134,11 @@ class RemovePropertyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                 
+              
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+              
                 <properties>
                   <a.version>a</a.version>
                 </properties>
@@ -155,4 +155,66 @@ class RemovePropertyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void removePropertyWithCommentAndEmptyParents() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+              
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              
+                <properties>
+                  <!-- I should remove this property -->
+                  <bla.version>b</bla.version>
+                </properties>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+              
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void removePropertyWithTwoComments() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+              
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              
+                <properties>
+                  <!-- And also remove this comment -->
+                  <!-- I should remove this property -->
+                  <bla.version>b</bla.version>
+                </properties>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+              
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemovePropertyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemovePropertyTest.java
@@ -111,4 +111,48 @@ class RemovePropertyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void removePropertyWithComment() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <properties>
+                  <a.version>a</a.version>
+                  <!-- I should remove this property -->
+                  <bla.version>b</bla.version>
+                </properties>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                 
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <properties>
+                  <a.version>a</a.version>
+                </properties>
+              </project>
+              """,
+            sourceSpecs ->
+              sourceSpecs.afterRecipe(d -> {
+                  MavenResolutionResult resolution = d.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                  Map<String, String> properties = resolution.getPom().getRequested().getProperties();
+                  assertThat(properties.get("a.version")).isEqualTo("a");
+                  assertThat(properties.get("bla.version")).isNull();
+              })
+          )
+        );
+    }
+
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveContentVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveContentVisitor.java
@@ -27,11 +27,6 @@ public class RemoveContentVisitor<P> extends XmlVisitor<P> {
     private final boolean removeEmptyAncestors;
     private final boolean removePrecedingComment;
 
-    @Deprecated
-    public RemoveContentVisitor(Content tag, boolean removeEmptyAncestors) {
-        this(tag, removeEmptyAncestors, false);
-    }
-
     public RemoveContentVisitor(Content tag, boolean removeEmptyAncestors, boolean removePrecedingComment) {
         this.scope = tag;
         this.removeEmptyAncestors = removeEmptyAncestors;

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveContentVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveContentVisitor.java
@@ -49,10 +49,8 @@ public class RemoveContentVisitor<P> extends XmlVisitor<P> {
                     int indexOf = contents.indexOf(content);
                     contents.remove(indexOf);
 
-                    if (removePrecedingComment) {
-                        if (0 < indexOf && contents.get(indexOf - 1) instanceof Xml.Comment) {
-                            doAfterVisit(new RemoveContentVisitor<>(contents.get(indexOf - 1), true, removePrecedingComment));
-                        }
+                    if (removePrecedingComment && 0 < indexOf && contents.get(indexOf - 1) instanceof Xml.Comment) {
+                        doAfterVisit(new RemoveContentVisitor<>(contents.get(indexOf - 1), true, removePrecedingComment));
                     }
 
                     if (removeEmptyAncestors && contents.isEmpty() && t.getAttributes().isEmpty()) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveEmptyXmlTags.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveEmptyXmlTags.java
@@ -39,7 +39,7 @@ public class RemoveEmptyXmlTags extends Recipe {
                 Xml.Tag t = super.visitTag(tag, ctx);
                 //noinspection ConstantValue
                 if (t != null && (t.getContent() == null || t.getContent().isEmpty()) && t.getAttributes().isEmpty()) {
-                    doAfterVisit(new RemoveContentVisitor<>(t, true));
+                    doAfterVisit(new RemoveContentVisitor<>(t, true, true));
                 }
                 return t;
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveXmlTag.java
@@ -55,7 +55,7 @@ public class RemoveXmlTag extends Recipe {
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 if (xPathMatcher.matches(getCursor())) {
-                    doAfterVisit(new RemoveContentVisitor<>(tag, true));
+                    doAfterVisit(new RemoveContentVisitor<>(tag, true, true));
                 }
                 return super.visitTag(tag, ctx);
             }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/RemoveContentTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/RemoveContentTest.java
@@ -34,7 +34,7 @@ class RemoveContentTest implements RewriteTest {
           spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
               @Override
               public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
-                  doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getContent()).get(1), false));
+                  doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getContent()).get(1), false, true));
                   return super.visitDocument(x, ctx);
               }
           }).withMaxCycles(1)),
@@ -61,7 +61,7 @@ class RemoveContentTest implements RewriteTest {
               @Override
               public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
                   doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getChildren()).get(1)
-                    .getChildren().get(0).getChildren().get(0), true));
+                    .getChildren().get(0).getChildren().get(0), true, true));
                   return super.visitDocument(x, ctx);
               }
           }).withMaxCycles(1)),
@@ -92,7 +92,7 @@ class RemoveContentTest implements RewriteTest {
               @Override
               public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
                   doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getChildren()).get(0)
-                    .getChildren().get(0).getChildren().get(0), true));
+                    .getChildren().get(0).getChildren().get(0), true, true));
                   return super.visitDocument(x, ctx);
               }
           }).withMaxCycles(1)),


### PR DESCRIPTION
I saw in many project maven properties with an attached comment.

When running some recipes to remove properties the comment is left behind

I don't know how to fix it but I've implemented a test that demonstrates the issue

Example when cleanup property override (that are defined on a parent pom)

I would expect the TODO comment is also gone

![Screenshot from 2024-10-06 07-43-46](https://github.com/user-attachments/assets/d0752c17-9620-4e2d-bf39-80e054e24509)


## Anything in particular you'd like reviewers to focus on?

Some help to implement it

## Have you considered any alternatives or workarounds?

Not really


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
