### PR TITLE
Allow RecipeSerializer to (de)serialize java.time.Duration for estimatedEffortPerOccurrence field

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeSerializer.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeSerializer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class RecipeSerializer {
                 // see https://cowtowncoder.medium.com/jackson-2-12-most-wanted-3-5-246624e2d3d0
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModule(new ParameterNamesModule())
+                .registerModules(new ParameterNamesModule(), new JavaTimeModule())
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
         maybeAddKotlinModule(m);

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSerializerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSerializerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite;
 
 import java.time.Duration;

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSerializerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSerializerTest.java
@@ -1,0 +1,52 @@
+package org.openrewrite;
+
+import java.time.Duration;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecipeSerializerTest {
+
+    @Test
+    void shouldBeAbleToSerializeAndDeserializeEstimatedEffortPerOccurrence() {
+        RecipeSerializer serializer = new RecipeSerializer();
+        final var recipe = new RecipeWithEstimatedEffortPerOccurrence(Duration.ofDays(1));
+        final Recipe read = serializer.read(serializer.write(recipe));
+        assertThat(read.getEstimatedEffortPerOccurrence()).isEqualTo(Duration.ofDays(1));
+    }
+
+    @NullMarked
+    static class RecipeWithEstimatedEffortPerOccurrence extends Recipe {
+        @Nullable
+        private Duration estimatedEffortPerOccurrence;
+
+        public RecipeWithEstimatedEffortPerOccurrence() {
+            this(null);
+        }
+
+        public RecipeWithEstimatedEffortPerOccurrence(@Nullable Duration estimatedEffortPerOccurrence) {
+            this.estimatedEffortPerOccurrence = estimatedEffortPerOccurrence;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Recipe with estimatedEffortPerOccurrence";
+        }
+
+        @Override
+        public String getDescription() {
+            return "A fancy description.";
+        }
+
+        @Override
+        public @Nullable Duration getEstimatedEffortPerOccurrence() {
+            return this.estimatedEffortPerOccurrence;
+        }
+
+        public void setEstimatedEffortPerOccurrence(@Nullable Duration estimatedEffortPerOccurrence) {
+            this.estimatedEffortPerOccurrence = estimatedEffortPerOccurrence;
+        }
+    }
+}


### PR DESCRIPTION

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Jackson's `JavaTimeModule` from `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` has been added to the `RecipeSerialiser`

## What's your motivation?
At a division within Port of Rotterdam's IT department we're looking into consolidating our landscape of microservices into a more concise and _better_ updated set. We've been starting to use openrewrite, including writing some own custom recipes. When testing the custom declarative recipes we found that our unit tests failed when the `estimatedEffortPerOccurrence` field was used.

A short discussion with @timtebeek on slack led to this RP: https://rewriteoss.slack.com/archives/C01A843MWG5/p1727732492972659

## Anything in particular you'd like reviewers to focus on?
The tests could use some improvement probably. They work and somewhat proof the point, but are very limited.

## Anyone you would like to review specifically?
Nope

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Nope, based on the discussion on slack this seems the way forward. (for now, we have commented out our `estimatedEffortPerOccurrence` fields in our declarative recipes

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
