### PR TITLE
Detect whitespace before import semicolon

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1682,6 +1682,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 t instanceof JCBreak ||
                 t instanceof JCContinue ||
                 t instanceof JCDoWhileLoop ||
+                t instanceof JCImport ||
                 t instanceof JCMethodInvocation ||
                 t instanceof JCNewClass ||
                 t instanceof JCReturn ||

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1761,6 +1761,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             case BREAK:
             case CONTINUE:
             case DO_WHILE_LOOP:
+            case IMPORT:
             case METHOD_INVOCATION:
             case NEW_CLASS:
             case RETURN:

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1771,6 +1771,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             case BREAK:
             case CONTINUE:
             case DO_WHILE_LOOP:
+            case IMPORT:
             case METHOD_INVOCATION:
             case NEW_CLASS:
             case RETURN:

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1675,6 +1675,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 t instanceof JCBreak ||
                 t instanceof JCContinue ||
                 t instanceof JCDoWhileLoop ||
+                t instanceof JCImport ||
                 t instanceof JCMethodInvocation ||
                 t instanceof JCNewClass ||
                 t instanceof JCReturn ||

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ImportTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ImportTest.java
@@ -31,10 +31,10 @@ class ImportTest implements RewriteTest {
             """
               import static java.util.Map.Entry;
               import java.util.Map.Entry;
-                            
+              
               import java.util.List;
               import java.util.*;
-                            
+              
               import static java.nio.charset.StandardCharsets.UTF_8;
               import static java.util.Collections.emptyList;
               """,
@@ -157,20 +157,31 @@ class ImportTest implements RewriteTest {
           ),
           java(
             """
-                  package org.openrewrite;
-                  
-                  import org.openrewrite.BadPackage.Foo;
-                  import org.openrewrite.BadPackage.Foo.Bar;
-                  
-                  public class Bar {
-                      private Foo foo;
-                  }
-                  
+              package org.openrewrite;
+              
+              import org.openrewrite.BadPackage.Foo;
+              import org.openrewrite.BadPackage.Foo.Bar;
+              
+              public class Bar {
+                  private Foo foo;
+              }
               """,
             spec -> spec.afterRecipe(cu -> {
                 assertThat(cu.getImports().get(0).getPackageName()).isEqualTo("org.openrewrite.BadPackage");
                 assertThat(cu.getImports().get(1).getPackageName()).isEqualTo("org.openrewrite.BadPackage");
             })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4569")
+    @Test
+    void spaceBeforeSemiColon() {
+        rewriteRun(
+          java(
+            """
+              import java.util.List ;
+              """
           )
         );
     }


### PR DESCRIPTION
## What's changed?
Add `import` to `statementDelim(Tree)` in Java ParserVisitors.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/4569

## Anyone you would like to review specifically?
@traceyyoshima 
