### PR TITLE
Add `addToRootPom` option to `AddPlugin` recipe

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -75,9 +75,9 @@ public class AddPlugin extends Recipe {
 
     @Option(displayName = "File pattern",
             description = "A glob expression that can be used to constrain which directories or source files should be searched. " +
-                                "Multiple patterns may be specified, separated by a semicolon `;`. " +
-                                "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
-                                "When not set, all source files are searched. ",
+                    "Multiple patterns may be specified, separated by a semicolon `;`. " +
+                    "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
+                    "When not set, all source files are searched. ",
             required = false,
             example = "**/*-parent/grpc-*/pom.xml")
     @Nullable

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -116,12 +116,16 @@ public class AddPlugin extends Recipe {
             if (filePattern != null) {
                 return PathUtils.matchesGlob(sourceFile.getSourcePath(), filePattern) && super.isAcceptable(sourceFile, ctx);
             }
-            Optional<MavenResolutionResult> mvnResult = sourceFile.getMarkers().findFirst(MavenResolutionResult.class);
-            if (mvnResult.isPresent()) {
-                if (!Boolean.TRUE.equals(addToRootPom) || mvnResult.get().getParent() == null) {
-                    return super.isAcceptable(sourceFile, ctx);
-                } else {
-                    return false;
+            if (!Boolean.TRUE.equals(addToRootPom)) {
+                return super.isAcceptable(sourceFile, ctx);
+            } else {
+                Optional<MavenResolutionResult> mvnResult = sourceFile.getMarkers().findFirst(MavenResolutionResult.class);
+                if (mvnResult.isPresent()) {
+                    if (mvnResult.get().getParent() == null) {
+                        return super.isAcceptable(sourceFile, ctx);
+                    } else {
+                        return false;
+                    }
                 }
             }
             return super.isAcceptable(sourceFile, ctx);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -75,9 +75,9 @@ public class AddPlugin extends Recipe {
 
     @Option(displayName = "File pattern",
             description = "A glob expression that can be used to constrain which directories or source files should be searched. " +
-                          "Multiple patterns may be specified, separated by a semicolon `;`. " +
-                          "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
-                          "When not set, all source files are searched. ",
+                    "Multiple patterns may be specified, separated by a semicolon `;`. " +
+                    "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
+                    "When not set, all source files are searched. ",
             required = false,
             example = "**/*-parent/grpc-*/pom.xml")
     @Nullable
@@ -159,8 +159,8 @@ public class AddPlugin extends Recipe {
                 Optional<Xml.Tag> maybePlugin = plugins.getChildren().stream()
                         .filter(plugin ->
                                 "plugin".equals(plugin.getName()) &&
-                                groupId.equals(plugin.getChildValue("groupId").orElse(null)) &&
-                                artifactId.equals(plugin.getChildValue("artifactId").orElse(null))
+                                        groupId.equals(plugin.getChildValue("groupId").orElse(null)) &&
+                                        artifactId.equals(plugin.getChildValue("artifactId").orElse(null))
                         )
                         .findAny();
 
@@ -173,13 +173,13 @@ public class AddPlugin extends Recipe {
                     }
                 } else {
                     Xml.Tag pluginTag = Xml.Tag.build("<plugin>\n" +
-                                                      "<groupId>" + groupId + "</groupId>\n" +
-                                                      "<artifactId>" + artifactId + "</artifactId>\n" +
-                                                      (version != null ? "<version>" + version + "</version>\n" : "") +
-                                                      (executions != null ? executions.trim() + "\n" : "") +
-                                                      (configuration != null ? configuration.trim() + "\n" : "") +
-                                                      (dependencies != null ? dependencies.trim() + "\n" : "") +
-                                                      "</plugin>");
+                            "<groupId>" + groupId + "</groupId>\n" +
+                            "<artifactId>" + artifactId + "</artifactId>\n" +
+                            (version != null ? "<version>" + version + "</version>\n" : "") +
+                            (executions != null ? executions.trim() + "\n" : "") +
+                            (configuration != null ? configuration.trim() + "\n" : "") +
+                            (dependencies != null ? dependencies.trim() + "\n" : "") +
+                            "</plugin>");
                     t = (Xml.Tag) new AddToTagVisitor<>(plugins, pluginTag).visitNonNull(t, ctx, getCursor().getParentOrThrow());
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -83,12 +83,6 @@ public class AddPlugin extends Recipe {
     @Nullable
     String filePattern;
 
-    @Option(displayName = "Add to the root pom",
-            description = "Add to the root pom where root is the eldest parent of the pom within the source set.",
-            required = false)
-    @Nullable
-    Boolean addToRootPom;
-
     @Override
     public String getDisplayName() {
         return "Add Maven plugin";
@@ -116,12 +110,12 @@ public class AddPlugin extends Recipe {
             if (filePattern != null) {
                 return PathUtils.matchesGlob(sourceFile.getSourcePath(), filePattern) && super.isAcceptable(sourceFile, ctx);
             }
-            if (Boolean.TRUE.equals(addToRootPom)) {
-                Optional<MavenResolutionResult> mvnResult = sourceFile.getMarkers().findFirst(MavenResolutionResult.class);
-                if (mvnResult.isPresent() && mvnResult.get().getParent() != null) {
-                    return false;
-                }
+
+            MavenResolutionResult mrr = sourceFile.getMarkers().findFirst(MavenResolutionResult.class).orElse(null);
+            if (mrr == null || mrr.parentPomIsProjectPom()) {
+                return false;
             }
+
             return super.isAcceptable(sourceFile, ctx);
         }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -75,9 +75,9 @@ public class AddPlugin extends Recipe {
 
     @Option(displayName = "File pattern",
             description = "A glob expression that can be used to constrain which directories or source files should be searched. " +
-                    "Multiple patterns may be specified, separated by a semicolon `;`. " +
-                    "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
-                    "When not set, all source files are searched. ",
+                          "Multiple patterns may be specified, separated by a semicolon `;`. " +
+                          "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
+                          "When not set, all source files are searched. ",
             required = false,
             example = "**/*-parent/grpc-*/pom.xml")
     @Nullable
@@ -116,16 +116,10 @@ public class AddPlugin extends Recipe {
             if (filePattern != null) {
                 return PathUtils.matchesGlob(sourceFile.getSourcePath(), filePattern) && super.isAcceptable(sourceFile, ctx);
             }
-            if (!Boolean.TRUE.equals(addToRootPom)) {
-                return super.isAcceptable(sourceFile, ctx);
-            } else {
+            if (Boolean.TRUE.equals(addToRootPom)) {
                 Optional<MavenResolutionResult> mvnResult = sourceFile.getMarkers().findFirst(MavenResolutionResult.class);
-                if (mvnResult.isPresent()) {
-                    if (mvnResult.get().getParent() == null) {
-                        return super.isAcceptable(sourceFile, ctx);
-                    } else {
-                        return false;
-                    }
+                if (mvnResult.isPresent() && mvnResult.get().getParent() != null) {
+                    return false;
                 }
             }
             return super.isAcceptable(sourceFile, ctx);
@@ -159,8 +153,8 @@ public class AddPlugin extends Recipe {
                 Optional<Xml.Tag> maybePlugin = plugins.getChildren().stream()
                         .filter(plugin ->
                                 "plugin".equals(plugin.getName()) &&
-                                        groupId.equals(plugin.getChildValue("groupId").orElse(null)) &&
-                                        artifactId.equals(plugin.getChildValue("artifactId").orElse(null))
+                                groupId.equals(plugin.getChildValue("groupId").orElse(null)) &&
+                                artifactId.equals(plugin.getChildValue("artifactId").orElse(null))
                         )
                         .findAny();
 
@@ -173,13 +167,13 @@ public class AddPlugin extends Recipe {
                     }
                 } else {
                     Xml.Tag pluginTag = Xml.Tag.build("<plugin>\n" +
-                            "<groupId>" + groupId + "</groupId>\n" +
-                            "<artifactId>" + artifactId + "</artifactId>\n" +
-                            (version != null ? "<version>" + version + "</version>\n" : "") +
-                            (executions != null ? executions.trim() + "\n" : "") +
-                            (configuration != null ? configuration.trim() + "\n" : "") +
-                            (dependencies != null ? dependencies.trim() + "\n" : "") +
-                            "</plugin>");
+                                                      "<groupId>" + groupId + "</groupId>\n" +
+                                                      "<artifactId>" + artifactId + "</artifactId>\n" +
+                                                      (version != null ? "<version>" + version + "</version>\n" : "") +
+                                                      (executions != null ? executions.trim() + "\n" : "") +
+                                                      (configuration != null ? configuration.trim() + "\n" : "") +
+                                                      (dependencies != null ? dependencies.trim() + "\n" : "") +
+                                                      "</plugin>");
                     t = (Xml.Tag) new AddToTagVisitor<>(plugins, pluginTag).visitNonNull(t, ctx, getCursor().getParentOrThrow());
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPlugin.java
@@ -75,9 +75,9 @@ public class AddPlugin extends Recipe {
 
     @Option(displayName = "File pattern",
             description = "A glob expression that can be used to constrain which directories or source files should be searched. " +
-                          "Multiple patterns may be specified, separated by a semicolon `;`. " +
-                          "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
-                          "When not set, all source files are searched. ",
+                                "Multiple patterns may be specified, separated by a semicolon `;`. " +
+                                "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
+                                "When not set, all source files are searched. ",
             required = false,
             example = "**/*-parent/grpc-*/pom.xml")
     @Nullable
@@ -153,8 +153,8 @@ public class AddPlugin extends Recipe {
                 Optional<Xml.Tag> maybePlugin = plugins.getChildren().stream()
                         .filter(plugin ->
                                 "plugin".equals(plugin.getName()) &&
-                                groupId.equals(plugin.getChildValue("groupId").orElse(null)) &&
-                                artifactId.equals(plugin.getChildValue("artifactId").orElse(null))
+                                        groupId.equals(plugin.getChildValue("groupId").orElse(null)) &&
+                                        artifactId.equals(plugin.getChildValue("artifactId").orElse(null))
                         )
                         .findAny();
 
@@ -166,14 +166,15 @@ public class AddPlugin extends Recipe {
                         }
                     }
                 } else {
-                    Xml.Tag pluginTag = Xml.Tag.build("<plugin>\n" +
-                                                      "<groupId>" + groupId + "</groupId>\n" +
-                                                      "<artifactId>" + artifactId + "</artifactId>\n" +
-                                                      (version != null ? "<version>" + version + "</version>\n" : "") +
-                                                      (executions != null ? executions.trim() + "\n" : "") +
-                                                      (configuration != null ? configuration.trim() + "\n" : "") +
-                                                      (dependencies != null ? dependencies.trim() + "\n" : "") +
-                                                      "</plugin>");
+                    Xml.Tag pluginTag = Xml.Tag.build(
+                            "<plugin>\n" +
+                            "<groupId>" + groupId + "</groupId>\n" +
+                            "<artifactId>" + artifactId + "</artifactId>\n" +
+                            (version != null ? "<version>" + version + "</version>\n" : "") +
+                            (executions != null ? executions.trim() + "\n" : "") +
+                            (configuration != null ? configuration.trim() + "\n" : "") +
+                            (dependencies != null ? dependencies.trim() + "\n" : "") +
+                            "</plugin>");
                     t = (Xml.Tag) new AddToTagVisitor<>(plugins, pluginTag).visitNonNull(t, ctx, getCursor().getParentOrThrow());
                 }
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @SuppressWarnings("unused")
@@ -192,8 +193,24 @@ public class MavenResolutionResult implements Marker {
         return getProjectPomsRecursive(new HashMap<>());
     }
 
+    /**
+     * Often recipes operating on multi-module projects will prefer to make changes to the parent pom rather than in multiple child poms.
+     * But if the parent isn't in the same repository as the child, the recipe would need to be applied to the child poms.
+     *
+     * @return true when the parent pom of the current pom is present in the same repository as the current pom
+     */
+    public boolean parentPomIsProjectPom() {
+        if (getParent() == null) {
+            return false;
+        }
+        ResolvedGroupArtifactVersion parentGav = getParent().getPom().getGav();
+        return getProjectPoms().values().stream()
+                .map(Pom::getGav)
+                .anyMatch(gav -> gav.equals(parentGav));
+    }
+
     private Map<Path, Pom> getProjectPomsRecursive(Map<Path, Pom> projectPoms) {
-        projectPoms.put(pom.getRequested().getSourcePath(), pom.getRequested());
+        projectPoms.put(requireNonNull(pom.getRequested().getSourcePath()), pom.getRequested());
         if (parent != null) {
             parent.getProjectPomsRecursive(projectPoms);
         }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
@@ -27,7 +27,7 @@ class AddPluginTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", "100.0", null, null, null, null, null));
+        spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", "100.0", null, null, null, null));
     }
 
     @DocumentExample
@@ -36,7 +36,7 @@ class AddPluginTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", "100.0",
             "<configuration>\n<activeRecipes>\n<recipe>io.moderne.FindTest</recipe>\n</activeRecipes>\n</configuration>",
-            null, null, null, null)),
+            null, null, null)),
           pomXml(
             """
               <project>
@@ -82,7 +82,7 @@ class AddPluginTest implements RewriteTest {
                           <version>1.0.0</version>
                       </dependency>
                   </dependencies>
-              """, null, null, null)),
+              """, null, null)),
           pomXml(
             """
               <project>
@@ -138,7 +138,7 @@ class AddPluginTest implements RewriteTest {
                       </configuration>
                     </execution>
                   </executions>
-              """, null, null)),
+              """, null)),
           pomXml(
             """
               <project>
@@ -256,7 +256,7 @@ class AddPluginTest implements RewriteTest {
     @Test
     void addPluginWithoutVersion() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, null, null)),
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, null)),
           pomXml(
             """
               <project>
@@ -287,7 +287,7 @@ class AddPluginTest implements RewriteTest {
     @Test
     void addPluginWithMatchingFilePattern() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, "dir/pom.xml", null)),
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, "dir/pom.xml")),
           pomXml(
             """
               <project>
@@ -319,7 +319,7 @@ class AddPluginTest implements RewriteTest {
     @Test
     void addPluginWithNonMatchingFilePattern() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, "dir/pom.xml", null)),
+          spec -> spec.recipe(new AddPlugin("org.openrewrite.maven", "rewrite-maven-plugin", null, null, null, null, "dir/pom.xml")),
           pomXml(
             """
               <project>
@@ -336,7 +336,7 @@ class AddPluginTest implements RewriteTest {
     @Test
     void addPluginWithExistingPlugin() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, null)),
+          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null)),
           pomXml(
             """
               <project>
@@ -366,7 +366,7 @@ class AddPluginTest implements RewriteTest {
     @Test
     void addPluginOnlyToRootPom() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, true)),
+          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null)),
           pomXml(
             """
               <project>
@@ -421,7 +421,7 @@ class AddPluginTest implements RewriteTest {
     @Test
     void addPluginOnlyToRootPomWithParent() {
         rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, true)),
+          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null)),
           pomXml(
             """
               <project>
@@ -476,82 +476,6 @@ class AddPluginTest implements RewriteTest {
                   </parent>
                   <build>
                     <plugins>
-                    </plugins>
-                  </build>
-                </project>
-                """))
-        );
-    }
-
-    @Test
-    void addPluginOnlyToAllPomsExplicitly() {
-        rewriteRun(
-          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, false)),
-          pomXml(
-            """
-              <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <build>
-                  <plugins>
-                  </plugins>
-                </build>
-              </project>
-              """,
-            """
-              <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <build>
-                  <plugins>
-                    <plugin>
-                      <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-maven-plugin</artifactId>
-                      <version>3.1.5</version>
-                    </plugin>
-                  </plugins>
-                </build>
-              </project>
-              """,
-            spec -> spec.path("pom.xml")
-          ),
-          mavenProject("my-app-child",
-            pomXml(
-              """
-                <project>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>my-app-child</artifactId>
-                  <version>1</version>
-                  <parent>
-                    <groupId>com.mycompany.app</groupId>
-                    <artifactId>my-app</artifactId>
-                    <version>1</version>
-                  </parent>
-                  <build>
-                    <plugins>
-                    </plugins>
-                  </build>
-                </project>
-                """,
-              """
-                <project>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>my-app-child</artifactId>
-                  <version>1</version>
-                  <parent>
-                    <groupId>com.mycompany.app</groupId>
-                    <artifactId>my-app</artifactId>
-                    <version>1</version>
-                  </parent>
-                  <build>
-                    <plugins>
-                      <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <version>3.1.5</version>
-                      </plugin>
                     </plugins>
                   </build>
                 </project>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
@@ -419,7 +419,7 @@ class AddPluginTest implements RewriteTest {
     }
 
     @Test
-    void addPluginOnlyToNonRootPom() {
+    void addPluginOnlyToAllPomsExplicitly() {
         rewriteRun(
           spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, false)),
           pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginTest.java
@@ -419,6 +419,71 @@ class AddPluginTest implements RewriteTest {
     }
 
     @Test
+    void addPluginOnlyToRootPomWithParent() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, true)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.1.5</version>
+                </parent>
+                <build>
+                  <plugins>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.1.5</version>
+                </parent>
+                <build>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-maven-plugin</artifactId>
+                      <version>3.1.5</version>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            spec -> spec.path("pom.xml")
+          ),
+          mavenProject("my-app-child",
+            pomXml(
+              """
+                <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app-child</artifactId>
+                  <version>1</version>
+                  <parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  </parent>
+                  <build>
+                    <plugins>
+                    </plugins>
+                  </build>
+                </project>
+                """))
+        );
+    }
+
+    @Test
     void addPluginOnlyToAllPomsExplicitly() {
         rewriteRun(
           spec -> spec.recipe(new AddPlugin("org.springframework.boot", "spring-boot-maven-plugin", "3.1.5", null, null, null, null, false)),


### PR DESCRIPTION
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Generally to avoid conflicts in a multimodule project you want to manage plugins from a parent/root pom.
However the current behavior of the `AddPlugin` is to add it to every single pom.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
