### PR TITLE
Fix missing junit-platform-launcher version

### DIFF
--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -21,8 +21,8 @@ dependencies {
 
     implementation("io.micrometer:micrometer-core:1.9.+")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     testImplementation(project(":rewrite-test"))
     "javaTck"(project(":rewrite-java-tck"))

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
         isTransitive = false
     }
     compileOnly(project(":rewrite-test"))
-    compileOnly("org.junit.jupiter:junit-jupiter-api:latest.release")
+    compileOnly("org.junit.jupiter:junit-jupiter-api")
     compileOnly("org.assertj:assertj-core:latest.release")
     implementation("org.apache.commons:commons-lang3:latest.release")
     implementation("org.apache.commons:commons-text:latest.release")

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -3,10 +3,11 @@ plugins {
 }
 
 dependencies {
+    api(platform("org.junit:junit-bom:latest.release"))
     api(project(":rewrite-core"))
     compileOnly("io.micrometer:micrometer-core:latest.release")
-    api("org.junit.jupiter:junit-jupiter-api:latest.release")
-    api("org.junit.jupiter:junit-jupiter-params:latest.release")
+    api("org.junit.jupiter:junit-jupiter-api")
+    api("org.junit.jupiter:junit-jupiter-params")
 
     implementation("org.assertj:assertj-core:latest.release")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")


### PR DESCRIPTION
## What's changed?
Use the JUnit BOM to specify the version of all JUnit dependencies.

Since `rewrite-test` uses JUnit as an `api()` dependency, this is done through `api(platform(…))` instead of `testImplementation(platform(…))`.

## What's your motivation?
I tried to build OpenRewrite on my Linux Desktop machine, and I kept getting the following error:
```
> Task :rewrite-java-17:compatibilityTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rewrite-java-17:compatibilityTest'.
> Could not resolve all files for configuration ':rewrite-java-17:compatibilityTestRuntimeClasspath'.
   > Could not find org.junit.platform:junit-platform-launcher:.
     Required by:
         project :rewrite-java-17
```
(also with the other `rewrite-java-*` modules)

I don’t really understand why it works in other environments, but the thing is that the `junit-platform-launcher` version wasn’t specified anywhere.

[JUnit documentation](https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom) suggests using their BOM to align dependency versions. I thought it couldn’t hurt anyway, and this allows centralizing the version of JUnit (though I kept `latest.release` for now)

## Anything in particular you'd like reviewers to focus on?
I am not very familiar with Gradle so better double check this :slightly_smiling_face: 

## Have you considered any alternatives or workarounds?
This is the only solution I found but maybe I should have posted a question as well :smirk: 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases – N/A
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices) – N/A
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files – actually I get different formatting if I do that on `rewrite-java-8/build.gradle.kts`
