### PR TITLE
Actually use TLS in (some) Maven tests and shove a few minutes from their execution

### DIFF
--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -38,7 +38,8 @@ dependencies {
 
     testImplementation(project(":rewrite-test"))
     testImplementation("com.squareup.okhttp3:mockwebserver:4.+")
-    testImplementation("com.squareup.okio:okio-jvm:3.0.0")
+    testImplementation("com.squareup.okhttp3:okhttp-tls:4.+")
+    testImplementation("com.squareup.okio:okio-jvm:3.9.1")
     testImplementation("org.mapdb:mapdb:latest.release")
     testImplementation("guru.nidi:graphviz-java:latest.release")
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -61,7 +61,7 @@ class UpgradeParentVersionTest implements RewriteTest {
     void nonMavenCentralRepository() {
         rewriteRun(
           spec -> spec
-            .recipe(new UpgradeParentVersion("org.jenkins-ci.plugins", "plugin", "4.40", null))
+            .recipe(new UpgradeParentVersion("org.codehaus.mojo", "mojo-parent", "86", null))
             .executionContext(
               MavenExecutionContextView
                 .view(new InMemoryExecutionContext())
@@ -73,22 +73,22 @@ class UpgradeParentVersionTest implements RewriteTest {
             """
               <project>
                   <parent>
-                      <groupId>org.jenkins-ci.plugins</groupId>
-                      <artifactId>plugin</artifactId>
-                      <version>4.33</version>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>mojo-parent</artifactId>
+                      <version>85s</version>
                   </parent>
-                  <artifactId>antisamy-markup-formatter</artifactId>
+                  <artifactId>example</artifactId>
                   <version>1.0.0</version>
               </project>
               """,
             """
               <project>
                   <parent>
-                      <groupId>org.jenkins-ci.plugins</groupId>
-                      <artifactId>plugin</artifactId>
-                      <version>4.40</version>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>mojo-parent</artifactId>
+                      <version>86</version>
                   </parent>
-                  <artifactId>antisamy-markup-formatter</artifactId>
+                  <artifactId>example</artifactId>
                   <version>1.0.0</version>
               </project>
               """

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -61,7 +61,7 @@ class UpgradeParentVersionTest implements RewriteTest {
     void nonMavenCentralRepository() {
         rewriteRun(
           spec -> spec
-            .recipe(new UpgradeParentVersion("org.codehaus.mojo", "mojo-parent", "86", null))
+            .recipe(new UpgradeParentVersion("org.jenkins-ci", "jenkins", "1.125", null))
             .executionContext(
               MavenExecutionContextView
                 .view(new InMemoryExecutionContext())
@@ -73,9 +73,9 @@ class UpgradeParentVersionTest implements RewriteTest {
             """
               <project>
                   <parent>
-                      <groupId>org.codehaus.mojo</groupId>
-                      <artifactId>mojo-parent</artifactId>
-                      <version>85s</version>
+                      <groupId>org.jenkins-ci</groupId>
+                      <artifactId>jenkins</artifactId>
+                      <version>1.124</version>
                   </parent>
                   <artifactId>example</artifactId>
                   <version>1.0.0</version>
@@ -84,9 +84,9 @@ class UpgradeParentVersionTest implements RewriteTest {
             """
               <project>
                   <parent>
-                      <groupId>org.codehaus.mojo</groupId>
-                      <artifactId>mojo-parent</artifactId>
-                      <version>86</version>
+                      <groupId>org.jenkins-ci</groupId>
+                      <artifactId>jenkins</artifactId>
+                      <version>1.125</version>
                   </parent>
                   <artifactId>example</artifactId>
                   <version>1.0.0</version>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -15,12 +15,16 @@
  */
 package org.openrewrite.maven.internal;
 
+import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.*;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
 import org.assertj.core.api.Condition;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,13 +33,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
+import org.openrewrite.ipc.http.OkHttpSender;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenParser;
 import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.tree.*;
 
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,10 +52,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -57,28 +61,6 @@ import static org.openrewrite.maven.tree.MavenRepository.MAVEN_CENTRAL;
 
 @SuppressWarnings({"HttpUrlsUsage"})
 class MavenPomDownloaderTest {
-    private final ExecutionContext ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
-      .setHttpSender(new HttpUrlConnectionSender(Duration.ofMillis(250), Duration.ofMillis(250)));
-
-    private void mockServer(Integer responseCode, Consumer<MockWebServer> block) {
-        try (MockWebServer mockRepo = new MockWebServer()) {
-            mockRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    return new MockResponse().setResponseCode(responseCode).setBody("");
-                }
-            });
-            mockRepo.start();
-            block.accept(mockRepo);
-            assertThat(mockRepo.getRequestCount())
-              .as("The mock repository received no requests. The test is not using it.")
-              .isGreaterThan(0);
-            mockRepo.shutdown();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     void ossSonatype() {
         InMemoryExecutionContext ctx = new InMemoryExecutionContext();
@@ -90,685 +72,6 @@ class MavenPomDownloaderTest {
         MavenRepository repo = new MavenPomDownloader(ctx).normalizeRepository(ossSonatype,
           MavenExecutionContextView.view(ctx), null);
         assertThat(repo).isNotNull().extracting((MavenRepository::getUri)).isEqualTo(ossSonatype.getUri());
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/3908")
-    @Test
-    void centralIdOverridesDefaultRepository() {
-        var ctx = MavenExecutionContextView.view(this.ctx);
-        ctx.setMavenSettings(MavenSettings.parse(Parser.Input.fromString(Paths.get("settings.xml"),
-          //language=xml
-          """
-            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                                  https://maven.apache.org/xsd/settings-1.0.0.xsd">
-              <profiles>
-                <profile>
-                    <id>central</id>
-                    <repositories>
-                        <repository>
-                            <id>central</id>
-                            <url>https://internalartifactrepository.yourorg.com</url>
-                        </repository>
-                    </repositories>
-                </profile>
-              </profiles>
-              <activeProfiles>
-                <activeProfile>central</activeProfile>
-              </activeProfiles>
-            </settings>
-            """
-        ), ctx));
-
-        // Avoid actually trying to reach the made-up https://internalartifactrepository.yourorg.com
-        for (MavenRepository repository : ctx.getRepositories()) {
-            repository.setKnownToExist(true);
-        }
-
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        Collection<MavenRepository> repos = downloader.distinctNormalizedRepositories(emptyList(), null, null);
-        assertThat(repos).areExactly(1, new Condition<>(repo -> "central".equals(repo.getId()),
-          "id \"central\""));
-        assertThat(repos).areExactly(1, new Condition<>(repo -> "https://internalartifactrepository.yourorg.com".equals(repo.getUri()),
-          "URI https://internalartifactrepository.yourorg.com"));
-    }
-
-    @Test
-    void listenerRecordsRepository() {
-        var ctx = MavenExecutionContextView.view(this.ctx);
-        // Avoid actually trying to reach the made-up https://internalartifactrepository.yourorg.com
-        for (MavenRepository repository : ctx.getRepositories()) {
-            repository.setKnownToExist(true);
-        }
-
-        MavenRepository nonexistentRepo = new MavenRepository("repo", "http://internalartifactrepository.yourorg.com", null, null, true, null, null, null, null);
-        List<String> attemptedUris = new ArrayList<>();
-        List<MavenRepository> discoveredRepositories = new ArrayList<>();
-        ctx.setResolutionListener(new ResolutionEventListener() {
-            @Override
-            public void downloadError(GroupArtifactVersion gav, List<String> uris, @Nullable Pom containing) {
-                attemptedUris.addAll(uris);
-            }
-
-            @Override
-            public void repository(MavenRepository mavenRepository, @Nullable ResolvedPom containing) {
-                discoveredRepositories.add(mavenRepository);
-            }
-        });
-
-        try {
-            new MavenPomDownloader(ctx)
-              .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
-        } catch (Exception e) {
-            // not expected to succeed
-        }
-        assertThat(attemptedUris)
-          .containsExactly("http://internalartifactrepository.yourorg.com/org/openrewrite/rewrite-core/7.0.0/rewrite-core-7.0.0.pom");
-        assertThat(discoveredRepositories)
-          .containsExactly(nonexistentRepo);
-    }
-
-    @Test
-    void listenerRecordsFailedRepositoryAccess() {
-        var ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
-        // Avoid actually trying to reach a made-up URL
-        String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
-        MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
-        Map<String, Throwable> attemptedUris = new HashMap<>();
-        List<MavenRepository> discoveredRepositories = new ArrayList<>();
-        ctx.setResolutionListener(new ResolutionEventListener() {
-            @Override
-            public void repositoryAccessFailed(String uri, Throwable e) {
-                attemptedUris.put(uri, e);
-            }
-        });
-
-        try {
-            new MavenPomDownloader(ctx)
-              .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
-        } catch (Exception e) {
-            // not expected to succeed
-        }
-        assertThat(attemptedUris).isNotEmpty();
-        assertThat(attemptedUris.get(httpUrl)).isInstanceOf(UnknownHostException.class);
-        assertThat(discoveredRepositories).isEmpty();
-    }
-
-    @Test
-    void mirrorsOverrideRepositoriesInPom() {
-        var ctx = MavenExecutionContextView.view(this.ctx);
-        ctx.setMavenSettings(MavenSettings.parse(Parser.Input.fromString(Paths.get("settings.xml"),
-          //language=xml
-          """
-            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                                  https://maven.apache.org/xsd/settings-1.0.0.xsd">
-              <mirrors>
-                <mirror>
-                  <id>mirror</id>
-                  <url>https://artifactory.moderne.ninja/artifactory/moderne-cache</url>
-                  <mirrorOf>*</mirrorOf>
-                </mirror>
-              </mirrors>
-            </settings>
-            """
-        ), ctx));
-
-        Path pomPath = Paths.get("pom.xml");
-        Pom pom = Pom.builder()
-          .sourcePath(pomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "org.openrewrite", "rewrite-core", "7.0.0", null))
-          .build();
-        ResolvedPom resolvedPom = ResolvedPom.builder()
-          .requested(pom)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .repositories(singletonList(MAVEN_CENTRAL))
-          .build();
-
-        Map<Path, Pom> pomsByPath = new HashMap<>();
-        pomsByPath.put(pomPath, pom);
-
-        MavenPomDownloader mpd = new MavenPomDownloader(pomsByPath, ctx);
-        MavenRepository normalized = mpd.normalizeRepository(
-          MavenRepository.builder().id("whatever").uri("${REPO_URL}").build(),
-          ctx,
-          resolvedPom
-        );
-        assertThat(normalized)
-          .extracting(MavenRepository::getUri)
-          .isEqualTo("https://artifactory.moderne.ninja/artifactory/moderne-cache/");
-    }
-
-    @Disabled("Flaky on CI")
-    @Test
-    void normalizeOssSnapshots() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        MavenRepository oss = downloader.normalizeRepository(
-          MavenRepository.builder().id("oss").uri("https://oss.sonatype.org/content/repositories/snapshots").build(),
-          MavenExecutionContextView.view(ctx), null);
-
-        assertThat(oss).isNotNull();
-        assertThat(oss.getUri()).isEqualTo("https://oss.sonatype.org/content/repositories/snapshots/");
-    }
-
-    @ParameterizedTest
-    @Issue("https://github.com/openrewrite/rewrite/issues/3141")
-    @ValueSource(strings = {"http://0.0.0.0", "https://0.0.0.0", "0.0.0.0:443"})
-    void skipBlockedRepository(String url) {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        MavenRepository oss = downloader.normalizeRepository(
-          MavenRepository.builder().id("myRepo").uri(url).build(),
-          MavenExecutionContextView.view(ctx), null);
-
-        assertThat(oss).isNull();
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {500, 400})
-    void normalizeAcceptErrorStatuses(Integer status) {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        mockServer(status, mockRepo -> {
-            var originalRepo = MavenRepository.builder()
-              .id("id")
-              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .build();
-            var normalizedRepo = downloader.normalizeRepository(originalRepo, MavenExecutionContextView.view(ctx), null);
-            assertThat(normalizedRepo).isEqualTo(originalRepo);
-        });
-    }
-
-    @Test
-    void retryConnectException() throws Throwable {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        try (MockWebServer server = new MockWebServer()) {
-            server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
-            server.enqueue(new MockResponse().setResponseCode(200).setBody("body"));
-            String body = new String(downloader.sendRequest(new HttpSender.Request(server.url("/test").url(), "request".getBytes(), HttpSender.Method.GET, Map.of(), null, null)));
-            assertThat(body).isEqualTo("body");
-            assertThat(server.getRequestCount()).isEqualTo(2);
-            server.shutdown();
-        }
-    }
-
-    @Test
-    void normalizeRejectConnectException() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        var normalizedRepository = downloader.normalizeRepository(
-          MavenRepository.builder().id("id").uri("https//localhost").build(),
-          MavenExecutionContextView.view(ctx), null);
-        assertThat(normalizedRepository).isEqualTo(null);
-    }
-
-    @Test
-    void invalidArtifact() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
-        mockServer(500,
-          repo1 -> mockServer(400, repo2 -> {
-              var repositories = List.of(
-                MavenRepository.builder()
-                  .id("id")
-                  .uri("http://%s:%d/maven".formatted(repo1.getHostName(), repo1.getPort()))
-                  .build(),
-                MavenRepository.builder()
-                  .id("id2")
-                  .uri("http://%s:%d/maven".formatted(repo2.getHostName(), repo2.getPort()))
-                  .build()
-              );
-
-              assertThatThrownBy(() -> downloader.download(gav, null, null, repositories))
-                .isInstanceOf(MavenDownloadingException.class)
-                .hasMessageContaining("http://%s:%d/maven".formatted(repo1.getHostName(), repo1.getPort()))
-                .hasMessageContaining("http://%s:%d/maven".formatted(repo2.getHostName(), repo2.getPort()));
-          })
-        );
-    }
-
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite/issues/3152")
-    void useSnapshotTimestampVersion() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        var gav = new GroupArtifactVersion("fred", "fred", "2020.0.2-20210127.131051-2");
-        try (MockWebServer mockRepo = new MockWebServer()) {
-            mockRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    assert recordedRequest.getPath() != null;
-                    return !recordedRequest.getPath().endsWith("fred/fred/2020.0.2-SNAPSHOT/fred-2020.0.2-20210127.131051-2.pom") ?
-                      new MockResponse().setResponseCode(404).setBody("") :
-                      new MockResponse().setResponseCode(200).setBody(
-                        //language=xml
-                        """
-                          <project>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dataflow-build</artifactId>
-                              <version>2.10.0-SNAPSHOT</version>
-                          </project>
-                          """);
-                }
-            });
-            mockRepo.start();
-            var repositories = List.of(MavenRepository.builder()
-              .id("id")
-              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .username("user")
-              .password("pass")
-              .build());
-
-            assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    void usesAnonymousRequestIfRepositoryRejectsCredentials() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
-        try (MockWebServer mockRepo = new MockWebServer()) {
-            mockRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    return recordedRequest.getHeaders().get("Authorization") != null ?
-                      new MockResponse().setResponseCode(401).setBody("") :
-                      new MockResponse().setResponseCode(200).setBody(
-                        //language=xml
-                        """
-                          <project>
-                              <groupId>org.springframework.cloud</groupId>
-                              <artifactId>spring-cloud-dataflow-build</artifactId>
-                              <version>2.10.0-SNAPSHOT</version>
-                          </project>
-                          """);
-                }
-            });
-            mockRepo.start();
-            var repositories = List.of(MavenRepository.builder()
-              .id("id")
-              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .username("user")
-              .password("pass")
-              .build());
-
-            assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    void usesAuthenticationIfRepositoryHasCredentials() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
-        try (MockWebServer mockRepo = new MockWebServer()) {
-            mockRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    MockResponse response = new MockResponse();
-                    if (recordedRequest.getHeaders().get("Authorization") != null) {
-                        response.setResponseCode(200);
-                        if (!"HEAD".equalsIgnoreCase(recordedRequest.getMethod())) {
-                            response.setBody(
-                              //language=xml
-                              """
-                                <project>
-                                    <groupId>org.springframework.cloud</groupId>
-                                    <artifactId>spring-cloud-dataflow-build</artifactId>
-                                    <version>2.10.0-SNAPSHOT</version>
-                                </project>
-                                """);
-                        }
-                    } else {
-                        response.setResponseCode(401);
-                    }
-                    return response;
-                }
-            });
-            mockRepo.start();
-            var repositories = List.of(MavenRepository.builder()
-              .id("id")
-              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .username("user")
-              .password("pass")
-              .build());
-
-            assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    @DisplayName("When username or password are environment properties that cannot be resolved, they should not be used")
-    @Issue("https://github.com/openrewrite/rewrite/issues/3142")
-    void doesNotUseAuthenticationIfCredentialsCannotBeResolved() {
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-        var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
-        try (MockWebServer mockRepo = new MockWebServer()) {
-            mockRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest recordedRequest) {
-                    MockResponse response = new MockResponse();
-                    if (recordedRequest.getHeaders().get("Authorization") != null) {
-                        response.setResponseCode(401);
-                    } else if (recordedRequest.getMethod() == null || !recordedRequest.getMethod().equalsIgnoreCase("HEAD")) {
-                        response.setBody(
-                          //language=xml
-                          """
-                            <project>
-                                <groupId>org.springframework.cloud</groupId>
-                                <artifactId>spring-cloud-dataflow-build</artifactId>
-                                <version>2.10.0-SNAPSHOT</version>
-                            </project>
-                            """);
-                    }
-                    return response;
-                }
-            });
-            mockRepo.start();
-            var repositories = List.of(MavenRepository.builder()
-              .id("id")
-              .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
-              .username("${env.ARTIFACTORY_USERNAME}")
-              .password("${env.ARTIFACTORY_USERNAME}")
-              .build());
-
-            assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    @Disabled
-    void dontFetchSnapshotsFromReleaseRepos() {
-        try (MockWebServer snapshotRepo = new MockWebServer();
-             MockWebServer releaseRepo = new MockWebServer()) {
-            snapshotRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest request) {
-                    MockResponse response = new MockResponse().setResponseCode(200);
-                    if (request.getPath() != null && request.getPath().contains("maven-metadata")) {
-                        response.setBody(
-                          //language=xml
-                          """
-                                <metadata modelVersion="1.1.0">
-                                  <groupId>org.springframework.cloud</groupId>
-                                  <artifactId>spring-cloud-dataflow-build</artifactId>
-                                  <version>2.10.0-SNAPSHOT</version>
-                                  <versioning>
-                                    <snapshot>
-                                      <timestamp>20220201.001946</timestamp>
-                                      <buildNumber>85</buildNumber>
-                                    </snapshot>
-                                    <lastUpdated>20220201001950</lastUpdated>
-                                    <snapshotVersions>
-                                      <snapshotVersion>
-                                        <extension>pom</extension>
-                                        <value>2.10.0-20220201.001946-85</value>
-                                        <updated>20220201001946</updated>
-                                      </snapshotVersion>
-                                    </snapshotVersions>
-                                  </versioning>
-                                </metadata>
-                            """
-                        );
-                    } else if (request.getPath() != null && request.getPath().endsWith(".pom")) {
-                        response.setBody(
-                          //language=xml
-                          """
-                                <project>
-                                    <groupId>org.springframework.cloud</groupId>
-                                    <artifactId>spring-cloud-dataflow-build</artifactId>
-                                    <version>2.10.0-SNAPSHOT</version>
-                                </project>
-                            """
-                        );
-                    }
-                    return response;
-                }
-            });
-
-            var metadataPaths = new AtomicInteger(0);
-            releaseRepo.setDispatcher(new Dispatcher() {
-                @Override
-                public MockResponse dispatch(RecordedRequest request) {
-                    MockResponse response = new MockResponse().setResponseCode(404);
-                    if (request.getPath() != null && request.getPath().contains("maven-metadata")) {
-                        metadataPaths.incrementAndGet();
-                    }
-                    return response;
-                }
-            });
-
-            releaseRepo.start();
-            snapshotRepo.start();
-
-            MavenParser.builder().build().parse(ctx,
-              //language=xml
-              """
-                    <project>
-                        <modelVersion>4.0.0</modelVersion>
-                
-                        <groupId>org.openrewrite.test</groupId>
-                        <artifactId>foo</artifactId>
-                        <version>0.1.0-SNAPSHOT</version>
-                
-                        <repositories>
-                          <repository>
-                            <id>snapshot</id>
-                            <snapshots>
-                              <enabled>true</enabled>
-                            </snapshots>
-                            <url>http://%s:%d</url>
-                          </repository>
-                          <repository>
-                            <id>release</id>
-                            <snapshots>
-                              <enabled>false</enabled>
-                            </snapshots>
-                            <url>http://%s:%d</url>
-                          </repository>
-                        </repositories>
-                
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.springframework.cloud</groupId>
-                                <artifactId>spring-cloud-dataflow-build</artifactId>
-                                <version>2.10.0-SNAPSHOT</version>
-                            </dependency>
-                        </dependencies>
-                    </project>
-                """.formatted(snapshotRepo.getHostName(), snapshotRepo.getPort(), releaseRepo.getHostName(), releaseRepo.getPort())
-            );
-
-            assertThat(snapshotRepo.getRequestCount()).isGreaterThan(1);
-            assertThat(metadataPaths.get()).isEqualTo(0);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    void deriveMetaDataFromFileRepository(@TempDir Path repoPath) throws IOException, MavenDownloadingException {
-        Path fred = repoPath.resolve("fred/fred");
-
-        for (String version : Arrays.asList("1.0.0", "1.1.0", "2.0.0")) {
-            Path versionPath = fred.resolve(version);
-            Files.createDirectories(versionPath);
-            Files.writeString(versionPath.resolve("fred-" + version + ".pom"), "");
-        }
-
-        MavenRepository repository = MavenRepository.builder()
-          .id("file-based")
-          .uri(repoPath.toUri().toString())
-          .knownToExist(true)
-          .deriveMetadataIfMissing(true)
-          .build();
-        MavenMetadata metaData = new MavenPomDownloader(emptyMap(), ctx)
-          .downloadMetadata(new GroupArtifact("fred", "fred"), null, List.of(repository));
-        assertThat(metaData.getVersioning().getVersions()).hasSize(3).containsAll(Arrays.asList("1.0.0", "1.1.0", "2.0.0"));
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Test
-    void mergeMetadata() throws IOException {
-        @Language("xml") String metadata1 = """
-              <metadata>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot</artifactId>
-                  <versioning>
-                      <versions>
-                          <version>2.3.3</version>
-                          <version>2.4.1</version>
-                          <version>2.4.2</version>
-                      </versions>
-                      <snapshot>
-                          <timestamp>20220927.033510</timestamp>
-                          <buildNumber>223</buildNumber>
-                      </snapshot>
-                      <snapshotVersions>
-                          <snapshotVersion>
-                              <extension>pom.asc</extension>
-                              <value>0.1.0-20220927.033510-223</value>
-                              <updated>20220927033510</updated>
-                          </snapshotVersion>
-                      </snapshotVersions>
-                  </versioning>
-              </metadata>
-          """;
-
-        @Language("xml") String metadata2 = """
-              <metadata modelVersion="1.1.0">
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot</artifactId>
-                  <versioning>
-                      <versions>
-                          <version>2.3.2</version>
-                          <version>2.3.3</version>
-                      </versions>
-                      <snapshot>
-                          <timestamp>20210115.042754</timestamp>
-                          <buildNumber>180</buildNumber>
-                      </snapshot>
-                      <snapshotVersions>
-                          <snapshotVersion>
-                              <extension>pom.asc</extension>
-                              <value>0.1.0-20210115.042754-180</value>
-                              <updated>20210115042754</updated>
-                          </snapshotVersion>
-                      </snapshotVersions>
-                  </versioning>
-              </metadata>
-          """;
-
-        var m1 = MavenMetadata.parse(metadata1.getBytes());
-        var m2 = MavenMetadata.parse(metadata2.getBytes());
-
-        var merged = new MavenPomDownloader(emptyMap(), ctx).mergeMetadata(m1, m2);
-
-        assertThat(merged.getVersioning().getSnapshot().getTimestamp()).isEqualTo("20220927.033510");
-        assertThat(merged.getVersioning().getSnapshot().getBuildNumber()).isEqualTo("223");
-        assertThat(merged.getVersioning().getVersions()).hasSize(4).contains("2.3.2", "2.3.3", "2.4.1", "2.4.2");
-        assertThat(merged.getVersioning().getSnapshotVersions()).hasSize(2);
-        assertThat(merged.getVersioning().getSnapshotVersions().get(0).getExtension()).isNotNull();
-        assertThat(merged.getVersioning().getSnapshotVersions().get(0).getValue()).isNotNull();
-        assertThat(merged.getVersioning().getSnapshotVersions().get(0).getUpdated()).isNotNull();
-    }
-
-    @Test
-    void skipsLocalInvalidArtifactsMissingJar(@TempDir Path localRepository) throws IOException {
-        Path localArtifact = localRepository.resolve("com/bad/bad-artifact");
-        assertThat(localArtifact.toFile().mkdirs()).isTrue();
-        Files.createDirectories(localArtifact.resolve("1"));
-
-        Path localPom = localRepository.resolve("com/bad/bad-artifact/1/bad-artifact-1.pom");
-        Files.writeString(localPom,
-          //language=xml
-          """
-             <project>
-               <groupId>com.bad</groupId>
-               <artifactId>bad-artifact</artifactId>
-               <version>1</version>
-             </project>
-            """
-        );
-
-        MavenRepository mavenLocal = MavenRepository.builder()
-          .id("local")
-          .uri(localRepository.toUri().toString())
-          .snapshots(false)
-          .knownToExist(true)
-          .build();
-
-        // Does not return invalid dependency.
-        assertThrows(MavenDownloadingException.class, () ->
-          new MavenPomDownloader(emptyMap(), ctx)
-            .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
-    }
-
-    @Test
-    void skipsLocalInvalidArtifactsEmptyJar(@TempDir Path localRepository) throws IOException {
-        Path localArtifact = localRepository.resolve("com/bad/bad-artifact");
-        assertThat(localArtifact.toFile().mkdirs()).isTrue();
-        Files.createDirectories(localArtifact.resolve("1"));
-
-        Path localPom = localRepository.resolve("com/bad/bad-artifact/1/bad-artifact-1.pom");
-        Files.writeString(localPom,
-          //language=xml
-          """
-             <project>
-               <groupId>com.bad</groupId>
-               <artifactId>bad-artifact</artifactId>
-               <version>1</version>
-             </project>
-            """
-        );
-        Path localJar = localRepository.resolve("com/bad/bad-artifact/1/bad-artifact-1.jar");
-        Files.writeString(localJar, "");
-
-        MavenRepository mavenLocal = MavenRepository.builder()
-          .id("local")
-          .uri(localRepository.toUri().toString())
-          .snapshots(false)
-          .knownToExist(true)
-          .build();
-
-        // Does not return invalid dependency.
-        assertThrows(MavenDownloadingException.class, () ->
-          new MavenPomDownloader(emptyMap(), ctx)
-            .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
-    }
-
-    @Test
-    void doNotRenameRepoForCustomMavenLocal(@TempDir Path tempDir) throws MavenDownloadingException, IOException {
-        GroupArtifactVersion gav = createArtifact(tempDir);
-        MavenExecutionContextView.view(ctx).setLocalRepository(MavenRepository.MAVEN_LOCAL_DEFAULT.withUri(tempDir.toUri().toString()));
-        var downloader = new MavenPomDownloader(emptyMap(), ctx);
-
-        var result = downloader.download(gav, null, null, List.of());
-        //noinspection DataFlowIssue
-        assertThat(result.getRepository()).isNotNull();
-        assertThat(result.getRepository().getUri()).startsWith(tempDir.toUri().toString());
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/4080")
-    @Test
-    void connectTimeout() {
-        var downloader = new MavenPomDownloader(ctx);
-        var gav = new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0");
-        var repos = singletonList(MavenRepository.builder()
-          .id("non-routable").uri("http://10.0.0.0/maven").knownToExist(true).build());
-
-        assertThatThrownBy(() -> downloader.download(gav, null, null, repos))
-          .isInstanceOf(MavenDownloadingException.class)
-          .hasMessageContaining("rewrite-core")
-          .hasMessageContaining("10.0.0.0");
     }
 
     @CsvSource(textBlock = """
@@ -790,133 +93,904 @@ class MavenPomDownloaderTest {
         assertThat(normalized.getUri()).isEqualTo(expectedUrl);
     }
 
-    private static GroupArtifactVersion createArtifact(Path repository) throws IOException {
-        Path target = repository.resolve(Paths.get("org", "openrewrite", "rewrite", "1.0.0"));
-        Path pom = target.resolve("rewrite-1.0.0.pom");
-        Path jar = target.resolve("rewrite-1.0.0.jar");
-        Files.createDirectories(target);
-        Files.createFile(pom);
-        Files.createFile(jar);
+    @Nested
+    class WithNativeHttpURLConnectionAndTLS {
+        private final ExecutionContext ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+          .setHttpSender(new HttpUrlConnectionSender(Duration.ofMillis(250), Duration.ofMillis(250)));
 
-        Files.write(pom,
-          //language=xml
-          """
-            <project>
-                <groupId>org.openrewrite</groupId>
-                <artifactId>rewrite</artifactId>
-                <version>1.0.0</version>
-            </project>
-            """.getBytes());
-        Files.write(jar, "I'm a jar".getBytes()); // empty jars get ignored
-        return new GroupArtifactVersion("org.openrewrite", "rewrite", "1.0.0");
+        @Issue("https://github.com/openrewrite/rewrite/issues/3908")
+        @Test
+        void centralIdOverridesDefaultRepository() {
+            var ctx = MavenExecutionContextView.view(this.ctx);
+            ctx.setMavenSettings(MavenSettings.parse(Parser.Input.fromString(Paths.get("settings.xml"),
+              //language=xml
+              """
+                <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+                  <profiles>
+                    <profile>
+                        <id>central</id>
+                        <repositories>
+                            <repository>
+                                <id>central</id>
+                                <url>https://internalartifactrepository.yourorg.com</url>
+                            </repository>
+                        </repositories>
+                    </profile>
+                  </profiles>
+                  <activeProfiles>
+                    <activeProfile>central</activeProfile>
+                  </activeProfiles>
+                </settings>
+                """
+            ), ctx));
+
+            // Avoid actually trying to reach the made-up https://internalartifactrepository.yourorg.com
+            for (MavenRepository repository : ctx.getRepositories()) {
+                repository.setKnownToExist(true);
+            }
+
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            Collection<MavenRepository> repos = downloader.distinctNormalizedRepositories(emptyList(), null, null);
+            assertThat(repos).areExactly(1, new Condition<>(repo -> "central".equals(repo.getId()),
+              "id \"central\""));
+            assertThat(repos).areExactly(1, new Condition<>(repo -> "https://internalartifactrepository.yourorg.com".equals(repo.getUri()),
+              "URI https://internalartifactrepository.yourorg.com"));
+        }
+
+        @Test
+        void listenerRecordsRepository() {
+            var ctx = MavenExecutionContextView.view(this.ctx);
+            // Avoid actually trying to reach the made-up https://internalartifactrepository.yourorg.com
+            for (MavenRepository repository : ctx.getRepositories()) {
+                repository.setKnownToExist(true);
+            }
+
+            MavenRepository nonexistentRepo = new MavenRepository("repo", "http://internalartifactrepository.yourorg.com", null, null, true, null, null, null, null);
+            List<String> attemptedUris = new ArrayList<>();
+            List<MavenRepository> discoveredRepositories = new ArrayList<>();
+            ctx.setResolutionListener(new ResolutionEventListener() {
+                @Override
+                public void downloadError(GroupArtifactVersion gav, List<String> uris, @Nullable Pom containing) {
+                    attemptedUris.addAll(uris);
+                }
+
+                @Override
+                public void repository(MavenRepository mavenRepository, @Nullable ResolvedPom containing) {
+                    discoveredRepositories.add(mavenRepository);
+                }
+            });
+
+            try {
+                new MavenPomDownloader(ctx)
+                  .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
+            } catch (Exception e) {
+                // not expected to succeed
+            }
+            assertThat(attemptedUris)
+              .containsExactly("http://internalartifactrepository.yourorg.com/org/openrewrite/rewrite-core/7.0.0/rewrite-core-7.0.0.pom");
+            assertThat(discoveredRepositories)
+              .containsExactly(nonexistentRepo);
+        }
+
+        @Test
+        void listenerRecordsFailedRepositoryAccess() {
+            var ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+            // Avoid actually trying to reach a made-up URL
+            String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
+            MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
+            Map<String, Throwable> attemptedUris = new HashMap<>();
+            List<MavenRepository> discoveredRepositories = new ArrayList<>();
+            ctx.setResolutionListener(new ResolutionEventListener() {
+                @Override
+                public void repositoryAccessFailed(String uri, Throwable e) {
+                    attemptedUris.put(uri, e);
+                }
+            });
+
+            try {
+                new MavenPomDownloader(ctx)
+                  .download(new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0"), null, null, singletonList(nonexistentRepo));
+            } catch (Exception e) {
+                // not expected to succeed
+            }
+            assertThat(attemptedUris).isNotEmpty();
+            assertThat(attemptedUris.get(httpUrl)).isInstanceOf(UnknownHostException.class);
+            assertThat(discoveredRepositories).isEmpty();
+        }
+
+        @Test
+        void mirrorsOverrideRepositoriesInPom() {
+            var ctx = MavenExecutionContextView.view(this.ctx);
+            ctx.setMavenSettings(MavenSettings.parse(Parser.Input.fromString(Paths.get("settings.xml"),
+              //language=xml
+              """
+                <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+                  <mirrors>
+                    <mirror>
+                      <id>mirror</id>
+                      <url>https://artifactory.moderne.ninja/artifactory/moderne-cache</url>
+                      <mirrorOf>*</mirrorOf>
+                    </mirror>
+                  </mirrors>
+                </settings>
+                """
+            ), ctx));
+
+            Path pomPath = Paths.get("pom.xml");
+            Pom pom = Pom.builder()
+              .sourcePath(pomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "org.openrewrite", "rewrite-core", "7.0.0", null))
+              .build();
+            ResolvedPom resolvedPom = ResolvedPom.builder()
+              .requested(pom)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .repositories(singletonList(MAVEN_CENTRAL))
+              .build();
+
+            Map<Path, Pom> pomsByPath = new HashMap<>();
+            pomsByPath.put(pomPath, pom);
+
+            MavenPomDownloader mpd = new MavenPomDownloader(pomsByPath, ctx);
+            MavenRepository normalized = mpd.normalizeRepository(
+              MavenRepository.builder().id("whatever").uri("${REPO_URL}").build(),
+              ctx,
+              resolvedPom
+            );
+            assertThat(normalized)
+              .extracting(MavenRepository::getUri)
+              .isEqualTo("https://artifactory.moderne.ninja/artifactory/moderne-cache/");
+        }
+
+        @Disabled("Flaky on CI")
+        @Test
+        void normalizeOssSnapshots() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            MavenRepository oss = downloader.normalizeRepository(
+              MavenRepository.builder().id("oss").uri("https://oss.sonatype.org/content/repositories/snapshots").build(),
+              MavenExecutionContextView.view(ctx), null);
+
+            assertThat(oss).isNotNull();
+            assertThat(oss.getUri()).isEqualTo("https://oss.sonatype.org/content/repositories/snapshots/");
+        }
+
+        @ParameterizedTest
+        @Issue("https://github.com/openrewrite/rewrite/issues/3141")
+        @ValueSource(strings = {"http://0.0.0.0", "https://0.0.0.0", "0.0.0.0:443"})
+        void skipBlockedRepository(String url) {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            MavenRepository oss = downloader.normalizeRepository(
+              MavenRepository.builder().id("myRepo").uri(url).build(),
+              MavenExecutionContextView.view(ctx), null);
+
+            assertThat(oss).isNull();
+        }
+
+        @Test
+        void retryConnectException() throws Throwable {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            try (MockWebServer server = new MockWebServer()) {
+                server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+                server.enqueue(new MockResponse().setResponseCode(200).setBody("body"));
+                String body = new String(downloader.sendRequest(new HttpSender.Request(server.url("/test").url(), "request".getBytes(), HttpSender.Method.GET, Map.of(), null, null)));
+                assertThat(body).isEqualTo("body");
+                assertThat(server.getRequestCount()).isEqualTo(2);
+                server.shutdown();
+            }
+        }
+
+        @Test
+        void normalizeRejectConnectException() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var normalizedRepository = downloader.normalizeRepository(
+              MavenRepository.builder().id("id").uri("https//localhost").build(),
+              MavenExecutionContextView.view(ctx), null);
+            assertThat(normalizedRepository).isEqualTo(null);
+        }
+
+        @Test
+        void useHttpWhenHttpsFails() throws IOException {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            try (MockWebServer mockRepo = new MockWebServer()) {
+                mockRepo.enqueue(new MockResponse().setResponseCode(200).setBody("body"));
+                var httpRepo = MavenRepository.builder()
+                  .id("id")
+                  .uri("http://%s:%d/maven/".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .build();
+
+                var normalizedRepository = downloader.normalizeRepository(httpRepo, MavenExecutionContextView.view(ctx), null);
+
+                assertThat(normalizedRepository).isEqualTo(httpRepo);
+            }
+        }
+
+        @Test
+        @Disabled
+        void dontFetchSnapshotsFromReleaseRepos() {
+            try (MockWebServer snapshotRepo = new MockWebServer();
+                 MockWebServer releaseRepo = new MockWebServer()) {
+                snapshotRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest request) {
+                        MockResponse response = new MockResponse().setResponseCode(200);
+                        if (request.getPath() != null && request.getPath().contains("maven-metadata")) {
+                            response.setBody(
+                              //language=xml
+                              """
+                                    <metadata modelVersion="1.1.0">
+                                      <groupId>org.springframework.cloud</groupId>
+                                      <artifactId>spring-cloud-dataflow-build</artifactId>
+                                      <version>2.10.0-SNAPSHOT</version>
+                                      <versioning>
+                                        <snapshot>
+                                          <timestamp>20220201.001946</timestamp>
+                                          <buildNumber>85</buildNumber>
+                                        </snapshot>
+                                        <lastUpdated>20220201001950</lastUpdated>
+                                        <snapshotVersions>
+                                          <snapshotVersion>
+                                            <extension>pom</extension>
+                                            <value>2.10.0-20220201.001946-85</value>
+                                            <updated>20220201001946</updated>
+                                          </snapshotVersion>
+                                        </snapshotVersions>
+                                      </versioning>
+                                    </metadata>
+                                """
+                            );
+                        } else if (request.getPath() != null && request.getPath().endsWith(".pom")) {
+                            response.setBody(
+                              //language=xml
+                              """
+                                    <project>
+                                        <groupId>org.springframework.cloud</groupId>
+                                        <artifactId>spring-cloud-dataflow-build</artifactId>
+                                        <version>2.10.0-SNAPSHOT</version>
+                                    </project>
+                                """
+                            );
+                        }
+                        return response;
+                    }
+                });
+
+                var metadataPaths = new AtomicInteger(0);
+                releaseRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest request) {
+                        MockResponse response = new MockResponse().setResponseCode(404);
+                        if (request.getPath() != null && request.getPath().contains("maven-metadata")) {
+                            metadataPaths.incrementAndGet();
+                        }
+                        return response;
+                    }
+                });
+
+                releaseRepo.start();
+                snapshotRepo.start();
+
+                MavenParser.builder().build().parse(ctx,
+                  //language=xml
+                  """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                    
+                            <groupId>org.openrewrite.test</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>0.1.0-SNAPSHOT</version>
+                    
+                            <repositories>
+                              <repository>
+                                <id>snapshot</id>
+                                <snapshots>
+                                  <enabled>true</enabled>
+                                </snapshots>
+                                <url>http://%s:%d</url>
+                              </repository>
+                              <repository>
+                                <id>release</id>
+                                <snapshots>
+                                  <enabled>false</enabled>
+                                </snapshots>
+                                <url>http://%s:%d</url>
+                              </repository>
+                            </repositories>
+                    
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.springframework.cloud</groupId>
+                                    <artifactId>spring-cloud-dataflow-build</artifactId>
+                                    <version>2.10.0-SNAPSHOT</version>
+                                </dependency>
+                            </dependencies>
+                        </project>
+                    """.formatted(snapshotRepo.getHostName(), snapshotRepo.getPort(), releaseRepo.getHostName(), releaseRepo.getPort())
+                );
+
+                assertThat(snapshotRepo.getRequestCount()).isGreaterThan(1);
+                assertThat(metadataPaths.get()).isEqualTo(0);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        void deriveMetaDataFromFileRepository(@TempDir Path repoPath) throws IOException, MavenDownloadingException {
+            Path fred = repoPath.resolve("fred/fred");
+
+            for (String version : Arrays.asList("1.0.0", "1.1.0", "2.0.0")) {
+                Path versionPath = fred.resolve(version);
+                Files.createDirectories(versionPath);
+                Files.writeString(versionPath.resolve("fred-" + version + ".pom"), "");
+            }
+
+            MavenRepository repository = MavenRepository.builder()
+              .id("file-based")
+              .uri(repoPath.toUri().toString())
+              .knownToExist(true)
+              .deriveMetadataIfMissing(true)
+              .build();
+            MavenMetadata metaData = new MavenPomDownloader(emptyMap(), ctx)
+              .downloadMetadata(new GroupArtifact("fred", "fred"), null, List.of(repository));
+            assertThat(metaData.getVersioning().getVersions()).hasSize(3).containsAll(Arrays.asList("1.0.0", "1.1.0", "2.0.0"));
+        }
+
+        @SuppressWarnings("ConstantConditions")
+        @Test
+        void mergeMetadata() throws IOException {
+            @Language("xml") String metadata1 = """
+                  <metadata>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot</artifactId>
+                      <versioning>
+                          <versions>
+                              <version>2.3.3</version>
+                              <version>2.4.1</version>
+                              <version>2.4.2</version>
+                          </versions>
+                          <snapshot>
+                              <timestamp>20220927.033510</timestamp>
+                              <buildNumber>223</buildNumber>
+                          </snapshot>
+                          <snapshotVersions>
+                              <snapshotVersion>
+                                  <extension>pom.asc</extension>
+                                  <value>0.1.0-20220927.033510-223</value>
+                                  <updated>20220927033510</updated>
+                              </snapshotVersion>
+                          </snapshotVersions>
+                      </versioning>
+                  </metadata>
+              """;
+
+            @Language("xml") String metadata2 = """
+                  <metadata modelVersion="1.1.0">
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot</artifactId>
+                      <versioning>
+                          <versions>
+                              <version>2.3.2</version>
+                              <version>2.3.3</version>
+                          </versions>
+                          <snapshot>
+                              <timestamp>20210115.042754</timestamp>
+                              <buildNumber>180</buildNumber>
+                          </snapshot>
+                          <snapshotVersions>
+                              <snapshotVersion>
+                                  <extension>pom.asc</extension>
+                                  <value>0.1.0-20210115.042754-180</value>
+                                  <updated>20210115042754</updated>
+                              </snapshotVersion>
+                          </snapshotVersions>
+                      </versioning>
+                  </metadata>
+              """;
+
+            var m1 = MavenMetadata.parse(metadata1.getBytes());
+            var m2 = MavenMetadata.parse(metadata2.getBytes());
+
+            var merged = new MavenPomDownloader(emptyMap(), ctx).mergeMetadata(m1, m2);
+
+            assertThat(merged.getVersioning().getSnapshot().getTimestamp()).isEqualTo("20220927.033510");
+            assertThat(merged.getVersioning().getSnapshot().getBuildNumber()).isEqualTo("223");
+            assertThat(merged.getVersioning().getVersions()).hasSize(4).contains("2.3.2", "2.3.3", "2.4.1", "2.4.2");
+            assertThat(merged.getVersioning().getSnapshotVersions()).hasSize(2);
+            assertThat(merged.getVersioning().getSnapshotVersions().get(0).getExtension()).isNotNull();
+            assertThat(merged.getVersioning().getSnapshotVersions().get(0).getValue()).isNotNull();
+            assertThat(merged.getVersioning().getSnapshotVersions().get(0).getUpdated()).isNotNull();
+        }
+
+        @Test
+        void skipsLocalInvalidArtifactsMissingJar(@TempDir Path localRepository) throws IOException {
+            Path localArtifact = localRepository.resolve("com/bad/bad-artifact");
+            assertThat(localArtifact.toFile().mkdirs()).isTrue();
+            Files.createDirectories(localArtifact.resolve("1"));
+
+            Path localPom = localRepository.resolve("com/bad/bad-artifact/1/bad-artifact-1.pom");
+            Files.writeString(localPom,
+              //language=xml
+              """
+                 <project>
+                   <groupId>com.bad</groupId>
+                   <artifactId>bad-artifact</artifactId>
+                   <version>1</version>
+                 </project>
+                """
+            );
+
+            MavenRepository mavenLocal = MavenRepository.builder()
+              .id("local")
+              .uri(localRepository.toUri().toString())
+              .snapshots(false)
+              .knownToExist(true)
+              .build();
+
+            // Does not return invalid dependency.
+            assertThrows(MavenDownloadingException.class, () ->
+              new MavenPomDownloader(emptyMap(), ctx)
+                .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
+        }
+
+        @Test
+        void skipsLocalInvalidArtifactsEmptyJar(@TempDir Path localRepository) throws IOException {
+            Path localArtifact = localRepository.resolve("com/bad/bad-artifact");
+            assertThat(localArtifact.toFile().mkdirs()).isTrue();
+            Files.createDirectories(localArtifact.resolve("1"));
+
+            Path localPom = localRepository.resolve("com/bad/bad-artifact/1/bad-artifact-1.pom");
+            Files.writeString(localPom,
+              //language=xml
+              """
+                 <project>
+                   <groupId>com.bad</groupId>
+                   <artifactId>bad-artifact</artifactId>
+                   <version>1</version>
+                 </project>
+                """
+            );
+            Path localJar = localRepository.resolve("com/bad/bad-artifact/1/bad-artifact-1.jar");
+            Files.writeString(localJar, "");
+
+            MavenRepository mavenLocal = MavenRepository.builder()
+              .id("local")
+              .uri(localRepository.toUri().toString())
+              .snapshots(false)
+              .knownToExist(true)
+              .build();
+
+            // Does not return invalid dependency.
+            assertThrows(MavenDownloadingException.class, () ->
+              new MavenPomDownloader(emptyMap(), ctx)
+                .download(new GroupArtifactVersion("com.bad", "bad-artifact", "1"), null, null, List.of(mavenLocal)));
+        }
+
+        @Test
+        void doNotRenameRepoForCustomMavenLocal(@TempDir Path tempDir) throws MavenDownloadingException, IOException {
+            GroupArtifactVersion gav = createArtifact(tempDir);
+            MavenExecutionContextView.view(ctx).setLocalRepository(MavenRepository.MAVEN_LOCAL_DEFAULT.withUri(tempDir.toUri().toString()));
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+
+            var result = downloader.download(gav, null, null, List.of());
+            //noinspection DataFlowIssue
+            assertThat(result.getRepository()).isNotNull();
+            assertThat(result.getRepository().getUri()).startsWith(tempDir.toUri().toString());
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite/issues/4080")
+        @Test
+        void connectTimeout() {
+            var downloader = new MavenPomDownloader(ctx);
+            var gav = new GroupArtifactVersion("org.openrewrite", "rewrite-core", "7.0.0");
+            var repos = singletonList(MavenRepository.builder()
+              .id("non-routable").uri("http://10.0.0.0/maven").knownToExist(true).build());
+
+            assertThatThrownBy(() -> downloader.download(gav, null, null, repos))
+              .isInstanceOf(MavenDownloadingException.class)
+              .hasMessageContaining("rewrite-core")
+              .hasMessageContaining("10.0.0.0");
+        }
+
+        private static GroupArtifactVersion createArtifact(Path repository) throws IOException {
+            Path target = repository.resolve(Paths.get("org", "openrewrite", "rewrite", "1.0.0"));
+            Path pom = target.resolve("rewrite-1.0.0.pom");
+            Path jar = target.resolve("rewrite-1.0.0.jar");
+            Files.createDirectories(target);
+            Files.createFile(pom);
+            Files.createFile(jar);
+
+            Files.write(pom,
+              //language=xml
+              """
+                <project>
+                    <groupId>org.openrewrite</groupId>
+                    <artifactId>rewrite</artifactId>
+                    <version>1.0.0</version>
+                </project>
+                """.getBytes());
+            Files.write(jar, "I'm a jar".getBytes()); // empty jars get ignored
+            return new GroupArtifactVersion("org.openrewrite", "rewrite", "1.0.0");
+        }
+
+        @Test
+        void shouldNotThrowExceptionForModulesInModulesWithRightProperty() {
+            var gav = new GroupArtifactVersion("test", "test2", "${test}");
+
+            Path pomPath = Paths.get("test/test2/pom.xml");
+            Pom pom = Pom.builder()
+              .sourcePath(pomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "test", "test2", "7.0.0", null))
+              .build();
+
+            ResolvedPom resolvedPom = ResolvedPom.builder()
+              .requested(pom)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .repositories(singletonList(MAVEN_CENTRAL))
+              .build();
+
+            Path pomPath2 = Paths.get("test/pom.xml");
+            Pom pom2 = Pom.builder()
+              .sourcePath(pomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "test", "test", "7.0.0", null))
+              .build();
+
+
+            Path parentPomPath = Paths.get("pom.xml");
+            Pom parentPom = Pom.builder()
+              .sourcePath(parentPomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("test", "7.0.0"))
+              .parent(null)
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "test", "root-test", "7.0.0", null))
+              .build();
+
+            Map<Path, Pom> pomsByPath = new HashMap<>();
+            pomsByPath.put(parentPomPath, parentPom);
+            pomsByPath.put(pomPath, pom);
+            pomsByPath.put(pomPath2, pom2);
+
+            String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
+            MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
+
+            MavenPomDownloader downloader = new MavenPomDownloader(pomsByPath, ctx);
+
+            assertDoesNotThrow(() -> downloader.download(gav, Objects.requireNonNull(pom.getParent()).getRelativePath(), resolvedPom, singletonList(nonexistentRepo)));
+        }
+
+        @Test
+        void shouldThrowExceptionForModulesInModulesWithNoRightProperty() {
+            var gav = new GroupArtifactVersion("test", "test2", "${test}");
+
+            Path pomPath = Paths.get("test/test2/pom.xml");
+            Pom pom = Pom.builder()
+              .sourcePath(pomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "test", "test2", "7.0.0", null))
+              .build();
+
+            ResolvedPom resolvedPom = ResolvedPom.builder()
+              .requested(pom)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .repositories(singletonList(MAVEN_CENTRAL))
+              .build();
+
+            Path pomPath2 = Paths.get("test/pom.xml");
+            Pom pom2 = Pom.builder()
+              .sourcePath(pomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
+              .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "test", "test", "7.0.0", null))
+              .build();
+
+
+            Path parentPomPath = Paths.get("pom.xml");
+            Pom parentPom = Pom.builder()
+              .sourcePath(parentPomPath)
+              .repository(MAVEN_CENTRAL)
+              .properties(singletonMap("tt", "7.0.0"))
+              .parent(null)
+              .gav(new ResolvedGroupArtifactVersion(
+                "${REPO_URL}", "test", "root-test", "7.0.0", null))
+              .build();
+
+            Map<Path, Pom> pomsByPath = new HashMap<>();
+            pomsByPath.put(parentPomPath, parentPom);
+            pomsByPath.put(pomPath, pom);
+            pomsByPath.put(pomPath2, pom2);
+
+            String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
+            MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
+
+            MavenPomDownloader downloader = new MavenPomDownloader(pomsByPath, ctx);
+
+            assertThrows(IllegalArgumentException.class, () -> downloader.download(gav, Objects.requireNonNull(pom.getParent()).getRelativePath(), resolvedPom, singletonList(nonexistentRepo)));
+        }
     }
 
-    @Test
-    void shouldNotThrowExceptionForModulesInModulesWithRightProperty() {
-        var gav = new GroupArtifactVersion("test", "test2", "${test}");
+    @Nested
+    class WithOkHttpClientAndSelfSignedTLS {
+        private final SSLSocketFactory sslSocketFactory;
+        private final ExecutionContext ctx;
 
-        Path pomPath = Paths.get("test/test2/pom.xml");
-        Pom pom = Pom.builder()
-          .sourcePath(pomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "test", "test2", "7.0.0", null))
-          .build();
+        WithOkHttpClientAndSelfSignedTLS() throws UnknownHostException {
+            String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
+            HeldCertificate localhostCertificate = new HeldCertificate.Builder()
+              .addSubjectAlternativeName(localhost)
+              .build();
+            sslSocketFactory = new HandshakeCertificates.Builder()
+              .heldCertificate(localhostCertificate)
+              .build().sslSocketFactory();
 
-        ResolvedPom resolvedPom = ResolvedPom.builder()
-          .requested(pom)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .repositories(singletonList(MAVEN_CENTRAL))
-          .build();
+            HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+              .addTrustedCertificate(localhostCertificate.certificate())
+              .build();
+            OkHttpClient client = new OkHttpClient.Builder()
+              .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager())
+              .connectTimeout(Duration.ofMillis(250))
+              .readTimeout(Duration.ofMillis(250))
+              .build();
+            ctx = HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+              .setHttpSender(new OkHttpSender(client));
+        }
 
-        Path pomPath2 = Paths.get("test/pom.xml");
-        Pom pom2 = Pom.builder()
-          .sourcePath(pomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "test", "test", "7.0.0", null))
-          .build();
+        private MockWebServer getMockServer() {
+            var mockWebServer = new MockWebServer();
+            mockWebServer.useHttps(sslSocketFactory, false);
+            return mockWebServer;
+        }
 
+        private void mockServer(Integer responseCode, Consumer<MockWebServer> block) {
+            try (MockWebServer mockRepo = getMockServer()) {
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        return new MockResponse().setResponseCode(responseCode).setBody("");
+                    }
+                });
+                mockRepo.start();
+                block.accept(mockRepo);
+                assertThat(mockRepo.getRequestCount())
+                  .as("The mock repository received no requests. The test is not using it.")
+                  .isGreaterThan(0);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
 
-        Path parentPomPath = Paths.get("pom.xml");
-        Pom parentPom = Pom.builder()
-          .sourcePath(parentPomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("test", "7.0.0"))
-          .parent(null)
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "test", "root-test", "7.0.0", null))
-          .build();
+        @Test
+        void useHttpsWhenAvailable() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            mockServer(200, mockRepo -> {
+                var normalizedRepository = downloader.normalizeRepository(
+                  MavenRepository.builder()
+                    .id("id")
+                    .uri("http://%s:%d/maven/".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                    .build(),
+                  MavenExecutionContextView.view(ctx),
+                  null);
 
-        Map<Path, Pom> pomsByPath = new HashMap<>();
-        pomsByPath.put(parentPomPath, parentPom);
-        pomsByPath.put(pomPath, pom);
-        pomsByPath.put(pomPath2, pom2);
+                assertThat(normalizedRepository).isEqualTo(
+                  MavenRepository.builder()
+                    .id("id")
+                    .uri("https://%s:%d/maven/".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                    .build());
+            });
+        }
 
-        String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
-        MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
+        @ParameterizedTest
+        @ValueSource(ints = {500, 400})
+        void normalizeAcceptErrorStatuses(Integer status) {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            mockServer(status, mockRepo -> {
+                var originalRepo = MavenRepository.builder()
+                  .id("id")
+                  .uri("https://%s:%d/maven/".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .build();
+                var normalizedRepo = downloader.normalizeRepository(originalRepo, MavenExecutionContextView.view(ctx), null);
+                assertThat(normalizedRepo).isEqualTo(originalRepo);
+            });
+        }
 
-        MavenPomDownloader downloader = new MavenPomDownloader(pomsByPath, ctx);
+        @Test
+        void invalidArtifact() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            mockServer(500,
+              repo1 -> mockServer(400, repo2 -> {
+                  var repositories = List.of(
+                    MavenRepository.builder()
+                      .id("id")
+                      .uri("http://%s:%d/maven".formatted(repo1.getHostName(), repo1.getPort()))
+                      .build(),
+                    MavenRepository.builder()
+                      .id("id2")
+                      .uri("http://%s:%d/maven".formatted(repo2.getHostName(), repo2.getPort()))
+                      .build()
+                  );
 
-        assertDoesNotThrow(() -> downloader.download(gav, Objects.requireNonNull(pom.getParent()).getRelativePath(), resolvedPom, singletonList(nonexistentRepo)));
+                  assertThatThrownBy(() -> downloader.download(gav, null, null, repositories))
+                    .isInstanceOf(MavenDownloadingException.class)
+                    .hasMessageContaining("https://%s:%d/maven".formatted(repo1.getHostName(), repo1.getPort()))
+                    .hasMessageContaining("https://%s:%d/maven".formatted(repo2.getHostName(), repo2.getPort()));
+              })
+            );
+        }
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite/issues/3152")
+        void useSnapshotTimestampVersion() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var gav = new GroupArtifactVersion("fred", "fred", "2020.0.2-20210127.131051-2");
+            try (MockWebServer mockRepo = getMockServer()) {
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        assert recordedRequest.getPath() != null;
+                        return !recordedRequest.getPath().endsWith("fred/fred/2020.0.2-SNAPSHOT/fred-2020.0.2-20210127.131051-2.pom") ?
+                          new MockResponse().setResponseCode(404).setBody("") :
+                          new MockResponse().setResponseCode(200).setBody(
+                            //language=xml
+                            """
+                              <project>
+                                  <groupId>org.springframework.cloud</groupId>
+                                  <artifactId>spring-cloud-dataflow-build</artifactId>
+                                  <version>2.10.0-SNAPSHOT</version>
+                              </project>
+                              """);
+                    }
+                });
+                mockRepo.start();
+                var repositories = List.of(MavenRepository.builder()
+                  .id("id")
+                  .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .username("user")
+                  .password("pass")
+                  .build());
+
+                assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        void usesAnonymousRequestIfRepositoryRejectsCredentials() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            try (MockWebServer mockRepo = getMockServer()) {
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        return recordedRequest.getHeaders().get("Authorization") != null ?
+                          new MockResponse().setResponseCode(401).setBody("") :
+                          new MockResponse().setResponseCode(200).setBody(
+                            //language=xml
+                            """
+                              <project>
+                                  <groupId>org.springframework.cloud</groupId>
+                                  <artifactId>spring-cloud-dataflow-build</artifactId>
+                                  <version>2.10.0-SNAPSHOT</version>
+                              </project>
+                              """);
+                    }
+                });
+                mockRepo.start();
+                var repositories = List.of(MavenRepository.builder()
+                  .id("id")
+                  .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .username("user")
+                  .password("pass")
+                  .build());
+
+                assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        void usesAuthenticationIfRepositoryHasCredentials() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            try (MockWebServer mockRepo = getMockServer()) {
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        MockResponse response = new MockResponse();
+                        if (recordedRequest.getHeaders().get("Authorization") != null) {
+                            response.setResponseCode(200);
+                            if (!"HEAD".equalsIgnoreCase(recordedRequest.getMethod())) {
+                                response.setBody(
+                                  //language=xml
+                                  """
+                                    <project>
+                                        <groupId>org.springframework.cloud</groupId>
+                                        <artifactId>spring-cloud-dataflow-build</artifactId>
+                                        <version>2.10.0-SNAPSHOT</version>
+                                    </project>
+                                    """);
+                            }
+                        } else {
+                            response.setResponseCode(401);
+                        }
+                        return response;
+                    }
+                });
+                mockRepo.start();
+                var repositories = List.of(MavenRepository.builder()
+                  .id("id")
+                  .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .username("user")
+                  .password("pass")
+                  .build());
+
+                assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        @DisplayName("When username or password are environment properties that cannot be resolved, they should not be used")
+        @Issue("https://github.com/openrewrite/rewrite/issues/3142")
+        void doesNotUseAuthenticationIfCredentialsCannotBeResolved() {
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            try (MockWebServer mockRepo = getMockServer()) {
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        MockResponse response = new MockResponse();
+                        if (recordedRequest.getHeaders().get("Authorization") != null) {
+                            response.setResponseCode(401);
+                        } else if (recordedRequest.getMethod() == null || !recordedRequest.getMethod().equalsIgnoreCase("HEAD")) {
+                            response.setBody(
+                              //language=xml
+                              """
+                                <project>
+                                    <groupId>org.springframework.cloud</groupId>
+                                    <artifactId>spring-cloud-dataflow-build</artifactId>
+                                    <version>2.10.0-SNAPSHOT</version>
+                                </project>
+                                """);
+                        }
+                        return response;
+                    }
+                });
+                mockRepo.start();
+                var repositories = List.of(MavenRepository.builder()
+                  .id("id")
+                  .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .username("${env.ARTIFACTORY_USERNAME}")
+                  .password("${env.ARTIFACTORY_USERNAME}")
+                  .build());
+
+                assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
-
-    @Test
-    void shouldThrowExceptionForModulesInModulesWithNoRightProperty() {
-        var gav = new GroupArtifactVersion("test", "test2", "${test}");
-
-        Path pomPath = Paths.get("test/test2/pom.xml");
-        Pom pom = Pom.builder()
-          .sourcePath(pomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "test", "test2", "7.0.0", null))
-          .build();
-
-        ResolvedPom resolvedPom = ResolvedPom.builder()
-          .requested(pom)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .repositories(singletonList(MAVEN_CENTRAL))
-          .build();
-
-        Path pomPath2 = Paths.get("test/pom.xml");
-        Pom pom2 = Pom.builder()
-          .sourcePath(pomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
-          .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "test", "test", "7.0.0", null))
-          .build();
-
-
-        Path parentPomPath = Paths.get("pom.xml");
-        Pom parentPom = Pom.builder()
-          .sourcePath(parentPomPath)
-          .repository(MAVEN_CENTRAL)
-          .properties(singletonMap("tt", "7.0.0"))
-          .parent(null)
-          .gav(new ResolvedGroupArtifactVersion(
-            "${REPO_URL}", "test", "root-test", "7.0.0", null))
-          .build();
-
-        Map<Path, Pom> pomsByPath = new HashMap<>();
-        pomsByPath.put(parentPomPath, parentPom);
-        pomsByPath.put(pomPath, pom);
-        pomsByPath.put(pomPath2, pom2);
-
-        String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
-        MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
-
-        MavenPomDownloader downloader = new MavenPomDownloader(pomsByPath, ctx);
-
-        assertThrows(IllegalArgumentException.class, () -> downloader.download(gav, Objects.requireNonNull(pom.getParent()).getRelativePath(), resolvedPom, singletonList(nonexistentRepo)));
-    }
-
 }


### PR DESCRIPTION
## What's changed?
I enabled TLS support in OkHttp MockWebServer for some tests, in order to be able to reply with an actual HTTPS response.

On my machine, `MavenPomDownloaderTest` goes down from 1m15 to 18s, and `MavenParserTest` goes from **7min** to 1min! (more on this minute below)

This can also serve as POC to be used in other tests.

## What's your motivation?
Some time ago, I got curious about what was making those tests so slow, so investigated them. I had kept this on the side while working on other things but I thought it was still worth integrating.

Without TLS support, the `MavenPomDownloader` first tries HTTPS before HTTP. As MockWebServer does not expect this, it tries to parse the TLS handshake as an HTTP request line, and since it does not receive a `\n`, it just waits for it until the client times out, and then it logs an error:

```
Oct 18, 2024 10:32:23 PM okhttp3.mockwebserver.MockWebServer$SocketHandler handle
WARNING: MockWebServer[47261] connection from /127.0.0.1 didn't make a request
Oct 18, 2024 10:32:26 PM okhttp3.mockwebserver.MockWebServer$SocketHandler handle
WARNING: MockWebServer[39339] connection from /127.0.0.1 didn't make a request
Oct 18, 2024 10:32:26 PM okhttp3.mockwebserver.MockWebServer$serveConnection$$inlined$execute$default$1 runOnce
SEVERE: MockWebServer[39339] connection from /127.0.0.1 crashed
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 24
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4608)
	at java.base/java.lang.String.substring(String.java:2711)
	at okhttp3.mockwebserver.RecordedRequest.<init>(RecordedRequest.kt:99)
	at okhttp3.mockwebserver.MockWebServer.readRequest(MockWebServer.kt:751)
	at okhttp3.mockwebserver.MockWebServer.access$readRequest(MockWebServer.kt:101)
	at okhttp3.mockwebserver.MockWebServer$SocketHandler.processOneRequest(MockWebServer.kt:593)
	at okhttp3.mockwebserver.MockWebServer$SocketHandler.handle(MockWebServer.kt:552)
	at okhttp3.mockwebserver.MockWebServer$serveConnection$$inlined$execute$default$1.runOnce(TaskQueue.kt:220)
	at okhttp3.internal.concurrent.TaskRunner.runTask(TaskRunner.kt:116)
	at okhttp3.internal.concurrent.TaskRunner.access$runTask(TaskRunner.kt:42)
	at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:65)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:842)
```
See also [the GitHub Actions log](https://github.com/openrewrite/rewrite/actions/runs/11393967499/job/31703386530#step:5:9431) and search for occurrences of `MavenParserTest` to find occurrences of the above error. You’ll notice they are all from `mirrorsAndAuth()`. Now check the timestamps! :smirk: 

By enabling HTTPS, we can avoid this timeout. As the client times out after 10s and retries multiple times, this can spare a lot of time.

## Anything in particular you'd like reviewers to focus on?
`MavenPomDownloaderTest`
--
I reorganized this test class by grouping most tests between two `@Nested` classes: with and without TLS. The remaining 18s are due mostly to tests actually relying on the timeout/fallback on HTTP, or contacting online servers.

Side note: I did this a few weeks ago, I now noticed a small change in behavior from `normalizeRepository()`, since, I guess, #4506: it does not seem to set `knownToExist` to `true` after validating the URL. I don’t know if this was intended. (My original `usesHttpsWhenAvailable()` test [was expecting it](https://github.com/DidierLoiseau/rewrite/commit/ae95e524cdf50b84c3be7915cbe7fd2f4c152cd2#diff-2fd46d951a4259e4925b08e3a1b94f8765163e2578f3386ca301f57c7a9c1335R664-R669), now I removed that)

`MavenParserTest`
--
I only changed `mirrorsAndAuth()` which goes down from 6min to ~300ms. I actually didn’t remember it was originally so slow, [the same test in this build](https://github.com/openrewrite/rewrite/actions/runs/10933330610/job/30351610250#step:5:9287) from mid-september seems to have taken ~1min. I did my changes around Sep 24th, commit d2c825c845bf9bf3259d633956fb0688b342d36b, I still have [my old branch](https://github.com/DidierLoiseau/rewrite/tree/feat/tls-support-in-tests-old) if you are interested

I also didn’t remember about the remaining 1 minute, but I think something has changed in between… and it’s not OpenRewrite!

The `prerequisite()` test now takes a varying 1-2minutes alone! And this test does… nothing! It’s just a pom without parent and a single dependency: [`org.apache.maven.reporting:maven-reporting-api:3.0`](https://repo1.maven.org/maven2/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom).

But that dependency has a transitive dependency: [`org.apache.maven.doxia:doxia-sink-api:1.0`](https://repo1.maven.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.pom). If you follow from parent to parent, you end up with [`org.apache:apache:4`](https://repo1.maven.org/maven2/org/apache/apache/4/apache-4.pom) (from 2007 :sweat_smile:) and it declares a single repository: http://people.apache.org/repo/m2-snapshot-repository

At the moment I am writing these lines, HTTPS seems available on that domain (and HTTP even redirects to it), but requests time out. Indeed, since September 12th, [they have shut down the service](https://infra.apache.org/blog/you-cant-go-home-again.html).

Maybe a different dependency should be used for this test?

## Anyone you would like to review specifically?
@timtebeek

## Have you considered any alternatives or workarounds?
The TLS setup could probably be centralized somewhere but I don’t think it is worth it until it gets used more broadly. Maybe a way to disable the HTTPS attempt in tests could be good.

## Any additional context
The strategy of trying HTTPS first is actually **inconsistent with Maven’s modern behavior**. Since [Maven 3.8.1](https://maven.apache.org/docs/3.8.1/release-notes.html), in order to fix CVE-2021-26291, **Maven completely blocks HTTP repositories** by default. I think OpenRewrite should do the same.

Moreover, OpenRewrite does not check if a port is specified in the URL (like with MockWebServer). If a port is specified in an HTTP URL, it does not make sense at all to try HTTPS **on the same port**! This was what was causing trouble with MockWebServer in the first place…

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files