### PR TITLE
ChangePropertyValue in list yaml entries

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
@@ -116,17 +116,18 @@ public class ChangePropertyValue extends Recipe {
                     scalar.getValue().replaceAll(Objects.requireNonNull(oldValue), newValue) :
                     newValue);
             return scalar.getValue().equals(newScalar.getValue()) ? null : newScalar;
-        } else if (value instanceof Yaml.Sequence) {
+        }
+        if (value instanceof Yaml.Sequence) {
             Yaml.Sequence sequence = (Yaml.Sequence) value;
-            Yaml.Sequence newSequence = sequence.withEntries(ListUtils.map(sequence.getEntries(), entry -> {
+            return sequence.withEntries(ListUtils.map(sequence.getEntries(), entry -> {
                 if (matchesOldValue(entry.getBlock())) {
                     Yaml.Block updatedValue = updateValue(entry.getBlock());
-                    return updatedValue != null ? entry.withBlock(updatedValue) : entry;
-                } else {
-                    return entry;
+                    if (updatedValue != null) {
+                        return entry.withBlock(updatedValue);
+                    }
                 }
+                return entry;
             }));
-            return sequence == newSequence ? null : newSequence;
         }
         return null;
     }
@@ -145,8 +146,11 @@ public class ChangePropertyValue extends Recipe {
                            Pattern.compile(oldValue).matcher(scalar.getValue()).find() :
                            scalar.getValue().equals(oldValue));
         } else if (value instanceof Yaml.Sequence) {
-            Yaml.Sequence sequence = (Yaml.Sequence) value;
-            return sequence.getEntries().stream().anyMatch(entry -> matchesOldValue(entry.getBlock()));
+            for (Yaml.Sequence.Entry entry : ((Yaml.Sequence) value).getEntries()) {
+                if (matchesOldValue(entry.getBlock())) {
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.NameCaseConvention;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.yaml.tree.Yaml;
@@ -26,6 +27,7 @@ import org.openrewrite.yaml.tree.Yaml;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -97,7 +99,7 @@ public class ChangePropertyValue extends Recipe {
                 Yaml.Mapping.Entry e = super.visitMappingEntry(entry, ctx);
                 String prop = getProperty(getCursor());
                 if (matchesPropertyKey(prop) && matchesOldValue(e.getValue())) {
-                    Yaml.Scalar updatedValue = updateValue(e.getValue());
+                    Yaml.Block updatedValue = updateValue(e.getValue());
                     if (updatedValue != null) {
                         e = e.withValue(updatedValue);
                     }
@@ -108,15 +110,26 @@ public class ChangePropertyValue extends Recipe {
     }
 
     // returns null if value should not change
-    private Yaml.@Nullable Scalar updateValue(Yaml.Block value) {
-        if (!(value instanceof Yaml.Scalar)) {
-            return null;
+    private Yaml.@Nullable Block updateValue(Yaml.Block value) {
+        if (value instanceof Yaml.Scalar) {
+            Yaml.Scalar scalar = (Yaml.Scalar) value;
+            Yaml.Scalar newScalar = scalar.withValue(Boolean.TRUE.equals(regex) ?
+                    scalar.getValue().replaceAll(Objects.requireNonNull(oldValue), newValue) :
+                    newValue);
+            return scalar.getValue().equals(newScalar.getValue()) ? null : newScalar;
+        } else if (value instanceof Yaml.Sequence) {
+            Yaml.Sequence sequence = (Yaml.Sequence) value;
+            Yaml.Sequence newSequence = sequence.withEntries(ListUtils.map(sequence.getEntries(), entry -> {
+                if (matchesOldValue(entry.getBlock())) {
+                    Yaml.Block updatedValue = updateValue(entry.getBlock());
+                    return updatedValue != null ? entry.withBlock(updatedValue) : entry;
+                } else {
+                    return entry;
+                }
+            }));
+            return sequence == newSequence ? null : newSequence;
         }
-        Yaml.Scalar scalar = (Yaml.Scalar) value;
-        Yaml.Scalar newScalar = scalar.withValue(Boolean.TRUE.equals(regex) ?
-                scalar.getValue().replaceAll(Objects.requireNonNull(oldValue), newValue) :
-                newValue);
-        return scalar.getValue().equals(newScalar.getValue()) ? null : newScalar;
+        return null;
     }
 
     private boolean matchesPropertyKey(String prop) {
@@ -126,14 +139,17 @@ public class ChangePropertyValue extends Recipe {
     }
 
     private boolean matchesOldValue(Yaml.Block value) {
-        if (!(value instanceof Yaml.Scalar)) {
-            return false;
+        if (value instanceof Yaml.Scalar) {
+            Yaml.Scalar scalar = (Yaml.Scalar) value;
+            return StringUtils.isNullOrEmpty(oldValue) ||
+                   (Boolean.TRUE.equals(regex) ?
+                           Pattern.compile(oldValue).matcher(scalar.getValue()).find() :
+                           scalar.getValue().equals(oldValue));
+        } else if (value instanceof Yaml.Sequence) {
+            Yaml.Sequence sequence = (Yaml.Sequence) value;
+            return sequence.getEntries().stream().anyMatch(entry -> matchesOldValue(entry.getBlock()));
         }
-        Yaml.Scalar scalar = (Yaml.Scalar) value;
-        return StringUtils.isNullOrEmpty(oldValue) ||
-               (Boolean.TRUE.equals(regex) ?
-                       Pattern.compile(oldValue).matcher(scalar.getValue()).find() :
-                       scalar.getValue().equals(oldValue));
+        return false;
     }
 
     private static String getProperty(Cursor cursor) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyValue.java
@@ -27,7 +27,6 @@ import org.openrewrite.yaml.tree.Yaml;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Value
 @EqualsAndHashCode(callSuper = false)

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyValueTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyValueTest.java
@@ -141,6 +141,80 @@ class ChangePropertyValueTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4593")
+    void supportYamlListValues() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyValue("**.script", "replaced", "replaceme", null, null, null)),
+          yaml(
+            """
+              job-name1:
+                script:
+                  - replaceme
+              job-name2:
+                script:
+                  - do not replaceme
+              job-name3:
+                script:
+                  - replaceme should not be done
+              job-name4:
+                script:
+                  - replaceme
+                  - replaceme
+                  - do not replaceme
+                  - replaceme should not be done
+                rules:
+                  - replaceme
+              """, """
+              job-name1:
+                script:
+                  - replaced
+              job-name2:
+                script:
+                  - do not replaceme
+              job-name3:
+                script:
+                  - replaceme should not be done
+              job-name4:
+                script:
+                  - replaced
+                  - replaced
+                  - do not replaceme
+                  - replaceme should not be done
+                rules:
+                  - replaceme
+              """)
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4593")
+    void supportYamlListValuesWithRegex() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyValue("**.script", "$1replaced$2", "(.*)replaceme(.*)", true, null, null)),
+          yaml(
+            """
+              job-name:
+                script:
+                  - replaceme
+                  - replaceme
+                  - this should be replaceme
+                  - replaceme should be done
+                rules:
+                  - replaceme
+              """, """
+              job-name:
+                script:
+                  - replaced
+                  - replaced
+                  - this should be replaced
+                  - replaced should be done
+                rules:
+                  - replaceme
+              """)
+        );
+    }
+
+    @Test
     void validatesThatOldValueIsRequiredIfRegexEnabled() {
         assertTrue(new ChangePropertyValue("my.prop", "bar", null, true, null, null).validate().isInvalid());
     }


### PR DESCRIPTION
- Fixes #4593

## What's changed?
Support Yaml.Sequence for ChangePropertyValue

## What's your motivation?
In our yamls we want to update an entry of a list in the yaml with a certain text value by another text value. If we would fo this with a simple text Find/Replace, the other occurences outside the propertyKey binding would also be updated.

## Anything in particular you'd like reviewers to focus on?
Thinking about backwards compatibilty, I did not add a boolean flag that enables this behaviour. 

## Anyone you would like to review specifically?
@timtebeek anyone you think of in particular?

## Have you considered any alternatives or workarounds?
Custom recipe for arrays?

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
