### PR TITLE
enhancing Java parsers to recover method invocation type attribution when arg types are missing

### DIFF
--- a/rewrite-java-tck/build.gradle.kts
+++ b/rewrite-java-tck/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation("org.assertj:assertj-core:latest.release")
+    implementation("org.junit-pioneer:junit-pioneer:2.0.0")
     implementation(project(":rewrite-java"))
     implementation(project(":rewrite-java-test"))
     implementation(project(":rewrite-test"))

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodInvocationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodInvocationTest.java
@@ -15,10 +15,13 @@
  */
 package org.openrewrite.java.tree;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import java.util.Optional;
 
@@ -63,6 +66,337 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
+    @Nested
+    class InfersMethodTypeWhenMissingArgTypes {
+        @Test
+        void noOverloads() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType().getName()).isEqualTo("foo");
+                        assertThat(TypeUtils.asFullyQualified(method.getType())
+                          .getFullyQualifiedName()).isEqualTo("java.lang.Integer");
+
+                        var effectParams = method.getMethodType().getParameterTypes();
+                        assertThat(effectParams.size()).isEqualTo(1);
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(0))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+
+                        assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName()).isEqualTo("A");
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer doStuff(String x) { return 0; }
+                      private Integer foo(String x) { return 0; }
+        
+                      public Integer bar() { return this.foo(unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @ExpectedToFail
+        void noOverloads_noSelect() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType().getName()).isEqualTo("foo");
+                        assertThat(TypeUtils.asFullyQualified(method.getType())
+                          .getFullyQualifiedName()).isEqualTo("java.lang.Integer");
+
+                        var effectParams = method.getMethodType().getParameterTypes();
+                        assertThat(effectParams.size()).isEqualTo(1);
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(0))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+
+                        assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName()).isEqualTo("A");
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer doStuff(String x) { return 0; }
+                      private Integer foo(String x) { return 0; }
+        
+                      public Integer bar() { return foo(unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void unknownSelect() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType()).isNull();
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+       
+                      public Integer bar() { return unknown.foo(); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void sameArgCountOverload() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getType()).isNull();
+
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer foo(String x) { return 0; }
+                      private Integer foo(Boolean x) { return 0; }
+        
+                      public Integer bar() { return this.foo(unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void sameArgCountOverload_inherited() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getType()).isNull();
+
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      protected Integer foo(String x) { return 0; }
+                      public static class B extends A {
+                          private Integer foo(Boolean x) { return 0; }
+        
+                          public Integer bar() { return this.foo(unknown); }
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void sameArgCountOverload_inherited_noSelect() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getType()).isNull();
+
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      protected Integer foo(String x) { return 0; }
+                      public static class B extends A {
+                          private Integer foo(Boolean x) { return 0; }
+        
+                          public Integer bar() { return foo(unknown); }
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void diffArgCountOverload1() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType().getName()).isEqualTo("foo");
+                        assertThat(TypeUtils.asFullyQualified(method.getType())
+                          .getFullyQualifiedName()).isEqualTo("java.lang.Integer");
+
+                        var effectParams = method.getMethodType().getParameterTypes();
+                        assertThat(effectParams.size()).isEqualTo(1);
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(0))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+
+                        assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName()).isEqualTo("A");
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer foo(String x) { return 0; }
+                      private Integer foo(String x, String y) { return 0; }
+                      private Integer foo(String x, String y, String z) { return 0; }
+        
+                      public Integer bar() { return this.foo(unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void diffArgCountOverload2() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType().getName()).isEqualTo("foo");
+                        assertThat(TypeUtils.asFullyQualified(method.getType())
+                          .getFullyQualifiedName()).isEqualTo("java.lang.Integer");
+
+                        var effectParams = method.getMethodType().getParameterTypes();
+                        assertThat(effectParams.size()).isEqualTo(2);
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(0))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(1))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+
+                        assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName()).isEqualTo("A");
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer foo(String x) { return 0; }
+                      private Integer foo(String x, String y) { return 0; }
+                      private Integer foo(String x, String y, String z) { return 0; }
+        
+                      public Integer bar() { return this.foo(unknown, unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void diffArgCountOverload3() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType().getName()).isEqualTo("foo");
+                        assertThat(TypeUtils.asFullyQualified(method.getType())
+                          .getFullyQualifiedName()).isEqualTo("java.lang.Integer");
+
+                        var effectParams = method.getMethodType().getParameterTypes();
+                        assertThat(effectParams.size()).isEqualTo(3);
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(0))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(1))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(2))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+
+                        assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName()).isEqualTo("A");
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer foo(String x) { return 0; }
+                      private Integer foo(String x, String y) { return 0; }
+                      private Integer foo(String x, String y, String z) { return 0; }
+        
+                      public Integer bar() { return this.foo(unknown, unknown, unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void diffArgCountOverload_dontAttributeUnknownArgType() {
+            rewriteRun(
+              spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        assertThat(method.getSimpleName()).isEqualTo("foo");
+                        assertThat(method.getMethodType().getName()).isEqualTo("foo");
+                        assertThat(TypeUtils.asFullyQualified(method.getType())
+                          .getFullyQualifiedName()).isEqualTo("java.lang.Integer");
+
+                        var effectParams = method.getMethodType().getParameterTypes();
+                        assertThat(effectParams.size()).isEqualTo(2);
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(0))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+                        assertThat(TypeUtils.asFullyQualified(effectParams.get(1))
+                          .getFullyQualifiedName()).isEqualTo("java.lang.String");
+
+                        assertThat(method.getArguments().get(0).getType())
+                          .isEqualTo(JavaType.Primitive.String);
+                        assertThat(method.getArguments().get(1).getType())
+                          .isEqualTo(JavaType.Unknown.getInstance());
+
+                        assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName()).isEqualTo("A");
+                        return method;
+                    }
+                }))
+                .typeValidationOptions(TypeValidation.none()),
+              java(
+                """
+                  public class A {
+                      private Integer foo(String x) { return 0; }
+                      private Integer foo(String x, String y) { return 0; }
+                      private Integer foo(String x, String y, String z) { return 0; }
+        
+                      public Integer bar() { return this.foo("", unknown); }
+                  }
+                  """
+              )
+            );
+        }
+
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void genericMethodInvocation() {
@@ -87,7 +421,7 @@ class MethodInvocationTest implements RewriteTest {
               public class A {
                   Integer o = generic ( 0, 1, 2 );
                   Integer p = this . < Integer > generic ( 0, 1, 2 );
-                            
+              
                   public <TTTT> TTTT generic(TTTT n, TTTT... ns) { return n; }
               }
               """, spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {


### PR DESCRIPTION
(if there's only one valid signature matching the method name and arg count)

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
see subject

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Lombok support (#1297) is presumably still far away. In the interim, this PR attempts to "patch over" one hole in type attribution which Lombok repos can introduce.

For example, I frequently work with ( / refactor) code like this:

```java
MyCoolBuilder.builder()
.propA(...)
.propB(...)
.propC(...)
.fancyConfig(...)
```

Sometimes developers will supply those props from a separate Properties class with getters from Lombok, eg, `.propA(lombokPropertyClass.getPropA())`. OpenRewrite won't know the type of the getter, because Lombok. That cascades to OpenRewrite not knowing the type of the `propA(...)` method invocation. That cascades to OpenRewrite not knowing the type of the `select` for the next method, and so on. If I want to refactor `fancyConfig(...)`, then even if those arg types *are* known, the `select` is unknown, and method matchers miss.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
- Conceptually, if we add support for annotation processors like Lombok in the future, then I believe this *should* become dead code as we *should* have "perfect" type attribution in the first place. But, I think it's worthwhile until then?
- Known gap: if the relevant methodInvocation is being called without a select, then I don't see a sturdy way to identify the implicit receiver, so basically this new code just doesn't apply
- I haven't touched the Java Parsers before; I expect by the time I'm done, I'd just need to copy-paste this new source bit (in JDK 8-friendly syntax) to each of the 4 parsers?
- Not sure if we'd want to do any preemptive integration test for LST generation before merging something like this?

## Anyone you would like to review specifically?
<!-- @mention them here -->
maybe @sambsnyd , @knutwannheden 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
- Wait for Lombok / annotation processor / code gen support
- Do nothing

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
It's a draft because I haven't ported to the other JDK versions yet (or tested much beyond the unit tests), and figured I'd solicit feedback first in case there were directional concerns.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
