### PR TITLE
Fix infinite loop in MavenPomDownloader

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -501,7 +501,7 @@ public class MavenPomDownloader {
                     return projectPom;
                 }
                 Parent parent = projectPom.getParent();
-                while (parent != null){
+                if (parent != null){
                     for (Pom project : projectPoms.values()) {
                         if (parent.getGroupId().equals(project.getGroupId()) && parent.getArtifactId().equals(project.getArtifactId())){
                             if (projectPom.getVersion().equals(project.getValue(gav.getVersion()))){


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fix an infinite loop in MavenPomDownloader

## What's your motivation?
Since this MR https://github.com/openrewrite/rewrite/pull/4472 , there is an infinite loop in `MavenPomDownloader.download()` when root pom have a parent.

- https://github.com/openrewrite/rewrite/pull/4472