### PR TITLE
Add used enums into the list of used variable names

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/VariableNameUtilsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/VariableNameUtilsTest.java
@@ -107,6 +107,23 @@ class VariableNameUtilsTest implements RewriteTest {
     }
 
     @Test
+    void enumFieldNames() {
+        rewriteRun(
+          baseTest("myType", "myType,TYPES"),
+          java(
+            """
+              class Test {
+                  TYPES myType;
+              }
+              enum TYPES {
+               VALUE, NUMBER, TEXT
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void allClassFieldsAreFound() {
         rewriteRun(
           baseTest("methodBlock", "methodBlock,classBlockA,classBlockB"),

--- a/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
@@ -263,6 +263,7 @@ public class VariableNameUtils {
             return super.visitVariable(variable, strings);
         }
 
+        @Override
         public J.Identifier visitIdentifier(J.Identifier identifier, Set<String> namesInScope) {
             J.Identifier v = super.visitIdentifier(identifier, namesInScope);
             if (v.getType() instanceof JavaType.Class &&

--- a/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
@@ -263,6 +263,15 @@ public class VariableNameUtils {
             return super.visitVariable(variable, strings);
         }
 
+        public J.Identifier visitIdentifier(J.Identifier identifier, Set<String> namesInScope) {
+            J.Identifier v = super.visitIdentifier(identifier, namesInScope);
+            if (v.getType() instanceof JavaType.Class &&
+                    ((JavaType.Class) v.getType()).getKind() == JavaType.FullyQualified.Kind.Enum) {
+                namesInScope.add(v.getSimpleName());
+            }
+            return v;
+        }
+
         private void addImportedStaticFieldNames(@Nullable JavaSourceFile cu, Cursor classCursor) {
             if (cu != null) {
                 List<J.Import> imports = cu.getImports();


### PR DESCRIPTION
Currently, Enums aren't being added to the list of used variable names which can result in collisions when naming new variable.

