### PR TITLE
Remove problematic `String#substring()` call

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1476,8 +1476,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                     elementType = ((JCArrayTypeTree) elementType).elemtype;
                 }
             }
-            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
-            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+            int idx = indexOfNextNonWhitespace(elementType.getEndPosition(endPosTable), source);
+            typeExpr = idx != -1 && (source.charAt(idx) == '[' || source.charAt(idx) == '@') ? convert(vartype) :
                     // we'll capture the array dimensions in a bit, just convert the element type
                     convert(elementType);
         } else {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1555,8 +1555,8 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                     elementType = ((JCArrayTypeTree) elementType).elemtype;
                 }
             }
-            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
-            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+            int idx = indexOfNextNonWhitespace(elementType.getEndPosition(endPosTable), source);
+            typeExpr = idx != -1 && (source.charAt(idx) == '[' || source.charAt(idx) == '@') ? convert(vartype) :
                     // we'll capture the array dimensions in a bit, just convert the element type
                     convert(elementType);
         } else {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1555,8 +1555,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                     elementType = ((JCArrayTypeTree) elementType).elemtype;
                 }
             }
-            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
-            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+            int idx = indexOfNextNonWhitespace(elementType.getEndPosition(endPosTable), source);
+            typeExpr = idx != -1 && (source.charAt(idx) == '[' || source.charAt(idx) == '@') ? convert(vartype) :
                     // we'll capture the array dimensions in a bit, just convert the element type
                     convert(elementType);
         } else {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1462,8 +1462,8 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                     elementType = ((JCArrayTypeTree) elementType).elemtype;
                 }
             }
-            String check = source.substring(elementType.getEndPosition(endPosTable)).trim();
-            typeExpr = check.startsWith("@") || check.startsWith("[") ? convert(vartype) :
+            int idx = indexOfNextNonWhitespace(elementType.getEndPosition(endPosTable), source);
+            typeExpr = idx != -1 && (source.charAt(idx) == '[' || source.charAt(idx) == '@') ? convert(vartype) :
                     // we'll capture the array dimensions in a bit, just convert the element type
                     convert(elementType);
         } else {


### PR DESCRIPTION
For large source files this results in a large object allocation for every array-typed variable in the source file, as it copies the entire source code following that variable.
