### PR TITLE
Fix failing test and infinity loop in MavenPomDownloader

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -642,7 +642,7 @@ class MavenPomDownloaderTest {
 
             Path pomPath2 = Paths.get("test/pom.xml");
             Pom pom2 = Pom.builder()
-              .sourcePath(pomPath)
+              .sourcePath(pomPath2)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
@@ -696,7 +696,7 @@ class MavenPomDownloaderTest {
 
             Path pomPath2 = Paths.get("test/pom.xml");
             Pom pom2 = Pom.builder()
-              .sourcePath(pomPath)
+              .sourcePath(pomPath2)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))


### PR DESCRIPTION
I'm really sorry for solving the problem so late. @philippe-granet #4598 tried to fix the infinity loop with an if statement. That's also probably why one of the tests mentioned by @nmck257 failed.

## What's changed?
I fixed the problem by implementing a method called resolveGav(). This uses the already available mergeProperties method to see if the property for the version is located in one of the modules.
## What's your motivation?
Since it was my own fault #4472 and the attempt to fix this problem led to a failing test #4598.

My sincere apologies for producing such a catastrophe.