### PR TITLE
Fix failing test and infinity loop in MavenPomDownloader

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -172,10 +172,10 @@ public class MavenPomDownloader {
 
     private Map<GroupArtifactVersion, Pom> projectPomsByGav(Map<Path, Pom> projectPoms) {
         Map<GroupArtifactVersion, Pom> result = new HashMap<>();
-        for (final Pom projectPom : projectPoms.values()) {
-            final List<Pom> ancestryWithinProject = getAncestryWithinProject(projectPom, projectPoms);
-            final Map<String, String> mergedProperties = mergeProperties(ancestryWithinProject);
-            final GroupArtifactVersion gav = new GroupArtifactVersion(
+        for (Pom projectPom : projectPoms.values()) {
+            List<Pom> ancestryWithinProject = getAncestryWithinProject(projectPom, projectPoms);
+            Map<String, String> mergedProperties = mergeProperties(ancestryWithinProject);
+            GroupArtifactVersion gav = new GroupArtifactVersion(
                     projectPom.getGroupId(),
                     projectPom.getArtifactId(),
                     ResolvedPom.placeholderHelper.replacePlaceholders(projectPom.getVersion(), mergedProperties::get)
@@ -195,8 +195,8 @@ public class MavenPomDownloader {
 
     private Map<String, String> mergeProperties(final List<Pom> pomAncestry) {
         Map<String, String> mergedProperties = new HashMap<>();
-        for (final Pom pom : pomAncestry) {
-            for (final Map.Entry<String, String> property : pom.getProperties().entrySet()) {
+        for (Pom pom : pomAncestry) {
+            for (Map.Entry<String, String> property : pom.getProperties().entrySet()) {
                 mergedProperties.putIfAbsent(property.getKey(), property.getValue());
             }
         }
@@ -213,7 +213,7 @@ public class MavenPomDownloader {
     }
 
     private @Nullable Pom getParentWithinProject(Pom projectPom, Map<Path, Pom> projectPoms) {
-        final Parent parent = projectPom.getParent();
+        Parent parent = projectPom.getParent();
         if (parent == null || projectPom.getSourcePath() == null) {
             return null;
         }
@@ -496,7 +496,7 @@ public class MavenPomDownloader {
 
         // The pom being examined might be from a remote repository or a local filesystem.
         // First try to match the requested download with one of the project POMs.
-        final Pom projectPomWithResolvedVersion = projectPomsByGav.get(gav);
+        Pom projectPomWithResolvedVersion = projectPomsByGav.get(gav);
         if (projectPomWithResolvedVersion != null) {
             return projectPomWithResolvedVersion;
         }
@@ -643,7 +643,7 @@ public class MavenPomDownloader {
     private GroupArtifactVersion handleSnapshotTimestampVersion(GroupArtifactVersion gav) {
         Matcher m = SNAPSHOT_TIMESTAMP.matcher(requireNonNull(gav.getVersion()));
         if (m.matches()) {
-            final String baseVersion;
+            String baseVersion;
             if (m.group(1) != null) {
                 baseVersion = m.group(1) + SNAPSHOT;
             } else {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -185,6 +185,14 @@ public class MavenPomDownloader {
         return result;
     }
 
+    private GroupArtifactVersion resolveGav(GroupArtifactVersion gav, Map<String, String> mergedProperties) {
+        return new GroupArtifactVersion(
+                gav.getGroupId(),
+                gav.getArtifactId(),
+                ResolvedPom.placeholderHelper.replacePlaceholders(gav.getVersion(), mergedProperties::get)
+        );
+    }
+
     private Map<String, String> mergeProperties(final List<Pom> pomAncestry) {
         Map<String, String> mergedProperties = new HashMap<>();
         for (final Pom pom : pomAncestry) {
@@ -495,25 +503,11 @@ public class MavenPomDownloader {
 
         // The requested gav might itself have an unresolved placeholder in the version, so also check raw values
         for (Pom projectPom : projectPoms.values()) {
-            if (gav.getGroupId().equals(projectPom.getGroupId()) &&
-                gav.getArtifactId().equals(projectPom.getArtifactId())){
-                if (gav.getVersion().equals(projectPom.getVersion()) || projectPom.getVersion().equals(projectPom.getValue(gav.getVersion()))) {
-                    return projectPom;
-                }
-                Parent parent = projectPom.getParent();
-                if (parent != null){
-                    for (Pom project : projectPoms.values()) {
-                        if (parent.getGroupId().equals(project.getGroupId()) && parent.getArtifactId().equals(project.getArtifactId())){
-                            if (projectPom.getVersion().equals(project.getValue(gav.getVersion()))){
-                                return projectPom;
-                            }
-                            parent = project.getParent();
-                            if (parent == null){
-                                break;
-                            }
-                        }
-                    }
-                }
+            GroupArtifactVersion resolvedGav = resolveGav(gav, mergeProperties(getAncestryWithinProject(projectPom, projectPoms)));
+            if (projectPom.getGroupId().equals(resolvedGav.getGroupId()) &&
+                    projectPom.getArtifactId().equals(resolvedGav.getArtifactId()) &&
+                    projectPom.getVersion().equals(resolvedGav.getVersion())) {
+                return projectPom;
             }
         }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -624,9 +624,9 @@ class MavenPomDownloaderTest {
         void shouldNotThrowExceptionForModulesInModulesWithRightProperty() {
             var gav = new GroupArtifactVersion("test", "test2", "${test}");
 
-            Path pomPath = Paths.get("test/test2/pom.xml");
+            Path testTest2PomXml = Paths.get("test/test2/pom.xml");
             Pom pom = Pom.builder()
-              .sourcePath(pomPath)
+              .sourcePath(testTest2PomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
@@ -640,9 +640,9 @@ class MavenPomDownloaderTest {
               .repositories(singletonList(MAVEN_CENTRAL))
               .build();
 
-            Path pomPath2 = Paths.get("test/pom.xml");
+            Path testPomXml = Paths.get("test/pom.xml");
             Pom pom2 = Pom.builder()
-              .sourcePath(pomPath2)
+              .sourcePath(testPomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
@@ -651,9 +651,9 @@ class MavenPomDownloaderTest {
               .build();
 
 
-            Path parentPomPath = Paths.get("pom.xml");
+            Path rootPomXml = Paths.get("pom.xml");
             Pom parentPom = Pom.builder()
-              .sourcePath(parentPomPath)
+              .sourcePath(rootPomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("test", "7.0.0"))
               .parent(null)
@@ -662,9 +662,9 @@ class MavenPomDownloaderTest {
               .build();
 
             Map<Path, Pom> pomsByPath = new HashMap<>();
-            pomsByPath.put(parentPomPath, parentPom);
-            pomsByPath.put(pomPath, pom);
-            pomsByPath.put(pomPath2, pom2);
+            pomsByPath.put(rootPomXml, parentPom);
+            pomsByPath.put(testTest2PomXml, pom);
+            pomsByPath.put(testPomXml, pom2);
 
             String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
             MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);
@@ -678,9 +678,9 @@ class MavenPomDownloaderTest {
         void shouldThrowExceptionForModulesInModulesWithNoRightProperty() {
             var gav = new GroupArtifactVersion("test", "test2", "${test}");
 
-            Path pomPath = Paths.get("test/test2/pom.xml");
+            Path testTest2PomXml = Paths.get("test/test2/pom.xml");
             Pom pom = Pom.builder()
-              .sourcePath(pomPath)
+              .sourcePath(testTest2PomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "test", "${test}"), "../pom.xml"))
@@ -694,9 +694,9 @@ class MavenPomDownloaderTest {
               .repositories(singletonList(MAVEN_CENTRAL))
               .build();
 
-            Path pomPath2 = Paths.get("test/pom.xml");
+            Path testPomXml = Paths.get("test/pom.xml");
             Pom pom2 = Pom.builder()
-              .sourcePath(pomPath2)
+              .sourcePath(testPomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
@@ -705,9 +705,9 @@ class MavenPomDownloaderTest {
               .build();
 
 
-            Path parentPomPath = Paths.get("pom.xml");
+            Path rootPomXml = Paths.get("pom.xml");
             Pom parentPom = Pom.builder()
-              .sourcePath(parentPomPath)
+              .sourcePath(rootPomXml)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("tt", "7.0.0"))
               .parent(null)
@@ -716,9 +716,9 @@ class MavenPomDownloaderTest {
               .build();
 
             Map<Path, Pom> pomsByPath = new HashMap<>();
-            pomsByPath.put(parentPomPath, parentPom);
-            pomsByPath.put(pomPath, pom);
-            pomsByPath.put(pomPath2, pom2);
+            pomsByPath.put(rootPomXml, parentPom);
+            pomsByPath.put(testTest2PomXml, pom);
+            pomsByPath.put(testPomXml, pom2);
 
             String httpUrl = "http://%s.com".formatted(UUID.randomUUID());
             MavenRepository nonexistentRepo = new MavenRepository("repo", httpUrl, null, null, false, null, null, null, null);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -642,7 +642,7 @@ class MavenPomDownloaderTest {
 
             Path pomPath2 = Paths.get("test/pom.xml");
             Pom pom2 = Pom.builder()
-              .sourcePath(pomPath)
+              .sourcePath(pomPath2)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))
@@ -696,7 +696,7 @@ class MavenPomDownloaderTest {
 
             Path pomPath2 = Paths.get("test/pom.xml");
             Pom pom2 = Pom.builder()
-              .sourcePath(pomPath)
+              .sourcePath(pomPath2)
               .repository(MAVEN_CENTRAL)
               .properties(singletonMap("REPO_URL", MAVEN_CENTRAL.getUri()))
               .parent(new Parent(new GroupArtifactVersion("test", "root-test", "${test}"), "../pom.xml"))


### PR DESCRIPTION
I'm really sorry for solving the problem so late. @philippe-granet 
- https://github.com/openrewrite/rewrite/pull/4598
tried to fix the infinity loop with an if statement. That's also probably why one of the tests mentioned by @nmck257 failed.

## What's changed?
I fixed the problem by implementing a method called resolveGav(). This uses the already available mergeProperties method to see if the property for the version is located in one of the modules.

## What's your motivation?
Since it was my own fault 
- https://github.com/openrewrite/rewrite/pull/4472

and the attempt to fix this problem led to a failing test 
- https://github.com/openrewrite/rewrite/pull/4598.

My sincere apologies for producing such a catastrophe.