### PR TITLE
Add Recipe that allows for the removal/negation of gitignore rules.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -63,7 +63,6 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
             @Override
             public PlainText visitText(PlainText text, ExecutionContext ctx) {
                 try {
-                    text.getSourcePath().getParent()
                     String gitignoreFileName = text.getSourcePath().toString();
                     gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
                     IgnoreNode ignoreNode = new IgnoreNode();

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -1,6 +1,5 @@
 package org.openrewrite;
 
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -10,14 +9,21 @@ import org.openrewrite.jgit.ignore.IgnoreNode;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
+import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.openrewrite.ExcludeFileFromGitignore.Repository;
 import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.CHECK_PARENT;
 import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.IGNORED;
+import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.NOT_IGNORED;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -30,14 +36,10 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
 
     @Override
     public String getDescription() {
-        return "This recipe will remove a file or directory to the .gitignore file. " +
-                "If the file or directory is already in the .gitignore file, it will be removed." +
-                "If the file or directory is not in the .gitignore file, no action will be taken.";
+        return "This recipe will remove a file or directory to the .gitignore file. " + "If the file or directory is already in the .gitignore file, it will be removed." + "If the file or directory is not in the .gitignore file, no action will be taken.";
     }
 
-    @Option(displayName = "Paths",
-            description = "The paths to find and remove from the gitignore files.",
-            example = "blacklist")
+    @Option(displayName = "Paths", description = "The paths to find and remove from the gitignore files.", example = "blacklist")
     List<String> paths;
 
     @Override
@@ -47,7 +49,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Repository acc) {
-        return new PlainTextVisitor<ExecutionContext>(){
+        return new PlainTextVisitor<ExecutionContext>() {
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
                 return super.isAcceptable(sourceFile, executionContext) && sourceFile.getSourcePath().endsWith(".gitignore");
@@ -61,6 +63,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                     IgnoreNode ignoreNode = new IgnoreNode();
                     ignoreNode.parse(gitignoreFileName, new ByteArrayInputStream(text.getText().getBytes()));
                     acc.getRules().put(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1), ignoreNode);
+                    acc.issue3Directories(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1), text.getText());
                 } catch (IOException e) {
                     throw new RuntimeException("Unknown error udring recipe run", e);
                 }
@@ -72,13 +75,16 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
     @Data
     public static class Repository {
         private final Map<String, IgnoreNode> rules = new HashMap<>();
+        private final Map<String, List<String>> issue3IgnoredDirectories = new HashMap<>();
+        private final Map<String, List<String>> issue3NegatedDirectories = new HashMap<>();
 
         public void exclude(String path) {
             String normalizedPath = path.startsWith("/") ? path : "/" + path;
-            List<String> impactingFiles = rules.keySet().stream()
-                    .filter(k -> normalizedPath.toLowerCase().startsWith(k.toLowerCase()))
-                    .sorted(Comparator.comparingInt(String::length).reversed())
-                    .collect(Collectors.toList());
+            List<String> impactingFiles = rules.keySet()
+                                               .stream()
+                                               .filter(k -> normalizedPath.toLowerCase().startsWith(k.toLowerCase()))
+                                               .sorted(Comparator.comparingInt(String::length).reversed())
+                                               .collect(Collectors.toList());
 
             IgnoreNode.MatchResult isIgnored;
             boolean isDirectory = path.endsWith("/");
@@ -86,13 +92,46 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                 IgnoreNode ignoreNode = rules.get(impactingFile);
                 String nestedPath = normalizedPath.substring(impactingFile.length() - 1);
                 isIgnored = ignoreNode.isIgnored(nestedPath, isDirectory);
+                // Overcoming issue3 in jgit repo for the pathMatch being false
+                if (CHECK_PARENT.equals(isIgnored) && isDirectory) {
+                    List<FastIgnoreRule> rules = ignoreNode.getRules();
+                    for (int i = rules.size() - 1; i > -1; i--) {
+                        FastIgnoreRule rule = rules.get(i);
+                        if (rule.isMatch(nestedPath, true, false)) {
+                            if (rule.getResult()) {
+                                isIgnored = IGNORED;
+                            } else {
+                                isIgnored = NOT_IGNORED;
+                            }
+                            break;
+                        }
+                    }
+                }
+                // Overcoming issue3 in jgit repo for the single directory rules
+                if (CHECK_PARENT.equals(isIgnored)) {
+                    Boolean ignored = isIgnoredByDirectoryIssue3Bypass(impactingFile, nestedPath);
+                    if (ignored != null) {
+                        if (ignored) {
+                            isIgnored = IGNORED;
+                        } else {
+                            isIgnored = NOT_IGNORED;
+                        }
+                    }
+                }
                 if (CHECK_PARENT.equals(isIgnored)) {
                     continue;
                 }
                 if (IGNORED.equals(isIgnored)) {
                     List<FastIgnoreRule> remainingRules = new ArrayList<>();
                     for (FastIgnoreRule rule : ignoreNode.getRules()) {
-                        if (!rule.isMatch(nestedPath, isDirectory, true) || !rule.getResult()) {
+                        // First 2 if clauses are for the jgit issue (#3) opened at openrewrite/jgit
+                        if (issue3IgnoredDirectories.getOrDefault(impactingFile, new ArrayList<>()).stream().anyMatch(nestedPath::equalsIgnoreCase)) {
+                            continue;
+                        } else if (issue3IgnoredDirectories.getOrDefault(impactingFile, new ArrayList<>()).stream().anyMatch(nestedPath::startsWith)) {
+                            remainingRules.add(rule);
+                            remainingRules.add(new FastIgnoreRule("!" + nestedPath));
+                            continue;
+                        } else if (!rule.isMatch(nestedPath, isDirectory, true) || !rule.getResult()) {
                             remainingRules.add(rule);
                             continue;
                         } else if (rule.toString().equals(nestedPath)) {
@@ -112,6 +151,47 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                 }
                 break;
             }
+        }
+
+        public void issue3Directories(final String gitignoreFileName, final String ignoreFile) {
+            Arrays.stream(ignoreFile.split("\\r?\\n")).forEach(line -> {
+                if (line.startsWith("#") || StringUtils.isBlank(line)) {
+                    return;
+                }
+                Map<String, List<String>> directories = issue3IgnoredDirectories;
+                if (line.startsWith("!")) {
+                    line = line.substring(1);
+                    directories = issue3NegatedDirectories;
+                }
+                if (!line.startsWith("/")) {
+                    // lines not starting with / are not exact directory matches but equivalent to **/line/
+                    return;
+                }
+                if (line.endsWith("/")) {
+                    directories.computeIfAbsent(gitignoreFileName, k -> new ArrayList<>()).add(line);
+                }
+            });
+        }
+
+        @Nullable
+        private Boolean isIgnoredByDirectoryIssue3Bypass(String gitignoreFileName, String path) {
+            List<String> ignoredDirectories = issue3IgnoredDirectories.get(gitignoreFileName);
+            List<String> negatedDirectories = issue3NegatedDirectories.get(gitignoreFileName);
+            if (negatedDirectories != null) {
+                for (String negatedDirectory : negatedDirectories) {
+                    if (path.startsWith(negatedDirectory)) {
+                        return false;
+                    }
+                }
+            }
+            if (ignoredDirectories != null) {
+                for (String ignoredDirectory : ignoredDirectories) {
+                    if (path.startsWith(ignoredDirectory)) {
+                        return true;
+                    }
+                }
+            }
+            return null;
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite;
 
 import lombok.Data;
@@ -51,8 +66,8 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
     public TreeVisitor<?, ExecutionContext> getScanner(Repository acc) {
         return new PlainTextVisitor<ExecutionContext>() {
             @Override
-            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
-                return super.isAcceptable(sourceFile, executionContext) && sourceFile.getSourcePath().endsWith(".gitignore");
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return super.isAcceptable(sourceFile, ctx) && sourceFile.getSourcePath().endsWith(".gitignore");
             }
 
             @Override
@@ -67,7 +82,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                 } catch (IOException e) {
                     throw new RuntimeException("Unknown error udring recipe run", e);
                 }
-                return super.visitText(text, executionContext);
+                return super.visitText(text, ctx);
             }
         };
     }
@@ -173,8 +188,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
             });
         }
 
-        @Nullable
-        private Boolean isIgnoredByDirectoryIssue3Bypass(String gitignoreFileName, String path) {
+        private @Nullable Boolean isIgnoredByDirectoryIssue3Bypass(String gitignoreFileName, String path) {
             List<String> ignoredDirectories = issue3IgnoredDirectories.get(gitignoreFileName);
             List<String> negatedDirectories = issue3NegatedDirectories.get(gitignoreFileName);
             if (negatedDirectories != null) {
@@ -204,8 +218,8 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
 
         return new PlainTextVisitor<ExecutionContext>() {
             @Override
-            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
-                return super.isAcceptable(sourceFile, executionContext) && sourceFile.getSourcePath().endsWith(".gitignore");
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return super.isAcceptable(sourceFile, ctx) && sourceFile.getSourcePath().endsWith(".gitignore");
             }
 
             @Override
@@ -241,7 +255,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                     }
                     return text.withText(sb.toString());
                 }
-                return super.visitText(text, executionContext);
+                return super.visitText(text, ctx);
             }
         };
     }

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -228,7 +228,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                     for (int i = 0; i < rules.size(); i++) {
                         FastIgnoreRule ignoreRule = rules.get(i);
                         if (newRules.stream().noneMatch(rule -> rule.equalsIgnoreCase(ignoreRule.toString()))) {
-                            //TODO find the position to insert the rule using surrounding rules as best as possible
+                            //Can we not find the position to insert the rule using surrounding rules as best as possible?
                             newRules.add(ignoreRule.toString());
                         }
                     }

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -71,7 +71,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
             }
 
             @Override
-            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+            public PlainText visitText(PlainText text, ExecutionContext ctx) {
                 try {
                     String gitignoreFileName = text.getSourcePath().toString();
                     gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
@@ -223,7 +223,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
             }
 
             @Override
-            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+            public PlainText visitText(PlainText text, ExecutionContext ctx) {
                 String gitignoreFileName = text.getSourcePath().toString();
                 gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
                 IgnoreNode ignoreNode = acc.getRules().get(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1));

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -27,18 +27,11 @@ import org.openrewrite.text.PlainTextVisitor;
 import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.openrewrite.ExcludeFileFromGitignore.Repository;
-import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.CHECK_PARENT;
-import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.IGNORED;
-import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.NOT_IGNORED;
+import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.*;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -96,10 +89,10 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
         public void exclude(String path) {
             String normalizedPath = path.startsWith("/") ? path : "/" + path;
             List<String> impactingFiles = rules.keySet()
-                                               .stream()
-                                               .filter(k -> normalizedPath.toLowerCase().startsWith(k.toLowerCase()))
-                                               .sorted(Comparator.comparingInt(String::length).reversed())
-                                               .collect(Collectors.toList());
+                    .stream()
+                    .filter(k -> normalizedPath.toLowerCase().startsWith(k.toLowerCase()))
+                    .sorted(Comparator.comparingInt(String::length).reversed())
+                    .collect(Collectors.toList());
 
             IgnoreNode.MatchResult isIgnored;
             boolean isDirectory = path.endsWith("/");

--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -1,0 +1,168 @@
+package org.openrewrite;
+
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.jgit.ignore.FastIgnoreRule;
+import org.openrewrite.jgit.ignore.IgnoreNode;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.openrewrite.ExcludeFileFromGitignore.Repository;
+import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.CHECK_PARENT;
+import static org.openrewrite.jgit.ignore.IgnoreNode.MatchResult.IGNORED;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove ignoral of files or directories in .gitignore";
+    }
+
+    @Override
+    public String getDescription() {
+        return "This recipe will remove a file or directory to the .gitignore file. " +
+                "If the file or directory is already in the .gitignore file, it will be removed." +
+                "If the file or directory is not in the .gitignore file, no action will be taken.";
+    }
+
+    @Option(displayName = "Paths",
+            description = "The paths to find and remove from the gitignore files.",
+            example = "blacklist")
+    List<String> paths;
+
+    @Override
+    public Repository getInitialValue(ExecutionContext ctx) {
+        return new Repository();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Repository acc) {
+        return new PlainTextVisitor<ExecutionContext>(){
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
+                return super.isAcceptable(sourceFile, executionContext) && sourceFile.getSourcePath().endsWith(".gitignore");
+            }
+
+            @Override
+            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+                try {
+                    String gitignoreFileName = text.getSourcePath().toString();
+                    gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
+                    IgnoreNode ignoreNode = new IgnoreNode();
+                    ignoreNode.parse(gitignoreFileName, new ByteArrayInputStream(text.getText().getBytes()));
+                    acc.getRules().put(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1), ignoreNode);
+                } catch (IOException e) {
+                    throw new RuntimeException("Unknown error udring recipe run", e);
+                }
+                return super.visitText(text, executionContext);
+            }
+        };
+    }
+
+    @Data
+    public static class Repository {
+        private final Map<String, IgnoreNode> rules = new HashMap<>();
+
+        public void exclude(String path) {
+            String normalizedPath = path.startsWith("/") ? path : "/" + path;
+            List<String> impactingFiles = rules.keySet().stream()
+                    .filter(k -> normalizedPath.toLowerCase().startsWith(k.toLowerCase()))
+                    .sorted(Comparator.comparingInt(String::length).reversed())
+                    .collect(Collectors.toList());
+
+            IgnoreNode.MatchResult isIgnored;
+            boolean isDirectory = path.endsWith("/");
+            for (String impactingFile : impactingFiles) {
+                IgnoreNode ignoreNode = rules.get(impactingFile);
+                String nestedPath = normalizedPath.substring(impactingFile.length() - 1);
+                isIgnored = ignoreNode.isIgnored(nestedPath, isDirectory);
+                if (CHECK_PARENT.equals(isIgnored)) {
+                    continue;
+                }
+                if (IGNORED.equals(isIgnored)) {
+                    List<FastIgnoreRule> remainingRules = new ArrayList<>();
+                    for (FastIgnoreRule rule : ignoreNode.getRules()) {
+                        if (!rule.isMatch(nestedPath, isDirectory, true) || !rule.getResult()) {
+                            remainingRules.add(rule);
+                            continue;
+                        } else if (rule.toString().equals(nestedPath)) {
+                            continue;
+                        } else if (rule.getNameOnly() || rule.dirOnly()) {
+                            remainingRules.add(rule);
+                            remainingRules.add(new FastIgnoreRule("!" + nestedPath));
+                            continue;
+                        }
+                        remainingRules.add(rule);
+                    }
+                    IgnoreNode replacedNode = new IgnoreNode(remainingRules);
+                    rules.put(impactingFile, replacedNode);
+                    if (CHECK_PARENT.equals(replacedNode.isIgnored(nestedPath, isDirectory))) {
+                        continue;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Repository acc) {
+
+        for (String path : paths) {
+            acc.exclude(path);
+        }
+
+        return new PlainTextVisitor<ExecutionContext>() {
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
+                return super.isAcceptable(sourceFile, executionContext) && sourceFile.getSourcePath().endsWith(".gitignore");
+            }
+
+            @Override
+            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+                String gitignoreFileName = text.getSourcePath().toString();
+                gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
+                IgnoreNode ignoreNode = acc.getRules().get(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1));
+                if (ignoreNode != null) {
+                    String separator = text.getText().contains("\r\n") ? "\r\n" : "\n";
+                    List<FastIgnoreRule> rules = ignoreNode.getRules();
+                    List<String> newRules = Arrays.stream(text.getText().split(separator)).filter(line -> {
+                        if (line.startsWith("#") || StringUtils.isBlank(line)) {
+                            return true;
+                        }
+                        if (rules.stream().anyMatch(rule -> line.equalsIgnoreCase(rule.toString()))) {
+                            return true;
+                        }
+                        return false;
+                    }).collect(Collectors.toList());
+                    for (int i = 0; i < rules.size(); i++) {
+                        FastIgnoreRule ignoreRule = rules.get(i);
+                        if (newRules.stream().noneMatch(rule -> rule.equalsIgnoreCase(ignoreRule.toString()))) {
+                            //TODO find the position to insert the rule using surrounding rules as best as possible
+                            newRules.add(ignoreRule.toString());
+                        }
+                    }
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < newRules.size(); i++) {
+                        if (i > 0) {
+                            sb.append(separator);
+                        }
+                        sb.append(newRules.get(i));
+                    }
+                    return text.withText(sb.toString());
+                }
+                return super.visitText(text, executionContext);
+            }
+        };
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -273,4 +273,41 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void ignoreWildcardedDirectory() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/nested/"))),
+          text(
+            """
+              /**/nested/
+              """,
+            """
+              /**/nested/
+              !/directory/nested/
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void ignoreWildcardedFile() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml", "directory/other.txt"))),
+          text(
+            """
+              /test.*
+              /*.txt
+              """,
+            """
+              /test.*
+              /*.txt
+              !/test.yml
+              !/other.txt
+              """,
+            spec -> spec.path("directory/.gitignore")
+          )
+        );
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -203,7 +203,7 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
     }
 
     @Test
-    void ignoredDirectories() {
+    void ignoredExactDirectories() {
         rewriteRun(
           spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/"))),
           text(
@@ -211,6 +211,23 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               /directory/
               """,
             """
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void ignoredDirectories() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/"))),
+          text(
+            """
+              directory/
+              """,
+            """
+              directory/
+              !/directory/
               """,
             spec -> spec.path(".gitignore")
           )

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -321,11 +321,61 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               """,
             """
               /test.*
-              /*.txt
               !/test.yml
+              /*.txt
               !/other.txt
               """,
             spec -> spec.path("directory/.gitignore")
+          )
+        );
+    }
+
+    @Test
+    void excludedPathsOnlyGetAddedOnce() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("nested/test.yml"))),
+          text(
+            """
+              test.yml
+              otherfile.yml
+              nested/test.yml
+              """,
+            """
+              test.yml
+              !/nested/test.yml
+              otherfile.yml
+              nested/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void newRulesGetAddedBesidesExistingRules() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("/test.yml", "/otherfile.yml", "end-of-file/file.yml"))),
+          text(
+            """
+              # comment
+              test.yml
+              /yet-another-file.yml
+              # comment
+              /otherfile.yml
+              # comment
+              end-of-file/file.yml
+              """,
+            """
+              # comment
+              test.yml
+              !/test.yml
+              /yet-another-file.yml
+              # comment
+              # comment
+              end-of-file/file.yml
+              !/end-of-file/file.yml
+              """,
+            spec -> spec.path(".gitignore")
           )
         );
     }

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite;
 
 import org.junit.jupiter.api.Test;

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -357,21 +357,21 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
           spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("/test.yml", "/otherfile.yml", "end-of-file/file.yml"))),
           text(
             """
-              # comment
+              # comment 1
               test.yml
               /yet-another-file.yml
-              # comment
+              # comment 2
               /otherfile.yml
-              # comment
+              # comment 3
               end-of-file/file.yml
               """,
             """
-              # comment
+              # comment 1
               test.yml
               !/test.yml
               /yet-another-file.yml
-              # comment
-              # comment
+              # comment 2
+              # comment 3
               end-of-file/file.yml
               !/end-of-file/file.yml
               """,

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -24,6 +24,7 @@ import static org.openrewrite.test.SourceSpecs.text;
 
 class ExcludeFileFromGitignoreTest implements RewriteTest {
 
+    @DocumentExample
     @Test
     void removesEntryIfExactPathMatch() {
         rewriteRun(
@@ -173,19 +174,22 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               """,
             spec -> spec.path(".gitignore")
           ),
-            text(
-                """
-                otherfile.yml
-                """,
-                spec -> spec.path("directory/.gitignore")
-            )
+          text(
+            """
+              otherfile.yml
+              """,
+            spec -> spec.path("directory/.gitignore")
+          )
         );
     }
 
     @Test
     void multiplePaths() {
         rewriteRun(
-          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml", "otherdirectory/otherfile.yml", "directory/nested/not-ignored.yml"))),
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of(
+            "directory/test.yml",
+            "otherdirectory/otherfile.yml",
+            "directory/nested/not-ignored.yml"))),
           text(
             """
               test.yml

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -1,0 +1,259 @@
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+class ExcludeFileFromGitignoreTest implements RewriteTest {
+
+    @Test
+    void removesEntryIfExactPathMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("test.yml"))),
+          text(
+            """
+              /test.yml
+              """,
+            """
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void addNegationIfFileNameMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("test.yml"))),
+          text(
+            """
+              test.yml
+              """,
+            """
+              test.yml
+              !/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void addNegationIfNestedFileNameMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              test.yml
+              """,
+            """
+              test.yml
+              !/directory/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void commentsAndEmptyLinesUntouched() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              # comment
+              
+              test.yml
+              """,
+            """
+              # comment
+              
+              test.yml
+              !/directory/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void looksInNestedGitignoreFiles() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          ),
+          text(
+            """
+              test.yml
+              """,
+            """
+              test.yml
+              !/test.yml
+              """,
+            spec -> spec.path("directory/.gitignore")
+          )
+        );
+    }
+
+    @Test
+    void removesInNestedGitignoreFiles() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              """,
+            spec -> spec.path(".gitignore")
+          ),
+          text(
+            """
+              /test.yml
+              """,
+            """
+              """,
+            spec -> spec.path("directory/.gitignore")
+          )
+        );
+    }
+
+    @Test
+    void recursivelyLooksInNestedGitignoreFiles() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              test.yml
+              """,
+            """
+              test.yml
+              !/directory/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          ),
+          text(
+            """
+              /test.yml
+              """,
+            """
+              """,
+            spec -> spec.path("directory/.gitignore")
+          )
+        );
+    }
+
+    @Test
+    void nothingToRemoveIfPathNotInGitignore() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              otherfile.yml
+              otherdirectory/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          ),
+            text(
+                """
+                otherfile.yml
+                """,
+                spec -> spec.path("directory/.gitignore")
+            )
+        );
+    }
+
+    @Test
+    void multiplePaths() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml", "otherdirectory/otherfile.yml", "directory/nested/not-ignored.yml"))),
+          text(
+            """
+              test.yml
+              /otherdirectory/otherfile.yml
+              """,
+            """
+              test.yml
+              !/directory/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void negateFileFromIgnoredDirectory() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/test.yml"))),
+          text(
+            """
+              /directory/
+              """,
+            """
+              /directory/
+              !/directory/test.yml
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void ignoredDirectories() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/"))),
+          text(
+            """
+              /directory/
+              """,
+            """
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void ignoreNestedDirectory() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/nested/"))),
+          text(
+            """
+              /directory/
+              """,
+            """
+              /directory/
+              !/directory/nested/
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void ignoreNestedDirectoryWithMultipleGitignoreFiles() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/nested/yet-another-nested/test.yml"))),
+          text(
+            """
+              otherfile.yml
+              """,
+            spec -> spec.path(".gitignore")
+          ),
+          text(
+            """
+              /yet-another-nested/
+              """,
+            """
+              /yet-another-nested/
+              !/yet-another-nested/test.yml
+              """,
+            spec -> spec.path("directory/nested/.gitignore")
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added a recipe

## What's your motivation?
First iteration of this seems to work well.

## Anyone you would like to review specifically?
@timtebeek as discussed

## Have you considered any alternatives or workarounds?
FindAndReplaceText is very restrictive on this. This really uses gitignore rules/logic to determine if a change to the gitignore is necessary.

## Any additional context
I've added a workaround for https://github.com/openrewrite/jgit/issues/3
In a next iteration, I want to remove this workaround again once jgit is fixed but guessing we will have some longer checks there. 
Planning on 2 later iterations: 
- removeEmptyGitignoreFile boolean option that removes a file if the last gitignore entry was removed or it only contains comments/empty lines after changes.
- support wildcard filepaths or directories with wildcard as input: This should match all files matching and for each of these files calculate same negations. Instead of iteration over paths variable, we iterate over all files matching the paths wildcard variables.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases (A LOT 😄 )
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
