### PR TITLE
Fix parsing of HCL comments using //

### DIFF
--- a/rewrite-hcl/build.gradle.kts
+++ b/rewrite-hcl/build.gradle.kts
@@ -26,4 +26,5 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
 
     testImplementation(project(":rewrite-test"))
+    testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")
 }

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/Assertions.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/Assertions.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.hcl;
 
+import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.hcl.tree.Hcl;
 import org.openrewrite.test.SourceSpec;
@@ -25,23 +26,23 @@ import java.util.function.Consumer;
 public class Assertions {
     private Assertions() {}
 
-    public static SourceSpecs hcl(@Nullable String before) {
+    public static SourceSpecs hcl(@Nullable @Language("hcl") String before) {
         return hcl(before, s -> {
         });
     }
 
-    public static SourceSpecs hcl(@Nullable String before, Consumer<SourceSpec<Hcl.ConfigFile>> spec) {
+    public static SourceSpecs hcl(@Nullable @Language("hcl") String before, Consumer<SourceSpec<Hcl.ConfigFile>> spec) {
         SourceSpec<Hcl.ConfigFile> hcl = new SourceSpec<>(Hcl.ConfigFile.class, null, HclParser.builder(), before, null);
         spec.accept(hcl);
         return hcl;
     }
 
-    public static SourceSpecs hcl(@Nullable String before, @Nullable String after) {
+    public static SourceSpecs hcl(@Nullable @Language("hcl") String before, @Nullable @Language("hcl") String after) {
         return hcl(before, after, s -> {
         });
     }
 
-    public static SourceSpecs hcl(@Nullable String before, @Nullable String after, Consumer<SourceSpec<Hcl.ConfigFile>> spec) {
+    public static SourceSpecs hcl(@Nullable @Language("hcl") String before, @Nullable @Language("hcl") String after, Consumer<SourceSpec<Hcl.ConfigFile>> spec) {
         SourceSpec<Hcl.ConfigFile> hcl = new SourceSpec<>(Hcl.ConfigFile.class, null, HclParser.builder(),  before, s -> after);
         spec.accept(hcl);
         return hcl;

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -740,6 +740,9 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
                         delimIndex++;
                     } else switch (source.substring(delimIndex, delimIndex + 2)) {
                         case "//":
+                            inSingleLineComment = true;
+                            delimIndex++;
+                            break;
                         case "/*":
                             inMultiLineComment = true;
                             delimIndex++;

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -98,7 +98,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
             // left can be unaryOp or exprTerm, right can be another operation or exprTerm
             if (c.unaryOp() != null) {
                 left = (Expression) visit(c.unaryOp());
-            }else {
+            } else {
                 left = (Expression) visit(c.exprTerm(0));
             }
 
@@ -150,7 +150,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
 
             if (c.unaryOp() != null) {
                 right = (Expression) visit(c.operation() != null ? c.operation() : c.exprTerm(0));
-            }else {
+            } else {
                 right = (Expression) visit(c.operation() != null ? c.operation() : c.exprTerm(1));
             }
 

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.hcl.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -95,6 +96,22 @@ class HclCommentTest implements RewriteTest {
                   a = 1
                   // test 3
               }
+              """
+          )
+        );
+    }
+
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite/issues/4611")
+    @Test
+    void commentAsTheLastLine() {
+        rewriteRun(
+          hcl(
+            """
+                locals {
+                  a = 3
+                }
+                # Nice code, right?
               """
           )
         );

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -108,10 +108,10 @@ class HclCommentTest implements RewriteTest {
         rewriteRun(
           hcl(
             """
-                locals {
-                  a = 3
-                }
-                # Nice code, right?
+              locals {
+                a = 3
+              }
+              # Nice code, right?
               """
           )
         );

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -71,9 +71,29 @@ class HclCommentTest implements RewriteTest {
                   myvar = {
                     # below {attributes}
                     myattribute = "myvalue"
-
+              
                     # add more attributes {here}
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void inLineCommentsNextLineAttribute() {
+        rewriteRun(
+          hcl(
+            """
+              # test
+              /*
+               multiline
+              */
+              resource {
+                  # test
+                  // test
+                  a = 1
+                  // test 3
               }
               """
           )

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclStringTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclStringTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hcl.tree;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.hcl.Assertions.hcl;
+
+class HclStringTest implements RewriteTest {
+
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite/issues/4612")
+    @Test
+    void quoteEscaping() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                quotedText = "this is a double quote: \". Look at me"
+              }
+              """
+          )
+        );
+    }
+
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite/issues/4613")
+    @Test
+    void trailingDollarSign() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                regexp = "^(.*?)-monitoring$"
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Handle single line comments starting with `//` separately in the HclParserVisitor.

Credits for discovering this omission and fix go to @rahul3509 ! 🙏🏻 

## What's your motivation?
- Fixes #4544

## Any addiotional context
- https://github.com/openrewrite/rewrite/issues/4611
- https://github.com/openrewrite/rewrite/issues/4612
- https://github.com/openrewrite/rewrite/issues/4613