### PR TITLE
Simplify constant ternary expressions too

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -475,6 +475,12 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
                   String alwaysA4() {
                       return !false ? "a" : "b";
                   }
+                  String alwaysA5() {
+                      return (!false) ? "a" : "b";
+                  }
+                  String alwaysA6() {
+                      return !(false) ? "a" : "b";
+                  }
                   String alwaysB() {
                       return false ? "a" : "b";
                   }
@@ -492,6 +498,12 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
                       return "a";
                   }
                   String alwaysA4() {
+                      return "a";
+                  }
+                  String alwaysA5() {
+                      return "a";
+                  }
+                  String alwaysA6() {
                       return "a";
                   }
                   String alwaysB() {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -458,6 +458,52 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
     }
 
     @Test
+    void ternaryConstant() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  String alwaysA() {
+                      return true ? "a" : "b";
+                  }
+                  String alwaysA2() {
+                      return (true) ? "a" : "b";
+                  }
+                  String alwaysA3() {
+                      return (true ? "a" : "b");
+                  }
+                  String alwaysA4() {
+                      return !false ? "a" : "b";
+                  }
+                  String alwaysB() {
+                      return false ? "a" : "b";
+                  }
+              }
+              """,
+            """
+              class A {
+                  String alwaysA() {
+                      return "a";
+                  }
+                  String alwaysA2() {
+                      return "a";
+                  }
+                  String alwaysA3() {
+                      return "a";
+                  }
+                  String alwaysA4() {
+                      return "a";
+                  }
+                  String alwaysB() {
+                      return "b";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void ternaryDoubleNegation() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -143,6 +143,21 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
                             .withTruePart(asTernary.getFalsePart())
                             .withFalsePart(asTernary.getTruePart());
                 }
+            } else if (asTernary.getCondition() instanceof J.Literal) {
+                if (isLiteralTrue(asTernary.getCondition())) {
+                    j = asTernary.getTruePart();
+                } else if (isLiteralFalse(asTernary.getCondition())) {
+                    j = asTernary.getFalsePart();
+                }
+            } else if (asTernary.getCondition() instanceof J.Parentheses) {
+                J.Parentheses<Expression> parenthesized = (J.Parentheses<Expression>) asTernary.getCondition();
+                if (parenthesized.getTree() instanceof J.Literal) {
+                    if (isLiteralTrue(parenthesized.getTree())) {
+                        j = asTernary.getTruePart();
+                    } else if (isLiteralFalse(parenthesized.getTree())) {
+                        j = asTernary.getFalsePart();
+                    }
+                }
             }
         }
         return j;


### PR DESCRIPTION
## What's changed?
Expand `SimplifyBooleanExpressionVisitor` to also clear out ternary expressions with a hardcoded true/false 

## What's your motivation?
- For https://github.com/openrewrite/rewrite-static-analysis/pull/258
- https://github.com/openrewrite/rewrite-feature-flags/pull/36

## Anything in particular you'd like reviewers to focus on?
Didn't want to duplicate or recurse too much for parentheses, instead assuming this is often combined with remove unnecessary parentheses already.