### PR TITLE
Comments cannot be parsed properly

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1816,6 +1816,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                             if(c2 == '/') {
                                 inMultiLineComment = false;
                                 delimIndex++;
+                                continue;
                             }
                             break;
                     }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1815,7 +1815,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                         case '*':
                             if(c2 == '/') {
                                 inMultiLineComment = false;
-                                delimIndex += 2;
+                                delimIndex++;
                             }
                             break;
                     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1904,6 +1904,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                             if (c2 == '/') {
                                 inMultiLineComment = false;
                                 delimIndex++;
+                                continue;
                             }
                             break;
                     }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1903,7 +1903,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                         case '*':
                             if (c2 == '/') {
                                 inMultiLineComment = false;
-                                delimIndex += 2;
+                                delimIndex++;
                             }
                             break;
                     }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1894,6 +1894,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                                 case '*':
                                     inMultiLineComment = true;
                                     delimIndex++;
+                                    break;
                             }
                             break;
                         case '*':

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1900,7 +1900,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                         case '*':
                             if (c2 == '/') {
                                 inMultiLineComment = false;
-                                delimIndex += 2;
+                                delimIndex++;
                             }
                             break;
                     }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1894,13 +1894,13 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                                 case '*':
                                     inMultiLineComment = true;
                                     delimIndex++;
-                                    break;
                             }
                             break;
                         case '*':
                             if (c2 == '/') {
                                 inMultiLineComment = false;
                                 delimIndex++;
+                                continue;
                             }
                             break;
                     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1808,7 +1808,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                         case '*':
                             if(c2 == '/') {
                                 inMultiLineComment = false;
-                                delimIndex += 2;
+                                delimIndex++;
                             }
                             break;
                     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1809,6 +1809,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                             if(c2 == '/') {
                                 inMultiLineComment = false;
                                 delimIndex++;
+                                continue;
                             }
                             break;
                     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -183,20 +183,7 @@ class JavaParserTest implements RewriteTest {
                    *//*
                    * public void setOther(Some value) { this.other =
                    * value; }
-
-                   *//*
-                   public Some createSome() {
-                       return new Some();
-                   }
-
-                  *//**
-                   * Create an instance of {@link Some }
-                   *
-                   *//*
-                   public Some createSome2() {
-                       return new Some();
-                   }
-                  */
+                   */
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -154,15 +154,39 @@ class JavaParserTest implements RewriteTest {
         rewriteRun(
           java(
             source,
-            spec -> spec.afterRecipe(cu -> assertThat(cu.getSourcePath()).isEqualTo(Path.of("my","example","PublicClass.java")))
+            spec -> spec.afterRecipe(cu -> assertThat(cu.getSourcePath()).isEqualTo(Path.of("my", "example", "PublicClass.java")))
           )
         );
     }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1895")
-    void moduleInfo(){
+    void moduleInfo() {
         // Ignored until properly handled: https://github.com/openrewrite/rewrite/issues/4054#issuecomment-2267605739
         assertFalse(JavaParser.fromJavaVersion().build().accept(Path.of("src/main/java/foo/module-info.java")));
+    }
+
+    @Test
+    void invalidComment() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  /*
+                   * public Some getOther() { return other; }
+                   *
+                   *//**
+                   * Sets the value of the other property.
+                   *
+                   * @param value allowed object is {@link Some }
+                   *
+                   *//*
+                   * public void setOther(Some value) { this.other =
+                   * value; }
+                   */
+              }
+              """
+          )
+        );
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -183,12 +183,12 @@ class JavaParserTest implements RewriteTest {
                    *//*
                    * public void setOther(Some value) { this.other =
                    * value; }
-              
-                  *//*
+
+                   *//*
                    public Some createSome() {
                        return new Some();
                    }
-              
+
                   *//**
                    * Create an instance of {@link Some }
                    *

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -167,7 +167,7 @@ class JavaParserTest implements RewriteTest {
     }
 
     @Test
-    void invalidComment() {
+    void shouldParseComments() {
         rewriteRun(
           java(
             """
@@ -183,7 +183,20 @@ class JavaParserTest implements RewriteTest {
                    *//*
                    * public void setOther(Some value) { this.other =
                    * value; }
-                   */
+              
+                  *//*
+                   public Some createSome() {
+                       return new Some();
+                   }
+              
+                  *//**
+                   * Create an instance of {@link Some }
+                   *
+                   *//*
+                   public Some createSome2() {
+                       return new Some();
+                   }
+                  */
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -167,6 +167,7 @@ class JavaParserTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/4624")
     void shouldParseComments() {
         rewriteRun(
           java(
@@ -185,7 +186,31 @@ class JavaParserTest implements RewriteTest {
                    * value; }
                    */
               }
-              """
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(cu.getClasses().get(0).getBody().getEnd().getComments())
+              .extracting("text")
+              .containsExactly(
+                """
+                  
+                       * public Some getOther() { return other; }
+                       *
+                       \
+                  """,
+                """
+                  *
+                       * Sets the value of the other property.
+                       *
+                       * @param value allowed object is {@link Some }
+                       *
+                       \
+                  """,
+                """
+                  
+                       * public void setOther(Some value) { this.other =
+                       * value; }
+                       \
+                  """
+              ))
           )
         );
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Identified a setup of comments that doesn't get parsed properly and added that as reproducer testcase

- Fixes https://github.com/openrewrite/rewrite/issues/4344

## Anyone you would like to review specifically?
<!-- @mention them here -->
@nielsdebruin @timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
