### PR TITLE
Check that we have downloaded the file successfully

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -25,5 +25,6 @@ dependencies {
     implementation("io.github.classgraph:classgraph:latest.release")
     implementation("org.yaml:snakeyaml:latest.release")
 
+    testImplementation("org.assertj:assertj-core:latest.release")
     testImplementation(project(":rewrite-test"))
 }

--- a/rewrite-core/src/main/java/org/openrewrite/remote/RemoteArchive.java
+++ b/rewrite-core/src/main/java/org/openrewrite/remote/RemoteArchive.java
@@ -93,7 +93,11 @@ public class RemoteArchive implements Remote {
             Path localArchive = cache.compute(uri, () -> {
                 //noinspection resource
                 HttpSender.Response response = httpSender.send(httpSender.get(uri.toString()).build());
-                return response.getBody();
+                if (response.isSuccessful()) {
+                    return response.getBody();
+                } else {
+                    throw new IllegalStateException("Failed to download " + uri + " to artifact cache got an " + response.getCode());
+                }
             }, ctx.getOnError());
 
             if (localArchive == null) {

--- a/rewrite-core/src/main/java/org/openrewrite/remote/RemoteFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/remote/RemoteFile.java
@@ -69,7 +69,11 @@ public class RemoteFile implements Remote {
             Path localFile = cache.compute(uri, () -> {
                 //noinspection resource
                 HttpSender.Response response = httpSender.get(uri.toString()).send();
-                return response.getBody();
+                if (response.isSuccessful()) {
+                    return response.getBody();
+                } else {
+                    throw new IllegalStateException("Failed to download " + uri + " to artifact cache got an " + response.getCode());
+                }
             }, ctx.getOnError());
 
             if (localFile == null) {

--- a/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/remote/RemoteFileTest.java
@@ -72,7 +72,7 @@ class RemoteFileTest {
 
         assertThatThrownBy(() -> getInputStreamSize(remoteFile.getInputStream(ctx)))
           .isInstanceOf(IllegalStateException.class)
-          .hasMessage("Failed to download");
+          .hasMessage("Failed to download " + distributionUrl.toURI() + " to artifact cache");
     }
 
     @Test

--- a/rewrite-test/src/main/java/org/openrewrite/test/MockHttpSender.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/MockHttpSender.java
@@ -25,13 +25,25 @@ import java.io.InputStream;
  */
 public class MockHttpSender implements HttpSender {
     final UncheckedSupplier<InputStream> is;
+    int responseCode = 200;
 
     public MockHttpSender(UncheckedSupplier<InputStream> is) {
         this.is = is;
     }
 
+    public MockHttpSender(int responseCode) {
+        this.is = null;
+        this.responseCode = responseCode;
+    }
+
     @Override
     public Response send(Request request) {
-        return new Response(200, is.get(), () -> {});
+        if (responseCode != 200) {
+            return new Response(responseCode, null, () -> {
+            });
+        } else {
+            return new Response(responseCode, is.get(), () -> {
+            });
+        }
     }
 }


### PR DESCRIPTION
When we are downloading files we should check that the http call was successful instead of assuming that because no exception was thrown that the http status was successful. In the case were we get a 408, we don't throw an exception. This results in a InputStream of null to be returned. When reading from a InputStream of null, it infinitely returns a list of null bytes. In our use case we end up writing null to a temporary file until we run out of disk space

We can also make this change in the `HttpSender` and throw when we get a none successful http code