### PR TITLE
Prevent NPE on older LSTs not yet containing ResolvedPom.subprojects

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -257,7 +257,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
 
             private boolean isAggregatorNotUsedAsParent() {
                 List<String> subprojects = getResolutionResult().getPom().getSubprojects();
-                if (subprojects.isEmpty()) {
+                if (subprojects == null || subprojects.isEmpty()) {
                     return false;
                 }
                 List<MavenResolutionResult> modules = getResolutionResult().getModules();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -210,7 +210,7 @@ public class MavenResolutionResult implements Marker {
     }
 
     public boolean isMultiModulePom() {
-        return !getPom().getSubprojects().isEmpty();
+        return getPom().getSubprojects() == null || !getPom().getSubprojects().isEmpty();
     }
 
     private Map<Path, Pom> getProjectPomsRecursive(Map<Path, Pom> projectPoms) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -116,6 +116,7 @@ public class Pom {
     List<Plugin> pluginManagement = emptyList();
 
     @Builder.Default
+    @Nullable
     List<String> subprojects = emptyList();
 
     public String getGroupId() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -116,8 +116,8 @@ public class ResolvedPom {
 
     @NonFinal
     @Builder.Default
+    @Nullable // on older LSTs, this field is not yet present
     List<String> subprojects = emptyList();
-
 
     /**
      * Deduplicate dependencies and dependency management dependencies


### PR DESCRIPTION
## What's your motivation?
- #4590 failed to take into account older serialized LSTs