### PR TITLE
Fixed negation of nested files and directories if excluded by another rule

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -153,15 +153,15 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                             continue;
                         } else if (isMatch(rule, nestedPath)) {
                             String rulePath = rule.toString();
-                            if (rulePath.contains("*")) {
+                            if (rulePath.contains("*") || ("/" + rule).equals(nestedPath)) {
                                 remainingRules.add(rule);
                                 remainingRules.add(new FastIgnoreRule("!" + nestedPath));
                                 continue;
                             }
                             if (!rule.dirOnly()) {
                                 remainingRules.add(rule);
-                                remainingRules.add(new FastIgnoreRule("!/" + rule + "/"));
-                                rulePath = rule + "/";
+                                remainingRules.add(new FastIgnoreRule("!" + normalizedPath));
+                                continue;
                             }
                             String pathToTraverse = nestedPath.substring(rule.toString().length());
                             if (pathToTraverse.replace("/", "").isEmpty()) {
@@ -174,7 +174,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                                 String s = splitPath[i];
                                 remainingRules.add(new FastIgnoreRule(rulePath + "*"));
                                 rulePath += s;
-                                remainingRules.add(new FastIgnoreRule("!" + rulePath + (i < splitPath.length - 1 ? "/" : "")));
+                                remainingRules.add(new FastIgnoreRule("!" + rulePath + (i < splitPath.length - 1 || nestedPath.endsWith("/") ? "/" : "")));
                                 rulePath += "/";
                             }
                             continue;

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -271,6 +271,46 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
     }
 
     @Test
+    void ignoreDeeplyNestedDirectory() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/deeply/nested/"))),
+          text(
+            """
+              /directory/
+              """,
+            """
+              /directory/*
+              !/directory/deeply/
+              /directory/deeply/*
+              !/directory/deeply/nested/
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
+    void ignoreDeeplyNestedFile() {
+        rewriteRun(
+          spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/deeply/nested/file.txt"))),
+          text(
+            """
+              /directory/
+              """,
+            """
+              /directory/*
+              !/directory/deeply/
+              /directory/deeply/*
+              !/directory/deeply/nested/
+              /directory/deeply/nested/*
+              !/directory/deeply/nested/file.txt
+              """,
+            spec -> spec.path(".gitignore")
+          )
+        );
+    }
+
+    @Test
     void ignoreNestedDirectoryWithMultipleGitignoreFiles() {
         rewriteRun(
           spec -> spec.recipe(new ExcludeFileFromGitignore(List.of("directory/nested/yet-another-nested/test.yml"))),

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -213,7 +213,7 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               /directory/
               """,
             """
-              /directory/
+              /directory/*
               !/directory/test.yml
               """,
             spec -> spec.path(".gitignore")
@@ -262,7 +262,7 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               /directory/
               """,
             """
-              /directory/
+              /directory/*
               !/directory/nested/
               """,
             spec -> spec.path(".gitignore")
@@ -285,7 +285,7 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               /yet-another-nested/
               """,
             """
-              /yet-another-nested/
+              /yet-another-nested/*
               !/yet-another-nested/test.yml
               """,
             spec -> spec.path("directory/nested/.gitignore")


### PR DESCRIPTION
As Leanne has mentioned in our slack, we need to handle negations slightly different leading to more negation rules.
This results in dirtier rules result 😞 
But openrewrite is not to blame for git's behaviour 😄 

This one should fix the nested traversal rules