### PR TITLE
Fix `Substitutions` for generic type variables

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -187,7 +187,7 @@ public class Substitutions {
                 // wildcards cannot be used as type parameters on method invocations
                 return "java.lang.Object";
             }
-            return TypeUtils.toString(type);
+            return genericTypeVariable.getName();
         }
         return TypeUtils.toString(type).replace("$", ".");
     }
@@ -241,7 +241,7 @@ public class Substitutions {
         }
 
         //noinspection unchecked
-        J2 unsub = (J2) new JavaVisitor<Integer>() {
+        return (J2) new JavaVisitor<Integer>() {
             @SuppressWarnings("ConstantConditions")
             @Override
             public J visitAnnotation(J.Annotation annotation, Integer integer) {
@@ -289,11 +289,11 @@ public class Substitutions {
                 return super.visitLiteral(literal, integer);
             }
 
-            private @Nullable J maybeParameter(J j) {
-                Integer param = parameterIndex(j.getPrefix());
+            private @Nullable J maybeParameter(J j1) {
+                Integer param = parameterIndex(j1.getPrefix());
                 if (param != null) {
                     J j2 = (J) parameters[param];
-                    return j2.withPrefix(j2.getPrefix().withWhitespace(j.getPrefix().getWhitespace()));
+                    return j2.withPrefix(j2.getPrefix().withWhitespace(j1.getPrefix().getWhitespace()));
                 }
                 return null;
             }
@@ -309,10 +309,7 @@ public class Substitutions {
                 }
                 return null;
             }
-        }.visit(j, 0);
-
-        assert unsub != null;
-        return unsub;
+        }.visitNonNull(j, 0);
     }
 
     private static class ThrowingErrorListener extends BaseErrorListener {


### PR DESCRIPTION
When substituting a generic type variable we should only add the name of the generic type variable, not its bounds, as that syntax is for declaration site only.

- Issue: openrewrite/rewrite-migrate-java#550
