### PR TITLE
reworked ExcludeFileFromGitignore to support leading and trailing wildcards

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -16,7 +16,9 @@
 package org.openrewrite;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.jgit.ignore.FastIgnoreRule;
 import org.openrewrite.jgit.ignore.IgnoreNode;
@@ -27,6 +29,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.*;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.join;
@@ -78,7 +82,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
         for (String path : paths) {
             acc.exclude(path);
         }
-        return Collections.emptyList();
+        return emptyList();
     }
 
     @Override
@@ -86,12 +90,10 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
         return Preconditions.check(new FindSourceFiles("**/.gitignore"), new PlainTextVisitor<ExecutionContext>() {
             @Override
             public PlainText visitText(PlainText text, ExecutionContext ctx) {
-                String gitignoreFileName = separatorsToUnix(text.getSourcePath().toString());
-                gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
-                IgnoreNode ignoreNode = acc.rules.get(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1));
+                CustomIgnoreNode ignoreNode = acc.rules.get(asGitignoreFileLocation(text));
                 if (ignoreNode != null) {
                     String separator = text.getText().contains("\r\n") ? "\r\n" : "\n";
-                    List<String> newRules = ignoreNode.getRules().stream().map(FastIgnoreRule::toString).collect(toList());
+                    List<String> newRules = ignoreNode.getRules().stream().map(IgnoreRule::getText).collect(toList());
                     String[] currentContent = text.getText().split(separator);
                     text = text.withText(join(sortRules(currentContent, newRules), separator));
                 }
@@ -141,7 +143,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
     }
 
     public static class Repository {
-        private final Map<String, IgnoreNode> rules = new HashMap<>();
+        private final Map<String, CustomIgnoreNode> rules = new HashMap<>();
 
         public void exclude(String path) {
             path = separatorsToUnix(path);
@@ -153,78 +155,26 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                     .collect(toList());
 
             for (String impactingFile : impactingFiles) {
-                IgnoreNode ignoreNode = rules.get(impactingFile);
+                CustomIgnoreNode ignoreNode = rules.get(impactingFile);
                 String nestedPath = normalizedPath.substring(impactingFile.length() - 1);
 
-                boolean escapeLoop = false;
-                while (IGNORED == isIgnored(ignoreNode, nestedPath) && !escapeLoop) {
+                while (IGNORED == ignoreNode.isIgnored(nestedPath)) {
+                    List<IgnoreRule> existingRules = ignoreNode.getRules();
                     LinkedHashSet<FastIgnoreRule> remainingRules = new LinkedHashSet<>();
-                    for (int i = ignoreNode.getRules().size() - 1; i > -1; i--) {
-                        FastIgnoreRule rule = ignoreNode.getRules().get(i);
-                        if (!isMatch(rule, nestedPath) || !rule.getResult()) {
-                            // If this rule has nothing to do with the path to remove, we keep it.
-                            // OR if this rule is a negation, we keep it.
-                            remainingRules.add(rule);
-                            continue;
-                        } else if (rule.toString().equals(nestedPath)) {
-                            // If this rule is an exact match to the path to remove, we remove it.
-                            continue;
-                        } else if (isMatch(rule, nestedPath)) {
-                            StringBuilder rulePath = new StringBuilder(rule.toString());
-                            if (rulePath.toString().contains("*")) {
-                                remainingRules.addAll(getWildcardRules(rule, rulePath, nestedPath));
-                            }
-                            if (rulePath.toString().indexOf("*") != -1 && rulePath.toString().indexOf("*") != rulePath.length() - 1) {
-                                //Only a single wildcard at the end is supported for now.
-                                remainingRules.add(rule);
-                                escapeLoop = true;
-                                continue;
-                            }
-                            // Double wildcard best effort
-                            if (rulePath.toString().replaceAll("[^*]", "").length() == 2 &&) {
-                                remainingRules.add(new FastIgnoreRule("!" + nestedPath));
-                                remainingRules.add(rule);
-                                continue;
-                            }
-                            if (("/" + rule).equals(nestedPath)) {
-                                remainingRules.add(new FastIgnoreRule("!" + nestedPath));
-                                remainingRules.add(rule);
-                                continue;
-                            }
-                            if (!rule.dirOnly()) {
-                                remainingRules.add(new FastIgnoreRule("!" + normalizedPath));
-                                remainingRules.add(rule);
-                                continue;
-                            }
-                            String pathToTraverse = nestedPath.substring(rule.toString().length());
-                            if (pathToTraverse.replace("/", "").isEmpty()) {
-                                continue;
-                            }
-                            String pathToSplit = pathToTraverse.startsWith("/") ? pathToTraverse.substring(1) : pathToTraverse;
-                            pathToSplit = pathToSplit.endsWith("/") ? pathToSplit.substring(0, pathToSplit.length() - 1) : pathToSplit;
-                            String[] splitPath = pathToSplit.split("/");
-                            ArrayList<FastIgnoreRule> traversedRemainingRules = new ArrayList<>();
-                            for (int j = 0; j < splitPath.length; j++) {
-                                String s = splitPath[j];
-                                traversedRemainingRules.add(new FastIgnoreRule(rulePath + "*"));
-                                rulePath.append(s);
-                                traversedRemainingRules.add(new FastIgnoreRule("!" + rulePath + (j < splitPath.length - 1 || nestedPath.endsWith("/") ? "/" : "")));
-                                rulePath.append("/");
-                            }
-                            Collections.reverse(traversedRemainingRules);
-                            remainingRules.addAll(traversedRemainingRules);
-                            continue;
-                        }
-                        // If we still have the rule, we keep it. --> not making changes to an unknown flow.
-                        remainingRules.add(rule);
+                    for (int i = existingRules.size() - 1; i > -1; i--) {
+                        IgnoreRule rule = existingRules.get(i);
+                        remainingRules.addAll(rule.negateIfNecessary(nestedPath));
                     }
                     ArrayList<FastIgnoreRule> ignoreRules = new ArrayList<>(remainingRules);
                     Collections.reverse(ignoreRules);
-                    ignoreNode = new IgnoreNode(ignoreRules);
+                    ignoreNode = new CustomIgnoreNode(ignoreRules, ignoreNode.getPath());
+                    if (ignoreRules.size() == existingRules.size()) {
+                        break;
+                    }
                 }
                 rules.put(impactingFile, ignoreNode);
 
-                if (CHECK_PARENT == isIgnored(ignoreNode, nestedPath)) {
+                if (CHECK_PARENT == ignoreNode.isIgnored(nestedPath)) {
                     continue;
                 }
                 // There is already an ignore rule for the path, so not needed to check parent rules.
@@ -233,30 +183,33 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
         }
 
         public void addGitignoreFile(PlainText text) throws IOException {
-            String gitignoreFileName = separatorsToUnix(text.getSourcePath().toString());
-            gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
+            CustomIgnoreNode ignoreNode = CustomIgnoreNode.of(text);
+            rules.put(ignoreNode.path, ignoreNode);
+        }
+    }
+
+    @Getter
+    private static class CustomIgnoreNode {
+        private final List<IgnoreRule> rules;
+        private final String path;
+
+        public CustomIgnoreNode(List<FastIgnoreRule> rules, String path) {
+            this.rules = rules.stream().map(IgnoreRule::new).collect(toList());
+            this.path = path;
+        }
+
+        static CustomIgnoreNode of(PlainText text) throws IOException {
+            String gitignoreFileName = asGitignoreFileLocation(text);
             IgnoreNode ignoreNode = new IgnoreNode();
             ignoreNode.parse(gitignoreFileName, new ByteArrayInputStream(text.getText().getBytes()));
-            rules.put(gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1), ignoreNode);
+
+            return new CustomIgnoreNode(ignoreNode.getRules(), gitignoreFileName);
         }
 
-        // We do not use jgit's IgnoreNode#isIgnored method because it does not handle the directory correct always.
-        // See the difference between rule.isMatch in the pathMatch parameter.
-        private boolean isMatch(FastIgnoreRule rule, String path) {
-            String rulePath = rule.toString();
-            if (rulePath.startsWith("!")) {
-                rulePath = rulePath.substring(1);
-            }
-            if (rule.dirOnly() && path.contains(rulePath)) {
-                return rule.isMatch(path, true, false);
-            }
-            return rule.isMatch(path, true, true);
-        }
-
-        private IgnoreNode.MatchResult isIgnored(IgnoreNode ignoreNode, String path) {
-            for (int i = ignoreNode.getRules().size() - 1; i > -1; i--) {
-                FastIgnoreRule rule = ignoreNode.getRules().get(i);
-                if (isMatch(rule, path)) {
+        public IgnoreNode.MatchResult isIgnored(String path) {
+            for (int i = rules.size() - 1; i > -1; i--) {
+                IgnoreRule rule = rules.get(i);
+                if (rule.isMatch(path)) {
                     if (rule.getResult()) {
                         return IGNORED;
                     } else {
@@ -266,5 +219,191 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
             }
             return CHECK_PARENT;
         }
+    }
+
+    private static class IgnoreRule {
+        private final FastIgnoreRule rule;
+
+        @Getter
+        private final String text;
+
+        public IgnoreRule(FastIgnoreRule rule) {
+            this.rule = rule;
+            this.text = rule.toString();
+        }
+
+        public boolean isMatch(String path) {
+            return rule.isMatch(path, true, false) ||  rule.isMatch(path, true, true);
+        }
+
+        public boolean getResult() {
+            return rule.getResult();
+        }
+
+        public List<FastIgnoreRule> negateIfNecessary(String nestedPath) {
+            if (!isMatch(nestedPath) || !getResult()) {
+                // If this rule has nothing to do with the path to remove, we keep it.
+                // OR if this rule is a negation, we keep it.
+                return Collections.singletonList(rule);
+            } else if (text.equals(nestedPath)) {
+                // If this rule is an exact match to the path to remove, we remove it.
+                return emptyList();
+            } else if (isMatch(nestedPath)) {
+                if (text.contains("*")) {
+                    return getWildcardRules(nestedPath);
+                }
+                if (("/" + text).equals(nestedPath)) {
+                    // An entry not starting with a slash, but exact match otherwise needs to be negated using exact path as that leftover entry can match nested paths also.
+                    return Arrays.asList(new FastIgnoreRule("!" + nestedPath), rule);
+                }
+                if (!rule.dirOnly()) {
+                    // If the rule does not end with a slash, it's a matcher for both filenames and directories, so we must negate it with an exact path.
+                    return Arrays.asList(new FastIgnoreRule("!" + nestedPath), rule);
+                }
+                return traversePaths(text, nestedPath, null, null);
+            }
+            // If we still have the rule, we keep it. --> not making changes to an unknown flow.
+            return Collections.singletonList(rule);
+        }
+
+        @Override
+        public String toString() {
+            return text;
+        }
+
+        private List<FastIgnoreRule> getWildcardRules(String nestedPath) {
+            if (!isMatch(nestedPath)) {
+                return singletonList(rule);
+            }
+            if (text.startsWith("!")) {
+                return singletonList(rule);
+            }
+            if (isWildcardedBetween(1, -1) || (splitRuleParts().length > 1 && isWildcardedBetween(0, 1) && isWildcardedBetween(-1, 0))) {
+                // No support for wildcard in the middle of the path (yet?). So, we keep the rule.
+                // No support for wildcards in both beginning and end.
+                return singletonList(rule);
+            }
+            if (!hasOnlyOneWildcardGroup()) {
+                // No support for multiple wildcard groups (yet?). So, we keep the rule.
+                // No support for wildcards + text (yet?). So, we keep the rule.
+                return singletonList(rule);
+            }
+            if (!isFullWildcard()) {
+                return Arrays.asList(new FastIgnoreRule("!" + nestedPath), rule);
+            }
+            String wildcard = "*";
+            if (text.contains("**")) {
+                wildcard = "**";
+            }
+            if (isWildcardedBetween(0, 1)) {
+                return traversePaths(text, nestedPath, null, (text.startsWith("/") ? "/" : "") + wildcard);
+            }
+            if (isWildcardedBetween(-1, 0)) {
+                // If the wildcard is at the end of the path, we should negate the rule.
+                return traversePaths(text, nestedPath, wildcard + (text.endsWith("/") ? "/" : ""), null);
+            }
+            // In any other case, we will keep the rule.
+            return singletonList(rule);
+        }
+
+        private boolean isFullWildcard() {
+            if (!text.contains("*")) {
+                return false;
+            }
+            // only / or empty before and after the wildcard
+            int begin = text.indexOf("*");
+            int end = text.lastIndexOf("*");
+
+            return (begin == 0 || text.charAt(begin - 1) == '/') && (end == text.length() - 1 || text.charAt(end + 1) == '/');
+        }
+
+        private boolean hasOnlyOneWildcardGroup() {
+            if (!text.contains("*")) {
+                return false;
+            }
+            int firstWildcard = text.indexOf("*");
+            int lastWildcard = text.lastIndexOf("*");
+            return firstWildcard == lastWildcard || lastWildcard - firstWildcard == 1;
+        }
+
+        private boolean isWildcardedBetween(int start, int end) {
+            if (!text.contains("*")) {
+                return false;
+            }
+            String[] parts = splitRuleParts();
+            int startIdx = start;
+            if (startIdx < 0) {
+                startIdx = parts.length + start;
+            }
+            int endIdx = end;
+            if (endIdx <= 0) {
+                endIdx = parts.length + end;
+            }
+            for (int i = startIdx; i < endIdx; i++) {
+                if (parts[i].contains("*")) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private String[] splitRuleParts() {
+            String rulePath = text;
+            if (rulePath.startsWith("!")) {
+                rulePath = rulePath.substring(1);
+            }
+            if (rulePath.startsWith("/")) {
+                rulePath = rulePath.substring(1);
+            }
+            if (rulePath.endsWith("/")) {
+                rulePath = rulePath.substring(0, rulePath.length() - 1);
+            }
+            return rulePath.split("/");
+        }
+
+        private static List<FastIgnoreRule> traversePaths(String originalRule, String path, @Nullable String wildcardSuffix, @Nullable String wildcardPrefix) {
+            String rule = originalRule;
+            ArrayList<FastIgnoreRule> traversedRemainingRules = new ArrayList<>();
+            if (wildcardSuffix != null && rule.endsWith(wildcardSuffix)) {
+                rule = rule.substring(0, rule.length()-wildcardSuffix.length());
+            }
+            if (wildcardPrefix != null && rule.startsWith(wildcardPrefix)) {
+                rule = path.substring(0, path.indexOf(rule.substring(wildcardPrefix.length()))) + rule.substring(wildcardPrefix.length());
+                traversedRemainingRules.add(new FastIgnoreRule(originalRule + (originalRule.endsWith("/") ? "*" : "/*")));
+                traversedRemainingRules.add(new FastIgnoreRule("!" + rule));
+            }
+            StringBuilder rulePath = new StringBuilder(rule);
+            String pathToTraverse = path.substring(rule.length());
+
+            if (originalRule.contains("*")) {
+                if (pathToTraverse.isEmpty() && wildcardSuffix != null) {
+                    return Arrays.asList(new FastIgnoreRule("!" + rule), new FastIgnoreRule(originalRule + (originalRule.endsWith("/") ? "*" : "/*")));
+                } else if (pathToTraverse.isEmpty() && wildcardPrefix != null) {
+                    return Arrays.asList(new FastIgnoreRule("!" + rule), new FastIgnoreRule(originalRule));
+                }
+            } else {
+                if (pathToTraverse.replace("/", "").isEmpty()) {
+                    return Arrays.asList(new FastIgnoreRule("!" + rule), new FastIgnoreRule(originalRule));
+                }
+            }
+            String pathToSplit = pathToTraverse.startsWith("/") ? pathToTraverse.substring(1) : pathToTraverse;
+            pathToSplit = pathToSplit.endsWith("/") ? pathToSplit.substring(0, pathToSplit.length() - 1) : pathToSplit;
+            String[] splitPath = pathToSplit.split("/");
+            for (int j = 0; j < splitPath.length; j++) {
+                String s = splitPath[j];
+                traversedRemainingRules.add(new FastIgnoreRule(rulePath + (wildcardSuffix != null ? wildcardSuffix : "*")));
+                rulePath.append(s);
+                traversedRemainingRules.add(new FastIgnoreRule("!" + rulePath + (j < splitPath.length - 1 || path.endsWith("/") ? "/" : "")));
+                rulePath.append("/");
+            }
+            Collections.reverse(traversedRemainingRules);
+            return traversedRemainingRules;
+        }
+    }
+
+    private static String asGitignoreFileLocation(PlainText text) {
+        String gitignoreFileName = separatorsToUnix(text.getSourcePath().toString());
+        gitignoreFileName = gitignoreFileName.startsWith("/") ? gitignoreFileName : "/" + gitignoreFileName;
+        return gitignoreFileName.substring(0, gitignoreFileName.lastIndexOf("/") + 1);
     }
 }


### PR DESCRIPTION
## What's changed?
There's a bug in the currect version with `**/path/` entries. This should be fixed by adding the support + tests.

## What's your motivation?
Fix the bug + add wildcard support. We do not support wildcards in the middle part of a path, nor entries with multiple wildcarded parts. Also only the * wildcard for now is supported. Not the `?` yet. 

## Anyone you would like to review specifically?
@lkerford , I thought I said I am DONE with gitignore and NEVER want to see them again... Yet here we go ;)

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files

Note: when I run the best practices, I also receive changes in lots of other files, so only kept these applicable on my 2 changed files. 
