### PR TITLE
Catch non-semver compatible exception in case of version update

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -262,7 +262,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                         acc.versionPropNameToGA.put(versionVariableName, ga);
                                         acc.gaToNewVersion.put(ga, resolvedVersion);
                                     }
-                                } catch (IllegalStateException | MavenDownloadingException e) {
+                                } catch (MavenDownloadingException e) {
                                     acc.gaToNewVersion.put(ga, e);
                                 }
                             }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -262,7 +262,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                         acc.versionPropNameToGA.put(versionVariableName, ga);
                                         acc.gaToNewVersion.put(ga, resolvedVersion);
                                     }
-                                } catch (MavenDownloadingException e) {
+                                } catch (IllegalStateException | MavenDownloadingException e) {
                                     acc.gaToNewVersion.put(ga, e);
                                 }
                             }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1049,4 +1049,29 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4655")
+    void issue4655() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "30.0.1", null)),
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              repositories {
+                mavenCentral()
+              }
+              
+              version='ORC-246-1-SNAPSHOT'
+              dependencies {
+                implementation "com.veon.eurasia.oraculum:jira-api:$version"
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1054,8 +1054,6 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/4655")
     void issue4655() {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi())
-            .recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "30.0.1", null)),
           buildGradle(
             """
               plugins {


### PR DESCRIPTION
See the slack exception logs -> https://rewriteoss.slack.com/archives/C01A843MWG5/p1730974519581749