### PR TITLE
Feature - YAML search - find properties with a specific scalar value

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindProperty.java
@@ -48,6 +48,7 @@ public class FindProperty extends Recipe {
     Boolean relaxedBinding;
 
     @Option(displayName = "Property value",
+            example = "false",
             description = "If provided, only properties specified in propertyKey having this value will be found. Works only for scalar values",
             required = false)
     @Nullable

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindProperty.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/search/FindProperty.java
@@ -28,6 +28,7 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 
 @Value
@@ -45,6 +46,12 @@ public class FindProperty extends Recipe {
             required = false)
     @Nullable
     Boolean relaxedBinding;
+
+    @Option(displayName = "Property value",
+            description = "If provided, only properties specified in propertyKey having this value will be found. Works only for scalar values",
+            required = false)
+    @Nullable
+    String propertyValue;
 
     @Override
     public String getDisplayName() {
@@ -66,7 +73,16 @@ public class FindProperty extends Recipe {
                 if (!Boolean.FALSE.equals(relaxedBinding) ?
                         NameCaseConvention.matchesGlobRelaxedBinding(prop, propertyKey) :
                         StringUtils.matchesGlob(prop, propertyKey)) {
-                    e = e.withValue(SearchResult.found(e.getValue()));
+                    if (!Objects.isNull(propertyValue)) {
+                        if (entry.getValue() instanceof Yaml.Scalar) {
+                            Yaml.Scalar scalar = (Yaml.Scalar) entry.getValue();
+                            if (scalar.getValue().equals(propertyValue)) {
+                                e = e.withValue(SearchResult.found(e.getValue()));
+                            }
+                        }
+                    } else {
+                        e = e.withValue(SearchResult.found(e.getValue()));
+                    }
                 }
                 return e;
             }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindPropertyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindPropertyTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml.search;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,7 +31,7 @@ class FindPropertyTest implements RewriteTest {
     @Test
     void findProperty() {
         rewriteRun(
-          spec -> spec.recipe(new FindProperty("management.metrics.binders.files.enabled", null)),
+          spec -> spec.recipe(new FindProperty("management.metrics.binders.files.enabled", null, null)),
           yaml(
             "management.metrics.binders.files.enabled: true",
             "management.metrics.binders.files.enabled: ~~>true"
@@ -41,10 +42,55 @@ class FindPropertyTest implements RewriteTest {
     @Test
     void findGlobProperty() {
         rewriteRun(
-          spec -> spec.recipe(new FindProperty("management.metrics.binders.*.enabled", null)),
+          spec -> spec.recipe(new FindProperty("management.metrics.binders.*.enabled", null, null)),
           yaml(
             "management.metrics.binders.files.enabled: true",
             "management.metrics.binders.files.enabled: ~~>true"
+          )
+        );
+    }
+
+    @Test
+    void findPropertyWithSpecificValueMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperty("my.cool.property", null, "my-matching-value")),
+          yaml(
+            "my.cool.property: my-matching-value",
+            "my.cool.property: ~~>my-matching-value"
+          )
+        );
+    }
+
+    @Test
+    void findPropertyWithSpecificValueMatchSingleQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperty("my.cool.property", null, "my-matching-value")),
+          yaml(
+            "my.cool.property: 'my-matching-value'",
+            "my.cool.property: ~~>'my-matching-value'"
+          )
+        );
+    }
+
+    @Test
+    void findPropertyWithSpecificValueMatchDoubleQuotes() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperty("my.cool.property", null, "my-matching-value")),
+          yaml(
+            "my.cool.property: \"my-matching-value\"",
+            "my.cool.property: ~~>\"my-matching-value\""
+          )
+        );
+    }
+
+    @Test
+    @Disabled("how do I test that the search has no hits?")
+    void findPropertyWithSpecificValueNoMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperty("my.cool.property", null, "my-non-matching-value")),
+          yaml(
+            "my.cool.property: my-matching-value",
+            "my.cool.property: my-matching-value"
           )
         );
     }
@@ -58,7 +104,7 @@ class FindPropertyTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1168")
     void relaxedBinding(String propertyKey) {
         rewriteRun(
-          spec -> spec.recipe(new FindProperty(propertyKey, true)),
+          spec -> spec.recipe(new FindProperty(propertyKey, true, null)),
           yaml(
                 """
               acme.my-project.person.first-name: example
@@ -78,7 +124,7 @@ class FindPropertyTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1168")
     void exactMatch() {
         rewriteRun(
-          spec -> spec.recipe(new FindProperty("acme.my-project.person.first-name", false)),
+          spec -> spec.recipe(new FindProperty("acme.my-project.person.first-name", false, null)),
           yaml(
                 """
               acme.my-project.person.first-name: example

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindPropertyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindPropertyTest.java
@@ -106,7 +106,7 @@ class FindPropertyTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new FindProperty(propertyKey, true, null)),
           yaml(
-                """
+            """
               acme.my-project.person.first-name: example
               acme.myProject.person.firstName: example
               acme.my_project.person.first_name: example
@@ -126,7 +126,7 @@ class FindPropertyTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new FindProperty("acme.my-project.person.first-name", false, null)),
           yaml(
-                """
+            """
               acme.my-project.person.first-name: example
               acme.myProject.person.firstName: example
               acme.my_project.person.first_name: example


### PR DESCRIPTION
## What's changed?
I have changed the org.openrewrite.yaml.search.FindProperty search recipe to allow searching for yaml properties which have a specific scalar value. The new reciped parameter propertyValue is OPTIONAL which ensures downwards-compatibility.

## What's your motivation?
 I need this search functionality for a specific use case I am working on.
 I want to alter a yamle file if the specified yaml key does have a certain value. The search recipe can act as a Precondition here.

## Anything in particular you'd like reviewers to focus on?
I thried to create a dedicated org.openrewrite.yaml.search.FindPropertyWithValue recipe inheriting from org.openrewrite.yaml.search.FindProperty, but recipes are final and do not allow for inheritance. This is why I added an optional parameter to the existing recipe instead.
Also I did not find out how to test a negative search case. I marked hence the negative test as `@Disabled`.

## Have you considered any alternatives or workarounds?
Alternative: Use SourceGraph to find the repos having the specified Yaml condition. Well then I can also run the change with Sourcegraph.

## Any additional context
I love the generic yaml stuff you have

### Checklist
- [x] I've added unit tests to cover both positive and negative cases (well comment about the negative test case)
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
