### PR TITLE
Keep multiple whitelines and same comments from the gitignore file

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExcludeFileFromGitignore.java
@@ -103,7 +103,7 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
             private List<String> sortRules(String[] originalRules, List<String> newRules) {
                 LinkedList<String> results = new LinkedList<>();
                 Arrays.stream(originalRules).filter(line -> {
-                    if (line.startsWith("#") || StringUtils.isBlank(line)) {
+                    if (StringUtils.isBlank(line) || line.startsWith("#")) {
                         return true;
                     }
                     return newRules.stream().anyMatch(line::equalsIgnoreCase);
@@ -127,17 +127,18 @@ public class ExcludeFileFromGitignore extends ScanningRecipe<Repository> {
                 return distinctValuesStartingReversed(results);
             }
 
-            private <T> List<T> distinctValuesStartingReversed(List<T> list) {
-                Set<T> set = new LinkedHashSet<>();
-                ListIterator<T> iterator = list.listIterator(list.size());
+            private List<String> distinctValuesStartingReversed(List<String> list) {
+                LinkedList<String> filteredList = new LinkedList<>();
+                ListIterator<String> iterator = list.listIterator(list.size());
 
                 while (iterator.hasPrevious()) {
-                    set.add(iterator.previous());
+                    String previous = iterator.previous();
+                    if (StringUtils.isBlank(previous) || previous.startsWith("#") || !filteredList.contains(previous)) {
+                        filteredList.addFirst(previous);
+                    }
                 }
 
-                List<T> result = new ArrayList<>(set);
-                Collections.reverse(result);
-                return result;
+                return filteredList;
             }
         });
     }

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -117,7 +117,7 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               # comment
               
               test.yml
-              # Another comment
+              # comment
               
               file.yaml
               """,
@@ -126,7 +126,7 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               
               test.yml
               !/directory/test.yml
-              # Another comment
+              # comment
               
               file.yaml
               """,

--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -117,12 +117,18 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
               # comment
               
               test.yml
+              # Another comment
+              
+              file.yaml
               """,
             """
               # comment
               
               test.yml
               !/directory/test.yml
+              # Another comment
+              
+              file.yaml
               """,
             spec -> spec.path(".gitignore")
           )
@@ -410,7 +416,6 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
           )
         );
     }
-
 
     @Test
     void ignoreWildcardedFile() {


### PR DESCRIPTION
As I originally used a Set, the empty lines and comments with same text where being filtered to a single occurence (the last one).

By changing the implementation to a LinkedList into which we add conditionally entries, we can save a new List instantiation + keep comments and whitelines non-distinct, maintaining dinstinction of the gitgnore lines (same line later in file makes sure we only keep that one)

See the changed test for the bug I was facing while first time running on a gitignore file with multiple empty lines. 