### PR TITLE
add gradle recipe: RemoveSettingsPluginManagement

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
@@ -24,11 +24,8 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.gradle.IsSettingsGradle;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Statement;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -50,16 +47,10 @@ public class RemoveSettingsPluginManagement extends Recipe {
             @Override
             public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
                 G.CompilationUnit g = super.visitCompilationUnit(cu, ctx);
-                List<Statement> statementList = g.getStatements();
-                for (Statement s : new ArrayList<Statement>(statementList)) {
-                    if (s instanceof J.MethodInvocation) {
-                        J.MethodInvocation m = (J.MethodInvocation) s;
-                        if (m.getName().getSimpleName().equals("pluginManagement")) {
-                            statementList.remove(s);
-                        }
-                    }
-                }
-                return g.withStatements(statementList);
+                return g.withStatements(ListUtils.map(g.getStatements(),
+                        s -> s instanceof J.MethodInvocation &&
+                             "pluginManagement".equals(((J.MethodInvocation) s).getName().getSimpleName()) ?
+                                null : s));
             }
         });
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.plugins;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.IsSettingsGradle;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RemoveSettingsPluginManagement extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Gradle settings pluginManagement";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove Gradle settings pluginManagement from `settings.gradle(.kts)`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new IsSettingsGradle<>(), new GroovyIsoVisitor<ExecutionContext>() {
+            @Override
+            public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+                G.CompilationUnit g = super.visitCompilationUnit(cu, ctx);
+                List<Statement> statementList = g.getStatements();
+                for (Statement s : new ArrayList<Statement>(statementList)) {
+                    if (s instanceof J.MethodInvocation) {
+                        J.MethodInvocation m = (J.MethodInvocation) s;
+                        if (m.getName().getSimpleName().equals("pluginManagement")) {
+                            statementList.remove(s);
+                        }
+                    }
+                }
+                return g.withStatements(statementList);
+            }
+        });
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
@@ -38,7 +38,7 @@ public class RemoveSettingsPluginManagement extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Remove Gradle settings pluginManagement from `settings.gradle(.kts)`.";
+        return "Remove Gradle settings pluginManagement from `settings.gradle`.";
     }
 
     @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagement.java
@@ -33,7 +33,7 @@ public class RemoveSettingsPluginManagement extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Remove Gradle settings pluginManagement";
+        return "Remove Gradle settings `pluginManagement`";
     }
 
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagementTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagementTest.java
@@ -17,16 +17,22 @@ package org.openrewrite.gradle.plugins;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.settingsGradle;
 
 class RemoveSettingsPluginManagementTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveSettingsPluginManagement());
+    }
+
     @DocumentExample
     @Test
     void existingPluginManagementBlock() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
           settingsGradle(
             """
               pluginManagement {
@@ -45,7 +51,6 @@ class RemoveSettingsPluginManagementTest implements RewriteTest {
     @Test
     void twoPluginManagementBlocks() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
           settingsGradle(
             """
               pluginManagement {
@@ -72,7 +77,6 @@ class RemoveSettingsPluginManagementTest implements RewriteTest {
     @Test
     void noPluginManagementBlock() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
           settingsGradle(
             """
               plugins {
@@ -87,7 +91,6 @@ class RemoveSettingsPluginManagementTest implements RewriteTest {
     @Test
     void emptySettingsFile() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
           settingsGradle(
             ""
           )
@@ -97,13 +100,12 @@ class RemoveSettingsPluginManagementTest implements RewriteTest {
     @Test
     void emptyPluginManagementBlock() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
           settingsGradle(
             """
               pluginManagement {
               }
               """,
-              ""
+            ""
           )
         );
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagementTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveSettingsPluginManagementTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.plugins;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.settingsGradle;
+
+class RemoveSettingsPluginManagementTest implements RewriteTest {
+    @DocumentExample
+    @Test
+    void existingPluginManagementBlock() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
+          settingsGradle(
+            """
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = "https://repo.example.com/snapshots"
+                      }
+                  }
+              }
+              """,
+            ""
+          )
+        );
+    }
+
+    @Test
+    void twoPluginManagementBlocks() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
+          settingsGradle(
+            """
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = "https://repo.example.com/snapshots"
+                      }
+                  }
+              }
+
+              pluginManagement {
+                  repositories {
+                      maven {
+                          url = "https://repo.example.com/snapshots2"
+                      }
+                  }
+              }
+              """,
+            ""
+          )
+        );
+    }
+
+    @Test
+    void noPluginManagementBlock() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
+          settingsGradle(
+            """
+              plugins {
+                id("com.example.ExamplePlugin")
+              }
+              rootProject.name = "demo"
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptySettingsFile() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
+          settingsGradle(
+            ""
+          )
+        );
+    }
+
+    @Test
+    void emptyPluginManagementBlock() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveSettingsPluginManagement()),
+          settingsGradle(
+            """
+              pluginManagement {
+              }
+              """,
+              ""
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

new recipe:  RemoveSettingsPluginManagement

This recipe removes "pluginManagement" from Gradle settings.gradle

## What's your motivation?

At work, I have hundreds of Gradle projects. I need to remove "pluginManagement" from all of my Gradle projects.


## Anything in particular you'd like reviewers to focus on?

n/a

## Anyone you would like to review specifically?

n/a


## Have you considered any alternatives or workarounds?

n/a

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
