### PR TITLE
Fixing the quoteEscaping test case for proper quote character escaping

### DIFF
--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclStringTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclStringTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.hcl.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -24,7 +23,6 @@ import static org.openrewrite.hcl.Assertions.hcl;
 
 class HclStringTest implements RewriteTest {
 
-    @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite/issues/4612")
     @Test
     void quoteEscaping() {
@@ -32,7 +30,7 @@ class HclStringTest implements RewriteTest {
           hcl(
             """
               locals {
-                quotedText = "this is a double quote: \". Look at me"
+                quotedText = "this is a double quote: \\". Look at me"
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Fixing the recently added (#4616) test case called `quoteEscaping` in HCL handling.
As is, the test runs rewrite against an invalid HCL fail and fails (as noted by `@ExpectedToFail`). Thus, fixing the tested HCL syntax, observing the test pass (with no code changes) and removing the `@ExpectedToFail` annotation.

Closes #4612.

## What's your motivation?
Fix the bug in tests.

## Anyone you would like to review specifically?
@timtebeek was the one to look at it before
