### PR TITLE
ChangeType does not work on J.ClassDeclaration

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -30,6 +30,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.xml.Assertions.xml;
@@ -2053,14 +2054,36 @@ class ChangeTypeTest implements RewriteTest {
           public class HelloClass {}
           """;
 
-        J.CompilationUnit sourceJavaFile = (J.CompilationUnit) JavaParser.fromJavaVersion()
+        J.CompilationUnit compilationUnit = (J.CompilationUnit) JavaParser
+          .fromJavaVersion()
           .build()
-          .parse(helloClass).findFirst().get();
+          .parse(helloClass)
+          .findFirst()
+          .get();
 
-        J.ClassDeclaration cd = sourceJavaFile.getClasses().get(0);
+        // Check that ChangeType changes the class name for a J.CompilationUnit
+        compilationUnit = (J.CompilationUnit) new ChangeType("hello.HelloClass", "hello.GoodbyeClass", false).getVisitor().visit(compilationUnit, new InMemoryExecutionContext());
+        assertEquals(compilationUnit.getClasses().get(0).getSimpleName(), "GoodbyeClass");
+    }
 
-        cd = (J.ClassDeclaration) new ChangeType("hello.HelloClass", "hello.GoodbyeClass", false).getVisitor().visit(cd, new InMemoryExecutionContext());
+    @Test
+    void classDeclarationTest() {
+        @Language("java")
+        String helloClass = """
+          package hello;
+          public class HelloClass {}
+          """;
 
-        assertTrue(cd.getSimpleName().equals("GoodbyeClass"));
+        J.CompilationUnit compilationUnit = (J.CompilationUnit) JavaParser
+          .fromJavaVersion()
+          .build()
+          .parse(helloClass)
+          .findFirst()
+          .get();
+        J.ClassDeclaration classDeclaration = compilationUnit.getClasses().get(0);
+
+        // Check that ChangeType changes the class name for a J.ClassDeclaration
+        classDeclaration = (J.ClassDeclaration) new ChangeType("hello.HelloClass", "hello.GoodbyeClass", false).getVisitor().visit(classDeclaration, new InMemoryExecutionContext());
+        assertEquals(classDeclaration.getSimpleName(), "GoodbyeClass");
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2063,7 +2063,7 @@ class ChangeTypeTest implements RewriteTest {
 
         // Check that ChangeType changes the class name for a J.CompilationUnit
         compilationUnit = (J.CompilationUnit) new ChangeType("hello.HelloClass", "hello.GoodbyeClass", false).getVisitor().visit(compilationUnit, new InMemoryExecutionContext());
-        assertEquals(compilationUnit.getClasses().get(0).getSimpleName(), "GoodbyeClass");
+        assertEquals("GoodbyeClass", compilationUnit.getClasses().get(0).getSimpleName());
     }
 
     @Test
@@ -2084,6 +2084,6 @@ class ChangeTypeTest implements RewriteTest {
 
         // Check that ChangeType changes the class name for a J.ClassDeclaration
         classDeclaration = (J.ClassDeclaration) new ChangeType("hello.HelloClass", "hello.GoodbyeClass", false).getVisitor().visit(classDeclaration, new InMemoryExecutionContext());
-        assertEquals(classDeclaration.getSimpleName(), "GoodbyeClass");
+        assertEquals("GoodbyeClass", classDeclaration.getSimpleName());
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -19,8 +19,10 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.PathUtils;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.test.RecipeSpec;
@@ -28,6 +30,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.xml.Assertions.xml;
 
@@ -2042,4 +2045,22 @@ class ChangeTypeTest implements RewriteTest {
 
     }
 
+    @Test
+    void compilationUnitTest() {
+        @Language("java")
+        String helloClass = """
+          package hello;
+          public class HelloClass {}
+          """;
+
+        J.CompilationUnit sourceJavaFile = (J.CompilationUnit) JavaParser.fromJavaVersion()
+          .build()
+          .parse(helloClass).findFirst().get();
+
+        J.ClassDeclaration cd = sourceJavaFile.getClasses().get(0);
+
+        cd = (J.ClassDeclaration) new ChangeType("hello.HelloClass", "hello.GoodbyeClass", false).getVisitor().visit(cd, new InMemoryExecutionContext());
+
+        assertTrue(cd.getSimpleName().equals("GoodbyeClass"));
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -107,7 +107,7 @@ public class ChangeType extends Recipe {
             @Override
             public @Nullable Tree preVisit(@Nullable Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
-                if (tree instanceof JavaSourceFile) {
+                if (tree instanceof J) {
                     return new JavaChangeTypeVisitor(oldFullyQualifiedTypeName, newFullyQualifiedTypeName, ignoreDefinition).visit(tree, ctx, requireNonNull(getCursor().getParent()));
                 } else if (tree instanceof SourceFileWithReferences) {
                     SourceFileWithReferences sourceFile = (SourceFileWithReferences) tree;


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
A test case was added to demonstrate an issue with using the `ChangeType` recipe on a `J.ClassDeclaration` object.

## What's your motivation?
`ChangeType` fails to change the class name for a `J.ClassDeclaration` object. This may be related to 
- #4648
since we noticed this new regression in a local recipe today.

## Anyone you would like to review specifically?
@timtebeek

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
