### PR TITLE
Fix bug using `AddOrUpdateAnnotationAttribute` on annotation with empty brackets

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -599,6 +599,41 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     }
 
     @Test
+    void addArrayInputInAnnotationAttributeEmptyBraces() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+            "org.example.Foo",
+            "array",
+            "newTest1,newTest2",
+            false)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String[] array() default {};
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.Foo;
+              
+              @Foo()
+              public class A {
+              }
+              """,
+            """
+              import org.example.Foo;
+              
+              @Foo(array = {"newTest1", "newTest2"})
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeArrayInputInAnnotationAttribute() {
         rewriteRun(
           spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -82,7 +82,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
 
                 String newAttributeValue = maybeQuoteStringArgument(attributeName, attributeValue, a);
                 List<Expression> currentArgs = a.getArguments();
-                if (currentArgs == null || currentArgs.isEmpty()) {
+                if (currentArgs == null || currentArgs.isEmpty() || currentArgs.get(0) instanceof J.Empty) {
                     if (newAttributeValue == null) {
                         return a;
                     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fixed bug that caused incorrect code when `AddOrUpdateAnnotationAttribute` on annotation with empty bracket e.g., `@Foo()`.

## What's your motivation?
<!-- This can link to close a separate issue or be described on the pull request itself -->
The recipe `AddOrUpdateAnnotationAttribute` can be used to modify the attribute values on annotation. When no attribute values have been specified, the recipe will work fine if the syntax `@Foo` is used. However, if `@Foo()` is used, which is also valid java. Then, the recipe breaks.

**Example**
```java
public @interface Foo {
    String[] array() default {};
}
```
If we run `AddOrUpdateAnnotationAttribute` on `A` annotated with `@Foo`, configured to set the value of `Foo.array` to "newTest1,newTest2" we **correctly** get:
```java
@Foo
public class A {}
@Foo(array = {"newTest1", "newTest2"})
public class A {
}
```
Yet applying it to `@Foo()`, **incorrectly** yields
```java
@Foo()
public class A {}
@Foo(array = "newTest1,newTest2", )
public class A {
}
```

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
