### PR TITLE
Remove redundant space for DeleteMethodArgument when argumentIndex=0

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindPluginsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindPluginsTest.java
@@ -69,7 +69,8 @@ class FindPluginsTest implements RewriteTest {
     void settingsResolutionStrategy() {
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi()),
-          settingsGradle("""
+          settingsGradle(
+              """
             pluginManagement {
                 repositories {
                     mavenLocal()
@@ -83,7 +84,8 @@ class FindPluginsTest implements RewriteTest {
                     }
                 }
             }
-            """),
+            """
+          ),
           buildGradle(
             """
               plugins {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/DeleteMethodArgumentTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/DeleteMethodArgumentTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -101,6 +102,19 @@ class DeleteMethodArgumentTest implements RewriteTest {
           java(
             "public class A { B b = new B(0); }",
             "public class A { B b = new B(); }"
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4676")
+    @Test
+    void deleteFirstArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new DeleteMethodArgument("B foo(int, int, int)", 0)),
+          java(b),
+          java(
+            "public class A {{ B.foo(0, 1, 2); }}",
+            "public class A {{ B.foo(1, 2); }}"
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
@@ -100,11 +100,11 @@ public class DeleteMethodArgument extends Recipe {
                                                     .count() >= argumentIndex + 1) {
                 List<Expression> args = new ArrayList<>(originalArgs);
 
-                args.remove(argumentIndex);
+                Expression removed = args.remove(argumentIndex);
                 if (args.isEmpty()) {
                     args = singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY));
                 } else if (argumentIndex == 0) {
-                    args.set(0, args.get(0).withPrefix(Space.EMPTY));
+                    args.set(0, args.get(0).withPrefix(removed.getPrefix()));
                 }
 
                 m = m.withArguments(args);

--- a/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
@@ -103,6 +103,8 @@ public class DeleteMethodArgument extends Recipe {
                 args.remove(argumentIndex);
                 if (args.isEmpty()) {
                     args = singletonList(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY));
+                } else if (argumentIndex == 0) {
+                    args.set(0, args.get(0).withPrefix(Space.EMPTY));
                 }
 
                 m = m.withArguments(args);


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

- Fix https://github.com/openrewrite/rewrite/issues/4676

Below case will failed because it will change to `"public class A {{ B.foo( 1, 2); }}"` which contains a redundant space before the first argument.

```java
    @Test
    void deleteFirstArgument() {
        rewriteRun(
          spec -> spec.recipe(new DeleteMethodArgument("B foo(int, int, int)", 0)),
          java(b),
          java(
            "public class A {{ B.foo(0, 1, 2); }}",
            "public class A {{ B.foo(1, 2); }}"
          )
        );
    }
```

correct answer: `"public class A {{ B.foo(1, 2); }}"`, no space before the first `1` element.
actual answer:    `"public class A {{ B.foo( 1, 2); }}"` has a redundant space before the first `1` element.

This PR aims to fix the issue.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Fix https://github.com/openrewrite/rewrite/issues/4676

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
