### PR TITLE
Make `FindMissingTypes` stricter for method invocations

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -686,6 +686,9 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 if (method.getName().equals(ref.memberName.toString())) {
                     if (ref.paramTypes != null) {
                         for (JCTree param : ref.paramTypes) {
+                            if (ref.paramTypes.size() != method.getParameterTypes().size()) {
+                                continue;
+                            }
                             for (JavaType testParamType : method.getParameterTypes()) {
                                 Type paramType = attr.attribType(param, symbol);
                                 if (testParamType instanceof JavaType.GenericTypeVariable) {
@@ -701,7 +704,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                                     continue nextMethod;
                                 }
 
-                                if (paramTypeMatches(testParamType, paramType)) {
+                                if (!paramTypeMatches(testParamType, paramType)) {
                                     continue nextMethod;
                                 }
                             }
@@ -725,12 +728,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     }
 
     private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        if (paramType instanceof Type.ClassType) {
-            JavaType.FullyQualified fqTestParamType = TypeUtils.asFullyQualified(testParamType);
-            return fqTestParamType == null || !fqTestParamType.getFullyQualifiedName().equals(((Symbol.ClassSymbol) paramType.tsym)
-                    .fullname.toString());
-        }
-        return false;
+        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -125,7 +125,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                 } else {
                     // Handle consecutive new lines.
                     if ((prev == '\n' ||
-                            prev == '\r' && source.charAt(i - 2) == '\n')) {
+                         prev == '\r' && source.charAt(i - 2) == '\n')) {
                         String prevLineLine = prev == '\n' ? "\n" : "\r\n";
                         lineBreaks.put(javadocContent.length(), new Javadoc.LineBreak(randomId(), prevLineLine, Markers.EMPTY));
                     } else if (marginBuilder != null) { // A new line with no '*' that only contains whitespace.
@@ -581,14 +581,14 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         if (ref.qualifierExpression != null) {
             try {
                 attr.attribType(ref.qualifierExpression, symbol);
-            } catch(NullPointerException ignored) {
+            } catch (NullPointerException ignored) {
                 // best effort, can result in:
                 // java.lang.NullPointerException: Cannot read field "info" because "env" is null
                 //   at com.sun.tools.javac.comp.Attr.attribType(Attr.java:404)
             }
         }
 
-        if(ref.qualifierExpression != null) {
+        if (ref.qualifierExpression != null) {
             qualifier = (TypedTree) javaVisitor.scan(ref.qualifierExpression, Space.EMPTY);
             qualifierType = qualifier.getType();
             if (ref.memberName != null) {
@@ -678,35 +678,23 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     }
 
     private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {
-        if (type instanceof  JavaType.Class) {
+        if (type instanceof JavaType.Class) {
             JavaType.Class classType = (JavaType.Class) type;
 
             nextMethod:
             for (JavaType.Method method : classType.getMethods()) {
                 if (method.getName().equals(ref.memberName.toString())) {
                     if (ref.paramTypes != null) {
-                        for (JCTree param : ref.paramTypes) {
-                            if (ref.paramTypes.size() != method.getParameterTypes().size()) {
-                                continue;
-                            }
-                            for (JavaType testParamType : method.getParameterTypes()) {
-                                Type paramType = attr.attribType(param, symbol);
-                                if (testParamType instanceof JavaType.GenericTypeVariable) {
-                                    List<JavaType> bounds = ((JavaType.GenericTypeVariable) testParamType).getBounds();
-                                    if (bounds.isEmpty() && paramType.tsym != null && "java.lang.Object".equals(paramType.tsym.getQualifiedName().toString())) {
-                                        return method;
-                                    }
-                                    for (JavaType bound : bounds) {
-                                        if (paramTypeMatches(bound, paramType)) {
-                                            return method;
-                                        }
-                                    }
-                                    continue nextMethod;
-                                }
-
-                                if (!paramTypeMatches(testParamType, paramType)) {
-                                    continue nextMethod;
-                                }
+                        List<JavaType> parameterTypes = method.getParameterTypes();
+                        if (ref.paramTypes.size() != parameterTypes.size()) {
+                            continue;
+                        }
+                        for (int i = 0; i < ref.paramTypes.size(); i++) {
+                            JCTree param = ref.paramTypes.get(i);
+                            JavaType testParamType = parameterTypes.get(i);
+                            Type paramType = attr.attribType(param, symbol);
+                            if (!paramTypeMatches(testParamType, paramType)) {
+                                continue nextMethod;
                             }
                         }
                     }
@@ -863,14 +851,14 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     @Override
     public Tree visitText(TextTree node, List<Javadoc> body) {
         throw new UnsupportedOperationException("Anywhere text can occur, we need to call the visitText override that " +
-                "returns a list of Javadoc elements.");
+                                                "returns a list of Javadoc elements.");
     }
 
     public List<Javadoc> visitText(String node) {
         List<Javadoc> texts = new ArrayList<>();
 
         if (!node.isEmpty() && Character.isWhitespace(node.charAt(0)) &&
-                !Character.isWhitespace(source.charAt(cursor))) {
+            !Character.isWhitespace(source.charAt(cursor))) {
             node = node.stripLeading();
         }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -688,6 +688,9 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             for (JavaType.Method method : classType.getMethods()) {
                 if (method.getName().equals(ref.memberName.toString())) {
                     if (ref.paramTypes != null) {
+                        if (ref.paramTypes.size() != method.getParameterTypes().size()) {
+                            continue;
+                        }
                         for (JCTree param : ref.paramTypes) {
                             for (JavaType testParamType : method.getParameterTypes()) {
                                 Type paramType = attr.attribType(param, symbol);
@@ -704,7 +707,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                                     continue nextMethod;
                                 }
 
-                                if (paramTypeMatches(testParamType, paramType)) {
+                                if (!paramTypeMatches(testParamType, paramType)) {
                                     continue nextMethod;
                                 }
                             }
@@ -728,12 +731,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     }
 
     private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        if (paramType instanceof Type.ClassType) {
-            JavaType.FullyQualified fqTestParamType = TypeUtils.asFullyQualified(testParamType);
-            return fqTestParamType == null || !fqTestParamType.getFullyQualifiedName().equals(((Symbol.ClassSymbol) paramType.tsym)
-                    .fullname.toString());
-        }
-        return false;
+        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -688,28 +688,16 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             for (JavaType.Method method : classType.getMethods()) {
                 if (method.getName().equals(ref.memberName.toString())) {
                     if (ref.paramTypes != null) {
-                        if (ref.paramTypes.size() != method.getParameterTypes().size()) {
+                        List<JavaType> parameterTypes = method.getParameterTypes();
+                        if (ref.paramTypes.size() != parameterTypes.size()) {
                             continue;
                         }
-                        for (JCTree param : ref.paramTypes) {
-                            for (JavaType testParamType : method.getParameterTypes()) {
-                                Type paramType = attr.attribType(param, symbol);
-                                if (testParamType instanceof JavaType.GenericTypeVariable) {
-                                    List<JavaType> bounds = ((JavaType.GenericTypeVariable) testParamType).getBounds();
-                                    if (bounds.isEmpty() && paramType.tsym != null && "java.lang.Object".equals(paramType.tsym.getQualifiedName().toString())) {
-                                        return method;
-                                    }
-                                    for (JavaType bound : bounds) {
-                                        if (paramTypeMatches(bound, paramType)) {
-                                            return method;
-                                        }
-                                    }
-                                    continue nextMethod;
-                                }
-
-                                if (!paramTypeMatches(testParamType, paramType)) {
-                                    continue nextMethod;
-                                }
+                        for (int i = 0; i < ref.paramTypes.size(); i++) {
+                            JCTree param = ref.paramTypes.get(i);
+                            JavaType testParamType = parameterTypes.get(i);
+                            Type paramType = attr.attribType(param, symbol);
+                            if (!paramTypeMatches(testParamType, paramType)) {
+                                continue nextMethod;
                             }
                         }
                     }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -688,6 +688,9 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             for (JavaType.Method method : classType.getMethods()) {
                 if (method.getName().equals(ref.memberName.toString())) {
                     if (ref.paramTypes != null) {
+                        if (ref.paramTypes.size() != method.getParameterTypes().size()) {
+                            continue;
+                        }
                         for (JCTree param : ref.paramTypes) {
                             for (JavaType testParamType : method.getParameterTypes()) {
                                 Type paramType = attr.attribType(param, symbol);
@@ -704,7 +707,7 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
                                     continue nextMethod;
                                 }
 
-                                if (paramTypeMatches(testParamType, paramType)) {
+                                if (!paramTypeMatches(testParamType, paramType)) {
                                     continue nextMethod;
                                 }
                             }
@@ -728,12 +731,7 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     }
 
     private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        if (paramType instanceof Type.ClassType) {
-            JavaType.FullyQualified fqTestParamType = TypeUtils.asFullyQualified(testParamType);
-            return fqTestParamType == null || !fqTestParamType.getFullyQualifiedName().equals(((Symbol.ClassSymbol) paramType.tsym)
-                    .fullname.toString());
-        }
-        return false;
+        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -688,28 +688,16 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             for (JavaType.Method method : classType.getMethods()) {
                 if (method.getName().equals(ref.memberName.toString())) {
                     if (ref.paramTypes != null) {
-                        if (ref.paramTypes.size() != method.getParameterTypes().size()) {
+                        List<JavaType> parameterTypes = method.getParameterTypes();
+                        if (ref.paramTypes.size() != parameterTypes.size()) {
                             continue;
                         }
-                        for (JCTree param : ref.paramTypes) {
-                            for (JavaType testParamType : method.getParameterTypes()) {
-                                Type paramType = attr.attribType(param, symbol);
-                                if (testParamType instanceof JavaType.GenericTypeVariable) {
-                                    List<JavaType> bounds = ((JavaType.GenericTypeVariable) testParamType).getBounds();
-                                    if (bounds.isEmpty() && paramType.tsym != null && "java.lang.Object".equals(paramType.tsym.getQualifiedName().toString())) {
-                                        return method;
-                                    }
-                                    for (JavaType bound : bounds) {
-                                        if (paramTypeMatches(bound, paramType)) {
-                                            return method;
-                                        }
-                                    }
-                                    continue nextMethod;
-                                }
-
-                                if (!paramTypeMatches(testParamType, paramType)) {
-                                    continue nextMethod;
-                                }
+                        for (int i = 0; i < ref.paramTypes.size(); i++) {
+                            JCTree param = ref.paramTypes.get(i);
+                            JavaType testParamType = parameterTypes.get(i);
+                            Type paramType = attr.attribType(param, symbol);
+                            if (!paramTypeMatches(testParamType, paramType)) {
+                                continue nextMethod;
                             }
                         }
                     }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -647,25 +647,16 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
         for (JavaType.Method method : classType.getMethods()) {
             if (method.getName().equals(ref.memberName.toString())) {
                 if (ref.paramTypes != null) {
-                    for (JCTree param : ref.paramTypes) {
-                        for (JavaType testParamType : method.getParameterTypes()) {
-                            Type paramType = attr.attribType(param, symbol);
-                            if (testParamType instanceof JavaType.GenericTypeVariable) {
-                                List<JavaType> bounds = ((JavaType.GenericTypeVariable) testParamType).getBounds();
-                                if (bounds.isEmpty() && paramType.tsym != null && "java.lang.Object".equals(paramType.tsym.getQualifiedName().toString())) {
-                                    return method;
-                                }
-                                for (JavaType bound : bounds) {
-                                    if (paramTypeMatches(bound, paramType)) {
-                                        return method;
-                                    }
-                                }
-                                continue nextMethod;
-                            }
-
-                            if (paramTypeMatches(testParamType, paramType)) {
-                                continue nextMethod;
-                            }
+                    List<JavaType> parameterTypes = method.getParameterTypes();
+                    if (ref.paramTypes.size() != parameterTypes.size()) {
+                        continue;
+                    }
+                    for (int i = 0; i < ref.paramTypes.size(); i++) {
+                        JCTree param = ref.paramTypes.get(i);
+                        JavaType testParamType = parameterTypes.get(i);
+                        Type paramType = attr.attribType(param, symbol);
+                        if (!paramTypeMatches(testParamType, paramType)) {
+                            continue nextMethod;
                         }
                     }
                 }
@@ -679,12 +670,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
     }
 
     private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        if (paramType instanceof Type.ClassType) {
-            JavaType.FullyQualified fqTestParamType = TypeUtils.asFullyQualified(testParamType);
-            return fqTestParamType == null || !fqTestParamType.getFullyQualifiedName().equals(((Symbol.ClassSymbol) paramType.tsym)
-                    .fullname.toString());
-        }
-        return false;
+        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -1662,7 +1662,7 @@ class JavadocTest implements RewriteTest {
         rewriteRun(
           java("" +
             "/**\n" +
-            " * <p>Values are converted to strings using {@link java.util.Arrays#compare(Comparable[], Comparable[])}}.\n" +
+            " * <p>Values are converted to strings using {@link java.util.Arrays#compare(Comparable[], Comparable[])}.\n" +
             " */\n" +
             "class A {}"
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
@@ -143,6 +143,18 @@ public class FindMissingTypes extends Recipe {
                     // A different object in one implies a type has changed, either in the method signature or deeper in the type tree.
                     mi = SearchResult.found(mi, "MethodInvocation#name#type is not the same instance as the MethodType of MethodInvocation.");
                 }
+                if (type != null) {
+                    int argCount = 0;
+                    for (Expression argument : mi.getArguments()) {
+                        if (!(argument instanceof J.Empty)) {
+                            argCount++;
+                        }
+                    }
+                    int minCount = type.hasFlags(Flag.Varargs) ? type.getParameterTypes().size() - 1 : type.getParameterTypes().size();
+                    if (argCount < minCount) {
+                        mi = SearchResult.found(mi, "argument count mismatch: " + argCount + " != " + type.getParameterTypes().size());
+                    }
+                }
             }
             return mi;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -273,7 +273,7 @@ public class TypeUtils {
                 JavaType.GenericTypeVariable toGeneric = (JavaType.GenericTypeVariable) to;
                 List<JavaType> toBounds = toGeneric.getBounds();
                 if (toBounds.isEmpty()) {
-                    return true;
+                    return from instanceof JavaType.FullyQualified;
                 } else if (toGeneric.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
                     for (JavaType toBound : toBounds) {
                         if (!isAssignableTo(toBound, from)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -273,7 +273,7 @@ public class TypeUtils {
                 JavaType.GenericTypeVariable toGeneric = (JavaType.GenericTypeVariable) to;
                 List<JavaType> toBounds = toGeneric.getBounds();
                 if (!toGeneric.getName().equals("?")) {
-                    return false;
+                    return !toBounds.isEmpty() && isAssignableTo(toBounds.get(0), from);
                 } else if (toGeneric.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
                     for (JavaType toBound : toBounds) {
                         if (!isAssignableTo(toBound, from)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -288,8 +288,6 @@ public class TypeUtils {
                         }
                     }
                     return true;
-                } else if (toBounds.isEmpty()) {
-                    return from instanceof JavaType.FullyQualified;
                 }
                 return false;
             } else if (to instanceof JavaType.Variable) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -273,7 +273,7 @@ public class TypeUtils {
                 JavaType.GenericTypeVariable toGeneric = (JavaType.GenericTypeVariable) to;
                 List<JavaType> toBounds = toGeneric.getBounds();
                 if (toBounds.isEmpty()) {
-                    return toGeneric.getName().equals("?");
+                    return true;
                 } else if (toGeneric.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
                     for (JavaType toBound : toBounds) {
                         if (!isAssignableTo(toBound, from)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -272,8 +272,8 @@ public class TypeUtils {
                 }
                 JavaType.GenericTypeVariable toGeneric = (JavaType.GenericTypeVariable) to;
                 List<JavaType> toBounds = toGeneric.getBounds();
-                if (!toGeneric.getName().equals("?")) {
-                    return !toBounds.isEmpty() && isAssignableTo(toBounds.get(0), from);
+                if (toBounds.isEmpty()) {
+                    return toGeneric.getName().equals("?");
                 } else if (toGeneric.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
                     for (JavaType toBound : toBounds) {
                         if (!isAssignableTo(toBound, from)) {


### PR DESCRIPTION
Validate argument count with respect to parameter count.
