### PR TITLE
Fix NPE in `SpringReference`

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/trait/SpringReference.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/trait/SpringReference.java
@@ -115,9 +115,12 @@ class SpringReference implements Reference {
         public boolean isAcceptable(SourceFile sourceFile) {
             if (sourceFile instanceof Xml.Document) {
                 Xml.Document doc = (Xml.Document) sourceFile;
-                for (Xml.Attribute attrib : doc.getRoot().getAttributes()) {
-                    if (attrib.getKeyAsString().equals("xsi:schemaLocation") && attrib.getValueAsString().contains("www.springframework.org/schema/beans")) {
-                        return true;
+                //noinspection ConstantValue
+                if (doc.getRoot() != null) {
+                    for (Xml.Attribute attrib : doc.getRoot().getAttributes()) {
+                        if (attrib.getKeyAsString().equals("xsi:schemaLocation") && attrib.getValueAsString().contains("www.springframework.org/schema/beans")) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Failure reported on platform

## Anyone you would like to review specifically?
<!-- @mention them here -->
@knutwannheden 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
# Error:
```
```
# Message:
```
Cannot invoke "org.openrewrite.xml.tree.Xml$Tag.getAttributes()" because the return value of "org.openrewrite.xml.tree.Xml$Document.getRoot()" is null
```
# Detail:
```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.xml.tree.Xml$Tag.getAttributes()" because the return value of "org.openrewrite.xml.tree.Xml$Document.getRoot()" is null
org.openrewrite.xml.trait.SpringReference$Provider.isAcceptable(SpringReference.java:118)
org.openrewrite.SourceFileWithReferences$References.lambda$build$0(SourceFileWithReferences.java:59)
java.base/java.lang.Iterable.forEach(Iterable.java:75)
org.openrewrite.SourceFileWithReferences$References.build(SourceFileWithReferences.java:58)
org.openrewrite.xml.tree.Xml$Document.getReferences(Xml.java:179)
org.openrewrite.java.search.UsesType.visit(UsesType.java:124)
org.openrewrite.TreeVisitor.visitNonNull(TreeVisitor.java:170)
org.openrewrite.java.ChangeType$1.preVisit(ChangeType.java:95)
org.openrewrite.java.ChangeType$1.preVisit(ChangeType.java:83)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:247)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:157)
org.openrewrite.Preconditions$Check.visit(Preconditions.java:174)
org.openrewrite.Preconditions$Check.visit(Preconditions.java:145)
org.openrewrite.scheduling.RecipeRunCycle.lambda$editSources$6(RecipeRunCycle.java:186)
io.micrometer.core.instrument.AbstractTimer.recordCallable(AbstractTimer.java:178)
org.openrewrite.table.RecipeRunStats.recordEdit(RecipeRunStats.java:67)
...
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
