### PR TITLE
Find Refaster style recipes as well

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/table/RewriteRecipeSource.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RewriteRecipeSource.java
@@ -53,6 +53,7 @@ public class RewriteRecipeSource extends DataTable<RewriteRecipeSource.Row> {
 
     public enum RecipeType {
         Java,
+        Refaster,
         Yaml
     }
 }


### PR DESCRIPTION
## What's changed?
Find Refaster style recipes as well; through proxy of `@RecipeDescriptor`.

## What's your motivation?
Be able to analyze the recipes we have, and potentially train on those found.

## Anything in particular you'd like reviewers to focus on?
Added a new `RecipeType.Refaster`; figured that be easier than an `@Option`.

## Have you considered any alternatives or workarounds?
* Separate recipe: more work to maintain.
* An option: needs repeated recipe runs.
* Match `@AfterTemplate`; would then also match those [from Picnic](https://github.com/PicnicSupermarket/error-prone-support/tree/master/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules), but those lack a guaranteed name & description, making them harder to train on.

## Any additional context
- https://bsky.app/profile/agoncal.bsky.social/post/3lbfd2lpny22v