### PR TITLE
`TypeUtils#isAssignable()` improvements

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -728,6 +728,8 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
         } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
             return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.GenericTypeVariable) {
+            return TypeUtils.isObject(mappedJavadocType);
         } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
             return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
         }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -715,8 +715,23 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         return null;
     }
 
-    private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
+    private boolean paramTypeMatches(JavaType parameterType, Type javadocType) {
+        return paramTypeMatches(parameterType, typeMapping.type(javadocType));
+    }
+
+    // Javadoc type references typically don't have generic type parameters
+    private static boolean paramTypeMatches(JavaType parameterType, JavaType mappedJavadocType) {
+        if (parameterType instanceof JavaType.Array && mappedJavadocType instanceof JavaType.Array) {
+            if (((JavaType.Array) parameterType).getElemType() instanceof JavaType.Primitive) {
+                return TypeUtils.isAssignableTo(parameterType, mappedJavadocType, TypeUtils.TypePosition.In);
+            }
+            return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
+        } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
+            return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
+            return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
+        }
+        return TypeUtils.isAssignableTo(parameterType, mappedJavadocType, TypeUtils.TypePosition.In);
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -718,8 +718,23 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         return null;
     }
 
-    private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
+    private boolean paramTypeMatches(JavaType parameterType, Type javadocType) {
+        return paramTypeMatches(parameterType, typeMapping.type(javadocType));
+    }
+
+    // Javadoc type references typically don't have generic type parameters
+    private static boolean paramTypeMatches(JavaType parameterType, JavaType mappedJavadocType) {
+        if (parameterType instanceof JavaType.Array && mappedJavadocType instanceof JavaType.Array) {
+            if (((JavaType.Array) parameterType).getElemType() instanceof JavaType.Primitive) {
+                return TypeUtils.isAssignableTo(parameterType, mappedJavadocType, TypeUtils.TypePosition.In);
+            }
+            return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
+        } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
+            return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
+            return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
+        }
+        return TypeUtils.isAssignableTo(parameterType, mappedJavadocType, TypeUtils.TypePosition.In);
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -731,6 +731,8 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
         } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
             return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.GenericTypeVariable) {
+            return TypeUtils.isObject(mappedJavadocType);
         } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
             return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
         }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -718,8 +718,23 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         return null;
     }
 
-    private boolean paramTypeMatches(JavaType testParamType, Type paramType) {
-        return TypeUtils.isAssignableTo(testParamType, typeMapping.type(paramType));
+    private boolean paramTypeMatches(JavaType parameterType, Type javadocType) {
+        return paramTypeMatches(parameterType, typeMapping.type(javadocType));
+    }
+
+    // Javadoc type references typically don't have generic type parameters
+    private static boolean paramTypeMatches(JavaType parameterType, JavaType mappedJavadocType) {
+        if (parameterType instanceof JavaType.Array && mappedJavadocType instanceof JavaType.Array) {
+            if (((JavaType.Array) parameterType).getElemType() instanceof JavaType.Primitive) {
+                return TypeUtils.isAssignableTo(parameterType, mappedJavadocType, TypeUtils.TypePosition.In);
+            }
+            return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
+        } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
+            return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
+            return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
+        }
+        return TypeUtils.isAssignableTo(parameterType, mappedJavadocType, TypeUtils.TypePosition.In);
     }
 
     private JavaType.@Nullable Variable fieldReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -731,6 +731,8 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
         } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
             return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.GenericTypeVariable) {
+            return TypeUtils.isObject(mappedJavadocType);
         } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
             return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
         }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -682,6 +682,8 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
             return paramTypeMatches(((JavaType.Array) parameterType).getElemType(), ((JavaType.Array) mappedJavadocType).getElemType());
         } else if (parameterType instanceof JavaType.GenericTypeVariable && !((JavaType.GenericTypeVariable) parameterType).getBounds().isEmpty()) {
             return paramTypeMatches(((JavaType.GenericTypeVariable) parameterType).getBounds().get(0), mappedJavadocType);
+        } else if (parameterType instanceof JavaType.GenericTypeVariable) {
+            return TypeUtils.isObject(mappedJavadocType);
         } else if (parameterType instanceof JavaType.Parameterized && !(mappedJavadocType instanceof JavaType.Parameterized)) {
             return paramTypeMatches(((JavaType.Parameterized) parameterType).getType(), mappedJavadocType);
         }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -23,10 +23,13 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
+import java.util.EnumSet;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -330,6 +333,154 @@ class TypeUtilsTest implements RewriteTest {
             }.visit(cu, new InMemoryExecutionContext()))
           )
         );
+    }
+
+    @Test
+    void isAssignableToLong() {
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Long));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Int));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Short));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Char));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Byte));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Double));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Long, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToInt() {
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Long));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Int));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Short));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Char));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Byte));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Double));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Int, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToShort() {
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Long));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Int));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Short));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Char));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Byte));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Double));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Short, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToChar() {
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Long));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Int));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Short));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Char));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Byte));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Double));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Char, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToByte() {
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Long));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Int));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Short));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Char));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Byte));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Double));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Byte, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToDouble() {
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Long));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Int));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Short));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Char));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Byte));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Double));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Double, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToFloat() {
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Long));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Int));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Short));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Char));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Byte));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Double));
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Float));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Boolean));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.None));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Void));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.String));
+        assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Float, JavaType.Primitive.Null));
+    }
+
+    @Test
+    void isAssignableToBoolean() {
+        EnumSet<JavaType.Primitive> others = EnumSet.complementOf(EnumSet.of(JavaType.Primitive.Boolean));
+        for (JavaType.Primitive other : others) {
+            assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Boolean, other));
+        }
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Boolean, JavaType.Primitive.Boolean));
+    }
+
+    @Test
+    void isAssignableToNone() {
+        EnumSet<JavaType.Primitive> others = EnumSet.complementOf(EnumSet.of(JavaType.Primitive.None));
+        for (JavaType.Primitive other : others) {
+            assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.None, other));
+        }
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.None, JavaType.Primitive.None));
+    }
+
+    @Test
+    void isAssignableToVoid() {
+        EnumSet<JavaType.Primitive> others = EnumSet.complementOf(EnumSet.of(JavaType.Primitive.Void));
+        for (JavaType.Primitive other : others) {
+            assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.Void, other));
+        }
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.Void, JavaType.Primitive.Void));
+    }
+
+    @Test
+    void isAssignableToString() {
+        EnumSet<JavaType.Primitive> others = EnumSet.complementOf(EnumSet.of(JavaType.Primitive.String));
+        for (JavaType.Primitive other : others) {
+            assertFalse(TypeUtils.isAssignableTo(JavaType.Primitive.String, other));
+        }
+        assertTrue(TypeUtils.isAssignableTo(JavaType.Primitive.String, JavaType.Primitive.String));
     }
 
     @SuppressWarnings("RedundantCast")

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -271,12 +271,13 @@ class TypeUtilsTest implements RewriteTest {
             spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
                 @Override
                 public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Object o) {
-                    JavaType type = variable.getVariableType().getType();
-                    JavaType exprType = variable.getInitializer().getType();
-                    assertThat(type).isInstanceOf(JavaType.Parameterized.class);
-                    assertThat(exprType).isInstanceOf(JavaType.Parameterized.class);
-                    assertThat(TypeUtils.isAssignableTo(type, exprType)).isTrue();
-                    return super.visitVariable(variable, o);
+                    JavaType.Parameterized wildcardList = (JavaType.Parameterized) variable.getVariableType().getType();
+                    JavaType.FullyQualified rawList = wildcardList.getType();
+                    JavaType.Parameterized stringArrayList = (JavaType.Parameterized) variable.getInitializer().getType();
+                    assertThat(TypeUtils.isAssignableTo(wildcardList, stringArrayList)).isTrue();
+                    assertThat(TypeUtils.isAssignableTo(wildcardList, stringArrayList)).isTrue();
+                    assertThat(TypeUtils.isAssignableTo(wildcardList, rawList)).isTrue();
+                    return variable;
                 }
             }.visit(cu, new InMemoryExecutionContext()))
           )

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -409,8 +409,8 @@ class TypeUtilsTest implements RewriteTest {
                         JavaType consumeClassParamType = ((J.VariableDeclarations) consumeClass.getParameters().get(0)).getVariables().get(0).getType();
                         JavaType consumeMethodParamType = ((J.VariableDeclarations) consumeMethod.getParameters().get(0)).getVariables().get(0).getType();
 
-                        assertThat(TypeUtils.isAssignableTo(consumeClassParamType, list.getType(), Out)).isFalse();
-                        assertThat(TypeUtils.isAssignableTo(consumeMethodParamType, list.getType(), Out)).isFalse();
+                        assertThat(TypeUtils.isAssignableTo(consumeClassParamType, list.getType(), Out)).isTrue();
+                        assertThat(TypeUtils.isAssignableTo(consumeMethodParamType, list.getType(), Out)).isTrue();
                     }
                     return method;
                 }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MinimumJava11;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
@@ -342,6 +343,7 @@ class TypeUtilsTest implements RewriteTest {
     }
 
     @Test
+    @MinimumJava11
     void isAssignableToGenericTypeVariable2() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -253,7 +253,8 @@ public class TypeUtils {
                         }
                         return false;
                     }
-                    return true;
+                    // all wildcards case
+                    return isAssignableTo(toParameterized.getType(), from);
                 }
 
                 JavaType.Parameterized fromParameterized = (JavaType.Parameterized) from;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -291,8 +291,12 @@ public class TypeUtils {
                             } else {
                                 // Bounded wildcard - use the variance from the wildcard
                                 TypePosition wildcardPosition = convertVarianceToPosition(toGeneric.getVariance());
-                                return toGeneric.getBounds().stream()
-                                        .allMatch(bound -> isAssignableTo(bound, fromParam, wildcardPosition));
+                                for (JavaType bound : toGeneric.getBounds()) {
+                                    if (!isAssignableTo(bound, fromParam, wildcardPosition)) {
+                                        return false;
+                                    }
+                                }
+                                return true;
                             }
                         }
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -315,19 +315,23 @@ public class TypeUtils {
 
                 switch (position) {
                     case In:
-                        // In parameter position, we accept any type that satisfies the bounds
+                        // In parameter position (contravariant), the provided type must be a supertype
+                        // of at least one possible type that could satisfy the bounds
+                        for (JavaType bound : toGeneric.getBounds()) {
+                            if (isAssignableTo(from, bound, TypePosition.Invariant)) {
+                                return true;
+                            }
+                        }
+                        return false;
+
+                    case Out:
+                        // In return position (covariant), we can assign any subtype that satisfies the bounds
                         for (JavaType bound : toGeneric.getBounds()) {
                             if (!isAssignableTo(bound, from, TypePosition.Invariant)) {
                                 return false;
                             }
                         }
                         return true;
-
-                    case Out:
-                        // In return position, we cannot safely assign to a type variable
-                        // unless the type is exactly the same type variable
-                        return from instanceof JavaType.GenericTypeVariable &&
-                               toGeneric.getName().equals(((JavaType.GenericTypeVariable) from).getName());
 
                     case Invariant:
                         // In invariant position, types must match exactly

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -302,45 +302,48 @@ public class TypeUtils {
                     return isAssignableTo(boxed, from);
                 } else if (from instanceof JavaType.Primitive) {
                     JavaType.Primitive fromPrimitive = (JavaType.Primitive) from;
-                    if (fromPrimitive == JavaType.Primitive.Boolean || fromPrimitive == JavaType.Primitive.Void) {
-                        return false;
-                    } else {
-                        switch (toPrimitive) {
-                            case Char:
-                                return fromPrimitive == JavaType.Primitive.Byte;
-                            case Short:
-                                switch (fromPrimitive) {
-                                    case Byte:
-                                    case Char:
-                                        return true;
-                                }
-                                return false;
-                            case Int:
-                                switch (fromPrimitive) {
-                                    case Byte:
-                                    case Char:
-                                    case Short:
-                                        return true;
-                                }
-                                return false;
-                            case Long:
-                                switch (fromPrimitive) {
-                                    case Byte:
-                                    case Char:
-                                    case Short:
-                                    case Int:
-                                        return true;
-                                }
-                                return false;
-                            case Float:
-                                return fromPrimitive != JavaType.Primitive.Double;
-                            case Double:
-                                return true;
-                            case String:
-                                return fromPrimitive == JavaType.Primitive.Null;
-                            default:
-                                return false;
-                        }
+                    switch (fromPrimitive) {
+                        case Boolean:
+                        case Void:
+                        case None:
+                        case Null:
+                        case String:
+                            return false;
+                        default:
+                            switch (toPrimitive) {
+                                case Char:
+                                    return false;
+                                case Short:
+                                    switch (fromPrimitive) {
+                                        case Byte:
+                                        case Char:
+                                            return true;
+                                    }
+                                    return false;
+                                case Int:
+                                    switch (fromPrimitive) {
+                                        case Byte:
+                                        case Char:
+                                        case Short:
+                                            return true;
+                                    }
+                                    return false;
+                                case Long:
+                                    switch (fromPrimitive) {
+                                        case Byte:
+                                        case Char:
+                                        case Short:
+                                        case Int:
+                                            return true;
+                                    }
+                                    return false;
+                                case Float:
+                                    return fromPrimitive != JavaType.Primitive.Double;
+                                case Double:
+                                    return true;
+                                default:
+                                    return false;
+                            }
                     }
                 }
             } else if (to instanceof JavaType.Array && from instanceof JavaType.Array) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -347,10 +347,13 @@ public class TypeUtils {
                     }
                 }
             } else if (to instanceof JavaType.Array && from instanceof JavaType.Array) {
-                return isAssignableTo(((JavaType.Array) to).getElemType(), ((JavaType.Array) from).getElemType());
+                JavaType.Array toArray = (JavaType.Array) to;
+                if (toArray.getElemType() instanceof JavaType.Primitive) {
+                    return isOfType(toArray.getElemType(), ((JavaType.Array) from).getElemType());
+                }
+                return isAssignableTo(toArray.getElemType(), ((JavaType.Array) from).getElemType());
             }
-        } catch (Exception e) {
-            return false;
+        } catch (Exception ignored) {
         }
         return false;
     }


### PR DESCRIPTION
`TypeUtils#isAssignable()` is used by many different recipes. One complexity that up until now hadn't been considered is that the assignability check when also considering the call-site variance. For example, checking if `java.util.List<String>` can be assigned to `<T extends java.util.Collection<String>>` depends a lot on where that `<T>` is declared (e.g. as the parameter or return type of a method or the type of a local variable). The API new allows the caller to provide an additional `TypePosition` parameter to indicate this.