### PR TITLE
Add initial support for java references in properties file

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.xml.Assertions.xml;
 
 @SuppressWarnings("ConstantConditions")
@@ -1724,5 +1725,23 @@ class ChangePackageTest implements RewriteTest {
           )
         );
 
+    }
+
+    @Test
+    void changeTypeInPropertiesFile() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackage("java.lang", "java.cool", true)),
+          properties(
+            """
+              a.property=java.lang.String
+              b.property=java.lang.test.String
+              c.property=String
+              """,
+            """
+              a.property=java.cool.String
+              b.property=java.cool.test.String
+              c.property=String
+              """)
+        );
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.xml.Assertions.xml;
+import static org.openrewrite.properties.Assertions.properties;
 
 @SuppressWarnings("ConstantConditions")
 class ChangeTypeTest implements RewriteTest {
@@ -2060,6 +2061,22 @@ class ChangeTypeTest implements RewriteTest {
                 J.ClassDeclaration cd = (J.ClassDeclaration) visitor.visit(source.getClasses().get(0), new InMemoryExecutionContext());
                 assertEquals("GoodbyeClass", cd.getSimpleName());
             }))
+        );
+    }
+
+    @Test
+    void changeTypeInPropertiesFile() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("java.lang.String", "java.lang.Integer", true)),
+          properties(
+            """
+              a.property=java.lang.String
+              b.property=String
+              """,
+            """
+              a.property=java.lang.Integer
+              b.property=String
+              """)
         );
     }
 }

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     api(project(":rewrite-core"))
     api(project(":rewrite-yaml"))
     api(project(":rewrite-xml"))
+    api(project(":rewrite-properties"))
 
     api("io.micrometer:micrometer-core:1.9.+")
     api("org.jetbrains:annotations:latest.release")

--- a/rewrite-java/src/main/java/org/openrewrite/java/PackageMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/PackageMatcher.java
@@ -21,6 +21,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.trait.Reference;
 import org.openrewrite.xml.tree.Xml;
 
@@ -58,6 +59,10 @@ public class PackageMatcher implements Reference.Renamer, Reference.Matcher {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (StringUtils.isNotEmpty(newValue)) {
+                    if (tree instanceof Properties.Entry) {
+                        Properties.Entry entry = (Properties.Entry) tree;
+                        return entry.withValue(entry.getValue().withText(getReplacement(entry.getValue().getText(), targetPackage, newValue)));
+                    }
                     if (tree instanceof Xml.Attribute) {
                         return ((Xml.Attribute) tree).withValue(((Xml.Attribute) tree).getValue().withValue(getReplacement(((Xml.Attribute) tree).getValueAsString(), targetPackage, newValue)));
                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/TypeMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/TypeMatcher.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.tree.TypeTree;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.trait.Reference;
 import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.properties.tree.Properties;
 
 import java.util.regex.Pattern;
 
@@ -126,6 +127,9 @@ public class TypeMatcher implements Reference.Renamer, Reference.Matcher {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (StringUtils.isNotEmpty(newValue)) {
+                    if (tree instanceof Properties.Entry) {
+                        return ((Properties.Entry) tree).withValue(((Properties.Entry) tree).getValue().withText(newValue));
+                    }
                     if (tree instanceof Xml.Attribute) {
                         return ((Xml.Attribute) tree).withValue(((Xml.Attribute) tree).getValue().withValue(newValue));
                     }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/trait/PropertiesReference.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/trait/PropertiesReference.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.properties.trait;
+
+import lombok.Value;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.trait.Reference;
+import org.openrewrite.trait.SimpleTraitMatcher;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Value
+public class PropertiesReference implements Reference {
+    Cursor cursor;
+    Kind kind;
+
+    @Override
+    public @NonNull Kind getKind() {
+        return kind;
+    }
+
+    @Override
+    public @NonNull String getValue() {
+        if (getTree() instanceof Properties.Entry) {
+            return ((Properties.Entry) getTree()).getValue().getText();
+        }
+        throw new IllegalArgumentException("getTree() must be an Properties.Entry: " + getTree().getClass());
+    }
+
+    @Override
+    public boolean supportsRename() {
+        return true;
+    }
+
+    public static class Matcher extends SimpleTraitMatcher<PropertiesReference> {
+        private static final Pattern javaFullyQualifiedTypePattern = Pattern.compile("\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*(?:\\.\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)*");
+
+        @Override
+        protected @Nullable PropertiesReference test(Cursor cursor) {
+            Object value = cursor.getValue();
+            if (value instanceof Properties.Entry && javaFullyQualifiedTypePattern.matcher(((Properties.Entry) value).getValue().getText()).matches()) {
+                if (determineKind(((Properties.Entry) value).getValue().getText()) == Kind.PACKAGE) {
+                    return new PropertiesReference(cursor, Kind.PACKAGE);
+                } else if (determineKind(((Properties.Entry) value).getValue().getText()) == Kind.TYPE) {
+                    return new PropertiesReference(cursor, Kind.TYPE);
+                }
+            }
+            return null;
+        }
+
+        private Kind determineKind(String value) {
+            return Character.isUpperCase(value.charAt(value.lastIndexOf('.') + 1)) ? Kind.TYPE : Kind.PACKAGE;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class Provider implements Reference.Provider {
+        @Override
+        public @NonNull Set<Reference> getReferences(SourceFile sourceFile) {
+            Set<Reference> references = new HashSet<>();
+            new Matcher().asVisitor(reference -> {
+                references.add(reference);
+                return reference.getTree();
+            }).visit(sourceFile, 0);
+            return references;
+        }
+
+        @Override
+        public boolean isAcceptable(SourceFile sourceFile) {
+            return sourceFile instanceof Properties.File;
+        }
+    }
+}

--- a/rewrite-properties/src/main/resources/META-INF/services/org.openrewrite.trait.Reference$Provider
+++ b/rewrite-properties/src/main/resources/META-INF/services/org.openrewrite.trait.Reference$Provider
@@ -1,0 +1,1 @@
+org.openrewrite.properties.trait.PropertiesReference$Provider

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/trait/PropertiesReferenceTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/trait/PropertiesReferenceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.properties.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.trait.Reference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.properties.Assertions.properties;
+
+class PropertiesReferenceTest implements RewriteTest {
+    @Test
+    void testFindJavaReferences() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new PropertiesReference.Matcher()
+            .asVisitor(ref -> SearchResult.found(ref.getTree(), ref.getValue())))),
+          properties(
+            """
+              a.fqt=java.lang.String
+              b.package=java.lang
+              c.type=Integer
+              """,
+            """
+              ~~(java.lang.String)~~>a.fqt=java.lang.String
+              ~~(java.lang)~~>b.package=java.lang
+              c.type=Integer
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                assertThat(doc.getReferences().getReferences().stream().filter(typeRef -> typeRef.getValue().equals("java.lang.String") && typeRef.getKind().equals(Reference.Kind.TYPE)).count()).isEqualTo(1);
+                assertThat(doc.getReferences().getReferences().stream().filter(typeRef -> typeRef.getValue().equals("java.lang") && typeRef.getKind().equals(Reference.Kind.PACKAGE)).count()).isEqualTo(1);
+                assertThat(doc.getReferences().getReferences().stream().anyMatch(typeRef -> typeRef.getValue().equals("Integer"))).isFalse();
+            })
+          ));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add initial support for generating java type references from a `.properties` file, support has only been added for the values, not the keys. 

## What's your motivation?
Adding this feature allows existing recipes that support references to be applied to `.properties` files. For more details see:
- #4681 

## Anything in particular you'd like reviewers to focus on?
The current implementation is still rather limited in its functionality and many design choices are still to be made. 

Currently, references of `Kind.Type` or `Kind.Package` are generated for either a Java package, e.g., `com.openrewrite`, or a fully qualified type, such as `java.lang.Integer`, but not `Integer`, using a regex derived from the current implementation of `SpringReference`. This matching is only done for the **_values_** in a properties file, not the keys. If this is not the case, nearly every key would likely qualify as a package since they usually contain at least a single ".". Is this as desired?

I have added support for renaming `Properties.Entry` in the `TypeMatcher` and `PackageMatcher` and added a test for `ChangeType` and `ChangePackage` recipes. It would perhaps be nice to have a list of all the classes which need to support properties, e.g. `AnnotationMatcher`?


## Anyone you would like to review specifically?
@timtebeek @Laurens-W 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
