### PR TITLE
When comparing Gradle configurations compare the contents not the reference equality 

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleProject.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleProject.java
@@ -135,11 +135,11 @@ public class GradleProject implements Marker, Serializable {
     ) {
         List<GradleDependencyConfiguration> result = new ArrayList<>();
         for (GradleDependencyConfiguration configuration : nameToConfiguration.values()) {
-            if (configuration == parentConfiguration) {
+            if (configuration.equals(parentConfiguration)) {
                 continue;
             }
             for (GradleDependencyConfiguration extendsFrom : configuration.getExtendsFrom()) {
-                if (extendsFrom == parentConfiguration) {
+                if (extendsFrom.equals(parentConfiguration)) {
                     result.add(configuration);
                     if (transitive) {
                         result.addAll(configurationsExtendingFrom(configuration, true));


### PR DESCRIPTION
When we compare Gradle configurations we are checking for reference equality not the contents. We are missing configuration we should be adding when retrieving the list of extended configurations 
