### PR TITLE
Add missing semicolon to JavaTemplate stub when replacing method arguments

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -24,7 +24,6 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Comparator.comparing;
@@ -1356,7 +1355,7 @@ class JavaTemplateTest implements RewriteTest {
                       return JavaTemplate.builder("\"Hello, {}\", \"World!\"")
                         .contextSensitive()
                         .build()
-                        .apply(new Cursor(getCursor().getParent(), mi), mi.getCoordinates().replaceArguments(), new ArrayList<>().toArray());
+                        .apply(new Cursor(getCursor().getParent(), mi), mi.getCoordinates().replaceArguments());
                   }
                   return mi;
               }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -200,7 +200,7 @@ public class JavaTemplateParser {
         J.MethodInvocation method = cursor.getValue();
         String methodWithReplacementArgs = method.withArguments(Collections.emptyList()).printTrimmed(cursor.getParentOrThrow())
                 .replaceAll("\\)$", template + ")");
-        if (!(cursor.getParentTreeCursor().getValue() instanceof J.MethodInvocation)){
+        if (!(cursor.getParentTreeCursor().getValue() instanceof J.MethodInvocation)) {
             methodWithReplacementArgs += ';';
         }
         // TODO: The stub string includes the scoped elements of each original AST, and therefore is not a good

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -200,6 +200,9 @@ public class JavaTemplateParser {
         J.MethodInvocation method = cursor.getValue();
         String methodWithReplacementArgs = method.withArguments(Collections.emptyList()).printTrimmed(cursor.getParentOrThrow())
                 .replaceAll("\\)$", template + ")");
+        if (!(cursor.getParentTreeCursor().getValue() instanceof J.MethodInvocation)){
+            methodWithReplacementArgs += ';';
+        }
         // TODO: The stub string includes the scoped elements of each original AST, and therefore is not a good
         //       cache key. There are virtual no cases where a stub key will result in re-use. If we can come up with
         //       a safe, reusable key, we can consider using the cache for block statements.


### PR DESCRIPTION
- Fixes https://github.com/openrewrite/rewrite-logging-frameworks/pull/186
- Fixes https://github.com/openrewrite/rewrite-logging-frameworks/issues/185
