### PR TITLE
Restrict usage of `RecipeList` methods from `ScanningRecipe`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java
@@ -19,6 +19,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -125,5 +126,16 @@ public abstract class ScanningRecipe<T> extends Recipe {
                 return delegate(ctx).visit(tree, ctx);
             }
         };
+    }
+
+    // For now, ScanningRecipes does not support `*RecipeList`, as the accumulator is not evaluated for these methods
+    @Override
+    public final List<Recipe> getRecipeList() {
+        return super.getRecipeList();
+    }
+
+    @Override
+    public final void buildRecipeList(RecipeList list) {
+        super.buildRecipeList(list);
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java
@@ -128,7 +128,7 @@ public abstract class ScanningRecipe<T> extends Recipe {
         };
     }
 
-    // For now, ScanningRecipes does not support `*RecipeList`, as the accumulator is not evaluated for these methods
+    // For now, ScanningRecipes do not support `*RecipeList`, as the accumulator is not evaluated for these methods
     @Override
     public final List<Recipe> getRecipeList() {
         return super.getRecipeList();

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -247,11 +247,6 @@ public class DeclarativeRecipe extends Recipe {
         }
 
         @Override
-        public List<Recipe> getRecipeList() {
-            return decorateWithPreconditionBellwether(bellwether, delegate.getRecipeList());
-        }
-
-        @Override
         public boolean causesAnotherCycle() {
             return delegate.causesAnotherCycle();
         }


### PR DESCRIPTION
## What's changed?
Make `getRecipeList` and `buildRecipeList` `final` in `ScanningRecipe`.

## What's your motivation?
Frequent source of confusion among users as the scanning conditions are not applied to these methods. Figured by making it explicit that this pattern is not expected or supported we'd see fewer questions like
- https://github.com/openrewrite/rewrite/issues/4711

## Anything in particular you'd like reviewers to focus on?
Any valid cases I'd missed that should support this still?