### PR TITLE
Skip `project` dependencies in `UpgradeDependencyVersion` recipe

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -374,8 +374,9 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
 
         @Override
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-            if ("constraints".equals(method.getSimpleName())) {
+            if ("constraints".equals(method.getSimpleName()) | "project".equals(method.getSimpleName())) {
                 // don't mess with anything inside a constraints block, leave that to UpgradeTransitiveDependency version recipe
+                // `project` dependencies should also be skipped
                 return method;
             }
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -139,6 +139,38 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void deeplyNestedProjectDependency() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              
+              dependencies {
+                implementation project(":foo:bar:baz:qux:quux")
+              }
+              """,
+            spec -> spec.path("build.gradle")
+          ),
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              """,
+            spec -> spec.path("foo/bar/baz/qux/quux/build.gradle")
+          ),
+          settingsGradle(
+            """
+              rootProject.name = 'my-project'
+              include("foo:bar:baz:qux:quux")
+              """
+          )
+        );
+    }
+
+    @Test
     void varargsDependency() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
Project dependencies don't take a GAV as an argument and could cause an exception to be thrown by `DependencyStringNotationConverter#assignValue()` if interpreted as GAVs.
