### PR TITLE
Add RegEx support to ChangeTageValue recipe 

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
@@ -77,7 +77,7 @@ public class ChangeTagValue extends Recipe {
                     if (!Boolean.TRUE.equals(regex) &&
                             (oldValue == null || oldValue.equals(tag.getValue().orElse(null)))) {
                         doAfterVisit(new ChangeTagValueVisitor<>(tag, oldValue, newValue, Boolean.FALSE));
-                    } else if(Boolean.TRUE.equals(regex) && oldValue != null) {
+                    } else if (Boolean.TRUE.equals(regex) && oldValue != null) {
                         doAfterVisit(new ChangeTagValueVisitor<>(tag, oldValue, newValue, Boolean.TRUE));
                     }
                 }
@@ -86,7 +86,8 @@ public class ChangeTagValue extends Recipe {
         };
     }
 
-    public ChangeTagValue(String elementName, @javax.annotation.Nullable String oldValue, String newValue) {
+    public ChangeTagValue(final String elementName, final @javax.annotation.Nullable String oldValue,
+                          final String newValue) {
         this.elementName = elementName;
         this.oldValue = oldValue;
         this.regex = Boolean.FALSE;

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValue.java
@@ -17,7 +17,8 @@ package org.openrewrite.xml;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.NoArgsConstructor;
+import lombok.Data;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
@@ -25,10 +26,10 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.xml.tree.Xml;
 
-
-@Value
-@EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@NoArgsConstructor
+@Data
 public class ChangeTagValue extends Recipe {
 
     @Option(displayName = "Element name",

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValueVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValueVisitor.java
@@ -34,14 +34,15 @@ public class ChangeTagValueVisitor<P> extends XmlVisitor<P> {
     private final String oldValue;
     private final boolean regexp;
 
-    public ChangeTagValueVisitor(Xml.Tag scope, @javax.annotation.Nullable String oldValue, String newValue, Boolean regexp) {
+    public ChangeTagValueVisitor(final Xml.Tag scope, final @javax.annotation.Nullable String oldValue,
+                                 final String newValue, final Boolean regexp) {
         this.scope = scope;
         this.oldValue = oldValue;
         this.newValue = newValue;
         this.regexp = Boolean.TRUE.equals(regexp);
     }
 
-    public ChangeTagValueVisitor(Xml.Tag scope, String newValue) {
+    public ChangeTagValueVisitor(final Xml.Tag scope, final String newValue) {
         this.scope = scope;
         this.oldValue = null;
         this.newValue = newValue;
@@ -60,10 +61,10 @@ public class ChangeTagValueVisitor<P> extends XmlVisitor<P> {
             String prefix = "";
             String afterText = "";
             if (t.getContent() != null && t.getContent().size() == 1 && t.getContent().get(0) instanceof Xml.CharData) {
-                Xml.CharData existingValue = (Xml.CharData) t.getContent().get(0);
-                String text = existingValue.getText();
+                final Xml.CharData existingValue = (Xml.CharData) t.getContent().get(0);
+                final String text = existingValue.getText();
 
-                boolean alreadyProcessed = this.regexp && existingValue.getMarkers()
+                final boolean alreadyProcessed = this.regexp && existingValue.getMarkers()
                         .findAll(AlreadyReplaced.class)
                         .stream()
                         .anyMatch(m -> m.getFind().equals(oldValue) && newValue.equals(m.getReplace()));
@@ -77,8 +78,10 @@ public class ChangeTagValueVisitor<P> extends XmlVisitor<P> {
                 afterText = existingValue.getAfterText();
 
                 if(regexp && oldValue != null && Pattern.compile(oldValue).matcher(text).find()) {
-                    String newContent = text.replaceAll(oldValue, Matcher.quoteReplacement(newValue));
-                    Markers markers = Markers.build(singletonList( new AlreadyReplaced(randomId(),oldValue, newValue)));
+                    final String newContent = text.replaceAll(oldValue, Matcher.quoteReplacement(newValue));
+                    final Markers markers = Markers.build(
+                            singletonList( new AlreadyReplaced(randomId(),oldValue, newValue))
+                    );
                     t = t.withContent(singletonList(new Xml.CharData(randomId(),
                             prefix, markers, false, newContent, afterText)));
                 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValueVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/ChangeTagValueVisitor.java
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 package org.openrewrite.xml;
-
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.marker.AlreadyReplaced;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.xml.tree.Xml;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
@@ -24,32 +29,65 @@ import static org.openrewrite.Tree.randomId;
 public class ChangeTagValueVisitor<P> extends XmlVisitor<P> {
 
     private final Xml.Tag scope;
-    private final String value;
+    private final String newValue;
+    @Nullable
+    private final String oldValue;
+    private final boolean regexp;
 
-    public ChangeTagValueVisitor(Xml.Tag scope, String value) {
+    public ChangeTagValueVisitor(Xml.Tag scope, @javax.annotation.Nullable String oldValue, String newValue, Boolean regexp) {
         this.scope = scope;
-        this.value = value;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+        this.regexp = Boolean.TRUE.equals(regexp);
+    }
+
+    public ChangeTagValueVisitor(Xml.Tag scope, String newValue) {
+        this.scope = scope;
+        this.oldValue = null;
+        this.newValue = newValue;
+        this.regexp = Boolean.FALSE;
     }
 
     @Override
     public Xml visitTag(Xml.Tag tag, P p) {
         Xml.Tag t = (Xml.Tag) super.visitTag(tag, p);
+
         if (scope.isScope(t)) {
+            if(Objects.equals(newValue, oldValue)) {
+                return tag;
+            }
+
             String prefix = "";
             String afterText = "";
             if (t.getContent() != null && t.getContent().size() == 1 && t.getContent().get(0) instanceof Xml.CharData) {
                 Xml.CharData existingValue = (Xml.CharData) t.getContent().get(0);
+                String text = existingValue.getText();
 
-                if (existingValue.getText().equals(value)) {
+                boolean alreadyProcessed = this.regexp && existingValue.getMarkers()
+                        .findAll(AlreadyReplaced.class)
+                        .stream()
+                        .anyMatch(m -> m.getFind().equals(oldValue) && newValue.equals(m.getReplace()));
+
+                if (alreadyProcessed || (!regexp && text.equals(newValue))) {
                     return tag;
                 }
 
                 // if the previous content was also character data, preserve its prefix and afterText
                 prefix = existingValue.getPrefix();
                 afterText = existingValue.getAfterText();
+
+                if(regexp && oldValue != null && Pattern.compile(oldValue).matcher(text).find()) {
+                    String newContent = text.replaceAll(oldValue, Matcher.quoteReplacement(newValue));
+                    Markers markers = Markers.build(singletonList( new AlreadyReplaced(randomId(),oldValue, newValue)));
+                    t = t.withContent(singletonList(new Xml.CharData(randomId(),
+                            prefix, markers, false, newContent, afterText)));
+                }
+
             }
-            t = t.withContent(singletonList(new Xml.CharData(randomId(),
-                    prefix, Markers.EMPTY, false, value, afterText)));
+            if(!regexp) {
+                t = t.withContent(singletonList(new Xml.CharData(randomId(),
+                        prefix, Markers.EMPTY, false, newValue, afterText)));
+            }
         }
 
         return t;

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+import static org.openrewrite.xml.Assertions.xml;
+
+class ChangeTagValueTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void rewriteEmptyTagValue() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new ChangeTagValue("/dependency/version",
+              null, "2.0", null)),
+          xml(
+            """
+              <dependency>
+                  <version/>
+              </dependency>
+              """,
+            """
+              <dependency>
+                  <version>2.0</version>
+              </dependency>
+              """
+            , spec -> spec.path("pom.xml"))
+        );
+    }
+
+    @Test
+    void rewriteTagValueSubstring() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new ChangeTagValue("/dependency/version",
+              "SNAPSHOT", "RELEASE", Boolean.TRUE)
+          ),
+          xml("""
+                          <dependency>
+                            <group>com.company.project</group>
+                            <group>artifact</group>
+                            <version>1.2.3-SNAPSHOT</version>
+                          </dependency>
+                    """,
+            """
+                  <dependency>
+                    <group>com.company.project</group>
+                    <group>artifact</group>
+                    <version>1.2.3-RELEASE</version>
+                  </dependency>
+            """, spec -> spec.path("pom.xml")
+          )
+        );
+    }
+
+
+    @Test
+    void appendTagValue() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new ChangeTagValue("/dependency/version",
+              "$", "-RELEASE", Boolean.TRUE)
+          ),
+          xml("""
+                          <dependency>
+                            <group>com.company.project</group>
+                            <group>artifact</group>
+                            <version>1.2.3</version>
+                          </dependency>
+                    """,
+            """
+                  <dependency>
+                    <group>com.company.project</group>
+                    <group>artifact</group>
+                    <version>1.2.3-RELEASE</version>
+                  </dependency>
+            """, spec -> spec.path("pom.xml")
+          )
+        );
+    }
+}

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueVisitorTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueVisitorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.xml;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What's changed?
Allows ChangeTagValue to take in regex in `oldValue` parameter.

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4731

## Anything in particular you'd like reviewers to focus on?
First of,  if there's no popular / recommended alternatives and if not then if this makes sense. Then I'll make it ready for review.

Please leave your thoughts here or on the issue https://github.com/openrewrite/rewrite/issues/4731. 

## Anyone you would like to review specifically?
@timtebeek? - Because I see you actively replying ;) 
@gadams00 - Because, history.

## Have you considered any alternatives or workarounds?

Not really. I found this to be more appealing.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
