### PR TITLE
Resove dependencies bom with properties on `ChangeParentPom`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
@@ -68,11 +68,11 @@ public class PropertyPlaceholderHelper {
         return replacePlaceholders(value, properties::getProperty);
     }
 
-    public String replacePlaceholders(String value, Function<String, String> placeholderResolver) {
+    public String replacePlaceholders(String value, Function<String, @Nullable String> placeholderResolver) {
         return parseStringValue(value, placeholderResolver, null);
     }
 
-    protected String parseStringValue(String value, Function<String, String> placeholderResolver,
+    protected String parseStringValue(String value, Function<String, @Nullable String> placeholderResolver,
                                       @Nullable Set<String> visitedPlaceholders) {
         int startIndex = value.indexOf(placeholderPrefix);
         if (startIndex == -1) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -81,6 +81,103 @@ class ChangeParentPomTest implements RewriteTest {
     }
 
     @Test
+    void changeParentShouldResolveDependenciesMangementWithMavenProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeParentPom(
+            "org.jenkins-ci.plugins",
+            "org.jenkins-ci.plugins",
+            "plugin",
+            "plugin",
+            "5.3",
+            null,
+            null,
+            null,
+            false
+          )),
+          pomXml(
+            """
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>example-plugin</artifactId>
+                  <version>0.8-SNAPSHOT</version>
+                  <properties>
+                      <jenkins.baseline>2.462</jenkins.baseline>
+                      <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                     <dependencies>
+                         <dependency>
+                             <groupId>io.jenkins.tools.bom</groupId>
+                             <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                             <version>3722.vcc62e7311580</version>
+                             <type>pom</type>
+                             <scope>import</scope>
+                         </dependency>
+                     </dependencies>
+                 </dependencyManagement>
+                 <dependencies>
+                     <dependency>
+                         <groupId>org.jenkins-ci.plugins</groupId>
+                         <artifactId>scm-api</artifactId>
+                     </dependency>
+                 </dependencies>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+              </project>
+              """,
+            """
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>5.3</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>example-plugin</artifactId>
+                  <version>0.8-SNAPSHOT</version>
+                  <properties>
+                      <jenkins.baseline>2.462</jenkins.baseline>
+                      <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                     <dependencies>
+                         <dependency>
+                             <groupId>io.jenkins.tools.bom</groupId>
+                             <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                             <version>3722.vcc62e7311580</version>
+                             <type>pom</type>
+                             <scope>import</scope>
+                         </dependency>
+                     </dependencies>
+                 </dependencyManagement>
+                 <dependencies>
+                     <dependency>
+                         <groupId>org.jenkins-ci.plugins</groupId>
+                         <artifactId>scm-api</artifactId>
+                     </dependency>
+                 </dependencies>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void changeParentWithRelativePath() {
         rewriteRun(
           spec -> spec.recipe(new ChangeParentPom(


### PR DESCRIPTION
~~This just demonstrate an issue we are facing with jenkins modernization.~~

The `ChangeParentPom` recipe wrongly add a dependency into dependency management when it should not

Such dependency is still managed by the bom.

```
    +            <dependency>
    +                <groupId>org.jenkins-ci.plugins</groupId>
    +                <artifactId>scm-api</artifactId>
    +                <version>698.v8e3b_c788f0a_6</version>
    +            </dependency>
```

I think it cause issue because the `${jenkins.baseline}` on the artifact id.

But I don't know how and the best way to fix it

Any help would be appreciated

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
