### PR TITLE
Fix Gradle/Groovy parser issue related to Java class references

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1374,7 +1374,7 @@ public class GroovyParserVisitor {
         public void visitConstructorCallExpression(ConstructorCallExpression ctor) {
             queue.add(insideParentheses(ctor, fmt -> {
                 cursor += 3; // skip "new"
-                TypeTree clazz = visitTypeTree(ctor.getType(), ctor.getMetaDataMap().containsKey(StaticTypesMarker.INFERRED_TYPE));
+                TypeTree clazz = visitTypeTree(ctor.getType(), ctor.getNodeMetaData().containsKey(StaticTypesMarker.INFERRED_TYPE));
                 JContainer<Expression> args = visit(ctor.getArguments());
                 J.Block body = null;
                 if (ctor.isUsingAnonymousInnerClass() && ctor.getType() instanceof InnerClassNode) {


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Use different way of retrieving metadata map

## Anyone you would like to review specifically?
<!-- @mention them here -->
@sambsnyd @timtebeek @knutwannheden 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Exception that was being swallowed:
`java.lang.NoSuchMethodError: org.codehaus.groovy.ast.expr.ConstructorCallExpression.getMetaDataMap()Ljava/util/Map;`

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
