### PR TITLE
Take `J.Case` into account in JavaTemplate

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -463,16 +463,17 @@ public class BlockStatementTemplateGenerator {
             // If prior is a type parameter, wrap in __M__.anyT<prior>()
             // For anything else, ignore the invocation
             J.MethodInvocation m = (J.MethodInvocation) j;
+            J firstEnclosing = cursor.getParentOrThrow().firstEnclosing(J.class);
             if (m.getArguments().stream().anyMatch(arg -> referToSameElement(prior, arg))) {
                 before.insert(0, "__M__.any(");
-                if (cursor.getParentOrThrow().firstEnclosing(J.class) instanceof J.Block) {
+                if (firstEnclosing instanceof J.Block || firstEnclosing instanceof J.Case) {
                     after.append(");");
                 } else {
                     after.append(")");
                 }
             } else if (m.getTypeParameters() != null && m.getTypeParameters().stream().anyMatch(tp -> referToSameElement(prior, tp))) {
                 before.insert(0, "__M__.anyT<");
-                if (cursor.getParentOrThrow().firstEnclosing(J.class) instanceof J.Block) {
+                if (firstEnclosing instanceof J.Block || firstEnclosing instanceof J.Case) {
                     after.append(">();");
                 } else {
                     after.append(">()");
@@ -481,7 +482,7 @@ public class BlockStatementTemplateGenerator {
                 List<Comment> comments = new ArrayList<>(1);
                 comments.add(new TextComment(true, STOP_COMMENT, "", Markers.EMPTY));
                 after.append(".").append(m.withSelect(null).withComments(comments).printTrimmed(cursor.getParentOrThrow()));
-                if (cursor.getParentOrThrow().firstEnclosing(J.class) instanceof J.Block) {
+                if (firstEnclosing instanceof J.Block || firstEnclosing instanceof J.Case) {
                     after.append(";");
                 }
             }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
`J.Case` is now handled as a block of code that needs method invocations to be ended with a semicolon

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- https://github.com/openrewrite/rewrite-logging-frameworks/issues/192

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Relevant test case
- https://github.com/openrewrite/rewrite-logging-frameworks/issues/192

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
