### PR TITLE
Always add closing semicolon for `J.Case` in JavaTemplate

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -562,6 +562,8 @@ public class BlockStatementTemplateGenerator {
             before.insert(0, ev.getName());
         } else if (j instanceof J.EnumValueSet) {
             after.append(";");
+        } else if (j instanceof J.Case) {
+            after.append(";");
         }
         contextTemplate(next(cursor), j, before, after, insertionPoint, REPLACEMENT);
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
`J.Case` is now handled as a block of code that needs method invocations to be ended with a semicolon

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- https://github.com/openrewrite/rewrite/pull/4744

feedback here after initial change

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
