### PR TITLE
Update get classpath by artifact name to support bazel

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -29,8 +29,10 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -213,5 +215,23 @@ class JavaParserTest implements RewriteTest {
               ))
           )
         );
+    }
+
+    @Test
+    void filterArtifacts() {
+        List<URI> classpath = List.of(
+          URI.create("file:/.m2/repository/com/google/guava/guava-24.1.1/com_google_guava_guava-24.1.1.jar"),
+          URI.create("file:/.m2/repository/org/threeten/threeten-extra-1.5.0/org_threeten_threeten_extra-1.5.0.jar"),
+          URI.create("file:/.m2/repository/com/amazonaws/aws-java-sdk-s3-1.11.546/com_amazonaws_aws_java_sdk_s3-1.11.546.jar"),
+          URI.create("file:/.m2/repository/org/openrewrite/rewrite-java/8.41.1/rewrite-java-8.41.1.jar")
+        );
+        assertThat(JavaParser.filterArtifacts("threeten-extra", classpath))
+          .containsOnly(Paths.get("/.m2/repository/org/threeten/threeten-extra-1.5.0/org_threeten_threeten_extra-1.5.0.jar"));
+        assertThat(JavaParser.filterArtifacts("guava", classpath))
+          .containsOnly(Paths.get("/.m2/repository/com/google/guava/guava-24.1.1/com_google_guava_guava-24.1.1.jar"));
+        assertThat(JavaParser.filterArtifacts("aws-java-sdk-s3", classpath))
+          .containsOnly(Paths.get("/.m2/repository/com/amazonaws/aws-java-sdk-s3-1.11.546/com_amazonaws_aws_java_sdk_s3-1.11.546.jar"));
+        assertThat(JavaParser.filterArtifacts("rewrite-java", classpath))
+          .containsOnly(Paths.get("/.m2/repository/org/openrewrite/rewrite-java/8.41.1/rewrite-java-8.41.1.jar"));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -77,8 +77,9 @@ public interface JavaParser extends Parser {
             List<Path> matchedArtifacts = filterArtifacts(artifactName, runtimeClasspath);
             if (matchedArtifacts.isEmpty()) {
                 missingArtifactNames.add(artifactName);
+            } else {
+                artifacts.addAll(matchedArtifacts);
             }
-            artifacts.addAll(matchedArtifacts);
         }
 
         if (!missingArtifactNames.isEmpty()) {
@@ -103,7 +104,7 @@ public interface JavaParser extends Parser {
         List<Path> artifacts = new ArrayList<>();
         // Bazel automatically replaces '-' with '_' when generating jar files.
         String normalizedArtifactName = artifactName.replace('-', '_');
-        Pattern jarPattern = Pattern.compile("(" + artifactName + "|" + normalizedArtifactName + ")" + "(?:" + "-.*?" + ")?" + "\\.jar$");
+        Pattern jarPattern = Pattern.compile(String.format("(%s|%s)(?:-.*?)?\\.jar$", artifactName, normalizedArtifactName));
         // In a multi-project IDE classpath, some classpath entries aren't jars
         Pattern explodedPattern = Pattern.compile("/" + artifactName + "/");
         for (URI cpEntry : runtimeClasspath) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -74,27 +74,11 @@ public interface JavaParser extends Parser {
         List<Path> artifacts = new ArrayList<>(artifactNames.length);
         List<String> missingArtifactNames = new ArrayList<>(artifactNames.length);
         for (String artifactName : artifactNames) {
-            Pattern jarPattern = Pattern.compile(artifactName + "(?:" + "-.*?" + ")?" + "\\.jar$");
-            // In a multi-project IDE classpath, some classpath entries aren't jars
-            Pattern explodedPattern = Pattern.compile("/" + artifactName + "/");
-            boolean lacking = true;
-            for (URI cpEntry : runtimeClasspath) {
-                if (!"file".equals(cpEntry.getScheme())) {
-                    // exclude any `jar` entries which could result from `Bundle-ClassPath` in `MANIFEST.MF`
-                    continue;
-                }
-                String cpEntryString = cpEntry.toString();
-                Path path = Paths.get(cpEntry);
-                if (jarPattern.matcher(cpEntryString).find() ||
-                    explodedPattern.matcher(cpEntryString).find() && path.toFile().isDirectory()) {
-                    artifacts.add(path);
-                    lacking = false;
-                    // Do not break because jarPattern matches "foo-bar-1.0.jar" and "foo-1.0.jar" to "foo"
-                }
-            }
-            if (lacking) {
+            List<Path> matchedArtifacts = filterArtifacts(artifactName, runtimeClasspath);
+            if (matchedArtifacts.isEmpty()) {
                 missingArtifactNames.add(artifactName);
             }
+            artifacts.addAll(matchedArtifacts);
         }
 
         if (!missingArtifactNames.isEmpty()) {
@@ -104,6 +88,37 @@ public interface JavaParser extends Parser {
                     ", classpath: " + runtimeClasspath);
         }
 
+        return artifacts;
+    }
+
+    /**
+     * Filters the classpath entries to find paths that match the given artifact name.
+     *
+     * @param artifactName    The artifact name to search for.
+     * @param runtimeClasspath The list of classpath URIs to search within.
+     * @return List of Paths that match the artifact name.
+     */
+    // VisibleForTesting
+    static List<Path> filterArtifacts(String artifactName, List<URI> runtimeClasspath) {
+        List<Path> artifacts = new ArrayList<>();
+        // Bazel automatically replaces '-' with '_' when generating jar files.
+        String normalizedArtifactName = artifactName.replace('-', '_');
+        Pattern jarPattern = Pattern.compile("(" + artifactName + "|" + normalizedArtifactName + ")" + "(?:" + "-.*?" + ")?" + "\\.jar$");
+        // In a multi-project IDE classpath, some classpath entries aren't jars
+        Pattern explodedPattern = Pattern.compile("/" + artifactName + "/");
+        for (URI cpEntry : runtimeClasspath) {
+            if (!"file".equals(cpEntry.getScheme())) {
+                // exclude any `jar` entries which could result from `Bundle-ClassPath` in `MANIFEST.MF`
+                continue;
+            }
+            String cpEntryString = cpEntry.toString();
+            Path path = Paths.get(cpEntry);
+            if (jarPattern.matcher(cpEntryString).find() ||
+                explodedPattern.matcher(cpEntryString).find() && path.toFile().isDirectory()) {
+                artifacts.add(path);
+                // Do not break because jarPattern matches "foo-bar-1.0.jar" and "foo-1.0.jar" to "foo"
+            }
+        }
         return artifacts;
     }
 


### PR DESCRIPTION
## What's changed?
Added support to retrieve the classpath by artifact name for Bazel projects.

## What's your motivation?
In Bazel projects, creating an instance of JavaParser with artifact names as classpath can fail when artifact names include a "-". This issue arises because Bazel replaces "-" with "_" when generating JAR files.

Example usage
```
JavaParser.fromJavaVersion().classpath("aws-java-sdk-s3").build()
```
Above code fails with `IllegalStateException Unable to construct JavaParser`.


To address this, updated JarPattern to include the normalized artifact name, ensuring it can correctly locate the JAR file names generated using bazel convention.

Note: A minor refactor to make code testable for the part which was updated.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
