### PR TITLE
`RemoveMethodInvocationsVisitor` can remove static method

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
@@ -85,7 +85,7 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
 
         if (matchers.entrySet().stream().anyMatch(entry -> matches(m, entry.getKey(), entry.getValue()))) {
             boolean hasSameReturnType = m.getSelect() != null && TypeUtils.isAssignableTo(m.getMethodType().getReturnType(), m.getSelect().getType());
-            boolean removable = ((isStatement || isStatic) && (depth == 0)) || hasSameReturnType;
+            boolean removable = ((isStatement || isStatic) && depth == 0) || hasSameReturnType;
             if (!removable) {
                 return expression;
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
@@ -81,11 +81,11 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
             return expression;
         }
 
-        boolean isStatement = isStatement();
+        boolean isStatementOrStatic = isStatement() || isStatic;
 
         if (matchers.entrySet().stream().anyMatch(entry -> matches(m, entry.getKey(), entry.getValue()))) {
             boolean hasSameReturnType = m.getSelect() != null && TypeUtils.isAssignableTo(m.getMethodType().getReturnType(), m.getSelect().getType());
-            boolean removable = (isStatement && depth == 0) || hasSameReturnType;
+            boolean removable = (isStatementOrStatic && depth == 0) || hasSameReturnType;
             if (!removable) {
                 return expression;
             }
@@ -100,7 +100,7 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
                     selectAfter.add(getSelectAfter(m));
                     return m.getSelect();
                 } else {
-                    if (isStatement) {
+                    if (isStatementOrStatic) {
                         return null;
                     } else if (isLambdaBody) {
                         return ToBeRemoved.withMarker(J.Block.createEmptyBlock());

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
@@ -69,26 +69,32 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
         return j;
     }
 
-    private @Nullable J removeMethods(Expression expression, int depth, boolean isLambdaBody, Stack<Space> selectAfter) {
-        if (!(expression instanceof J.MethodInvocation)) {
+    private @Nullable J removeMethods(@Nullable Expression expression, int depth, boolean isLambdaBody, Stack<Space> selectAfter) {
+        if (!(expression instanceof J.MethodInvocation) || ((J.MethodInvocation) expression).getMethodType() == null) {
+            return expression;
+        }
+
+        J.MethodInvocation m = (J.MethodInvocation) expression;
+        boolean isStatic = m.getMethodType().hasFlags(Flag.Static);
+
+        if (m.getSelect() == null && !isStatic) {
             return expression;
         }
 
         boolean isStatement = isStatement();
-        J.MethodInvocation m = (J.MethodInvocation) expression;
-
-        if (m.getMethodType() == null || m.getSelect() == null) {
-            return expression;
-        }
 
         if (matchers.entrySet().stream().anyMatch(entry -> matches(m, entry.getKey(), entry.getValue()))) {
-            boolean hasSameReturnType = TypeUtils.isAssignableTo(m.getMethodType().getReturnType(), m.getSelect().getType());
+            boolean hasSameReturnType = m.getSelect() != null && TypeUtils.isAssignableTo(m.getMethodType().getReturnType(), m.getSelect().getType());
             boolean removable = (isStatement && depth == 0) || hasSameReturnType;
             if (!removable) {
                 return expression;
             }
 
-            if (m.getSelect() instanceof J.Identifier || m.getSelect() instanceof J.NewClass) {
+            maybeRemoveImport(m.getMethodType().getDeclaringType());
+
+            if (isStatic) {
+                return null;
+            } else if (m.getSelect() instanceof J.Identifier || m.getSelect() instanceof J.NewClass) {
                 boolean keepSelect = depth != 0;
                 if (keepSelect) {
                     selectAfter.add(getSelectAfter(m));
@@ -241,7 +247,7 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
 
     @Value
     @With
-    static class ToBeRemoved implements Marker {
+    private static class ToBeRemoved implements Marker {
         UUID id;
         static <J2 extends J> J2 withMarker(J2 j) {
             return j.withMarkers(j.getMarkers().addIfAbsent(new ToBeRemoved(randomId())));

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocationsVisitor.java
@@ -77,7 +77,7 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
         J.MethodInvocation m = (J.MethodInvocation) expression;
         boolean isStatic = m.getMethodType().hasFlags(Flag.Static);
 
-        if ((m.getSelect() == null && !isStatic) || (isStatic && !isStatementInParentBlock(m))) {
+        if (isStatic && !isStatementInParentBlock(m)) {
             return expression;
         }
 
@@ -92,7 +92,7 @@ public class RemoveMethodInvocationsVisitor extends JavaVisitor<ExecutionContext
 
             maybeRemoveImport(m.getMethodType().getDeclaringType());
 
-            if (isStatic) {
+            if (m.getSelect() == null) {
                 return null;
             } else if (m.getSelect() instanceof J.Identifier || m.getSelect() instanceof J.NewClass) {
                 boolean keepSelect = depth != 0;

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -520,7 +520,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
-    void removeStaticMethodFromImportWithAssignment() {
+    void keepStaticMethodFromImportWithAssignment() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
           // language=java
@@ -533,6 +533,28 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList = emptyList();
+                      emptyList.isEmpty();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepStaticMethodFromImportWithAssignment2() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          // language=java
+          java(
+            """
+              import java.util.List;
+              
+              import static java.util.Collections.emptyList;
+              
+              class Test {
+                  List<Object> emptyList = emptyList();
+                  void method() {
                       emptyList.isEmpty();
                   }
               }
@@ -567,7 +589,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
-    void removeStaticMethodWithAssignment() {
+    void keepStaticMethodWithAssignment() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
           // language=java
@@ -579,6 +601,27 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList = Collections.emptyList();
+                      emptyList.size();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepStaticMethodWithAssignment2() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          // language=java
+          java(
+            """
+              import java.util.List;
+              import java.util.Collections;
+              
+              class Test {
+                  List<Object> emptyList = Collections.emptyList();
+                  void method() {
                       emptyList.size();
                   }
               }

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -531,6 +531,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList = emptyList();
+                      emptyList.isEmpty();
                   }
               }
               """,
@@ -538,6 +539,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList;
+                      emptyList.isEmpty();
                   }
               }
               """
@@ -582,6 +584,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList = Collections.emptyList();
+                      emptyList.isEmpty();
                   }
               }
               """,
@@ -589,6 +592,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList;
+                      emptyList.isEmpty();
                   }
               }
               """

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -578,8 +578,8 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               
               class Test {
                   void method() {
-                      List<String> l = Collections.emptyList();
-                      l.size();
+                      List<Object> emptyList = Collections.emptyList();
+                      emptyList.size();
                   }
               }
               """

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -542,7 +542,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
-    void keepStaticMethodFromImportWithAssignment2() {
+    void keepStaticMethodFromImportClassField() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
           // language=java
@@ -610,7 +610,7 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
-    void keepStaticMethodWithAssignment2() {
+    void keepStaticMethodClassField() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
           // language=java

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -520,6 +520,32 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
+    void removeStaticMethodFromImportWithAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          // language=java
+          java(
+            """
+              import static java.util.Collections.emptyList;
+              
+              class Test {
+                  void method() {
+                      List<Object> emptyList = emptyList();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      List<Object> emptyList;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeStaticMethod() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("org.junit.jupiter.api.Assertions assertTrue(..)")),
@@ -537,6 +563,32 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
             """
               class Test {
                   void method() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeStaticMethodWithAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          // language=java
+          java(
+            """
+              import java.util.Collections;
+              
+              class Test {
+                  void method() {
+                      List<Object> emptyList = Collections.emptyList();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      List<Object> emptyList;
                   }
               }
               """

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -173,7 +173,6 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
-    @ExpectedToFail
     void removeWithoutSelect() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("Test foo()")),
@@ -487,37 +486,6 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
                       } catch (Exception e) {
                       } finally {
                       }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void removeLocalMethodInvocation() {
-        rewriteRun(
-          spec -> spec.recipe(createRemoveMethodsRecipe("a.A b(..)")),
-          // language=java
-          java(
-            """
-              package a;
-              
-              class A {
-                  void a() {
-                      b();
-                  }
-                  void b() {
-                  }
-              }
-              """,
-            """
-              package a;
-              
-              class A {
-                  void a() {
-                  }
-                  void b() {
                   }
               }
               """

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -534,14 +534,6 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
                       emptyList.isEmpty();
                   }
               }
-              """,
-            """
-              class Test {
-                  void method() {
-                      List<Object> emptyList;
-                      emptyList.isEmpty();
-                  }
-              }
               """
           )
         );
@@ -584,14 +576,6 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
               class Test {
                   void method() {
                       List<Object> emptyList = Collections.emptyList();
-                      emptyList.isEmpty();
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void method() {
-                      List<Object> emptyList;
                       emptyList.isEmpty();
                   }
               }

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -15,13 +15,14 @@
  */
 package org.openrewrite.java;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.List;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -486,6 +487,56 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
                       } catch (Exception e) {
                       } finally {
                       }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeStaticMethodFromImport() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          // language=java
+          java(
+            """
+              import static java.util.Collections.emptyList;
+              
+              class Test {
+                  void method() {
+                      List<Object> emptyList = emptyList();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeStaticMethod() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          // language=java
+          java(
+            """
+              import java.util.Collections;
+              
+              class Test {
+                  void method() {
+                      List<Object> emptyList = Collections.emptyList();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
                   }
               }
               """

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -497,15 +497,15 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     @Test
     void removeStaticMethodFromImport() {
         rewriteRun(
-          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          spec -> spec.recipe(createRemoveMethodsRecipe("org.junit.jupiter.api.Assertions assertTrue(..)")),
           // language=java
           java(
             """
-              import static java.util.Collections.emptyList;
+              import static org.junit.jupiter.api.Assertions.assertTrue;
               
               class Test {
                   void method() {
-                      List<Object> emptyList = emptyList();
+                      assertTrue(true);
                   }
               }
               """,
@@ -522,15 +522,15 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     @Test
     void removeStaticMethod() {
         rewriteRun(
-          spec -> spec.recipe(createRemoveMethodsRecipe("java.util.Collections emptyList()")),
+          spec -> spec.recipe(createRemoveMethodsRecipe("org.junit.jupiter.api.Assertions assertTrue(..)")),
           // language=java
           java(
             """
-              import java.util.Collections;
+              import org.junit.jupiter.api.Assertions;
               
               class Test {
                   void method() {
-                      List<Object> emptyList = Collections.emptyList();
+                      Assertions.assertTrue(true);
                   }
               }
               """,

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -495,6 +495,37 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
     }
 
     @Test
+    void removeLocalMethodInvocation() {
+        rewriteRun(
+          spec -> spec.recipe(createRemoveMethodsRecipe("a.A b(..)")),
+          // language=java
+          java(
+            """
+              package a;
+              
+              class A {
+                  void a() {
+                      b();
+                  }
+                  void b() {
+                  }
+              }
+              """,
+            """
+              package a;
+              
+              class A {
+                  void a() {
+                  }
+                  void b() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeStaticMethodFromImport() {
         rewriteRun(
           spec -> spec.recipe(createRemoveMethodsRecipe("org.junit.jupiter.api.Assertions assertTrue(..)")),

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodInvocationsVisitorTest.java
@@ -526,6 +526,8 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
           // language=java
           java(
             """
+              import java.util.List;
+              
               import static java.util.Collections.emptyList;
               
               class Test {
@@ -571,12 +573,13 @@ class RemoveMethodInvocationsVisitorTest implements RewriteTest {
           // language=java
           java(
             """
+              import java.util.List;
               import java.util.Collections;
               
               class Test {
                   void method() {
-                      List<Object> emptyList = Collections.emptyList();
-                      emptyList.isEmpty();
+                      List<String> l = Collections.emptyList();
+                      l.size();
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Add test to verify if RemoveMethodInvocationsVisitor can delete static method

## What's your motivation?
After moving recipe `org.openrewrite.java.migrate.RemoveMethodInvocation` defined on project `rewrite-migrate-java` to `org.openrewrite.java.RemoveMethodInvocations` in `rewrite-java' some custom recipe now failed 

```yaml
type: specs.openrewrite.org/v1beta/recipe
name: org.openrewrite.java.testing.easymock.EasymockRemoveReplay
displayName: Remove EasyMock `replay()`"
description: Remove EasyMock `replay()` method calls.
recipeList:
  - org.openrewrite.java.migrate.RemoveMethodInvocation:
      methodPattern: org.easymock..EasyMock replay(..)
```

this exemple work but the recipe has been removed : 
- recipe : https://github.com/dralagen/rewrite-testing-frameworks/blob/java-migrate-removeMethodInvocation/src/main/resources/META-INF/rewrite/easymock.yml
- test : https://github.com/dralagen/rewrite-testing-frameworks/blob/java-migrate-removeMethodInvocation/src/test/java/org/openrewrite/java/testing/easymock/EasymockRemoveReplayTest.java 

this exemple break TU : https://github.com/dralagen/rewrite-testing-frameworks/blob/removeMethodInvocations/src/main/resources/META-INF/rewrite/easymock.yml

## Anyone you would like to review specifically?
@timtebeek  I created the PR as draft with test the remove Method static invocation detect on the Migration from easymock to mockito

## Have you considered any alternatives or workarounds?
I see the same issue on PR : 
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/639 



### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
