### PR TITLE
Performance improvements of `Find` recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/Find.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/Find.java
@@ -142,10 +142,14 @@ public class Find extends Recipe {
                 List<PlainText.Snippet> snippets = new ArrayList<>();
                 int previousEnd = 0;
 
-                LinkedList<Integer> newlineIndexes = findAllNewLineIndexes(rawText);
+                LinkedList<Integer> newlineIndexes = null;
                 int lastNewLineIndex = -1;
 
                 while (matcher.find()) {
+                    if (newlineIndexes == null) {
+                        newlineIndexes = findAllNewLineIndexes(rawText);
+                    }
+
                     int matchStart = matcher.start();
                     snippets.add(snippet(rawText.substring(previousEnd, matchStart)));
                     snippets.add(SearchResult.found(snippet(rawText.substring(matchStart, matcher.end()))));

--- a/rewrite-core/src/main/java/org/openrewrite/text/Find.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/Find.java
@@ -26,10 +26,7 @@ import org.openrewrite.quark.Quark;
 import org.openrewrite.remote.Remote;
 import org.openrewrite.table.TextMatches;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -92,10 +89,14 @@ public class Find extends Recipe {
     @Nullable
     String filePattern;
 
-    private static LinkedList<Integer> findAllNewLineIndexes(String input) {
-        LinkedList<Integer> indexes = new LinkedList<>();
-        int index = input.indexOf('\n'); // Find the first occurrence
+    private static Deque<Integer> findAllNewLineIndexes(String input, int offset) {
+        ArrayDeque<Integer> indexes = new ArrayDeque<>();
+        int index = input.lastIndexOf('\n', offset); // Find the first occurrence
+        if (index != -1) {
+            indexes.add(index);
+        }
 
+        index = input.indexOf('\n', offset); // Find occurrence after the offset
         while (index != -1) {
             indexes.add(index); // Add the index to the list
             index = input.indexOf('\n', index + 1); // Find the next occurrence
@@ -142,12 +143,12 @@ public class Find extends Recipe {
                 List<PlainText.Snippet> snippets = new ArrayList<>();
                 int previousEnd = 0;
 
-                LinkedList<Integer> newlineIndexes = null;
+                Deque<Integer> newlineIndexes = null;
                 int lastNewLineIndex = -1;
 
                 while (matcher.find()) {
                     if (newlineIndexes == null) {
-                        newlineIndexes = findAllNewLineIndexes(rawText);
+                        newlineIndexes = findAllNewLineIndexes(rawText, matcher.start());
                     }
 
                     int matchStart = matcher.start();

--- a/rewrite-core/src/test/java/org/openrewrite/text/FindTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindTest.java
@@ -144,6 +144,7 @@ class FindTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void regexMatchingWhitespaceWithoutMultilineWithDotall() {
         rewriteRun(
@@ -153,11 +154,6 @@ class FindTest implements RewriteTest {
             """
               Zero
               One Two
-              Three
-              """,
-            """
-              Zero
-              ~~>One Two
               Three
               """
           )

--- a/rewrite-core/src/test/java/org/openrewrite/text/FindTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindTest.java
@@ -111,4 +111,106 @@ class FindTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void regexBasicMultiLine() {
+        rewriteRun(
+          spec -> spec.recipe(new Find("[T\\s]", true, true, true, null, null)),
+          text(
+            """
+              This is\ttext.
+              This is\ttext.
+              """,
+            """
+              ~~>This~~> is~~>\ttext.~~>
+              ~~>This~~> is~~>\ttext.
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexWithoutMultilineAndDotall() {
+        rewriteRun(
+          spec -> spec.recipe(new Find("^This.*below\\.$", true, true, false, false, null)),
+          text(
+            """
+              This is text.
+              This is a line below.
+              This is a line above.
+              This is text.
+              This is a line below.
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexWithoutMultilineAndWithDotAll() {
+        rewriteRun(
+          spec -> spec.recipe(new Find("^This.*below\\.$", true, true, false, true, null)),
+          text(
+            """
+              This is text.
+              This is a line below.
+              This is a line above.
+              This is text.
+              This is a line below.
+              """,
+            """
+              ~~>This is text.
+              This is a line below.
+              This is a line above.
+              This is text.
+              This is a line below.
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexWithMultilineAndWithoutDotall() {
+        rewriteRun(
+          spec -> spec.recipe(new Find("^This.*below\\.$", true, true, true, false, null)),
+          text(
+            """
+              This is text.
+              This is a line below.
+              This is a line above.
+              This is text.
+              This is a line below.
+              """,
+            """
+              This is text.
+              ~~>This is a line below.
+              This is a line above.
+              This is text.
+              ~~>This is a line below.
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexWithBothMultilineAndDotAll() {
+        rewriteRun(
+          spec -> spec.recipe(new Find("^This.*below\\.$", true, true, true, true, null)),
+          text(
+            """
+              This is text.
+              This is a line below.
+              This is a line above.
+              This is text.
+              This is a line below.
+              """,
+            """
+              ~~>This is text.
+              This is a line below.
+              This is a line above.
+              This is text.
+              This is a line below.
+              """
+          )
+        );
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/text/FindTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/text/FindTest.java
@@ -144,6 +144,25 @@ class FindTest implements RewriteTest {
           )
         );
     }
+    @Test
+    void regexMatchingWhitespaceWithoutMultilineWithDotall() {
+        rewriteRun(
+          spec -> spec.recipe(new Find("One.Two$", true, true, false, true, null)),
+          //language=csv
+          text( // the `.` above matches the space character on the same line
+            """
+              Zero
+              One Two
+              Three
+              """,
+            """
+              Zero
+              ~~>One Two
+              Three
+              """
+          )
+        );
+    }
 
     @Test
     void regexWithoutMultilineAndWithDotAll() {
@@ -197,15 +216,15 @@ class FindTest implements RewriteTest {
           spec -> spec.recipe(new Find("^This.*below\\.$", true, true, true, true, null)),
           text(
             """
-              This is text.
+              The first line.
               This is a line below.
               This is a line above.
               This is text.
               This is a line below.
               """,
             """
-              ~~>This is text.
-              This is a line below.
+              The first line.
+              ~~>This is a line below.
               This is a line above.
               This is text.
               This is a line below.


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The `Find` has been modified to increase its performance. Nearly all these optimizations are related to how Strings are handled. 

#### Main changes
- Replace basic String concatenation with a `StringBuilder` where we set the capacity to the exact length of the final String. Apart from setting the capacity exactly, this will mostly only affect OpenRewrite users using old JVM, since most modern JVM will often already generate optimized bytecode using a StringBuilder.
- **Significantly** reduce the number of generated substrings, e.g., while looking up line ending on substrings.
- Avoid recomputing common values, byte precomputing them outside the loop.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Make it faster.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@kmccarp @timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
