### PR TITLE
Make sure provided download target exist before writing files to it

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -108,6 +108,16 @@ class JavaParserTest implements RewriteTest {
     }
 
     @Test
+    void getParserClasspathDownloadCreateRequiredFolder(@TempDir Path temp) throws Exception {
+        Path updatedTemp = Path.of(temp.toString(), "someFolder");
+        assertThat(updatedTemp.toFile().exists()).isFalse();
+        JavaParserExecutionContextView ctx = JavaParserExecutionContextView.view(new InMemoryExecutionContext());
+        ctx.setParserClasspathDownloadTarget(updatedTemp.toFile());
+        ctx.getParserClasspathDownloadTarget();
+        assertThat(updatedTemp.toFile().exists()).isTrue();
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3222")
     void parseFromByteArray() {
         try (ScanResult scan = new ClassGraph().scan()) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParserExecutionContextView.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParserExecutionContextView.java
@@ -45,11 +45,10 @@ public class JavaParserExecutionContextView extends DelegatingExecutionContext {
     public File getParserClasspathDownloadTarget() {
         File target = getMessage(PARSER_CLASSPATH_DOWNLOAD_LOCATION);
         if (target == null) {
-            File defaultTarget = new File(System.getProperty("user.home") + "/.rewrite/classpath");
-            if (!defaultTarget.mkdirs() && !defaultTarget.exists()) {
-                throw new UncheckedIOException(new IOException("Failed to create directory " + defaultTarget.getAbsolutePath()));
-            }
-            return defaultTarget;
+            target = new File(System.getProperty("user.home") + "/.rewrite/classpath");
+        }
+        if (!target.mkdirs() && !target.exists()) {
+            throw new UncheckedIOException(new IOException("Failed to create directory " + target.getAbsolutePath()));
         }
         return target;
     }


### PR DESCRIPTION
## What's changed?
When we use the default download location we create the folder if it is missing. We also need to do this if a custom location is provided

## What's your motivation?
If the custom location is not created, the recipe which requires the associated resources will fail because it cannot find the associated resources 


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
