### PR TITLE
Allow building uri from origin, path and service type

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -113,51 +113,55 @@ public class GitRemote {
          * @return the clone url
          */
         public URI toUri(GitRemote remote, String protocol) {
+            return buildUri(remote.service, remote.origin, remote.path, protocol);
+        }
+
+        public URI buildUri(Service service, String origin, String path, String protocol) {
             if (!ALLOWED_PROTOCOLS.contains(protocol)) {
                 throw new IllegalArgumentException("Invalid protocol: " + protocol + ". Must be one of: " + ALLOWED_PROTOCOLS);
             }
             URI selectedBaseUrl;
 
-            if (remote.service == Service.Unknown) {
-                if (PORT_PATTERN.matcher(remote.origin).find()) {
-                    throw new IllegalArgumentException("Unable to determine protocol/port combination for an unregistered origin with a port: " + remote.origin);
+            if (service == Service.Unknown) {
+                if (PORT_PATTERN.matcher(origin).find()) {
+                    throw new IllegalArgumentException("Unable to determine protocol/port combination for an unregistered origin with a port: " + origin);
                 }
-                selectedBaseUrl = URI.create(protocol + "://" + stripProtocol(remote.origin));
+                selectedBaseUrl = URI.create(protocol + "://" + stripProtocol(origin));
             } else {
                 selectedBaseUrl = servers.stream()
                         .filter(server -> server.allOrigins()
                                 .stream()
-                                .anyMatch(origin -> origin.equalsIgnoreCase(stripProtocol(remote.origin)))
+                                .anyMatch(o -> o.equalsIgnoreCase(stripProtocol(origin)))
                         )
                         .flatMap(server -> server.getUris().stream())
                         .filter(uri -> uri.getScheme().equals(protocol))
                         .findFirst()
                         .orElseGet(() -> {
-                            URI normalizedUri = Parser.normalize(remote.origin);
+                            URI normalizedUri = Parser.normalize(origin);
                             if (!normalizedUri.getScheme().equals(protocol)) {
-                                throw new IllegalStateException("No matching server found that supports ssh for origin: " + remote.origin);
+                                throw new IllegalStateException("No matching server found that supports ssh for origin: " + origin);
                             }
                             return normalizedUri;
                         });
             }
 
-            String path = remote.path.replaceFirst("^/", "");
+            path = path.replaceFirst("^/", "");
             boolean ssh = protocol.equals("ssh");
-            switch (remote.service) {
+            switch (service) {
                 case Bitbucket:
                     if (!ssh) {
-                        path = "scm/" + remote.path;
+                        path = "scm/" + path;
                     }
                     break;
                 case AzureDevOps:
                     if (ssh) {
-                        path = "v3/" + remote.path;
+                        path = "v3/" + path;
                     } else {
-                        path = remote.path.replaceFirst("([^/]+)/([^/]+)/(.*)", "$1/$2/_git/$3");
+                        path = path.replaceFirst("([^/]+)/([^/]+)/(.*)", "$1/$2/_git/$3");
                     }
                     break;
             }
-            if (remote.service != Service.AzureDevOps) {
+            if (service != Service.AzureDevOps) {
                 path += ".git";
             }
             String maybeSlash = selectedBaseUrl.toString().endsWith("/") ? "" : "/";

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -110,16 +110,6 @@ public class GitRemoteTest {
         assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
     }
 
-    @Test
-    void parseRegisteredRemoteWithAlternate() {
-        GitRemote.Parser parser = new GitRemote.Parser().registerRemote(GitRemote.Service.Bitbucket, URI.create("https://bitbucket.moderne.ninja/stash"), List.of(URI.create("ssh://bitbucket.moderne.ninja:7999/stash")));
-        GitRemote remote = parser.parse("ssh://bitbucket.moderne.ninja:7999/stash/org/repo.git");
-        assertThat(remote.getOrigin()).isEqualTo("bitbucket.moderne.ninja/stash");
-        assertThat(remote.getPath()).isEqualTo("org/repo");
-        assertThat(remote.getOrganization()).isEqualTo("org");
-        assertThat(remote.getRepositoryName()).isEqualTo("repo");
-    }
-
     @ParameterizedTest
     @CsvSource(textBlock = """
       https://scm.company.com/very/long/context/path/org/repo.git,

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -110,6 +110,16 @@ public class GitRemoteTest {
         assertThat(remote.getRepositoryName()).isEqualTo(expectedRepositoryName);
     }
 
+    @Test
+    void parseRegisteredRemoteWithAlternate() {
+        GitRemote.Parser parser = new GitRemote.Parser().registerRemote(GitRemote.Service.Bitbucket, URI.create("https://bitbucket.moderne.ninja/stash"), List.of(URI.create("ssh://bitbucket.moderne.ninja:7999/stash")));
+        GitRemote remote = parser.parse("ssh://bitbucket.moderne.ninja:7999/stash/org/repo.git");
+        assertThat(remote.getOrigin()).isEqualTo("bitbucket.moderne.ninja/stash");
+        assertThat(remote.getPath()).isEqualTo("org/repo");
+        assertThat(remote.getOrganization()).isEqualTo("org");
+        assertThat(remote.getRepositoryName()).isEqualTo("repo");
+    }
+
     @ParameterizedTest
     @CsvSource(textBlock = """
       https://scm.company.com/very/long/context/path/org/repo.git,
@@ -260,18 +270,18 @@ public class GitRemoteTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-      GitHub, GitHub
-      GITLAB, GitLab
-      bitbucket, Bitbucket
-      BitbucketCloud, BitbucketCloud
-      Bitbucket Cloud, BitbucketCloud
-      BITBUCKET_CLOUD, BitbucketCloud
-      AzureDevOps, AzureDevOps
-      AZURE_DEVOPS, AzureDevOps
-      Azure DevOps, AzureDevOps
-      idontknow, Unknown
-    """)
-    void findServiceForName(String name, GitRemote.Service service){
+        GitHub, GitHub
+        GITLAB, GitLab
+        bitbucket, Bitbucket
+        BitbucketCloud, BitbucketCloud
+        Bitbucket Cloud, BitbucketCloud
+        BITBUCKET_CLOUD, BitbucketCloud
+        AzureDevOps, AzureDevOps
+        AZURE_DEVOPS, AzureDevOps
+        Azure DevOps, AzureDevOps
+        idontknow, Unknown
+      """)
+    void findServiceForName(String name, GitRemote.Service service) {
         assertThat(GitRemote.Service.forName(name)).isEqualTo(service);
     }
 


### PR DESCRIPTION
This can be used to generate a clone url without first needing to build a `GitRemote` object out of it (having to pass nulls where they are not allowed)