### PR TITLE
Strip origin in findRemoteServer

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -116,6 +116,14 @@ public class GitRemote {
             return buildUri(remote.service, remote.origin, remote.path, protocol);
         }
 
+        /**
+         * Build a {@link URI} clone url from components, if that protocol is supported (configured) by the matched server
+         * @param service  the type of SCM service
+         * @param origin   the origin of the SCM service, any protocol will be stripped (and not used for matching)
+         * @param path     the path to the repository
+         * @param protocol the protocol to use. Supported protocols: ssh, http, https
+         * @return
+         */
         public URI buildUri(Service service, String origin, String path, String protocol) {
             if (!ALLOWED_PROTOCOLS.contains(protocol)) {
                 throw new IllegalArgumentException("Invalid protocol: " + protocol + ". Must be one of: " + ALLOWED_PROTOCOLS);
@@ -207,11 +215,17 @@ public class GitRemote {
             return this;
         }
 
+        /**
+         * Find a registered remote server by an origin.
+         * @param origin the origin of the server. Any protocol will be stripped (and not used to match)
+         * @return The server if found, or an unknown type server with a normalized url/origin if not found.
+         */
         public RemoteServer findRemoteServer(String origin) {
-            return servers.stream().filter(server -> server.origin.equalsIgnoreCase(origin))
+            String strippedOrigin = stripProtocol(origin);
+            return servers.stream().filter(server -> server.origin.equalsIgnoreCase(strippedOrigin))
                     .findFirst()
                     .orElseGet(() -> {
-                        URI normalizedUri = normalize(origin);
+                        URI normalizedUri = normalize(strippedOrigin);
                         String normalizedOrigin = normalizedUri.getHost() + maybePort(normalizedUri.getPort(), normalizedUri.getScheme());
                         return new RemoteServer(Service.Unknown, normalizedOrigin, normalizedUri);
                     });

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -233,10 +233,20 @@ public class GitRemoteTest {
     }
 
     @Test
+    void shouldNotReplaceExistingWellKnownServer(){
+        GitRemote.Parser parser = new GitRemote.Parser()
+          .registerRemote(GitRemote.Service.GitHub, URI.create("https://github.com"), List.of(URI.create("ssh://notgithub.com")));
+
+        assertThat(parser.findRemoteServer("github.com").getUris())
+          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://github.com"));
+    }
+
+    @Test
     void findRemote() {
         GitRemote.Parser parser = new GitRemote.Parser()
           .registerRemote(GitRemote.Service.Bitbucket, URI.create("scm.company.com/stash"), Collections.emptyList());
         assertThat(parser.findRemoteServer("github.com").getService()).isEqualTo(GitRemote.Service.GitHub);
+        assertThat(parser.findRemoteServer("https://github.com").getService()).isEqualTo(GitRemote.Service.GitHub);
         assertThat(parser.findRemoteServer("gitlab.com").getService()).isEqualTo(GitRemote.Service.GitLab);
         assertThat(parser.findRemoteServer("bitbucket.org").getService()).isEqualTo(GitRemote.Service.BitbucketCloud);
         assertThat(parser.findRemoteServer("dev.azure.com").getService()).isEqualTo(GitRemote.Service.AzureDevOps);

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -238,7 +238,7 @@ public class GitRemoteTest {
           .registerRemote(GitRemote.Service.GitHub, URI.create("https://github.com"), List.of(URI.create("ssh://notgithub.com")));
 
         assertThat(parser.findRemoteServer("github.com").getUris())
-          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://github.com"));
+          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://git@github.com"));
     }
 
     @Test


### PR DESCRIPTION
This will allow finding a server without first stripping the protocol on the consumers end.