### PR TITLE
Correct `J.FieldAccess#isFullyQualifiedClassReference()`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -209,7 +209,7 @@ class ChangeTypeTest implements RewriteTest {
               
               class Test {
                   List p;
-                  List p2;
+                  java.util.List p2;
                   java.util.List p3;
               }
               """
@@ -2152,6 +2152,68 @@ class ChangeTypeTest implements RewriteTest {
                   public boolean isDirty() {
                       return false;
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeTypeOfInnerClass() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("foo.A$Builder", "bar.A$Builder", true))
+            .parser(JavaParser.fromJavaVersion().dependsOn(
+                """
+                  package foo;
+                  
+                  public class A {
+                    public A.Builder builder() {
+                      return new A.Builder();
+                    }
+                  
+                    public static class Builder {
+                      public A build() {
+                        return new A();
+                      }
+                    }
+                  }
+                  """,
+                """
+                  package bar;
+                  
+                  public class A {
+                    public A.Builder builder() {
+                      return new A.Builder();
+                    }
+                  
+                    public static class Builder {
+                      public A build() {
+                        return new A();
+                      }
+                    }
+                  }
+                  """
+              )
+            ),
+          java(
+            """
+              import foo.A;
+              import foo.A.Builder;
+              
+              class Test {
+                A test() {
+                    A.Builder b = A.builder();
+                    return b.build();
+                }
+              }
+              """, """
+              import foo.A;
+              
+              class Test {
+                A test() {
+                    bar.A.Builder b = A.builder();
+                    return b.build();
+                }
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -25,7 +25,6 @@ import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
-import org.openrewrite.test.TypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -2112,8 +2111,7 @@ class ChangeTypeTest implements RewriteTest {
     void noRenameOfTypeWithMatchingPrefix() {
         // language=java
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.all())
-            .recipe(new ChangeType("org.codehaus.jackson.annotate.JsonIgnoreProperties", "com.fasterxml.jackson.annotation.JsonIgnoreProperties", false))
+          spec -> spec.recipe(new ChangeType("org.codehaus.jackson.annotate.JsonIgnoreProperties", "com.fasterxml.jackson.annotation.JsonIgnoreProperties", false))
             .parser(JavaParser.fromJavaVersion()
               .dependsOn(
                 """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2108,6 +2108,7 @@ class ChangeTypeTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4773")
     void noRenameOfTypeWithMatchingPrefix() {
         rewriteRun(
           spec -> spec.recipe(new ChangeType("org.codehaus.jackson.annotate.JsonIgnoreProperties", "com.fasterxml.jackson.annotation.JsonIgnoreProperties", false))
@@ -2156,6 +2157,7 @@ class ChangeTypeTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4764")
     void changeTypeOfInnerClass() {
         rewriteRun(
           spec -> spec.recipe(new ChangeType("foo.A$Builder", "bar.A$Builder", true))

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2109,7 +2109,7 @@ class ChangeTypeTest implements RewriteTest {
     }
 
     @Test
-    void testRecipe() {
+    void noRenameOfTypeWithMatchingPrefix() {
         // language=java
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.all())

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2109,7 +2109,6 @@ class ChangeTypeTest implements RewriteTest {
 
     @Test
     void noRenameOfTypeWithMatchingPrefix() {
-        // language=java
         rewriteRun(
           spec -> spec.recipe(new ChangeType("org.codehaus.jackson.annotate.JsonIgnoreProperties", "com.fasterxml.jackson.annotation.JsonIgnoreProperties", false))
             .parser(JavaParser.fromJavaVersion()

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -64,7 +64,7 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void foo() {
+    void skipMissingTypeAttribution() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).build()),
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1991,7 +1991,7 @@ public interface J extends Tree {
                 return false;
             }
             String simpleName = fieldAccess.getName().getSimpleName();
-            if (!simpleName.regionMatches(0, className, dotIndex + 1, Math.max(className.length() - dotIndex - 1, simpleName.length()))) {
+            if (!simpleName.regionMatches(0, className, dotIndex + 1, prevDotIndex - dotIndex - 1)) {
                 return false;
             }
             if (fieldAccess.getTarget() instanceof J.FieldAccess) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1986,12 +1986,18 @@ public interface J extends Tree {
         }
 
         private boolean isFullyQualifiedClassReference(J.FieldAccess fieldAccess, String className, int prevDotIndex) {
+            if (fieldAccess.getName().getFieldType() == null &&
+                fieldAccess.getName().getType() instanceof JavaType.FullyQualified &&
+                ((JavaType.FullyQualified) fieldAccess.getName().getType()).getFullyQualifiedName().equals(className)) {
+                return true;
+            }
+
             int dotIndex = className.lastIndexOf('.', prevDotIndex - 1);
             if (dotIndex < 0) {
                 return false;
             }
             String simpleName = fieldAccess.getName().getSimpleName();
-            if (!simpleName.regionMatches(0, className, dotIndex + 1, prevDotIndex - dotIndex - 1)) {
+            if (!simpleName.regionMatches(0, className, dotIndex + 1, Math.max(simpleName.length(), prevDotIndex - dotIndex - 1))) {
                 return false;
             }
             if (fieldAccess.getTarget() instanceof J.FieldAccess) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1979,19 +1979,16 @@ public interface J extends Tree {
         }
 
         public boolean isFullyQualifiedClassReference(String className) {
-            if (!className.contains(".")) {
+            if (getName().getFieldType() == null && getName().getType() instanceof JavaType.FullyQualified &&
+                ((JavaType.FullyQualified) getName().getType()).getFullyQualifiedName().equals(className)) {
+                return true;
+            } else if (!className.contains(".")) {
                 return false;
             }
-            return isFullyQualifiedClassReference(this, className, className.length());
+            return isFullyQualifiedClassReference(this, className.replace('$', '.'), className.length());
         }
 
         private boolean isFullyQualifiedClassReference(J.FieldAccess fieldAccess, String className, int prevDotIndex) {
-            if (fieldAccess.getName().getFieldType() == null &&
-                fieldAccess.getName().getType() instanceof JavaType.FullyQualified &&
-                ((JavaType.FullyQualified) fieldAccess.getName().getType()).getFullyQualifiedName().equals(className)) {
-                return true;
-            }
-
             int dotIndex = className.lastIndexOf('.', prevDotIndex - 1);
             if (dotIndex < 0) {
                 return false;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1991,7 +1991,7 @@ public interface J extends Tree {
                 return false;
             }
             String simpleName = fieldAccess.getName().getSimpleName();
-            if (!simpleName.regionMatches(0, className, dotIndex + 1, className.length())) {
+            if (!simpleName.regionMatches(0, className, dotIndex + 1, Math.max(className.length() - dotIndex - 1, simpleName.length()))) {
                 return false;
             }
             if (fieldAccess.getTarget() instanceof J.FieldAccess) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1991,7 +1991,7 @@ public interface J extends Tree {
                 return false;
             }
             String simpleName = fieldAccess.getName().getSimpleName();
-            if (!simpleName.regionMatches(0, className, dotIndex + 1, simpleName.length())) {
+            if (!simpleName.regionMatches(0, className, dotIndex + 1, className.length())) {
                 return false;
             }
             if (fieldAccess.getTarget() instanceof J.FieldAccess) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1980,12 +1980,12 @@ public interface J extends Tree {
 
         public boolean isFullyQualifiedClassReference(String className) {
             if (getName().getFieldType() == null && getName().getType() instanceof JavaType.FullyQualified &&
-                ((JavaType.FullyQualified) getName().getType()).getFullyQualifiedName().equals(className)) {
+                TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) getName().getType()).getFullyQualifiedName(), className)) {
                 return true;
             } else if (!className.contains(".")) {
                 return false;
             }
-            return isFullyQualifiedClassReference(this, className.replace('$', '.'), className.length());
+            return isFullyQualifiedClassReference(this, TypeUtils.toFullyQualifiedName(className), className.length());
         }
 
         private boolean isFullyQualifiedClassReference(J.FieldAccess fieldAccess, String className, int prevDotIndex) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -1980,6 +1980,7 @@ public interface J extends Tree {
 
         public boolean isFullyQualifiedClassReference(String className) {
             if (getName().getFieldType() == null && getName().getType() instanceof JavaType.FullyQualified &&
+                !(getName().getType() instanceof JavaType.Unknown) &&
                 TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) getName().getType()).getFullyQualifiedName(), className)) {
                 return true;
             } else if (!className.contains(".")) {


### PR DESCRIPTION
The commit e536ed273fda87ce6857b06f200488130b3ef5f3 introduced a regression here when dealing with classes that share a common prefix (such as `foo.Foo` and `foo.Foobar`).

- Fixes: #4773
- Fixes: #4764