### PR TITLE
Tolerate missing pom when jar is present

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -681,7 +681,7 @@ public class MavenPomDownloader {
         return gav.getVersion();
     }
 
-    Collection<MavenRepository> distinctNormalizedRepositories(
+    public Collection<MavenRepository> distinctNormalizedRepositories(
             List<MavenRepository> repositories,
             @Nullable ResolvedPom containingPom,
             @Nullable String acceptsVersion) {


### PR DESCRIPTION
## What's changed?
Catch a failure to download a pom in ResolvedPom, and if caught check to see if the corresponding jar can be found. If so, continue without issue.

## What's your motivation?
- Fix https://github.com/openrewrite/rewrite/issues/4687


## Anything in particular you'd like reviewers to focus on?
- The `MavenArtifactDownloader` had previously been unused for quite a while; figured to bring that back here to check for jar availability. We could possibly move that to the same package as MavenPomDownloader, such that we don't need:
- the visibility of `MavenPomDownloader.distinctNormalizedRepositories` changed to `public`, as we need to look across all repositories for the `.jar` file. Not just the ones defined in the `ResolvedPom`.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
There is an alternative implementation in
- https://github.com/openrewrite/rewrite/pull/4738

That chose the route of having changes mostly in MavenPomDownloader, which then also looks at jars and if so returns a dummy pom.xml;  I think it's better not to mix responsibilities there, nor to continue processing a known dummy pom.