### PR TITLE
Normalize server URLs to avoid missing scheme

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -128,7 +128,7 @@ public class GitRemote {
          */
         public URI buildUri(Service service, String origin, String path, String protocol) {
             if (!ALLOWED_PROTOCOLS.contains(protocol)) {
-                throw new IllegalStateException("Invalid protocol: " + protocol + ". Must be one of: " + ALLOWED_PROTOCOLS);
+                throw new IllegalArgumentException("Invalid protocol: " + protocol + ". Must be one of: " + ALLOWED_PROTOCOLS);
             }
             URI selectedBaseUrl;
             if (service == Service.Unknown) {
@@ -148,7 +148,7 @@ public class GitRemote {
                         .orElseGet(() -> {
                             URI normalizedUri = Parser.normalize(origin);
                             if (!normalizedUri.getScheme().equals(protocol)) {
-                                throw new IllegalStateException("Unable to build clone URL. No matching server found that supports " + protocol + " for origin: " + origin);
+                                throw new IllegalArgumentException("Unable to build clone URL. No matching server found that supports " + protocol + " for origin: " + origin);
                             }
                             return normalizedUri;
                         });

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -149,7 +149,7 @@ public class GitRemote {
                         .orElseGet(() -> {
                             URI normalizedUri = Parser.normalize(origin);
                             if (!normalizedUri.getScheme().equals(protocol)) {
-                                throw new IllegalStateException("No matching server found that supports " + protocol + " for origin: " + origin);
+                                throw new IllegalStateException("Unable to build clone URL. No matching server found that supports " + protocol + " for origin: " + origin);
                             }
                             return normalizedUri;
                         });

--- a/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
+++ b/rewrite-core/src/main/java/org/openrewrite/GitRemote.java
@@ -128,7 +128,7 @@ public class GitRemote {
          */
         public URI buildUri(Service service, String origin, String path, String protocol) {
             if (!ALLOWED_PROTOCOLS.contains(protocol)) {
-                throw new IllegalArgumentException("Invalid protocol: " + protocol + ". Must be one of: " + ALLOWED_PROTOCOLS);
+                throw new IllegalStateException("Invalid protocol: " + protocol + ". Must be one of: " + ALLOWED_PROTOCOLS);
             }
             URI selectedBaseUrl;
 

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -180,25 +180,25 @@ public class GitRemoteTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
       GitHub, github.com, org/repo, https, https://github.com/org/repo.git
-      GitHub, github.com, org/repo, ssh, ssh://git@github.com/org/repo.git
+      GitHub, github.com, org/repo, ssh, ssh://github.com/org/repo.git
       GitHub, https://github.com, org/repo, https, https://github.com/org/repo.git
-      GitHub, https://github.com, org/repo, ssh, ssh://git@github.com/org/repo.git
+      GitHub, https://github.com, org/repo, ssh, ssh://github.com/org/repo.git
       
       GitLab, gitlab.com, group/subgroup/repo, https, https://gitlab.com/group/subgroup/repo.git
-      GitLab, gitlab.com, group/subgroup/repo, ssh, ssh://git@gitlab.com/group/subgroup/repo.git
+      GitLab, gitlab.com, group/subgroup/repo, ssh, ssh://gitlab.com/group/subgroup/repo.git
       AzureDevOps, dev.azure.com, org/project/repo, https, https://dev.azure.com/org/project/_git/repo
-      AzureDevOps, dev.azure.com, org/project/repo, ssh, ssh://git@ssh.dev.azure.com/v3/org/project/repo
+      AzureDevOps, dev.azure.com, org/project/repo, ssh, ssh://ssh.dev.azure.com/v3/org/project/repo
       BitbucketCloud, bitbucket.org, org/repo, https, https://bitbucket.org/org/repo.git
-      BitbucketCloud, bitbucket.org, org/repo, ssh, ssh://git@bitbucket.org/org/repo.git
+      BitbucketCloud, bitbucket.org, org/repo, ssh, ssh://bitbucket.org/org/repo.git
       
       Bitbucket, scm.company.com/context/bitbucket, org/repo, https, https://scm.company.com/context/bitbucket/scm/org/repo.git
       Bitbucket, scm.company.com/context/bitbucket, org/repo, http, http://scm.company.com/context/bitbucket/scm/org/repo.git
-      Bitbucket, scm.company.com/context/bitbucket, org/repo, ssh, ssh://git@scm.company.com:7999/context/bitbucket/org/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, ssh, ssh://scm.company.com:7999/context/bitbucket/org/repo.git
       GitHub, scm.company.com/context/github, org/repo, https, https://scm.company.com/context/github/org/repo.git
-      GitHub, scm.company.com/context/github, org/repo, ssh, ssh://git@scm.company.com/context/github/org/repo.git
+      GitHub, scm.company.com/context/github, org/repo, ssh, ssh://scm.company.com/context/github/org/repo.git
       GitLab, scm.company.com/context/gitlab, group/subgroup/repo, https, https://scm.company.com/context/gitlab/group/subgroup/repo.git
       GitLab, scm.company.com:8443/context/gitlab, group/subgroup/repo, https, https://scm.company.com:8443/context/gitlab/group/subgroup/repo.git
-      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, ssh, ssh://git@scm.company.com:8022/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, ssh, ssh://scm.company.com:8022/context/gitlab/group/subgroup/repo.git
       
       Bitbucket, scm.company.com:12345/context/bitbucket, org/repo, https, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
       Bitbucket, scm.company.com:12346/context/bitbucket, org/repo, https, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
@@ -238,7 +238,7 @@ public class GitRemoteTest {
           .registerRemote(GitRemote.Service.GitHub, URI.create("https://github.com"), List.of(URI.create("ssh://notgithub.com")));
 
         assertThat(parser.findRemoteServer("github.com").getUris())
-          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://git@github.com"));
+          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://github.com"));
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/GitRemoteTest.java
@@ -180,25 +180,25 @@ public class GitRemoteTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
       GitHub, github.com, org/repo, https, https://github.com/org/repo.git
-      GitHub, github.com, org/repo, ssh, ssh://github.com/org/repo.git
+      GitHub, github.com, org/repo, ssh, ssh://git@github.com/org/repo.git
       GitHub, https://github.com, org/repo, https, https://github.com/org/repo.git
-      GitHub, https://github.com, org/repo, ssh, ssh://github.com/org/repo.git
+      GitHub, https://github.com, org/repo, ssh, ssh://git@github.com/org/repo.git
       
       GitLab, gitlab.com, group/subgroup/repo, https, https://gitlab.com/group/subgroup/repo.git
-      GitLab, gitlab.com, group/subgroup/repo, ssh, ssh://gitlab.com/group/subgroup/repo.git
+      GitLab, gitlab.com, group/subgroup/repo, ssh, ssh://git@gitlab.com/group/subgroup/repo.git
       AzureDevOps, dev.azure.com, org/project/repo, https, https://dev.azure.com/org/project/_git/repo
-      AzureDevOps, dev.azure.com, org/project/repo, ssh, ssh://ssh.dev.azure.com/v3/org/project/repo
+      AzureDevOps, dev.azure.com, org/project/repo, ssh, ssh://git@ssh.dev.azure.com/v3/org/project/repo
       BitbucketCloud, bitbucket.org, org/repo, https, https://bitbucket.org/org/repo.git
-      BitbucketCloud, bitbucket.org, org/repo, ssh, ssh://bitbucket.org/org/repo.git
+      BitbucketCloud, bitbucket.org, org/repo, ssh, ssh://git@bitbucket.org/org/repo.git
       
       Bitbucket, scm.company.com/context/bitbucket, org/repo, https, https://scm.company.com/context/bitbucket/scm/org/repo.git
       Bitbucket, scm.company.com/context/bitbucket, org/repo, http, http://scm.company.com/context/bitbucket/scm/org/repo.git
-      Bitbucket, scm.company.com/context/bitbucket, org/repo, ssh, ssh://scm.company.com:7999/context/bitbucket/org/repo.git
+      Bitbucket, scm.company.com/context/bitbucket, org/repo, ssh, ssh://git@scm.company.com:7999/context/bitbucket/org/repo.git
       GitHub, scm.company.com/context/github, org/repo, https, https://scm.company.com/context/github/org/repo.git
-      GitHub, scm.company.com/context/github, org/repo, ssh, ssh://scm.company.com/context/github/org/repo.git
+      GitHub, scm.company.com/context/github, org/repo, ssh, ssh://git@scm.company.com/context/github/org/repo.git
       GitLab, scm.company.com/context/gitlab, group/subgroup/repo, https, https://scm.company.com/context/gitlab/group/subgroup/repo.git
       GitLab, scm.company.com:8443/context/gitlab, group/subgroup/repo, https, https://scm.company.com:8443/context/gitlab/group/subgroup/repo.git
-      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, ssh, ssh://scm.company.com:8022/context/gitlab/group/subgroup/repo.git
+      GitLab, scm.company.com/context/gitlab, group/subgroup/repo, ssh, ssh://git@scm.company.com:8022/context/gitlab/group/subgroup/repo.git
       
       Bitbucket, scm.company.com:12345/context/bitbucket, org/repo, https, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
       Bitbucket, scm.company.com:12346/context/bitbucket, org/repo, https, https://scm.company.com:12345/context/bitbucket/scm/org/repo.git
@@ -238,7 +238,7 @@ public class GitRemoteTest {
           .registerRemote(GitRemote.Service.GitHub, URI.create("https://github.com"), List.of(URI.create("ssh://notgithub.com")));
 
         assertThat(parser.findRemoteServer("github.com").getUris())
-          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://github.com"));
+          .containsExactlyInAnyOrder(URI.create("https://github.com"), URI.create("ssh://git@github.com"));
     }
 
     @Test


### PR DESCRIPTION
This changes the output slightly (no more user in the URL) but that is fine as the user is not required/used in matching anyway.

Also fixed the comment and exception text.
