### PR TITLE
Move the OkHttpSender to rewrite-maven tests

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -15,10 +15,6 @@ dependencies {
 
     api("org.jspecify:jspecify:latest.release")
 
-    // Pinning okhttp while waiting on 5.0.0
-    // https://github.com/openrewrite/rewrite/issues/1479
-    compileOnly("com.squareup.okhttp3:okhttp:4.9.3")
-
     implementation("org.apache.commons:commons-compress:latest.release")
 
     implementation("io.micrometer:micrometer-core:1.9.+")

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     implementation("org.apache.commons:commons-text:latest.release")
 
     testImplementation(project(":rewrite-test"))
+
+    testImplementation("com.squareup.okhttp3:okhttp:4.+")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.+")
     testImplementation("com.squareup.okhttp3:okhttp-tls:4.+")
     testImplementation("com.squareup.okio:okio-jvm:3.9.1")

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -31,7 +31,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.ParseExceptionResult;
 import org.openrewrite.Parser;
-import org.openrewrite.ipc.http.OkHttpSender;
+import org.openrewrite.maven.http.OkHttpSender;
 import org.openrewrite.maven.internal.MavenParsingException;
 import org.openrewrite.maven.tree.*;
 import org.openrewrite.test.RewriteTest;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/http/OkHttpSender.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/http/OkHttpSender.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.ipc.http;
+package org.openrewrite.maven.http;
 
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import org.openrewrite.ipc.http.HttpSender;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.ipc.http.HttpSender;
 import org.openrewrite.ipc.http.HttpUrlConnectionSender;
-import org.openrewrite.ipc.http.OkHttpSender;
+import org.openrewrite.maven.http.OkHttpSender;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenParser;


### PR DESCRIPTION
As it's only ever used there; reduces the dependencies pulled into rewrite-core.