### PR TITLE
Add explicit imports to avoid conflicts with classes added to java.lang, like record

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -185,6 +185,47 @@ class AddImportTest implements RewriteTest {
     }
 
     @Test
+    void forceImportNoJavaRecord() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false))),
+          //language=java
+          java(
+            """
+              package com.acme.bank;
+
+              class Foo {
+              }
+              """,
+            """
+              package com.acme.bank;
+
+              import com.acme.bank.Record;
+
+              class Foo {
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
+          )
+        );
+    }
+
+    @Test
+    void forceImportJavaRecord() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.lang.Record", null, false))),
+          //language=java
+          java(
+            """
+              package com.acme.bank;
+
+              class Foo {
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
+          )
+        );
+    }
+    @Test
     void dontImportJavaLang() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.lang.String", null, false))),

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -186,6 +186,7 @@ class AddImportTest implements RewriteTest {
 
     @Test
     void forceImportNoJavaRecord() {
+        // Add import for a class named `Record`, even within the same package, to avoid conflicts with java.lang.Record
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false))),
           //language=java
@@ -211,6 +212,7 @@ class AddImportTest implements RewriteTest {
 
     @Test
     void notForceImportJavaRecord() {
+        // Do not add import for java.lang.Record by default
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.lang.Record", null, false))),
           //language=java

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -184,6 +184,7 @@ class AddImportTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
     @Test
     void forceImportNoJavaRecord() {
         // Add import for a class named `Record`, even within the same package, to avoid conflicts with java.lang.Record
@@ -210,6 +211,7 @@ class AddImportTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
     @Test
     void notForceImportJavaRecord() {
         // Do not add import for java.lang.Record by default

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -210,7 +210,7 @@ class AddImportTest implements RewriteTest {
     }
 
     @Test
-    void forceImportJavaRecord() {
+    void notForceImportJavaRecord() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new AddImport<>("java.lang.Record", null, false))),
           //language=java

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -105,10 +105,14 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                 return cu;
             }
 
-            // No need to add imports if the class to import is in java.lang, or if the classes are within the same package
-            if (("java.lang".equals(packageName) && StringUtils.isBlank(member)) ||
-                (!"Record".equals(typeName) && cu.getPackageDeclaration() != null &&
-                    packageName.equals(cu.getPackageDeclaration().getExpression().printTrimmed(getCursor())))) {
+            // No need to add imports if the class to import is in java.lang
+            if ("java.lang".equals(packageName) && StringUtils.isBlank(member)) {
+                return cu;
+            }
+            // Nor if the classes are within the same package
+            if (!"Record".equals(typeName) && // Record's late addition to `java.lang` might conflict with user class
+                    cu.getPackageDeclaration() != null &&
+                    packageName.equals(cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()))) {
                 return cu;
             }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -106,7 +106,8 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
             }
 
             // No need to add imports if the class to import is in java.lang, or if the classes are within the same package
-            if (("java.lang".equals(packageName) && StringUtils.isBlank(member)) || (cu.getPackageDeclaration() != null &&
+            if (("java.lang".equals(packageName) && StringUtils.isBlank(member)) ||
+                (!"Record".equals(typeName) && cu.getPackageDeclaration() != null &&
                     packageName.equals(cu.getPackageDeclaration().getExpression().printTrimmed(getCursor())))) {
                 return cu;
             }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Add explicit imports to avoid conflicts with classes added to java.lang, like record

- For https://github.com/openrewrite/rewrite-migrate-java/issues/540

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
