### PR TITLE
Add `testRuntimeOnly` dependency on `junit-platform-launcher` with Gradle 8.+

### DIFF
--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-8.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle-8.yml
@@ -24,6 +24,9 @@ recipeList:
       version: 8.x
       addIfMissing: false
 
+  # https://docs.gradle.org/8.11.1/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
+  - org.openrewrite.gradle.AddJUnitPlatformLauncher
+
   # https://github.com/gradle/gradle/blob/v7.6.4/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
   # https://github.com/gradle/gradle/blob/v8.10.1/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
   - org.openrewrite.gradle.RemoveEnableFeaturePreview:
@@ -32,3 +35,16 @@ recipeList:
       previewFeatureName: VERSION_ORDERING_V2
   - org.openrewrite.gradle.RemoveEnableFeaturePreview:
       previewFeatureName: VERSION_CATALOGS
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.gradle.AddJUnitPlatformLauncher
+displayName: Add JUnit Platform Launcher
+description: Add the JUnit Platform Launcher to the buildscript dependencies.
+recipeList:
+  - org.openrewrite.gradle.AddDependency:
+      groupId: org.junit.platform
+      artifactId: junit-platform-launcher
+      version: 1.x
+      acceptTransitive: true
+      configuration: testRuntimeOnly
+      onlyIfUsing: org.junit.jupiter.api.Test

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddJUnitPlatformLauncherTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddJUnitPlatformLauncherTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.*;
+
+class AddJUnitPlatformLauncherTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .beforeRecipe(withToolingApi())
+          .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api"))
+          .recipeFromResources("org.openrewrite.gradle.AddJUnitPlatformLauncher");
+    }
+
+    @DocumentExample
+    @Test
+    void addJUnitPlatformLauncher() {
+        rewriteRun(
+          mavenProject("project",
+            srcTestJava(
+              java(
+                """
+                  import org.junit.jupiter.api.Test;
+                  public class A {
+                      @Test
+                      void foo() {
+                      }
+                  }
+                  """
+              )
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                """,
+              spec -> spec.after(buildGradle -> {
+                  assertThat(buildGradle).contains("testRuntimeOnly \"org.junit.platform:junit-platform-launcher:");
+                  return buildGradle;
+              })
+            )
+          )
+        );
+    }
+}

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     compileOnly("io.micrometer:micrometer-core:latest.release")
     api("org.junit.jupiter:junit-jupiter-api")
     api("org.junit.jupiter:junit-jupiter-params")
+    api("org.junit.platform:junit-platform-launcher")
 
     implementation("org.assertj:assertj-core:latest.release")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")


### PR DESCRIPTION
## What's changed?
- Add recipe to add Gradle dependency on `org.junit.platform:junit-platform-launcher`
- Add transitive dependency when using `rewrite-test`

## What's your motivation?
Reduce the warnings seen in build logs when using Gradle 8.x, ahead of a migration to Gradle 9.
https://docs.gradle.org/8.11.1/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

## Anything in particular you'd like reviewers to focus on?
Would the `api` dependency already prevent that we have to add the testRuntimeOnly dependency for `rewrite-*`?

## Have you considered any alternatives or workarounds?
We could delay this until Gradle 9, but the warnings are already annoying right now.