### PR TITLE
Always add import for `Record` classes not from `java.lang` package, to avoid conflicts on Java 14+

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -210,6 +210,36 @@ class AddImportTest implements RewriteTest {
           )
         );
     }
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
+    @Test
+    void forceImportNoJavaRecord2() {
+        // Add import for a class named `Record`, even within the same package, to avoid conflicts with java.lang.Record
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false))),
+          //language=java
+          java(
+            """
+              package com.acme.bank;
+              
+              import com.acme.bank.*;
+              
+              class Foo {
+              }
+              """,
+            """
+              package com.acme.bank;
+              
+              import com.acme.bank.*;
+              
+              import com.acme.bank.Record;
+
+              class Foo {
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
+          )
+        );
+    }
 
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
     @Test

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -210,6 +210,7 @@ class AddImportTest implements RewriteTest {
           )
         );
     }
+
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
     @Test
     void forceImportNoJavaRecord2() {
@@ -232,7 +233,7 @@ class AddImportTest implements RewriteTest {
               import com.acme.bank.*;
               
               import com.acme.bank.Record;
-
+              
               class Foo {
               }
               """,

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -186,10 +186,11 @@ class AddImportTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
     @Test
-    void forceImportNoJavaRecord() {
+    void forceImportNonJavaLangRecord() {
         // Add import for a class named `Record`, even within the same package, to avoid conflicts with java.lang.Record
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false))),
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false)))
+            .parser(JavaParser.fromJavaVersion().dependsOn("package com.acme.bank; public class Record {}")),
           //language=java
           java(
             """
@@ -213,10 +214,11 @@ class AddImportTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/540")
     @Test
-    void forceImportNoJavaRecord2() {
+    void forceImportNonJavaLangRecordFromWildcardImport() {
         // Add import for a class named `Record`, even within the same package, to avoid conflicts with java.lang.Record
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false))),
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("com.acme.bank.Record", null, false)))
+            .parser(JavaParser.fromJavaVersion().dependsOn("package com.acme.bank; public class Record {}")),
           //language=java
           java(
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -126,7 +126,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                     return !isRecord() && !i.isStatic() && i.getPackageName().equals(packageName) &&
                             (ending.equals(typeName) || "*".equals(ending));
                 }
-                return !isRecord()  && i.isStatic() && i.getTypeName().equals(fullyQualifiedName) &&
+                return !isRecord() && i.isStatic() && i.getTypeName().equals(fullyQualifiedName) &&
                         (ending.equals(member) || "*".equals(ending));
             })) {
                 return cu;
@@ -143,18 +143,17 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
 
             List<JRightPadded<J.Import>> imports = new ArrayList<>(cu.getPadding().getImports());
 
-            if (imports.isEmpty() && !cu.getClasses().isEmpty() &&
-                cu.getPackageDeclaration() == null) {
-                    // leave javadocs on the class and move other comments up to the import
-                    // (which could include license headers and the like)
-                    Space firstClassPrefix = cu.getClasses().get(0).getPrefix();
-                    importToAdd = importToAdd.withPrefix(firstClassPrefix
-                            .withComments(ListUtils.map(firstClassPrefix.getComments(), comment -> comment instanceof Javadoc ? null : comment))
-                            .withWhitespace(""));
+            if (imports.isEmpty() && !cu.getClasses().isEmpty() && cu.getPackageDeclaration() == null) {
+                // leave javadocs on the class and move other comments up to the import
+                // (which could include license headers and the like)
+                Space firstClassPrefix = cu.getClasses().get(0).getPrefix();
+                importToAdd = importToAdd.withPrefix(firstClassPrefix
+                        .withComments(ListUtils.map(firstClassPrefix.getComments(), comment -> comment instanceof Javadoc ? null : comment))
+                        .withWhitespace(""));
 
-                    cu = cu.withClasses(ListUtils.mapFirst(cu.getClasses(), clazz ->
-                            clazz.withComments(ListUtils.map(clazz.getComments(), comment -> comment instanceof Javadoc ? comment : null))
-                    ));
+                cu = cu.withClasses(ListUtils.mapFirst(cu.getClasses(), clazz ->
+                        clazz.withComments(ListUtils.map(clazz.getComments(), comment -> comment instanceof Javadoc ? comment : null))
+                ));
             }
 
             ImportLayoutStyle layoutStyle = Optional.ofNullable(((SourceFile) cu).getStyle(ImportLayoutStyle.class))

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -110,8 +110,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                 return cu;
             }
             // Nor if the classes are within the same package
-            if (!isRecord() && // Record's late addition to `java.lang` might conflict with user class
-                    cu.getPackageDeclaration() != null &&
+            if (!"Record".equals(typeName) && cu.getPackageDeclaration() != null &&
                     packageName.equals(cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()))) {
                 return cu;
             }
@@ -120,13 +119,13 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                 return cu;
             }
 
-            if (cu.getImports().stream().anyMatch(i -> {
+            if (!"Record".equals(typeName) && cu.getImports().stream().anyMatch(i -> {
                 String ending = i.getQualid().getSimpleName();
                 if (member == null) {
-                    return !isRecord() && !i.isStatic() && i.getPackageName().equals(packageName) &&
+                    return !i.isStatic() && i.getPackageName().equals(packageName) &&
                             (ending.equals(typeName) || "*".equals(ending));
                 }
-                return !isRecord() && i.isStatic() && i.getTypeName().equals(fullyQualifiedName) &&
+                return i.isStatic() && i.getTypeName().equals(fullyQualifiedName) &&
                         (ending.equals(member) || "*".equals(ending));
             })) {
                 return cu;
@@ -179,10 +178,6 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
             j = cu;
         }
         return j;
-    }
-
-    private boolean isRecord() {
-        return "Record".equals(typeName);
     }
 
     private List<JRightPadded<J.Import>> checkCRLF(JavaSourceFile cu, List<JRightPadded<J.Import>> newImports) {


### PR DESCRIPTION
## What's changed?
Force Importing No Java Record 

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
