### PR TITLE
Add `MarkerMode` to select a `MarkerPrinter`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/PrintOutputCapture.java
+++ b/rewrite-core/src/main/java/org/openrewrite/PrintOutputCapture.java
@@ -75,11 +75,31 @@ public class PrintOutputCapture<P> implements Cloneable {
         @Incubating(since = "8.41.4")
         @RequiredArgsConstructor
         enum MarkerMode {
+            /**
+             * Does not print any markers.
+             */
             NONE(MarkerPrinter.NONE),
+            /**
+             * Prints a squiggly line arrow in front of the marked element wrapped in a comment.
+             * /*~~>* /Thing thing
+             */
             DEFAULT(MarkerPrinter.DEFAULT),
+            /**
+             * Prints a squiggly line arrow in front of the marked element wrapped in a comment.
+             * Possibly adding verbose information, depending on the marker
+             * /*~~>(this is some verbose information)* /Thing thing
+             */
             VERBOSE(MarkerPrinter.VERBOSE),
-            FENCED(MarkerPrinter.FENCED),
-            SEARCH_ONLY(MarkerPrinter.SEARCH_ONLY);
+            /**
+             * Prints a squiggly arrow in front and after the marked element. It only includes {@link SearchResult}
+             * /*~~>* /Thing thing /**~~>* /
+             */
+            SEARCH_ONLY(MarkerPrinter.SEARCH_ONLY),
+            /**
+             * Prints a fenced marker ID in front and after the marked element. It only includes {@link Markup} and {@link SearchResult}
+             * /*{{3e2a36bb-7c16-4b03-bdde-bffda08838e7}}* /Thing thing /*{{3e2a36bb-7c16-4b03-bdde-bffda08838e7}}* /
+             */
+            FENCED_MARKUP_AND_SEARCH(MarkerPrinter.FENCED_MARKUP_AND_SEARCH);
             @Getter
             private final MarkerPrinter printer;
         }
@@ -101,7 +121,7 @@ public class PrintOutputCapture<P> implements Cloneable {
             }
         };
 
-        MarkerPrinter FENCED = new MarkerPrinter() {
+        MarkerPrinter FENCED_MARKUP_AND_SEARCH = new MarkerPrinter() {
             @Override
             public String beforeSyntax(Marker marker, Cursor cursor, UnaryOperator<String> commentWrapper) {
                 return marker instanceof SearchResult || marker instanceof Markup ? "{{" + marker.getId() + "}}" : "";

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -192,6 +192,16 @@ public class Result {
         return diff(relativeTo, markerPrinter, false);
     }
 
+    @Incubating(since = "8.41.4")
+    public String diff(@Nullable Path relativeTo, PrintOutputCapture.MarkerPrinter.MarkerMode markerMode) {
+        return diff(relativeTo, markerMode, false);
+    }
+
+    @Incubating(since = "8.41.4")
+    public String diff(@Nullable Path relativeTo, PrintOutputCapture.MarkerPrinter.MarkerMode markerMode, boolean ignoreAllWhitespace) {
+        return diff(relativeTo, markerMode.getPrinter(), ignoreAllWhitespace);
+    }
+
     @Incubating(since = "7.34.0")
     public String diff(@Nullable Path relativeTo, PrintOutputCapture.@Nullable MarkerPrinter markerPrinter, @Nullable Boolean ignoreAllWhitespace) {
         Path beforePath = before == null ? null : before.getSourcePath();

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -185,7 +185,7 @@ public class Result {
      * @return Git-style patch diff representing the changes to this compilation unit.
      */
     public String diff(@Nullable Path relativeTo) {
-        return diff(relativeTo, null);
+        return diff(relativeTo, (PrintOutputCapture.MarkerPrinter) null);
     }
 
     public String diff(@Nullable Path relativeTo, PrintOutputCapture.@Nullable MarkerPrinter markerPrinter) {


### PR DESCRIPTION
Instead of having to redefine `MarkerPrinter` everywhere we have a few standard `MarkerPrinter`s that can be used. There is a new diff method that uses the enum to select the right marker printer.

## What's changed?
Add `MarkerMode` and define `MarkerPrinter`s

## What's your motivation?
Reuse

## Anything in particular you'd like reviewers to focus on?
the set of marker printers

## Anyone you would like to review specifically?
@knutwannheden 

## Have you considered any alternatives or workarounds?
Not doing this

## Any additional context
No
