### PR TITLE
Make Groovy Parser correctly handle nested parenthesis

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -720,4 +720,14 @@ public class StringUtils {
     public static boolean hasLineBreak(@Nullable String s) {
         return s != null && LINE_BREAK.matcher(s).find();
     }
+
+    public static boolean containsWhitespace(String s) {
+        for(int i = 0; i < s.length(); ++i) {
+            if (Character.isWhitespace(s.charAt(i))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -722,7 +722,7 @@ public class StringUtils {
     }
 
     public static boolean containsWhitespace(String s) {
-        for(int i = 0; i < s.length(); ++i) {
+        for (int i = 0; i < s.length(); ++i) {
             if (Character.isWhitespace(s.charAt(i))) {
                 return true;
             }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2539,16 +2539,21 @@ public class GroovyParserVisitor {
             return (Integer) rawIpl;
         } else if (node instanceof MethodCallExpression) {
             MethodCallExpression expr = (MethodCallExpression) node;
-            int saveCursor = cursor;
-            whitespace();
-            int count = determineParenthesisLevel(expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
-            cursor = saveCursor;
-            return count;
+            return determineParenthesisLevel(expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
         }
         return null;
     }
 
+    /**
+     * @param childLineNumber the beginning line number of the first sub node
+     * @param parentLineNumber the beginning line number of the parent node
+     * @param childColumn the column on the {@code childLineNumber} line where the sub node starts
+     * @param parentColumn the column on the {@code parentLineNumber} line where the parent node starts
+     * @return the level of parenthesis parsed from the source
+     */
     private int determineParenthesisLevel(int childLineNumber, int parentLineNumber, int childColumn, int parentColumn) {
+        int saveCursor = cursor;
+        whitespace();
         int childBeginCursor = cursor;
         if (childLineNumber > parentLineNumber) {
             for (int i = 0; i < (childColumn - parentLineNumber); i++) {
@@ -2564,6 +2569,7 @@ public class GroovyParserVisitor {
                 count++;
             }
         }
+        cursor = saveCursor;
         return count;
     }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -763,10 +763,7 @@ public class GroovyParserVisitor {
         }
 
         private Expression insideParentheses(ASTNode node, Function<Space, Expression> parenthesizedTree) {
-            int saveCursor = cursor;
-            whitespace();
             Integer insideParenthesesLevel = getInsideParenthesesLevel(node);
-            cursor = saveCursor;
             if (insideParenthesesLevel != null && insideParenthesesLevel > 0) {
                 Stack<Space> openingParens = new Stack<>();
                 for (int i = 0; i < insideParenthesesLevel; i++) {
@@ -2536,6 +2533,8 @@ public class GroovyParserVisitor {
             return (Integer) rawIpl;
         } else if (node instanceof MethodCallExpression) {
             MethodCallExpression expr = (MethodCallExpression) node;
+            int saveCursor = cursor;
+            whitespace();
             int childBegin = cursor;
             if (expr.getObjectExpression().getLineNumber() != expr.getLineNumber()) {
                 for (int i = 0; i < (expr.getObjectExpression().getLineNumber() - expr.getLineNumber()) - 1; i++) {
@@ -2551,6 +2550,7 @@ public class GroovyParserVisitor {
                     count++;
                 }
             }
+            cursor = saveCursor;
             return count;
         } else {
             return null;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -763,7 +763,8 @@ public class GroovyParserVisitor {
         }
 
         private Expression insideParentheses(ASTNode node, Function<Space, Expression> parenthesizedTree) {
-            int saveCursor = cursor;whitespace();
+            int saveCursor = cursor;
+            whitespace();
             Integer insideParenthesesLevel = getInsideParenthesesLevel(node);
             cursor = saveCursor;
             if (insideParenthesesLevel != null && insideParenthesesLevel > 0) {
@@ -2532,23 +2533,23 @@ public class GroovyParserVisitor {
         if (rawIpl instanceof AtomicInteger) {
             // On Java 11 and newer _INSIDE_PARENTHESES_LEVEL is an AtomicInteger
             return ((AtomicInteger) rawIpl).get();
-        }  else if (rawIpl instanceof Integer) {
+        } else if (rawIpl instanceof Integer) {
             // On Java 8 _INSIDE_PARENTHESES_LEVEL is a regular Integer
             return (Integer) rawIpl;
         } else if (node instanceof MethodCallExpression) {
             MethodCallExpression expr = (MethodCallExpression) node;
             int childBegin = cursor;
             if (expr.getObjectExpression().getLineNumber() != expr.getLineNumber()) {
-                for (int i = 0; i < (expr.getObjectExpression().getLineNumber() - expr.getLineNumber()) - 1 ; i++) {
+                for (int i = 0; i < (expr.getObjectExpression().getLineNumber() - expr.getLineNumber()) - 1; i++) {
                     childBegin = source.indexOf('\n', childBegin);
                 }
                 childBegin += expr.getObjectExpression().getColumnNumber();
             } else {
-                childBegin += expr.getObjectExpression().getColumnNumber() - expr.getColumnNumber() ;
+                childBegin += expr.getObjectExpression().getColumnNumber() - expr.getColumnNumber();
             }
             int count = 0;
             for (int i = cursor; i < childBegin; i++) {
-                if (source.charAt(i) == '('){
+                if (source.charAt(i) == '(') {
                     count++;
                 }
             }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -778,8 +778,6 @@ public class GroovyParserVisitor {
                             padRight(parenthesized, sourceBefore(")")));
                 }
                 return parenthesized;
-            } else {
-                cursor = saveCursor;
             }
             return parenthesizedTree.apply(whitespace());
         }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -764,7 +764,7 @@ public class GroovyParserVisitor {
 
         private Expression insideParentheses(ASTNode node, Function<Space, Expression> parenthesizedTree) {
             Integer insideParenthesesLevel = getInsideParenthesesLevel(node);
-            if (insideParenthesesLevel != null && insideParenthesesLevel > 0) {
+            if (insideParenthesesLevel != null) {
                 Stack<Space> openingParens = new Stack<>();
                 for (int i = 0; i < insideParenthesesLevel; i++) {
                     openingParens.push(sourceBefore("("));

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1361,7 +1361,7 @@ public class GroovyParserVisitor {
                     String valueAccordingToAST = source.substring(cursor, cursor + length + (attributeSelector ? 1 : 0));
                     int delimiterLength = getDelimiterLength();
                     if (StringUtils.containsWhitespace(valueAccordingToAST)) {
-                        length = delimiterLength + ((String) expression.getValue()).length() + delimiterLength;
+                        length = delimiterLength + expression.getValue().toString().length() + delimiterLength;
                         text = source.substring(cursor, cursor + length + (attributeSelector ? 1 : 0));
                     } else {
                         text = valueAccordingToAST;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2554,7 +2554,7 @@ public class GroovyParserVisitor {
             for (int i = 0; i < (childColumn - parentLineNumber); i++) {
                 childBeginCursor = source.indexOf('\n', childBeginCursor);
             }
-            childBeginCursor += childBeginCursor;
+            childBeginCursor += childColumn;
         } else {
             childBeginCursor += childColumn - parentColumn;
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -35,7 +35,6 @@ class AttributeTest implements RewriteTest {
       }
       """;
 
-
     @Test
     void attribute() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -39,11 +39,7 @@ class AttributeTest implements RewriteTest {
     void attribute() {
         rewriteRun(
           srcTestGroovy(groovy(SOME_USER)),
-          groovy(
-            """
-              new User("Bob").@name == 'Bob'
-              """
-          )
+          groovy("new User('Bob').@name == 'Bob'")
         );
     }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -25,21 +25,21 @@ class AttributeTest implements RewriteTest {
     @Test
     void attribute() {
         rewriteRun(
-          groovy("new User('Bob').@name == 'Bob'")
+          groovy("new User('Bob').@name")
         );
     }
 
     @Test
     void attributeInClosure() {
         rewriteRun(
-          groovy("[new User('Bob')].find { it.@name == 'Bob' }")
+          groovy("[new User('Bob')].collect { it.@name }")
         );
     }
 
     @Test
     void attributeWithParentheses() {
         rewriteRun(
-          groovy("(new User('Bob').@name) == 'Bob'")
+          groovy("(new User('Bob').@name)")
         );
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -15,39 +15,52 @@
  */
 package org.openrewrite.groovy.tree;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.groovy.Assertions.srcTestGroovy;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.srcTestJava;
 
 @SuppressWarnings({"GroovyUnusedAssignment", "GrUnnecessarySemicolon"})
 class AttributeTest implements RewriteTest {
 
+    @Language("groovy")
+    private static final String SOME_USER = """
+      class User {
+        public final String name
+        User(String name) { this.name = name}
+      }
+      """;
+
+
     @Test
-    void usingGroovyNode() {
+    void attribute() {
         rewriteRun(
+          srcTestGroovy(groovy(SOME_USER)),
           groovy(
             """
-              def xml = new Node(null, "ivy")
-              def n = xml.dependencies.dependency.find { it.@name == 'test-module' }
-              n.@conf = 'runtime->default;docs->docs;sources->sources'
+              new User("Bob").@name == 'Bob'
               """
           )
         );
     }
 
     @Test
+    void attributeInClosure() {
+        rewriteRun(
+          srcTestGroovy(groovy(SOME_USER)),
+          groovy("[new User('Bob')].find { it.@name == 'Bob' }")
+        );
+    }
+
+    @Test
     void attributeWithParentheses() {
         rewriteRun(
-          groovy(
-            """
-              class User {
-                public final String name
-                User(String name) { this.name = name}
-             }
-             (new User("henk").@name) == 'henk'
-             """
-          )
+          srcTestGroovy(groovy(SOME_USER)),
+          groovy("(new User('Bob').@name) == 'Bob'")
         );
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -15,30 +15,16 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
-import static org.openrewrite.groovy.Assertions.srcTestGroovy;
-import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.srcTestJava;
 
-@SuppressWarnings({"GroovyUnusedAssignment", "GrUnnecessarySemicolon"})
 class AttributeTest implements RewriteTest {
-
-    @Language("groovy")
-    private static final String SOME_USER = """
-      class User {
-        public final String name
-        User(String name) { this.name = name}
-      }
-      """;
 
     @Test
     void attribute() {
         rewriteRun(
-          srcTestGroovy(groovy(SOME_USER)),
           groovy("new User('Bob').@name == 'Bob'")
         );
     }
@@ -46,7 +32,6 @@ class AttributeTest implements RewriteTest {
     @Test
     void attributeInClosure() {
         rewriteRun(
-          srcTestGroovy(groovy(SOME_USER)),
           groovy("[new User('Bob')].find { it.@name == 'Bob' }")
         );
     }
@@ -54,7 +39,6 @@ class AttributeTest implements RewriteTest {
     @Test
     void attributeWithParentheses() {
         rewriteRun(
-          srcTestGroovy(groovy(SOME_USER)),
           groovy("(new User('Bob').@name) == 'Bob'")
         );
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -35,4 +35,19 @@ class AttributeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void attributeWithParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              class User {
+                public final String name
+                User(String name) { this.name = name}
+             }
+             (new User("henk").@name) == 'henk'
+             """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
@@ -34,6 +33,7 @@ class BinaryTest implements RewriteTest {
 
           // NOT inside parentheses, but verifies the parser's
           // test for "inside parentheses" condition
+          groovy("( 1 ) + 1"),
           groovy("(1) + 1"),
           // And combine the two cases
           groovy("((1) + 1)")
@@ -211,6 +211,35 @@ class BinaryTest implements RewriteTest {
           groovy(
             """
               def foo = ("-" * 4)
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4703")
+    @Test
+    void cxds() {
+        rewriteRun(
+          groovy(
+            """
+              def differenceInDays(int time) {
+                  return (int) ((time)/(1000*60*60*24))
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4703")
+    @Test
+    void extraParensAroundInfixOxxxperator() {
+        rewriteRun(
+          groovy(
+            """
+              def timestamp(int hours, int minutes, int seconds) {
+                  30 * (hours)
+                  (((((hours))))) * 30
+              }
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -24,6 +23,18 @@ import static org.openrewrite.groovy.Assertions.groovy;
 
 @SuppressWarnings({"UnnecessaryQualifiedReference", "GroovyUnusedAssignment", "GrUnnecessarySemicolon"})
 class CastTest implements RewriteTest {
+
+    @Test
+    void javaStyleCastNew() {
+        rewriteRun(
+          groovy(
+            """
+              String foo = ( String ) "hallo"
+              String bar = "hallo" as String
+              """
+          )
+        );
+    }
 
     @Test
     void javaStyleCast() {
@@ -74,14 +85,13 @@ class CastTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              ( "" as String ).toString()
+              ( "x" as String      ).toString()
               """
           )
         );
     }
 
     @Test
-    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     void groovyCastAndInvokeMethodWithParentheses() {
         rewriteRun(
           groovy(
@@ -103,7 +113,6 @@ class CastTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Test
     void javaCastAndInvokeMethodWithParentheses() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
@@ -25,7 +25,7 @@ import static org.openrewrite.groovy.Assertions.groovy;
 class CastTest implements RewriteTest {
 
     @Test
-    void javaStyleCastNew() {
+    void cast() {
         rewriteRun(
           groovy(
             """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ListTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ListTest.java
@@ -24,11 +24,45 @@ import static org.openrewrite.groovy.Assertions.groovy;
 class ListTest implements RewriteTest {
 
     @Test
+    void emptyListLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              def a = []
+              def b = [   ]
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyListLiteralWithParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              def y = ([])
+              """
+          )
+        );
+    }
+
+    @Test
     void listLiteral() {
         rewriteRun(
           groovy(
             """
               def numbers = [1, 2, 3]
+              """
+          )
+        );
+    }
+
+    @Test
+    void listLiteralTrailingComma() {
+        rewriteRun(
+          groovy(
+            """
+              def a = [ "foo" /* "foo" suffix */ , /* "]" prefix */ ]
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -217,29 +217,6 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
-    void emptyListLiteral() {
-        rewriteRun(
-          groovy(
-            """
-              def a = []
-              def b = [   ]
-              """
-          )
-        );
-    }
-
-    @Test
-    void emptyListLiteralWithParentheses() {
-        rewriteRun(
-          groovy(
-            """
-              def y = ([])
-              """
-          )
-        );
-    }
-
-    @Test
     void multilineStringWithApostrophes() {
         rewriteRun(
           groovy(
@@ -260,17 +237,6 @@ class LiteralTest implements RewriteTest {
           groovy(
             """
               def a = [ foo : "bar" , ]
-              """
-          )
-        );
-    }
-
-    @Test
-    void listLiteralTrailingComma() {
-        rewriteRun(
-          groovy(
-            """
-              def a = [ "foo" /* "foo" suffix */ , /* "]" prefix */ ]
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -229,6 +229,17 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void emptyListLiteralWithParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              def y = ([])
+              """
+          )
+        );
+    }
+
+    @Test
     void multilineStringWithApostrophes() {
         rewriteRun(
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
@@ -56,6 +56,13 @@ class MapEntryTest implements RewriteTest {
     }
 
     @Test
+    void emptyMapLiteralWithParentheses() {
+        rewriteRun(
+          groovy("Map m =  ([  :  ])")
+        );
+    }
+
+    @Test
     void mapAccess() {
         rewriteRun(
           groovy("def a = someMap /*[*/ [ /*'*/ 'someKey' /*]*/ ]")

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -31,11 +30,11 @@ class MethodInvocationTest implements RewriteTest {
               plugins {
                   id 'java-library'
               }
-
+              
               repositories {
                   mavenCentral()
               }
-
+              
               dependencies {
                   implementation 'org.hibernate:hibernate-core:3.6.7.Final'
                   api 'com.google.guava:guava:23.0'
@@ -46,7 +45,6 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4615")
     void gradleWithParentheses() {
@@ -349,7 +347,7 @@ class MethodInvocationTest implements RewriteTest {
                 static boolean isEmpty(String value) {
                   return value == null || value.isEmpty()
                 }
-
+              
                 static void main(String[] args) {
                   isEmpty("")
                 }
@@ -359,7 +357,29 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Parentheses with method invocation is not yet supported")
+    @Issue("https://github.com/openrewrite/rewrite/issues/4703")
+    @Test
+    void insideParenthesesSimple() {
+        rewriteRun(
+          groovy(
+            """
+              ((a.invoke "b" ))
+              """
+          )
+        );
+    }
+
+    @Test
+    void lotOfSpacesAroundConstantWithParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              (  ( (    "x"         )        ).toString()       )
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4703")
     @Test
     void insideParentheses() {
@@ -375,7 +395,6 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Issue("https://github.com/openrewrite/rewrite/issues/4703")
     @Test
     void insideParenthesesWithoutNewLineAndEscapedMethodName() {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -406,4 +406,17 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void insideFourParenthesesAndEnters() {
+        rewriteRun(
+          groovy(
+            """
+              ((((
+                something(a)
+              ))))
+              """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -395,6 +395,21 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
+    @Test
+    void insideParenthesesWithNewline() {
+        rewriteRun(
+          groovy(
+            """              
+              static def foo(Map map) {
+                  ((
+                  map.containsKey("foo"))
+                      && ((map.get("foo")).equals("bar")))
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4703")
     @Test
     void insideParenthesesWithoutNewLineAndEscapedMethodName() {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -412,7 +412,7 @@ class MethodInvocationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              def a = ((((
+              ((((
                 something(a)
               ))))
               """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -412,7 +412,7 @@ class MethodInvocationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              ((((
+              def a = ((((
                 something(a)
               ))))
               """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RangeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RangeTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
@@ -48,7 +47,6 @@ class RangeTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Test
     void parenthesizedAndInvokeMethodWithParentheses() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Nested parentheses around method invocations are supported as well for the groovy parser.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- https://github.com/openrewrite/rewrite/issues/4703
- https://github.com/openrewrite/rewrite/issues/4615

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
