### PR TITLE
Add fallback for determining parenthesis level for `BinaryExpression`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2540,6 +2540,10 @@ public class GroovyParserVisitor {
         } else if (node instanceof MethodCallExpression) {
             MethodCallExpression expr = (MethodCallExpression) node;
             return determineParenthesisLevel(expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
+        } else if (node instanceof BinaryExpression) {
+            BinaryExpression expr = (BinaryExpression) node;
+            return determineParenthesisLevel(expr.getLeftExpression().getLineNumber(), expr.getLineNumber(), expr.getLeftExpression().getColumnNumber(), expr.getColumnNumber());
+
         }
         return null;
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Added fallback for determining parenthesis level for `BinaryExpression`

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @jevanlingen @knutwannheden @sambsnyd 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Lower versions of Gradle do not provide the `_INSIDE_PARENTHESES_LEVEL` flag we expect

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
