### PR TITLE
Add recipe to remove Gradle Enterprise and Develocity

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveDevelocityConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/RemoveDevelocityConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.plugins;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.gradle.IsSettingsGradle;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+import static org.openrewrite.Preconditions.or;
+
+public class RemoveDevelocityConfiguration extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Remove Develocity configuration";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove Develocity configuration from a Gradle build.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                or(new IsBuildGradle<>(), new IsSettingsGradle<>()),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.@Nullable MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        if ("develocity".equals(method.getSimpleName()) ||
+                            "gradleEnterprise".equals(method.getSimpleName())) {
+                            return null;
+                        }
+                        return super.visitMethodInvocation(method, ctx);
+                    }
+                }
+        );
+    }
+}

--- a/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle.yml
+++ b/rewrite-gradle/src/main/resources/META-INF/rewrite/gradle.yml
@@ -42,3 +42,18 @@ recipeList:
       key: org.gradle.parallel
       value: true
       filePattern: gradle.properties
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.gradle.plugins.RemoveDevelocity
+displayName: Remove Develocity
+description: Remove the Develocity plugin and configuration from the Gradle build and settings files.
+recipeList:
+  - org.openrewrite.gradle.plugins.RemoveBuildPlugin:
+      pluginId: com.gradle.develocity
+  - org.openrewrite.gradle.plugins.RemoveSettingsPlugin:
+      pluginId: com.gradle.develocity
+  - org.openrewrite.gradle.plugins.RemoveBuildPlugin:
+      pluginId: com.gradle.enterprise
+  - org.openrewrite.gradle.plugins.RemoveSettingsPlugin:
+      pluginId: com.gradle.enterprise
+  - org.openrewrite.gradle.plugins.RemoveDevelocityConfiguration

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveDevelocityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveDevelocityTest.java
@@ -38,7 +38,6 @@ class RemoveDevelocityTest implements RewriteTest {
           settingsGradle(
             """
               plugins {
-                  id 'java'
                   id 'com.gradle.enterprise' version '3.16'
               }
               gradleEnterprise {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveDevelocityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveDevelocityTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.plugins;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+
+class RemoveDevelocityTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .beforeRecipe(withToolingApi())
+          .recipeFromResource("/META-INF/rewrite/gradle.yml", "org.openrewrite.gradle.plugins.RemoveDevelocity");
+    }
+
+    @Test
+    @DocumentExample
+    void removeGradleEnterprise() {
+        rewriteRun(
+          settingsGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'com.gradle.enterprise' version '3.16'
+              }
+              gradleEnterprise {
+                  server = 'https://ge.sam.com/'
+                  allowUntrustedServer = true
+                  buildScan {
+                      publishAlways()
+                      uploadInBackground = true
+                      capture {
+                          taskInputFiles = true
+                      }
+                  }
+                  buildCache {
+                      remote(gradleEnterprise.buildCache) {
+                          enabled = true
+                          push = System.getenv("CI") != null
+                      }
+                  }
+              }
+              """,
+            ""
+          )
+        );
+    }
+
+    @Test
+    void removeDevelocity() {
+        rewriteRun(
+          settingsGradle(
+            """
+              plugins {
+                  id 'com.gradle.develocity' version '3.17.6'
+              }
+              develocity {
+                  server = 'https://ge.sam.com/'
+                  allowUntrustedServer = true
+                  buildScan {
+                      uploadInBackground = true
+                      capture {
+                          fileFingerprints = true
+                      }
+                  }
+                  buildCache {
+                      remote(develocity.buildCache) {
+                          enabled = true
+                          push = System.getenv("CI") != null
+                      }
+                  }
+              }
+              """,
+            ""
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's your motivation?
We had recipes to add and migrate, but lacked recipes to remove. Some internal repositories for now can not use Gradle Enterprise/Develocity, so I'd like to remove these with a recipe.