### PR TITLE
Add a `isClassAvailable` method to the ReflectionUtils

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ReflectionUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ReflectionUtils.java
@@ -36,7 +36,18 @@ public class ReflectionUtils {
      * Cache for {@link Class#getDeclaredMethods()} plus equivalent default methods
      * from Java 8 based interfaces, allowing for fast iteration.
      */
-    private static final Map<Class<?>, Method[]> declaredMethodsCache = new ConcurrentHashMap<>(256);
+    private static final Map<Class<?>, Method[]> DECLARED_METHODS_CACHE = new ConcurrentHashMap<>(256);
+
+    public static boolean isClassAvailable(String fullyQualifiedClassName) {
+        try {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            ClassLoader classLoader = contextClassLoader == null ? ReflectionUtils.class.getClassLoader() : contextClassLoader;
+            Class.forName(fullyQualifiedClassName, false, classLoader);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 
     public static @Nullable Method findMethod(Class<?> clazz, String name, Class<?>... paramTypes) {
         Class<?> searchType = clazz;
@@ -54,7 +65,7 @@ public class ReflectionUtils {
     }
 
     private static Method[] getDeclaredMethods(Class<?> clazz) {
-        Method[] result = declaredMethodsCache.get(clazz);
+        Method[] result = DECLARED_METHODS_CACHE.get(clazz);
         if (result == null) {
             try {
                 Method[] declaredMethods = clazz.getDeclaredMethods();
@@ -70,7 +81,7 @@ public class ReflectionUtils {
                 } else {
                     result = declaredMethods;
                 }
-                declaredMethodsCache.put(clazz, (result.length == 0 ? EMPTY_METHOD_ARRAY : result));
+                DECLARED_METHODS_CACHE.put(clazz, (result.length == 0 ? EMPTY_METHOD_ARRAY : result));
             } catch (Throwable ex) {
                 throw new IllegalStateException("Failed to introspect Class [" + clazz.getName() +
                                                 "] from ClassLoader [" + clazz.getClassLoader() + "]", ex);

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ReflectionUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ReflectionUtilsTest.java
@@ -29,8 +29,8 @@ class ReflectionUtilsTest {
 
     @Test
     void classNotAvailable() {
-        boolean result = ReflectionUtils.isClassAvailable("org.openrewrite.internal.ReflectionUtilsTest");
-        assertTrue(result);
+        boolean result = ReflectionUtils.isClassAvailable("org.openrewrite.internal.ReflectionUtilsTest2");
+        assertFalse(result);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ReflectionUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ReflectionUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.internal;
 
 import org.junit.jupiter.api.Test;

--- a/rewrite-core/src/test/java/org/openrewrite/internal/ReflectionUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/ReflectionUtilsTest.java
@@ -1,0 +1,26 @@
+package org.openrewrite.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReflectionUtilsTest {
+
+    @Test
+    void classAvailable() {
+        boolean result = ReflectionUtils.isClassAvailable("org.openrewrite.internal.ReflectionUtilsTest");
+        assertTrue(result);
+    }
+
+    @Test
+    void classNotAvailable() {
+        boolean result = ReflectionUtils.isClassAvailable("org.openrewrite.internal.ReflectionUtilsTest");
+        assertTrue(result);
+    }
+
+    @Test
+    void classNotAvailableWhenFQNOmitted() {
+        boolean result = ReflectionUtils.isClassAvailable("ReflectionUtilsTest");
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
## What's changed?
Extra utility method to check if a class is available on the classpath.

## What's your motivation?
- https://github.com/openrewrite/rewrite-static-analysis/pull/411#discussion_r1895916548

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
