### PR TITLE
Keep the names of generic type variables defined by methods.

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -470,12 +470,14 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
             return existing;
         }
 
-        List<String> paramNames = null;
+        String[] paramNames = null;
         if (!methodSymbol.params().isEmpty()) {
-            paramNames = new ArrayList<>(methodSymbol.params().size());
-            for (Symbol.VarSymbol p : methodSymbol.params()) {
+            paramNames = new String[methodSymbol.params().size()];
+            com.sun.tools.javac.util.List<Symbol.VarSymbol> params = methodSymbol.params();
+            for (int i = 0; i < params.size(); i++) {
+                Symbol.VarSymbol p = params.get(i);
                 String s = p.name.toString();
-                paramNames.add(s);
+                paramNames[i] = s;
             }
         }
 
@@ -486,7 +488,7 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
                 methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
                 null,
                 paramNames,
-                null, null, null, null
+                null, null, null, null, null
         );
         typeCache.put(signature, method);
 
@@ -551,12 +553,14 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
                 return existing;
             }
 
-            List<String> paramNames = null;
+            String[] paramNames = null;
             if (!methodSymbol.params().isEmpty()) {
-                paramNames = new ArrayList<>(methodSymbol.params().size());
-                for (Symbol.VarSymbol p : methodSymbol.params()) {
+                paramNames = new String[methodSymbol.params().size()];
+                com.sun.tools.javac.util.List<Symbol.VarSymbol> params = methodSymbol.params();
+                for (int i = 0; i < params.size(); i++) {
+                    Symbol.VarSymbol p = params.get(i);
                     String s = p.name.toString();
-                    paramNames.add(s);
+                    paramNames[i] = s;
                 }
             }
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11TypeMapping.java
@@ -574,6 +574,17 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
                     }
                 }
             }
+
+            List<String> declaredFormalTypeNames = null;
+            for (Symbol.TypeVariableSymbol typeParam : methodSymbol.getTypeParameters()) {
+                if(typeParam.owner == methodSymbol) {
+                    if (declaredFormalTypeNames == null) {
+                        declaredFormalTypeNames = new ArrayList<>();
+                    }
+                    declaredFormalTypeNames.add(typeParam.name.toString());
+                }
+            }
+
             JavaType.Method method = new JavaType.Method(
                     null,
                     methodSymbol.flags_field,
@@ -582,8 +593,8 @@ class ReloadableJava11TypeMapping implements JavaTypeMapping<Tree> {
                     null,
                     paramNames,
                     null, null, null,
-                    // TODO: Figure out the correct thing to put here based on methodSymbol.defaultValue.getValue()
-                    defaultValues
+                    defaultValues,
+                    declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0])
             );
             typeCache.put(signature, method);
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17TypeMapping.java
@@ -494,7 +494,7 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                 methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
                 null,
                 paramNames,
-                null, null, null, null
+                null, null, null, null, null
         );
         typeCache.put(signature, method);
 
@@ -583,6 +583,17 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                     }
                 }
             }
+
+            List<String> declaredFormalTypeNames = null;
+            for (Symbol.TypeVariableSymbol typeParam : methodSymbol.getTypeParameters()) {
+                if(typeParam.owner == methodSymbol) {
+                    if (declaredFormalTypeNames == null) {
+                        declaredFormalTypeNames = new ArrayList<>();
+                    }
+                    declaredFormalTypeNames.add(typeParam.name.toString());
+                }
+            }
+
             JavaType.Method method = new JavaType.Method(
                     null,
                     methodSymbol.flags_field,
@@ -591,7 +602,8 @@ class ReloadableJava17TypeMapping implements JavaTypeMapping<Tree> {
                     null,
                     paramNames,
                     null, null, null,
-                    defaultValues
+                    defaultValues,
+                    declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0])
             );
             typeCache.put(signature, method);
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -505,7 +505,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                 methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
                 null,
                 paramNames,
-                null, null, null, null
+                null, null, null, null, null
         );
         typeCache.put(signature, method);
 
@@ -594,6 +594,17 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                     }
                 }
             }
+
+            List<String> declaredFormalTypeNames = null;
+            for (Symbol.TypeVariableSymbol typeParam : methodSymbol.getTypeParameters()) {
+                if(typeParam.owner == methodSymbol) {
+                    if (declaredFormalTypeNames == null) {
+                        declaredFormalTypeNames = new ArrayList<>();
+                    }
+                    declaredFormalTypeNames.add(typeParam.name.toString());
+                }
+            }
+
             JavaType.Method method = new JavaType.Method(
                     null,
                     methodSymbol.flags_field,
@@ -602,7 +613,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                     null,
                     paramNames,
                     null, null, null,
-                    defaultValues
+                    defaultValues,
+                    declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0])
             );
             typeCache.put(signature, method);
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -576,6 +576,17 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                     }
                 }
             }
+
+            List<String> declaredFormalTypeNames = null;
+            for (Symbol.TypeVariableSymbol typeParam : methodSymbol.getTypeParameters()) {
+                if(typeParam.owner == methodSymbol) {
+                    if (declaredFormalTypeNames == null) {
+                        declaredFormalTypeNames = new ArrayList<>();
+                    }
+                    declaredFormalTypeNames.add(typeParam.name.toString());
+                }
+            }
+
             JavaType.Method method = new JavaType.Method(
                     null,
                     methodSymbol.flags_field,
@@ -584,7 +595,8 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                     null,
                     paramNames,
                     null, null, null,
-                    defaultValues
+                    defaultValues,
+                    declaredFormalTypeNames == null ? null : declaredFormalTypeNames.toArray(new String[0])
             );
             typeCache.put(signature, method);
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8TypeMapping.java
@@ -472,12 +472,14 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
             return existing;
         }
 
-        List<String> paramNames = null;
+        String[] paramNames = null;
         if (!methodSymbol.params().isEmpty()) {
-            paramNames = new ArrayList<>(methodSymbol.params().size());
-            for (Symbol.VarSymbol p : methodSymbol.params()) {
+            paramNames = new String[methodSymbol.params().size()];
+            com.sun.tools.javac.util.List<Symbol.VarSymbol> params = methodSymbol.params();
+            for (int i = 0; i < params.size(); i++) {
+                Symbol.VarSymbol p = params.get(i);
                 String s = p.name.toString();
-                paramNames.add(s);
+                paramNames[i] = s;
             }
         }
 
@@ -488,7 +490,7 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                 methodSymbol.isConstructor() ? "<constructor>" : methodSymbol.getSimpleName().toString(),
                 null,
                 paramNames,
-                null, null, null, null
+                null, null, null, null, null
         );
         typeCache.put(signature, method);
 
@@ -554,14 +556,17 @@ class ReloadableJava8TypeMapping implements JavaTypeMapping<Tree> {
                 return existing;
             }
 
-            List<String> paramNames = null;
+            String[] paramNames = null;
             if (!methodSymbol.params().isEmpty()) {
-                paramNames = new ArrayList<>(methodSymbol.params().size());
-                for (Symbol.VarSymbol p : methodSymbol.params()) {
+                paramNames = new String[methodSymbol.params().size()];
+                com.sun.tools.javac.util.List<Symbol.VarSymbol> params = methodSymbol.params();
+                for (int i = 0; i < params.size(); i++) {
+                    Symbol.VarSymbol p = params.get(i);
                     String s = p.name.toString();
-                    paramNames.add(s);
+                    paramNames[i] = s;
                 }
             }
+
             List<String> defaultValues = null;
             if(methodSymbol.getDefaultValue() != null) {
                 if(methodSymbol.getDefaultValue() instanceof Attribute.Array) {

--- a/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeMappingTest.java
+++ b/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeMappingTest.java
@@ -64,6 +64,21 @@ public interface JavaTypeMappingTest {
     }
 
     @Test
+    default void shadowedDeclaredFormalTypeParameters() {
+        // this method overrides the class definition of the type variable T
+        assertThat(methodType("nameShadow").getDeclaredFormalTypeNames())
+                .containsExactly("T");
+
+        // this method provides an unshadowed definition of U
+        assertThat(methodType("genericUnbounded").getDeclaredFormalTypeNames())
+                .containsExactly("U");
+
+        // this method uses the definition of T from the class level
+        assertThat(methodType("genericT").getDeclaredFormalTypeNames())
+                .isEmpty();
+    }
+
+    @Test
     default void javaLangObjectHasNoSupertype() {
         assertThat(goatType().getSupertype().getSupertype()).isNull();
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -341,7 +341,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
                 "<constructor>",
                 null,
                 paramNames,
-                null, null, null, null
+                null, null, null, null, null
         );
         typeCache.put(signature, mappedMethod);
 
@@ -439,6 +439,17 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
                 defaultValues = Collections.singletonList(method.getDefaultValue().toString());
             }
         }
+
+        List<String> declaredFormalTypeNames = null;
+        for (TypeVariable<?> typeVariable : method.getTypeParameters()) {
+            if (typeVariable.getGenericDeclaration() == method) {
+                if (declaredFormalTypeNames == null) {
+                    declaredFormalTypeNames = new ArrayList<>();
+                }
+                declaredFormalTypeNames.add(typeVariable.getName());
+            }
+        }
+
         JavaType.Method mappedMethod = new JavaType.Method(
                 null,
                 method.getModifiers(),
@@ -447,7 +458,10 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
                 null,
                 paramNames,
                 null, null, null,
-                defaultValues
+                defaultValues,
+                declaredFormalTypeNames == null ?
+                        null :
+                        declaredFormalTypeNames.toArray(new String[0])
         );
         typeCache.put(signature, mappedMethod);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1116,6 +1116,33 @@ public interface JavaType {
         @NonFinal
         List<String> defaultValue;
 
+        /**
+         * The names of the generic type variables declared by this method. These names
+         * will occur as the name in a {@link GenericTypeVariable} parameter,
+         * return type, or thrown exception declaration elsewhere in the method definition. We
+         * keep track of the names of those variables that were defined by this method in order
+         * to be able to distinguish them from generic type variables, potentially of the same
+         * name, defined on a containing class. Some examples:
+         * <br><br>
+         * <pre>
+         * {@code
+         * interface Test<T> {
+         *   <U> U m1();   // [U] used as return type
+         *   <U> void m2(U); // [U] used as parameter
+         *   <U extends FileNotFoundException> void m3() throws U; // [U]
+         *
+         *   T m4(T);      // ∅ since T refers to the class definition of T
+         *   <T> T m3(T);  // [T] since it shadows the class definition of T
+         *   <U> U m4(T);  // [U] but not T because T refers to the class
+         * }
+         * }
+         * </pre>
+         */
+        @With
+        @NonFinal
+        String @Nullable [] declaredFormalTypeNames;
+
+        @Deprecated
         public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
                       @Nullable JavaType returnType, @Nullable List<String> parameterNames,
                       @Nullable List<JavaType> parameterTypes, @Nullable List<JavaType> thrownExceptions,
@@ -1124,10 +1151,20 @@ public interface JavaType {
                     thrownExceptions, annotations, null);
         }
 
+        @Deprecated
         public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
                       @Nullable JavaType returnType, @Nullable List<String> parameterNames,
                       @Nullable List<JavaType> parameterTypes, @Nullable List<JavaType> thrownExceptions,
                       @Nullable List<FullyQualified> annotations, @Nullable List<String> defaultValue) {
+            this(managedReference, flagsBitMap, declaringType, name, returnType, parameterNames, parameterTypes,
+                    thrownExceptions, annotations, defaultValue, null);
+        }
+
+        public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
+                      @Nullable JavaType returnType, @Nullable List<String> parameterNames,
+                      @Nullable List<JavaType> parameterTypes, @Nullable List<JavaType> thrownExceptions,
+                      @Nullable List<FullyQualified> annotations, @Nullable List<String> defaultValue,
+                      @Nullable List<String> declaredFormalTypeNames) {
             this(
                     managedReference,
                     flagsBitMap,
@@ -1138,14 +1175,16 @@ public interface JavaType {
                     arrayOrNullIfEmpty(parameterTypes, EMPTY_JAVA_TYPE_ARRAY),
                     arrayOrNullIfEmpty(thrownExceptions, EMPTY_FULLY_QUALIFIED_ARRAY),
                     arrayOrNullIfEmpty(annotations, EMPTY_FULLY_QUALIFIED_ARRAY),
-                    defaultValue
+                    defaultValue,
+                    arrayOrNullIfEmpty(declaredFormalTypeNames, EMPTY_STRING_ARRAY)
             );
         }
 
         public Method(@Nullable Integer managedReference, long flagsBitMap, @Nullable FullyQualified declaringType, String name,
                       @Nullable JavaType returnType, String @Nullable [] parameterNames,
                       JavaType @Nullable [] parameterTypes, JavaType @Nullable [] thrownExceptions,
-                      FullyQualified @Nullable [] annotations, @Nullable List<String> defaultValue) {
+                      FullyQualified @Nullable [] annotations, @Nullable List<String> defaultValue,
+                      String @Nullable [] declaredFormalTypeNames) {
             this.managedReference = managedReference;
             this.flagsBitMap = flagsBitMap & Flag.VALID_FLAGS;
             this.declaringType = unknownIfNull(declaringType);
@@ -1156,6 +1195,7 @@ public interface JavaType {
             this.thrownExceptions = nullIfEmpty(thrownExceptions);
             this.annotations = nullIfEmpty(annotations);
             this.defaultValue = nullIfEmpty(defaultValue);
+            this.declaredFormalTypeNames = nullIfEmpty(declaredFormalTypeNames);
         }
 
         @JsonCreator
@@ -1191,6 +1231,7 @@ public interface JavaType {
             this.parameterTypes = ListUtils.nullIfEmpty(parameterTypes);
             this.thrownExceptions = ListUtils.nullIfEmpty(thrownExceptions);
             this.annotations = ListUtils.nullIfEmpty(annotations);
+            this.declaredFormalTypeNames = ListUtils.nullIfEmpty(declaredFormalTypeNames);
             return this;
         }
 
@@ -1290,13 +1331,18 @@ public interface JavaType {
             return parameterNames == null ? emptyList() : Arrays.asList(parameterNames);
         }
 
+        public List<String> getDeclaredFormalTypeNames() {
+            return declaredFormalTypeNames == null ? emptyList() : Arrays.asList(declaredFormalTypeNames);
+        }
+
         public Method withParameterNames(@Nullable List<String> parameterNames) {
             String[] parameterNamesArray = arrayOrNullIfEmpty(parameterNames, EMPTY_STRING_ARRAY);
             if (Arrays.equals(parameterNamesArray, this.parameterNames)) {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    parameterNamesArray, this.parameterTypes, this.thrownExceptions, this.annotations, this.defaultValue);
+                    parameterNamesArray, this.parameterTypes, this.thrownExceptions, this.annotations, this.defaultValue,
+                    this.declaredFormalTypeNames);
         }
 
         public List<JavaType> getParameterTypes() {
@@ -1309,7 +1355,8 @@ public interface JavaType {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    this.parameterNames, parameterTypesArray, this.thrownExceptions, this.annotations, this.defaultValue);
+                    this.parameterNames, parameterTypesArray, this.thrownExceptions, this.annotations, this.defaultValue,
+                    this.declaredFormalTypeNames);
         }
 
         public List<JavaType> getThrownExceptions() {
@@ -1322,7 +1369,8 @@ public interface JavaType {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    this.parameterNames, this.parameterTypes, thrownExceptionsArray, this.annotations, this.defaultValue);
+                    this.parameterNames, this.parameterTypes, thrownExceptionsArray, this.annotations, this.defaultValue,
+                    this.declaredFormalTypeNames);
         }
 
         public List<FullyQualified> getAnnotations() {
@@ -1335,7 +1383,8 @@ public interface JavaType {
                 return this;
             }
             return new Method(this.managedReference, this.flagsBitMap, this.declaringType, this.name, this.returnType,
-                    this.parameterNames, this.parameterTypes, this.thrownExceptions, annotationsArray, this.defaultValue);
+                    this.parameterNames, this.parameterTypes, this.thrownExceptions, annotationsArray, this.defaultValue,
+                    this.declaredFormalTypeNames);
         }
 
         public boolean hasFlags(Flag... test) {


### PR DESCRIPTION
## What's changed?

A new field has been added to `JavaType.Method` called `declaredFormalTypeNames`. The phrase "formal type name" is a reference to the grammar of `FormalTypeParameters` in [JVMS 4.3.4](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.4).

Previously, we were unable to detect whether a generic type variable name that was used in either a parameter, return type, or a thrown exception declaration in a method declaration was defined by that method or was instead referring to a type variable of the same name defined by an enclosing class. We could determine whether the class or method defined the type variable only when there was no possibility that the method was shadowing the class.

Some examples for when there will and will not be names in this new array of data:

<img width="560" alt="image" src="https://github.com/user-attachments/assets/ef3f1976-5608-467b-af06-a971c0840614" />

## What's your motivation?

The last type mapping change that I'm aware of that needs to be made to support compile verification as a post-recipe task.

## Anything in particular you'd like reviewers to focus on?

I think we are fine with LST deserialization since this is additive.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases