### PR TITLE
Fix Java reflection mapping of generic typed fields.

### DIFF
--- a/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
+++ b/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeGoat.java
@@ -26,8 +26,9 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
 
     public static final PT<TypeA> parameterizedField = new PT<TypeA>() {
     };
-    public static final Double PI = 3.14;
-    public static final double PI_PRIMITIVE = 3.14;
+
+    public static Double PI;
+    public static double PI_PRIMITIVE;
 
     public static abstract class InheritedJavaTypeGoat<T, U extends PT<U> & C> extends JavaTypeGoat<T, U> {
         public InheritedJavaTypeGoat() {

--- a/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeMappingTest.java
+++ b/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeMappingTest.java
@@ -25,9 +25,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.CONTRAVARIANT;
-import static org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.COVARIANT;
-import static org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.INVARIANT;
+import static org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.*;
 
 /**
  * Based on type attribution mappings of [JavaTypeGoat].
@@ -51,6 +49,19 @@ public interface JavaTypeMappingTest {
 
     default JavaType firstMethodParameter(String methodName) {
         return methodType(methodName).getParameterTypes().get(0);
+    }
+
+    @Test
+    default void declaredFields() {
+        JavaType.Parameterized goat = goatType();
+        assertThat(goat.getMembers().stream().filter(m -> m.getName().equals("parameterizedField")))
+                .anySatisfy(field ->
+                        assertThat(field).isInstanceOfSatisfying(JavaType.Variable.class, variable ->
+                                assertThat(variable.getType()).isInstanceOfSatisfying(JavaType.Parameterized.class, param ->
+                                        assertThat(param.getTypeParameters()).hasOnlyElementsOfType(JavaType.FullyQualified.class)
+                                )
+                        )
+                );
     }
 
     @Test

--- a/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeMappingTest.java
+++ b/rewrite-java-test/src/main/java/org/openrewrite/java/JavaTypeMappingTest.java
@@ -54,14 +54,13 @@ public interface JavaTypeMappingTest {
     @Test
     default void declaredFields() {
         JavaType.Parameterized goat = goatType();
-        assertThat(goat.getMembers().stream().filter(m -> m.getName().equals("parameterizedField")))
-                .anySatisfy(field ->
-                        assertThat(field).isInstanceOfSatisfying(JavaType.Variable.class, variable ->
-                                assertThat(variable.getType()).isInstanceOfSatisfying(JavaType.Parameterized.class, param ->
-                                        assertThat(param.getTypeParameters()).hasOnlyElementsOfType(JavaType.FullyQualified.class)
-                                )
+        assertThat(goat.getMembers().stream().filter(m -> m.getName().equals("parameterizedField"))).anySatisfy(field ->
+                assertThat(field).isInstanceOfSatisfying(JavaType.Variable.class, variable ->
+                        assertThat(variable.getType()).isInstanceOfSatisfying(JavaType.Parameterized.class, param ->
+                                assertThat(param.getTypeParameters()).hasOnlyElementsOfType(JavaType.FullyQualified.class)
                         )
-                );
+                )
+        );
     }
 
     @Test

--- a/rewrite-java-test/src/main/resources/JavaTypeGoat.java
+++ b/rewrite-java-test/src/main/resources/JavaTypeGoat.java
@@ -26,8 +26,9 @@ public abstract class JavaTypeGoat<T, S extends PT<S> & C> {
 
     public static final PT<TypeA> parameterizedField = new PT<TypeA>() {
     };
-    public static final Double PI = 3.14;
-    public static final double PI_PRIMITIVE = 3.14;
+
+    public static Double PI;
+    public static double PI_PRIMITIVE;
 
     public static abstract class InheritedJavaTypeGoat<T, U extends PT<U> & C> extends JavaTypeGoat<T, U> {
         public InheritedJavaTypeGoat() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java
@@ -302,7 +302,7 @@ public class JavaReflectionTypeMapping implements JavaTypeMapping<Type> {
             }
         }
 
-        mappedVariable.unsafeSet(type(field.getDeclaringClass()), type(field.getType()), annotations);
+        mappedVariable.unsafeSet(type(field.getDeclaringClass()), type(field.getGenericType()), annotations);
         return mappedVariable;
     }
 


### PR DESCRIPTION
## What's changed?

Previously `JavaReflectionTypeMapping` was mapping the raw instead of generic type for `JavaType.Variable`. This corrects that to use the generic type declaration as was done in the other type mapping implementations.

## What's your motivation?

Pursuing compiler verification as a post-recipe task.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases