### PR TITLE
Revert parenthesis changes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -720,14 +720,4 @@ public class StringUtils {
     public static boolean hasLineBreak(@Nullable String s) {
         return s != null && LINE_BREAK.matcher(s).find();
     }
-
-    public static boolean containsWhitespace(String s) {
-        for (int i = 0; i < s.length(); ++i) {
-            if (Character.isWhitespace(s.charAt(i))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2540,10 +2540,6 @@ public class GroovyParserVisitor {
         } else if (node instanceof MethodCallExpression) {
             MethodCallExpression expr = (MethodCallExpression) node;
             return determineParenthesisLevel(expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
-        } else if (node instanceof BinaryExpression) {
-            BinaryExpression expr = (BinaryExpression) node;
-            return determineParenthesisLevel(expr.getLeftExpression().getLineNumber(), expr.getLineNumber(), expr.getLeftExpression().getColumnNumber(), expr.getColumnNumber());
-
         }
         return null;
     }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -34,7 +34,6 @@ import org.openrewrite.groovy.marker.*;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.EncodingDetectingInputStream;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.marker.OmitParentheses;
@@ -1351,20 +1350,20 @@ public class GroovyParserVisitor {
                     jType = JavaType.Primitive.Short;
                 } else if (type == ClassHelper.STRING_TYPE) {
                     jType = JavaType.Primitive.String;
+                    // String literals value returned by getValue()/getText() has already processed sequences like "\\" -> "\"
+                    int length = sourceLengthOfString(expression);
                     // this is an attribute selector
-                    boolean attributeSelector = source.startsWith("@" + value, cursor);
-                    int length = lengthAccordingToAst(expression);
-                    Integer insideParenthesesLevel = getInsideParenthesesLevel(expression);
-                    if (insideParenthesesLevel != null) {
-                        length = length - insideParenthesesLevel * 2;
+                    if (source.startsWith("@" + value, cursor)) {
+                        length += 1;
                     }
-                    String valueAccordingToAST = source.substring(cursor, cursor + length + (attributeSelector ? 1 : 0));
-                    int delimiterLength = getDelimiterLength();
-                    if (StringUtils.containsWhitespace(valueAccordingToAST)) {
-                        length = delimiterLength + expression.getValue().toString().length() + delimiterLength;
-                        text = source.substring(cursor, cursor + length + (attributeSelector ? 1 : 0));
-                    } else {
-                        text = valueAccordingToAST;
+                    text = source.substring(cursor, cursor + length);
+                    int delimiterLength = 0;
+                    if (text.startsWith("$/")) {
+                        delimiterLength = 2;
+                    } else if (text.startsWith("\"\"\"") || text.startsWith("'''")) {
+                        delimiterLength = 3;
+                    } else if (text.startsWith("/") || text.startsWith("\"") || text.startsWith("'")) {
+                        delimiterLength = 1;
                     }
                     value = text.substring(delimiterLength, text.length() - delimiterLength);
                 } else if (expression.isNullExpression()) {
@@ -1691,18 +1690,15 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitListExpression(ListExpression list) {
-            queue.add(insideParentheses(list, fmt -> {
-                skip("[");
-                if (list.getExpressions().isEmpty()) {
-                    return new G.ListLiteral(randomId(), fmt, Markers.EMPTY,
-                            JContainer.build(singletonList(new JRightPadded<>(new J.Empty(randomId(), EMPTY, Markers.EMPTY), sourceBefore("]"), Markers.EMPTY))),
-                            typeMapping.type(list.getType()));
-                } else {
-                    return new G.ListLiteral(randomId(), fmt, Markers.EMPTY,
-                            JContainer.build(visitRightPadded(list.getExpressions().toArray(new ASTNode[0]), "]")),
-                            typeMapping.type(list.getType()));
-                }
-            }));
+            if (list.getExpressions().isEmpty()) {
+                queue.add(new G.ListLiteral(randomId(), sourceBefore("["), Markers.EMPTY,
+                        JContainer.build(singletonList(new JRightPadded<>(new J.Empty(randomId(), EMPTY, Markers.EMPTY), sourceBefore("]"), Markers.EMPTY))),
+                        typeMapping.type(list.getType())));
+            } else {
+                queue.add(new G.ListLiteral(randomId(), sourceBefore("["), Markers.EMPTY,
+                        JContainer.build(visitRightPadded(list.getExpressions().toArray(new ASTNode[0]), "]")),
+                        typeMapping.type(list.getType())));
+            }
         }
 
         @Override
@@ -1717,19 +1713,17 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitMapExpression(MapExpression map) {
-            queue.add(insideParentheses(map, fmt -> {
-                skip("[");
-                JContainer<G.MapEntry> entries;
-                if (map.getMapEntryExpressions().isEmpty()) {
-                    entries = JContainer.build(Collections.singletonList(JRightPadded.build(
-                            new G.MapEntry(randomId(), whitespace(), Markers.EMPTY,
-                                    JRightPadded.build(new J.Empty(randomId(), sourceBefore(":"), Markers.EMPTY)),
-                                    new J.Empty(randomId(), sourceBefore("]"), Markers.EMPTY), null))));
-                } else {
-                    entries = JContainer.build(visitRightPadded(map.getMapEntryExpressions().toArray(new ASTNode[0]), "]"));
-                }
-                return new G.MapLiteral(randomId(), fmt, Markers.EMPTY, entries, typeMapping.type(map.getType()));
-            }));
+            Space prefix = sourceBefore("[");
+            JContainer<G.MapEntry> entries;
+            if (map.getMapEntryExpressions().isEmpty()) {
+                entries = JContainer.build(Collections.singletonList(JRightPadded.build(
+                        new G.MapEntry(randomId(), whitespace(), Markers.EMPTY,
+                                JRightPadded.build(new J.Empty(randomId(), sourceBefore(":"), Markers.EMPTY)),
+                                new J.Empty(randomId(), sourceBefore("]"), Markers.EMPTY), null))));
+            } else {
+                entries = JContainer.build(visitRightPadded(map.getMapEntryExpressions().toArray(new ASTNode[0]), "]"));
+            }
+            queue.add(new G.MapLiteral(randomId(), prefix, Markers.EMPTY, entries, typeMapping.type(map.getType())));
         }
 
         @Override
@@ -1907,24 +1901,23 @@ public class GroovyParserVisitor {
 
         @Override
         public void visitAttributeExpression(AttributeExpression attr) {
-            queue.add(insideParentheses(attr, fmt -> {
-                Expression target = visit(attr.getObjectExpression());
-                Space beforeDot = attr.isSafe() ? sourceBefore("?.") :
-                        sourceBefore(attr.isSpreadSafe() ? "*." : ".");
-                J name = visit(attr.getProperty());
-                if (name instanceof J.Literal) {
-                    String nameStr = ((J.Literal) name).getValueSource();
-                    assert nameStr != null;
-                    name = new J.Identifier(randomId(), name.getPrefix(), Markers.EMPTY, emptyList(), nameStr, null, null);
-                }
-                if (attr.isSpreadSafe()) {
-                    name = name.withMarkers(name.getMarkers().add(new StarDot(randomId())));
-                }
-                if (attr.isSafe()) {
-                    name = name.withMarkers(name.getMarkers().add(new NullSafe(randomId())));
-                }
-                return new J.FieldAccess(randomId(), fmt, Markers.EMPTY, target, padLeft(beforeDot, (J.Identifier) name), null);
-            }));
+            Space fmt = whitespace();
+            Expression target = visit(attr.getObjectExpression());
+            Space beforeDot = attr.isSafe() ? sourceBefore("?.") :
+                    sourceBefore(attr.isSpreadSafe() ? "*." : ".");
+            J name = visit(attr.getProperty());
+            if (name instanceof J.Literal) {
+                String nameStr = ((J.Literal) name).getValueSource();
+                assert nameStr != null;
+                name = new J.Identifier(randomId(), name.getPrefix(), Markers.EMPTY, emptyList(), nameStr, null, null);
+            }
+            if (attr.isSpreadSafe()) {
+                name = name.withMarkers(name.getMarkers().add(new StarDot(randomId())));
+            }
+            if (attr.isSafe()) {
+                name = name.withMarkers(name.getMarkers().add(new NullSafe(randomId())));
+            }
+            queue.add(new J.FieldAccess(randomId(), fmt, Markers.EMPTY, target, padLeft(beforeDot, (J.Identifier) name), null));
         }
 
         @Override
@@ -2529,48 +2522,15 @@ public class GroovyParserVisitor {
         return lengthAccordingToAst;
     }
 
-    private @Nullable Integer getInsideParenthesesLevel(ASTNode node) {
+    private static @Nullable Integer getInsideParenthesesLevel(ASTNode node) {
         Object rawIpl = node.getNodeMetaData("_INSIDE_PARENTHESES_LEVEL");
         if (rawIpl instanceof AtomicInteger) {
             // On Java 11 and newer _INSIDE_PARENTHESES_LEVEL is an AtomicInteger
             return ((AtomicInteger) rawIpl).get();
-        } else if (rawIpl instanceof Integer) {
+        } else {
             // On Java 8 _INSIDE_PARENTHESES_LEVEL is a regular Integer
             return (Integer) rawIpl;
-        } else if (node instanceof MethodCallExpression) {
-            MethodCallExpression expr = (MethodCallExpression) node;
-            return determineParenthesisLevel(expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
         }
-        return null;
-    }
-
-    /**
-     * @param childLineNumber the beginning line number of the first sub node
-     * @param parentLineNumber the beginning line number of the parent node
-     * @param childColumn the column on the {@code childLineNumber} line where the sub node starts
-     * @param parentColumn the column on the {@code parentLineNumber} line where the parent node starts
-     * @return the level of parenthesis parsed from the source
-     */
-    private int determineParenthesisLevel(int childLineNumber, int parentLineNumber, int childColumn, int parentColumn) {
-        int saveCursor = cursor;
-        whitespace();
-        int childBeginCursor = cursor;
-        if (childLineNumber > parentLineNumber) {
-            for (int i = 0; i < (childColumn - parentLineNumber); i++) {
-                childBeginCursor = source.indexOf('\n', childBeginCursor);
-            }
-            childBeginCursor += childColumn;
-        } else {
-            childBeginCursor += childColumn - parentColumn;
-        }
-        int count = 0;
-        for (int i = cursor; i < childBeginCursor; i++) {
-            if (source.charAt(i) == '(') {
-                count++;
-            }
-        }
-        cursor = saveCursor;
-        return count;
     }
 
     private int getDelimiterLength() {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AttributeTest.java
@@ -20,26 +20,19 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
 
+@SuppressWarnings({"GroovyUnusedAssignment", "GrUnnecessarySemicolon"})
 class AttributeTest implements RewriteTest {
 
     @Test
-    void attribute() {
+    void usingGroovyNode() {
         rewriteRun(
-          groovy("new User('Bob').@name")
-        );
-    }
-
-    @Test
-    void attributeInClosure() {
-        rewriteRun(
-          groovy("[new User('Bob')].collect { it.@name }")
-        );
-    }
-
-    @Test
-    void attributeWithParentheses() {
-        rewriteRun(
-          groovy("(new User('Bob').@name)")
+          groovy(
+            """
+              def xml = new Node(null, "ivy")
+              def n = xml.dependencies.dependency.find { it.@name == 'test-module' }
+              n.@conf = 'runtime->default;docs->docs;sources->sources'
+              """
+          )
         );
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.groovy.tree;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
@@ -33,7 +34,6 @@ class BinaryTest implements RewriteTest {
 
           // NOT inside parentheses, but verifies the parser's
           // test for "inside parentheses" condition
-          groovy("( 1 ) + 1"),
           groovy("(1) + 1"),
           // And combine the two cases
           groovy("((1) + 1)")
@@ -211,35 +211,6 @@ class BinaryTest implements RewriteTest {
           groovy(
             """
               def foo = ("-" * 4)
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/4703")
-    @Test
-    void cxds() {
-        rewriteRun(
-          groovy(
-            """
-              def differenceInDays(int time) {
-                  return (int) ((time)/(1000*60*60*24))
-              }
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/4703")
-    @Test
-    void extraParensAroundInfixOxxxperator() {
-        rewriteRun(
-          groovy(
-            """
-              def timestamp(int hours, int minutes, int seconds) {
-                  30 * (hours)
-                  (((((hours))))) * 30
-              }
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CastTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -23,18 +24,6 @@ import static org.openrewrite.groovy.Assertions.groovy;
 
 @SuppressWarnings({"UnnecessaryQualifiedReference", "GroovyUnusedAssignment", "GrUnnecessarySemicolon"})
 class CastTest implements RewriteTest {
-
-    @Test
-    void cast() {
-        rewriteRun(
-          groovy(
-            """
-              String foo = ( String ) "hallo"
-              String bar = "hallo" as String
-              """
-          )
-        );
-    }
 
     @Test
     void javaStyleCast() {
@@ -85,13 +74,14 @@ class CastTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              ( "x" as String      ).toString()
+              ( "" as String ).toString()
               """
           )
         );
     }
 
     @Test
+    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     void groovyCastAndInvokeMethodWithParentheses() {
         rewriteRun(
           groovy(
@@ -113,6 +103,7 @@ class CastTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Test
     void javaCastAndInvokeMethodWithParentheses() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ListTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ListTest.java
@@ -24,45 +24,11 @@ import static org.openrewrite.groovy.Assertions.groovy;
 class ListTest implements RewriteTest {
 
     @Test
-    void emptyListLiteral() {
-        rewriteRun(
-          groovy(
-            """
-              def a = []
-              def b = [   ]
-              """
-          )
-        );
-    }
-
-    @Test
-    void emptyListLiteralWithParentheses() {
-        rewriteRun(
-          groovy(
-            """
-              def y = ([])
-              """
-          )
-        );
-    }
-
-    @Test
     void listLiteral() {
         rewriteRun(
           groovy(
             """
               def numbers = [1, 2, 3]
-              """
-          )
-        );
-    }
-
-    @Test
-    void listLiteralTrailingComma() {
-        rewriteRun(
-          groovy(
-            """
-              def a = [ "foo" /* "foo" suffix */ , /* "]" prefix */ ]
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -217,6 +217,18 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void emptyListLiteral() {
+        rewriteRun(
+          groovy(
+            """
+              def a = []
+              def b = [   ]
+              """
+          )
+        );
+    }
+
+    @Test
     void multilineStringWithApostrophes() {
         rewriteRun(
           groovy(
@@ -237,6 +249,17 @@ class LiteralTest implements RewriteTest {
           groovy(
             """
               def a = [ foo : "bar" , ]
+              """
+          )
+        );
+    }
+
+    @Test
+    void listLiteralTrailingComma() {
+        rewriteRun(
+          groovy(
+            """
+              def a = [ "foo" /* "foo" suffix */ , /* "]" prefix */ ]
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MapEntryTest.java
@@ -56,13 +56,6 @@ class MapEntryTest implements RewriteTest {
     }
 
     @Test
-    void emptyMapLiteralWithParentheses() {
-        rewriteRun(
-          groovy("Map m =  ([  :  ])")
-        );
-    }
-
-    @Test
     void mapAccess() {
         rewriteRun(
           groovy("def a = someMap /*[*/ [ /*'*/ 'someKey' /*]*/ ]")

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -30,11 +31,11 @@ class MethodInvocationTest implements RewriteTest {
               plugins {
                   id 'java-library'
               }
-              
+
               repositories {
                   mavenCentral()
               }
-              
+
               dependencies {
                   implementation 'org.hibernate:hibernate-core:3.6.7.Final'
                   api 'com.google.guava:guava:23.0'
@@ -45,6 +46,7 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4615")
     void gradleWithParentheses() {
@@ -347,7 +349,7 @@ class MethodInvocationTest implements RewriteTest {
                 static boolean isEmpty(String value) {
                   return value == null || value.isEmpty()
                 }
-              
+
                 static void main(String[] args) {
                   isEmpty("")
                 }
@@ -357,29 +359,7 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/4703")
-    @Test
-    void insideParenthesesSimple() {
-        rewriteRun(
-          groovy(
-            """
-              ((a.invoke "b" ))
-              """
-          )
-        );
-    }
-
-    @Test
-    void lotOfSpacesAroundConstantWithParentheses() {
-        rewriteRun(
-          groovy(
-            """
-              (  ( (    "x"         )        ).toString()       )
-              """
-          )
-        );
-    }
-
+    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Issue("https://github.com/openrewrite/rewrite/issues/4703")
     @Test
     void insideParentheses() {
@@ -395,21 +375,7 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
-    @Test
-    void insideParenthesesWithNewline() {
-        rewriteRun(
-          groovy(
-            """              
-              static def foo(Map map) {
-                  ((
-                  map.containsKey("foo"))
-                      && ((map.get("foo")).equals("bar")))
-              }
-              """
-          )
-        );
-    }
-
+    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Issue("https://github.com/openrewrite/rewrite/issues/4703")
     @Test
     void insideParenthesesWithoutNewLineAndEscapedMethodName() {
@@ -417,19 +383,6 @@ class MethodInvocationTest implements RewriteTest {
           groovy(
             """
               static def foo(Map someMap) {((((((someMap.get("(bar")))) ).'equals' "baz" )   )      }
-              """
-          )
-        );
-    }
-
-    @Test
-    void insideFourParenthesesAndEnters() {
-        rewriteRun(
-          groovy(
-            """
-              ((((
-                something(a)
-              ))))
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RangeTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RangeTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
@@ -47,6 +48,7 @@ class RangeTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail("Parentheses with method invocation is not yet supported")
     @Test
     void parenthesizedAndInvokeMethodWithParentheses() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
- Revert https://github.com/openrewrite/rewrite/pull/4801
- Revert https://github.com/openrewrite/rewrite/pull/4807

## What's your motivation?
Seeing increases parser failures as compared to before: https://app.moderne.io/results/Ab8rNRMZz

## Have you considered any alternatives or workarounds?
In parallel we'll briefly explore a roll forward as well, but this ensures we have a workable version soon.