### PR TITLE
Use `@org.jspecify.annotations.NonNull` for `@org.openrewrite.internal.lang.NonNull` instead of `@javax.annotation.Nonnull`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNull.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/NonNull.java
@@ -18,14 +18,13 @@ package org.openrewrite.internal.lang;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import javax.annotation.meta.TypeQualifierNickname;
 import java.lang.annotation.*;
 
 /**
  * A common annotation to declare that annotated elements cannot be {@code null}.
- * Leverages JSR 305 meta-annotations to indicate nullability in Java to common tools with
- * JSR 305 support and used by Kotlin to infer nullability of the API.
+ * Leverages JSpecify meta-annotations to indicate nullability in Java to common tools with
+ * JSpecify support and used by Kotlin to infer nullability of the API.
  * <p>Should be used at parameter, return value, and field level. Method overrides should
  * repeat parent {@code @NonNull} annotations unless they behave differently.
  * <p>Use {@code @NonNullApi} (scope = parameters + return values) and/or {@code @NonNullFields}
@@ -40,7 +39,7 @@ import java.lang.annotation.*;
 @Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Nonnull
+@org.jspecify.annotations.NonNull
 @TypeQualifierNickname
 @Deprecated
 public @interface NonNull {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/lang/Nullable.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/lang/Nullable.java
@@ -22,8 +22,8 @@ import java.lang.annotation.*;
 
 /**
  * A common annotation to declare that annotated elements can be {@code null} under
- * some circumstance. Leverages JSR 305 meta-annotations to indicate nullability in Java
- * to common tools with JSR 305 support and used by Kotlin to infer nullability of the API.
+ * some circumstance. Leverages JSpecify meta-annotations to indicate nullability in Java
+ * to common tools with JSpecify support and used by Kotlin to infer nullability of the API.
  * <p>Should be used at parameter, return value, and field level. Methods override should
  * repeat parent {@code @Nullable} annotations unless they behave differently.
  * <p>Can be used in association with {@code NonNullApi} or {@code @NonNullFields} to


### PR DESCRIPTION
## What's changed?

- This PR polishes the changes made in gh-4415 a bit.
