### PR TITLE
`AddAnnotationProcessor` should compare and update versions using a property

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
@@ -85,8 +85,11 @@ public class AddAnnotationProcessor extends Recipe {
                                             artifactId.equals(child.getChildValue("artifactId").orElse(null))) {
                                             if (!version.equals(child.getChildValue("version").orElse(null))) {
                                                 String oldVersion = child.getChildValue("version").orElse("");
-                                                VersionComparator comparator = Semver.validate(oldVersion, null).getValue();
-                                                if (comparator.compare(version, oldVersion) > 0) {
+                                                String lookupVersion = oldVersion.startsWith("${") ?
+                                                    getResolutionResult().getPom().getValue(oldVersion.trim()) :
+                                                    oldVersion;
+                                                VersionComparator comparator = Semver.validate(lookupVersion, null).getValue();
+                                                if (comparator.compare(version, lookupVersion) > 0) {
                                                     List<Xml.Tag> tags = tg.getChildren();
                                                     tags.set(i, child.withChildValue("version", version));
                                                     return tg.withContent(tags);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -178,4 +178,96 @@ class AddAnnotationProcessorTest implements RewriteTest {
           )
         );
     }
+
+
+    @Test
+    void addAnnotationWithVersionAsMavenProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new AddAnnotationProcessor(
+            "org.projectlombok",
+            "lombok-mapstruct-binding",
+            "0.2.0"
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <properties>
+                      <version.mapstruct>1.6.3</version.mapstruct>
+                      <version.lombok>1.18.36</version.lombok>
+                      <version.lombok.mapstruct.binding>0.2.0</version.lombok.mapstruct.binding>
+                  </properties>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <configuration>
+                                  <annotationProcessorPaths>
+                                      <path>
+                                          <groupId>org.mapstruct</groupId>
+                                          <artifactId>mapstruct-processor</artifactId>
+                                          <version>${version.mapstruct}</version>
+                                      </path>
+                                      <path>
+                                          <groupId>org.projectlombok</groupId>
+                                          <artifactId>lombok</artifactId>
+                                          <version>${version.lombok}</version>
+                                      </path>
+                                      <path>
+                                          <groupId>org.projectlombok</groupId>
+                                          <artifactId>lombok-mapstruct-binding</artifactId>
+                                          <version>${version.lombok.mapstruct.binding}</version>
+                                      </path>
+                                  </annotationProcessorPaths>
+                              </configuration>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <properties>
+                      <version.mapstruct>1.6.3</version.mapstruct>
+                      <version.lombok>1.18.36</version.lombok>
+                      <version.lombok.mapstruct.binding>0.1.0</version.lombok.mapstruct.binding>
+                  </properties>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <configuration>
+                                  <annotationProcessorPaths>
+                                      <path>
+                                          <groupId>org.mapstruct</groupId>
+                                          <artifactId>mapstruct-processor</artifactId>
+                                          <version>${version.mapstruct}</version>
+                                      </path>
+                                      <path>
+                                          <groupId>org.projectlombok</groupId>
+                                          <artifactId>lombok</artifactId>
+                                          <version>${version.lombok}</version>
+                                      </path>
+                                      <path>
+                                          <groupId>org.projectlombok</groupId>
+                                          <artifactId>lombok-mapstruct-binding</artifactId>
+                                          <version>0.2.0</version>
+                                      </path>
+                                  </annotationProcessorPaths>
+                              </configuration>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -222,7 +222,7 @@ class AddAnnotationProcessorTest implements RewriteTest {
                   <artifactId>my-app</artifactId>
                   <version>1</version>
                   <properties>
-                      <version.lombok.mapstruct.binding>0.1.0</version.lombok.mapstruct.binding>
+                      <version.lombok.mapstruct.binding>0.2.0</version.lombok.mapstruct.binding>
                   </properties>
                   <build>
                       <plugins>
@@ -233,7 +233,7 @@ class AddAnnotationProcessorTest implements RewriteTest {
                                       <path>
                                           <groupId>org.projectlombok</groupId>
                                           <artifactId>lombok-mapstruct-binding</artifactId>
-                                          <version>0.2.0</version>
+                                          <version>${version.lombok.mapstruct.binding}</version>
                                       </path>
                                   </annotationProcessorPaths>
                               </configuration>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -179,9 +179,8 @@ class AddAnnotationProcessorTest implements RewriteTest {
         );
     }
 
-
     @Test
-    void addAnnotationWithVersionAsMavenProperty() {
+    void addAnnotationWithOlderVersionAsMavenProperty() {
         rewriteRun(
           spec -> spec.recipe(new AddAnnotationProcessor(
             "org.projectlombok",
@@ -196,9 +195,7 @@ class AddAnnotationProcessorTest implements RewriteTest {
                   <artifactId>my-app</artifactId>
                   <version>1</version>
                   <properties>
-                      <version.mapstruct>1.6.3</version.mapstruct>
-                      <version.lombok>1.18.36</version.lombok>
-                      <version.lombok.mapstruct.binding>0.2.0</version.lombok.mapstruct.binding>
+                      <version.lombok.mapstruct.binding>0.1.0</version.lombok.mapstruct.binding>
                   </properties>
                   <build>
                       <plugins>
@@ -206,16 +203,6 @@ class AddAnnotationProcessorTest implements RewriteTest {
                               <artifactId>maven-compiler-plugin</artifactId>
                               <configuration>
                                   <annotationProcessorPaths>
-                                      <path>
-                                          <groupId>org.mapstruct</groupId>
-                                          <artifactId>mapstruct-processor</artifactId>
-                                          <version>${version.mapstruct}</version>
-                                      </path>
-                                      <path>
-                                          <groupId>org.projectlombok</groupId>
-                                          <artifactId>lombok</artifactId>
-                                          <version>${version.lombok}</version>
-                                      </path>
                                       <path>
                                           <groupId>org.projectlombok</groupId>
                                           <artifactId>lombok-mapstruct-binding</artifactId>
@@ -235,8 +222,6 @@ class AddAnnotationProcessorTest implements RewriteTest {
                   <artifactId>my-app</artifactId>
                   <version>1</version>
                   <properties>
-                      <version.mapstruct>1.6.3</version.mapstruct>
-                      <version.lombok>1.18.36</version.lombok>
                       <version.lombok.mapstruct.binding>0.1.0</version.lombok.mapstruct.binding>
                   </properties>
                   <build>
@@ -246,19 +231,49 @@ class AddAnnotationProcessorTest implements RewriteTest {
                               <configuration>
                                   <annotationProcessorPaths>
                                       <path>
-                                          <groupId>org.mapstruct</groupId>
-                                          <artifactId>mapstruct-processor</artifactId>
-                                          <version>${version.mapstruct}</version>
-                                      </path>
-                                      <path>
-                                          <groupId>org.projectlombok</groupId>
-                                          <artifactId>lombok</artifactId>
-                                          <version>${version.lombok}</version>
-                                      </path>
-                                      <path>
                                           <groupId>org.projectlombok</groupId>
                                           <artifactId>lombok-mapstruct-binding</artifactId>
                                           <version>0.2.0</version>
+                                      </path>
+                                  </annotationProcessorPaths>
+                              </configuration>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void addAnnotationWithSameVersionAsMavenProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new AddAnnotationProcessor(
+            "org.projectlombok",
+            "lombok-mapstruct-binding",
+            "0.2.0"
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <properties>
+                      <version.lombok.mapstruct.binding>0.2.0</version.lombok.mapstruct.binding>
+                  </properties>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <configuration>
+                                  <annotationProcessorPaths>
+                                      <path>
+                                          <groupId>org.projectlombok</groupId>
+                                          <artifactId>lombok-mapstruct-binding</artifactId>
+                                          <version>${version.lombok.mapstruct.binding}</version>
                                       </path>
                                   </annotationProcessorPaths>
                               </configuration>


### PR DESCRIPTION
## What's changed?
When adding a Maven annotation processor, handle a version specified as a property correctly.