### PR TITLE
Add support for lombok @Builder.Default Annotation

### DIFF
--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/BuilderDefaultNoOpHandler.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/BuilderDefaultNoOpHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.lombok;
+
+import com.sun.tools.javac.tree.JCTree;
+import lombok.Builder;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+
+@HandlerPriority(-1025)
+public class BuilderDefaultNoOpHandler extends JavacAnnotationHandler<Builder.Default> {
+    @Override
+    public void handle(AnnotationValues<Builder.Default> annotationValues, JCTree.JCAnnotation jcAnnotation, JavacNode javacNode) {
+    }
+}

--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/BuilderHandler.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/BuilderHandler.java
@@ -103,7 +103,7 @@ public class BuilderHandler extends JavacAnnotationHandler<Builder> {
         ListBuffer<Integer> indexes = new ListBuffer<>();
         for (int i = 0; i < nodes.size(); i++) {
             JavacNode node = nodes.get(i);
-            if (node.getKind().equals(ANNOTATION) && "lombok.Builder.Default".equals(node.get().type.toString())) {
+            if (node.getKind() == ANNOTATION && "lombok.Builder.Default".equals(node.get().type.toString())) {
                 indexes.add(i);
             }
         }

--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/BuilderHandler.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/BuilderHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.lombok;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import lombok.Builder;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.core.LombokImmutableList;
+import lombok.core.LombokNode;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.handlers.HandleBuilder;
+import lombok.javac.handlers.HandleConstructor;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static lombok.core.AST.Kind.ANNOTATION;
+
+@HandlerPriority(-1024)
+public class BuilderHandler extends JavacAnnotationHandler<Builder> {
+    @Override
+    public void handle(AnnotationValues<Builder> annotationValues, JCTree.JCAnnotation jcAnnotation, JavacNode javacNode) {
+        JavacNode parent = javacNode.up();
+        if (!(parent.get() instanceof JCTree.JCClassDecl)) {
+            new HandleBuilder().handle(annotationValues, jcAnnotation, javacNode);
+            return;
+        }
+        Map<JCTree.JCModifiers, List<JCTree.JCAnnotation>> modifiersAndOriginalAnnotationMap = new HashMap<>();
+        Map<JavacNode, LombokImmutableList<JavacNode>> nodeToChildrenMap = new HashMap<>();
+        Field childrenField = null;
+        try {
+            childrenField = LombokNode.class.getDeclaredField("children");
+            childrenField.setAccessible(true);
+            // The Lombok handler for the @Builder annotation sets the init expression to null for fields annotated
+            // with @Builder.Default. Unlike typical Lombok behavior, which either creates new methods or fields, the
+            // handler for Builder annotation modifies the existing variable declaration. As a result, the AST-to-LST
+            // converter never encounters the init expression, causing it to behave unexpectedly.
+            // Additionally, the @Builder.Default annotation generates a private method named $default$<varname>,
+            // which is unlikely to be called in original code. Therefore, it is safe to temporarily remove the
+            // @Builder.Default annotation during processing.
+            for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
+                LombokImmutableList<JavacNode> children = (LombokImmutableList<JavacNode>) childrenField.get(fieldNode);
+                nodeToChildrenMap.put(fieldNode, children);
+                LombokImmutableList<JavacNode> filtered = children;
+                for (int i : findBuilderDefaultIndexes(children)) {
+                    filtered = filtered.removeElementAt(i);
+                }
+                childrenField.set(fieldNode, filtered);
+                JCTree.JCVariableDecl fd = (JCTree.JCVariableDecl) fieldNode.get();
+                JCTree.JCModifiers modifiers = fd.getModifiers();
+                List<JCTree.JCAnnotation> originalAnnotations = modifiers.getAnnotations();
+                modifiersAndOriginalAnnotationMap.put(modifiers, originalAnnotations);
+                modifiers.annotations = removeBuilderDefault(originalAnnotations);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // On exception just continue with the original handler
+        }
+        new HandleBuilder().handle(annotationValues, jcAnnotation, javacNode);
+
+        // restore values
+        for (Map.Entry<JCTree.JCModifiers, List<JCTree.JCAnnotation>> entry : modifiersAndOriginalAnnotationMap.entrySet()) {
+            entry.getKey().annotations = entry.getValue();
+        }
+        for (Map.Entry<JavacNode, LombokImmutableList<JavacNode>> entry : nodeToChildrenMap.entrySet()) {
+            try {
+                childrenField.set(entry.getKey(), entry.getValue());
+            } catch (IllegalAccessException e) {
+                // Not possible.
+            }
+        }
+    }
+
+    private List<JCTree.JCAnnotation> removeBuilderDefault(List<JCTree.JCAnnotation> annotations) {
+        ListBuffer<JCTree.JCAnnotation> filteredAnnotations = new ListBuffer<>();
+        for (JCTree.JCAnnotation annotation : annotations) {
+            if (annotation.getAnnotationType().toString().equals("lombok.Builder.Default")) {
+                continue;
+            }
+            filteredAnnotations = filteredAnnotations.append(annotation);
+        }
+        return filteredAnnotations.toList();
+    }
+
+    private List<Integer> findBuilderDefaultIndexes(LombokImmutableList<JavacNode> nodes) {
+        ListBuffer<Integer> indexes = new ListBuffer<>();
+        for (int i = 0; i < nodes.size(); i++) {
+            JavacNode node = nodes.get(i);
+            if (node.getKind().equals(ANNOTATION) && "lombok.Builder.Default".equals(node.get().type.toString())) {
+                indexes.add(i);
+            }
+        }
+        return indexes.toList();
+    }
+}

--- a/rewrite-java-lombok/src/main/resources/META-INF/services/lombok.javac.JavacAnnotationHandler
+++ b/rewrite-java-lombok/src/main/resources/META-INF/services/lombok.javac.JavacAnnotationHandler
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 org.openrewrite.java.lombok.AllArgsConstructorHandler
+org.openrewrite.java.lombok.BuilderHandler
+org.openrewrite.java.lombok.BuilderDefaultNoOpHandler
 org.openrewrite.java.lombok.CleanupNoOpHandler
 org.openrewrite.java.lombok.ExtensionMethodHandler
 org.openrewrite.java.lombok.GetterHandler

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -119,6 +119,30 @@ class LombokTest implements RewriteTest {
     }
 
     @Test
+    void builderWithDefault() {
+        rewriteRun(
+          java(
+            """
+              import lombok.Builder;
+              
+              @Builder
+              class A {
+                  @Builder.Default boolean b = false;
+                  @Builder.Default int n = 0;
+                  @Builder.Default String s = "Hello, Anshuman!";
+              
+                  void test() {
+                      A x = A.builder().n(1).b(true).s("foo").build();
+                      A y = A.builder().n(1).b(true).build();
+                      A z = A.builder().n(1).build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void tostring() {
         rewriteRun(
           java(


### PR DESCRIPTION
## What's changed?
Added support for lombok Annotation @Builder.Default 

## What's your motivation?

### Issues
The JavaParser fails to parse source files containing the @Builder.Default annotation.
1.  The Lombok handler for @Builder sets the [init expression to null](https://github.com/projectlombok/lombok/blob/master/src/core/lombok/javac/handlers/HandleBuilder.java#L814) for fields annotated with @Builder.Default. As a result, the AST-to-LST converter never see this init expression, since it was removed from the original code.
2. The Lombok handler uses a [hack](https://github.com/projectlombok/lombok/blob/master/src/core/lombok/javac/handlers/HandleBuilderDefault.java#L53) to convert @Builder.Default into a fully qualified name, which disrupts the AST positions.

### Fix
1. Added logic to Remove the @Builder.Default annotation before invoking the Lombok @Builder handler and restored the original value after processing.
2. Updated the @Builder.Default annotation handler to NoOp, as it doesn't produce any output necessary for type attribution.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
