### PR TITLE
Groovy parsers should be able to support `.class`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -915,9 +915,14 @@ public class GroovyParserVisitor {
         @Override
         public void visitClassExpression(ClassExpression clazz) {
             String unresolvedName = clazz.getType().getUnresolvedName().replace('$', '.');
+            Space space = sourceBefore(unresolvedName);
+            if (source.substring(cursor).startsWith(".class")) {
+                unresolvedName += ".class";
+                cursor += 6;
+            }
             queue.add(TypeTree.build(unresolvedName)
                     .withType(typeMapping.type(clazz.getType()))
-                    .withPrefix(sourceBefore(unresolvedName)));
+                    .withPrefix(space));
         }
 
         @Override

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
@@ -86,6 +86,28 @@ class AssignmentTest implements RewriteTest {
     }
 
     @Test
+    void classAssignment() {
+        rewriteRun(
+          groovy(
+            """
+              def s = String
+              """
+          )
+        );
+    }
+
+    @Test
+    void classAssignmentJavaStyle() {
+        rewriteRun(
+          groovy(
+            """
+              def s = String.class
+              """
+          )
+        );
+    }
+
+    @Test
     void unaryMinus() {
         rewriteRun(
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -342,36 +342,6 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void useClassAsArgument() {
-        rewriteRun(
-          groovy(
-            """
-              class A {}
-              
-              def test(Class clazz) {}
-              
-              test(A)
-              """
-          )
-        );
-    }
-
-    @Test
-    void useClassAsArgumentJavaStyle() {
-        rewriteRun(
-          groovy(
-            """
-              class A {}
-              
-              def test(Class clazz) {}
-              
-              test(A.class)
-              """
-          )
-        );
-    }
-
-    @Test
     @ExpectedToFail("Anonymous inner class is not yet supported") // https://groovy-lang.org/objectorientation.html#_anonymous_inner_class
     void anonymousInnerClass() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -357,7 +357,6 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
-    @ExpectedToFail("Java style class argument is not yet supported") // https://groovy-lang.org/style-guide.html#_classes_as_first_class_citizens
     void useClassAsArgumentJavaStyle() {
         rewriteRun(
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -177,6 +177,28 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void useClassAsArgument() {
+        rewriteRun(
+          groovy(
+            """
+              foo(String)
+              """
+          )
+        );
+    }
+
+    @Test
+    void useClassAsArgumentJavaStyle() {
+        rewriteRun(
+          groovy(
+            """
+              foo(String.class)
+              """
+          )
+        );
+    }
+
+    @Test
     @SuppressWarnings("GroovyAssignabilityCheck")
     void closureWithImplicitParameter() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
@@ -195,7 +195,7 @@ class RealWorldGroovyTest implements RewriteTest {
               
                       project.rootProject.subprojects.each { module ->
               
-                          module.getPlugins().withType(JavaPlugin).all {
+                          module.getPlugins().withType(JavaPlugin.class).all {
               
                               Properties schemas = new Properties();
               


### PR DESCRIPTION
## What's changed?
Support JavaStyle `.class` suffix.

## What's your motivation?
Though the suffix is [optional](https://groovy-lang.org/style-guide.html#_classes_as_first_class_citizens) in Groovy, you can still use them, see for example: [SchemaZipPlugin](https://github.com/spring-projects/spring-session-data-geode/blob/1ca81cc330f800311be7bfca0aa16030107de288/buildSrc/src/main/groovy/io/spring/gradle/convention/SchemaZipPlugin.groovy).

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
