### PR TITLE
Support inner classes for groovy

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -619,13 +619,13 @@ public class GroovyParserVisitor {
 
             J.Block body = null;
             if (method.getCode() != null) {
-                ASTNode block = isConstructorOfInnerNonStaticClass ?
+                ASTNode code = isConstructorOfInnerNonStaticClass ?
                         new BlockStatement(
                                 ((BlockStatement) method.getCode()).getStatements().subList(2, ((BlockStatement) method.getCode()).getStatements().size()),
                                 ((BlockStatement) method.getCode()).getVariableScope()
                         )
                         : method.getCode();
-                body = bodyVisitor.visit(block);
+                body = bodyVisitor.visit(code);
             }
 
             queue.add(new J.MethodDeclaration(

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -542,7 +542,7 @@ public class GroovyParserVisitor {
                 In our LST, we don't need this internal logic, so we'll skip the first param + first two statements (ConstructorCallExpression and BlockStatement)}
                 See also: https://groovy-lang.org/differences.html#_creating_instances_of_non_static_inner_classes
                 */
-                isConstructorOfInnerNonStaticClass = method.getDeclaringClass().getName().contains("$") && (method.getDeclaringClass().getModifiers() & Modifier.STATIC) == 0;
+                isConstructorOfInnerNonStaticClass = method.getDeclaringClass() instanceof InnerClassNode && (method.getDeclaringClass().getModifiers() & Modifier.STATIC) == 0;
                 methodName = method.getDeclaringClass().getName().replaceFirst(".*\\$", "");
             } else if (source.startsWith(method.getName(), cursor)) {
                 methodName = method.getName();

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -393,6 +393,8 @@ public class GroovyParserVisitor {
                     JRightPadded.build(false),
                     sortedByPosition.values().stream()
                             .flatMap(asts -> asts.stream()
+                                    // anonymous classes will be visited as part of visiting the ConstructorCallExpression
+                                    .filter(ast -> !(ast instanceof InnerClassNode && ((InnerClassNode) ast).isAnonymous()))
                                     .map(ast -> {
                                         if (ast instanceof FieldNode) {
                                             visitField((FieldNode) ast);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -565,7 +565,7 @@ public class GroovyParserVisitor {
                     }                                       }
                   }                                       }
                 }
-                For our LST, we should skip that placeholder param + first two statements (ConstructorCallExpression and BlockStatement)}
+                In our LST, we don't need this internal logic, so we'll skip the placeholder param + first two statements (ConstructorCallExpression and BlockStatement)}
                 See also: https://groovy-lang.org/differences.html#_creating_instances_of_non_static_inner_classes
                 */
                 if (isConstructorOfInnerNonStaticClass && param.getName().startsWith("$")) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -607,7 +607,7 @@ public class GroovyParserVisitor {
                         singletonList(paramName))).withAfter(rightPad));
             }
 
-            if (unparsedParams.length == 0) {
+            if (unparsedParams.length == 0 || (isConstructorOfInnerNonStaticClass && unparsedParams.length == 1)) {
                 params.add(JRightPadded.build(new J.Empty(randomId(), sourceBefore(")"), Markers.EMPTY)));
             }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -342,7 +342,6 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
-    @ExpectedToFail("Anonymous inner class is not yet supported") // https://groovy-lang.org/objectorientation.html#_anonymous_inner_class
     void anonymousInnerClass() {
         rewriteRun(
           groovy(
@@ -350,6 +349,7 @@ class ClassDeclarationTest implements RewriteTest {
               interface Something {}
               
               class Test {
+                  Something something = new Something() {}
                   static def test() {
                       new Something() {}
                   }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -361,6 +361,22 @@ class ClassDeclarationTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4063")
+    void nestedClassWithoutParameters() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  class B {
+                      B() {}
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4063")
     void nestedClass() {
         rewriteRun(
           groovy(
@@ -372,6 +388,22 @@ class ClassDeclarationTest implements RewriteTest {
                           this.a = $a
                           this.b = b
                       }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4063")
+    void nestedStaticClassWithoutParameters() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  static class B {
+                      B() {}
                   }
               }
               """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -358,4 +358,44 @@ class ClassDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4063")
+    void nestedClass() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  class B {
+                      String a;String b
+                      B(String a, String b) {
+                          this.a = a
+                          this.b = b
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4063")
+    void nestedStaticClass() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  static class B {
+                      String a;String b
+                      B(String a, String b) {
+                          this.a = a
+                          this.b = b
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -383,8 +383,8 @@ class ClassDeclarationTest implements RewriteTest {
             """
               class A {
                   class B {
-                      String a;String b
-                      B(String $a, String b) {
+                      String a;String[] b
+                      B(String $a, String... b) {
                           this.a = $a
                           this.b = b
                       }
@@ -419,8 +419,8 @@ class ClassDeclarationTest implements RewriteTest {
             """
               class A {
                   static class B {
-                      String a;String b
-                      B(String a, String b) {
+                      String a;String[] b
+                      B(String a, String... b) {
                           this.a = a
                           this.b = b
                       }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -368,8 +368,8 @@ class ClassDeclarationTest implements RewriteTest {
               class A {
                   class B {
                       String a;String b
-                      B(String a, String b) {
-                          this.a = a
+                      B(String $a, String b) {
+                          this.a = $a
                           this.b = b
                       }
                   }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
@@ -135,7 +135,6 @@ class RealWorldGroovyTest implements RewriteTest {
     }
 
     @Test
-    @ExpectedToFail("Anonymous inner class is not yet supported") // https://groovy-lang.org/objectorientation.html#_anonymous_inner_class
     @Issue("https://github.com/spring-projects/spring-ldap/blob/v3.4.1/buildSrc/src/test/resources/samples/integrationtest/withgroovy/src/integration-test/groovy/sample/TheTest.groovy")
     void springLdapTheTest() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Inner classes our now totally supported (including anonymous classes).

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4063

## Anything in particular you'd like reviewers to focus on?
Most work to support inner classes was already done, the new code just adds some missing pieces.

## Any additional context
To support
- https://github.com/openrewrite/rewrite/issues/4704

 a `visitConstructor` was added. The code was 95% the same as the `visitMethod`. So I merged the `visitMethod` and `visitConstructor` again (a _ConstructorNode_ extends a _MethodNode_, so _visitMethod_ is enough).

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
