### PR TITLE
Don't skip type attribution on compilation error

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -118,6 +118,11 @@ public class ReloadableJava11Parser implements JavaParser {
         Options.instance(context).put("-g", "-g");
         Options.instance(context).put("-proc", "none");
 
+        // Ensure type attribution continues despite errors in individual files or nodes.
+        // If an error occurs in a single file or node, type attribution should still proceed
+        // for all other source files and unaffected nodes within the same file.
+        Options.instance(context).put("should-stop.ifError", "GENERATE");
+
         LOMBOK:
         if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
                 classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -116,6 +116,11 @@ public class ReloadableJava17Parser implements JavaParser {
         Options.instance(context).put("-g", "-g");
         Options.instance(context).put("-proc", "none");
 
+        // Ensure type attribution continues despite errors in individual files or nodes.
+        // If an error occurs in a single file or node, type attribution should still proceed
+        // for all other source files and unaffected nodes within the same file.
+        Options.instance(context).put("should-stop.ifError", "GENERATE");
+
         LOMBOK:
         if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
             classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.search.FindMissingTypes;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -706,6 +707,78 @@ class LombokTest implements RewriteTest {
         );
     }
 
+    @Test
+    void onConstructor() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().allowMissingType(o -> {
+              assert o instanceof FindMissingTypes.MissingTypeResult;
+              FindMissingTypes.MissingTypeResult result = (FindMissingTypes.MissingTypeResult) o;
+              // type attribution is missing for annotation args, as it was intentionally removed for processing.
+              return result.getPath().startsWith("Identifier->Annotation->");
+          }).build()),
+          java(
+            """
+              import lombok.AllArgsConstructor;
+              import lombok.Getter;
+              import lombok.Setter;
+              
+              import javax.inject.Inject;
+              import javax.persistence.Id;
+              import javax.persistence.Column;
+              import javax.validation.constraints.Max;
+              
+              @AllArgsConstructor(onConstructor=@__(@Inject))
+              public class OnXExample {
+                  @Getter(onMethod_={@Id, @Column(name="unique-id")}) //JDK8
+                  @Setter(onParam_=@Max(10000)) //JDK8
+                  private long unid;
+              
+                  public void test() {
+                      OnXExample x = new OnXExample(1L);
+                      x.setUnid(2L);
+                      System.out.println(x.getUnid());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void onConstructorNoArgs() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().allowMissingType(o -> {
+              assert o instanceof FindMissingTypes.MissingTypeResult;
+              FindMissingTypes.MissingTypeResult result = (FindMissingTypes.MissingTypeResult) o;
+              if (result.getJ() instanceof J.Identifier identifier) {
+                  // type attribution is missing for annotation args, as it was intentionally removed for processing.
+                  return identifier.getSimpleName().equals("__") || identifier.getSimpleName().equals("Inject");
+              }
+              return false;
+          }).build()),
+          java(
+            """
+              import lombok.NoArgsConstructor;
+              import lombok.NonNull;
+              import lombok.RequiredArgsConstructor;
+              
+              import javax.inject.Inject;
+              
+              @NoArgsConstructor(onConstructor = @__(@Inject))
+              @RequiredArgsConstructor(onConstructor = @__(@Inject))
+              public class OnXExample {
+                  @NonNull private Long unid;
+              
+                  public void test() {
+                      new OnXExample();
+                      new OnXExample(1L);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     /**
      * These test lombok features that we do not fully support.
      * Code should still parse and print back to its original source code but type information may be missing.
@@ -739,55 +812,6 @@ class LombokTest implements RewriteTest {
                           if (in.isEmpty()) return in;
                           return "" + Character.toTitleCase(in.charAt(0)) + in.substring(1).toLowerCase();
                       }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void onConstructor() {
-            rewriteRun(
-              spec -> spec.typeValidationOptions(TypeValidation.none()),
-              java(
-                """
-                  import lombok.AllArgsConstructor;
-                  import lombok.Getter;
-                  import lombok.Setter;
-                  
-                  import javax.inject.Inject;
-                  import javax.persistence.Id;
-                  import javax.persistence.Column;
-                  import javax.validation.constraints.Max;
-                  
-                  // @__ missing attribution
-                  @AllArgsConstructor(onConstructor=@__(@Inject))
-                  public class OnXExample {
-                      @Getter(onMethod_={@Id, @Column(name="unique-id")}) //JDK8
-                      @Setter(onParam_=@Max(10000)) //JDK8
-                      private long unid;
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void onConstructorNoArgs() {
-            rewriteRun(
-              spec -> spec.typeValidationOptions(TypeValidation.none()),
-              java(
-                """
-                  import lombok.NoArgsConstructor;
-                  import lombok.Getter;
-                  import lombok.RequiredArgsConstructor;import lombok.Setter;
-                  
-                  import javax.inject.Inject;
-                  // @__ missing attribution
-                  @NoArgsConstructor(onConstructor = @__(@Inject))
-                  @RequiredArgsConstructor(onConstructor_ = @__(@Inject))
-                  public class OnXExample {
-                      private long unid;
                   }
                   """
               )

--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -84,6 +84,7 @@ public class Assertions {
                             return true;
                         }
                     })
+                    .filter(missingType -> !typeValidation.allowMissingType().apply(missingType))
                     .collect(Collectors.toList());
             if (!missingTypeResults.isEmpty()) {
                 String missingTypes = missingTypeResults.stream()

--- a/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
@@ -21,6 +21,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
+import java.util.function.Function;
+
 /**
  * Controls the test framework's validation of invariants which are expected to hold true in an LST both before and
  * after the recipe run. Originally this applied only to validating the well-formedness of type metadata in Java LSTs
@@ -89,6 +91,12 @@ public class TypeValidation {
     private boolean cursorAcyclic = true;
 
     /**
+     * Given finer control to client when they need to allow missing type metadata for a specific node.
+     */
+    @Builder.Default
+    private Function<Object, Boolean> allowMissingType = o -> false;
+
+    /**
      * Enable all invariant validation checks.
      */
     public static TypeValidation all() {
@@ -99,7 +107,7 @@ public class TypeValidation {
      * Skip all invariant validation checks.
      */
     public static TypeValidation none() {
-        return new TypeValidation(false, false, false, false, false, false, false, false);
+        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false);
     }
 
     static TypeValidation before(RecipeSpec testMethodSpec, RecipeSpec testClassSpec) {


### PR DESCRIPTION
## What's changed?
Modified the compilation process to continue even when some steps encounter errors.

## What's your motivation?
While enabling Lombok annotation processing, custom logic was introduced to skip the processing of certain annotation arguments. This led to errors during the process step of the compilation. By default, the compiler [halts](https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java#L470) at any step encountering an error, which caused the subsequent type attribution step to be skipped entirely. As a result, a single error in the **process** step affected the entire project.

### Changes
1. Introduced a flag to allow compilation to continue despite errors in any step. (Applied changes to Java 11 and Java 17 parsers as Lombok is supported only for these versions.)
2. Added a new field in TypeValidation to enable finer control, allowing specific nodes to bypass type validation.
3. Added unit test to verify behavior for Lombok annotations with skipped arguments.

Before this change, a single skipped annotation argument in project would result in missing type attribution for the entire project.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
