### PR TITLE
Add missing override annotation

### DIFF
--- a/rewrite-gradle/src/main/groovy/RewriteGradleProject.groovy
+++ b/rewrite-gradle/src/main/groovy/RewriteGradleProject.groovy
@@ -78,6 +78,7 @@ interface DependencyHandlerSpec extends DependencyHandler {
     Dependency earlib(Object... dependencyNotation)
     Dependency earlib(Object dependencyNotation, @DelegatesTo(strategy=Closure.DELEGATE_ONLY, value= ExternalDependency) Closure closure)
 
+    @Override
     void constraints(Action<? super DependencyConstraintHandler> configureAction)
 }
 


### PR DESCRIPTION
## What's your motivation?
Mostly to silence the review bot on other PRs. There's an identical method defined on DependencyHandler since 4.5 ; Not sure why this has only just now been flagged, but perhaps the parser improvements mean we can now parse this class.