### PR TITLE
HCL - UT for slash signs in string literals

### DIFF
--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclStringTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclStringTest.java
@@ -66,4 +66,17 @@ class HclStringTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void slashesInStrings() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                cidr = "192.168.0.0/24"
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Minor thing.
Adding one unit test to cover using slash signs (`/`) in String literals of HCL code.

## What's your motivation?
To make sure it works :)
