### PR TITLE
Support nested annotations with properties and annotations with empty arguments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -494,7 +494,7 @@ public class GroovyParserVisitor {
                                     Expression expression;
                                     if (arg.getValue() instanceof AnnotationConstantExpression) {
                                         visitAnnotation((AnnotationNode) ((AnnotationConstantExpression) arg.getValue()).getValue());
-                                        expression = (Expression) queue.poll();
+                                        expression = (J.Annotation) queue.poll();
                                     } else {
                                         expression = bodyVisitor.visit(arg.getValue());
                                     }
@@ -510,8 +510,9 @@ public class GroovyParserVisitor {
                 );
             } else if (source.startsWith("(", indexOfNextNonWhitespace(cursor, source))) {
                 // An annotation with empty arguments like @Foo()
-                arguments = JContainer.build(sourceBefore("("), emptyList(), Markers.EMPTY);
-                sourceBefore(")");
+                arguments = JContainer.build(sourceBefore("("),
+                        singletonList(JRightPadded.build(new J.Empty(randomId(), sourceBefore(")"), Markers.EMPTY))),
+                        Markers.EMPTY);
             }
 
             queue.add(new J.Annotation(randomId(), prefix, Markers.EMPTY, annotationType, arguments));

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -30,8 +30,43 @@ class AnnotationTest implements RewriteTest {
           groovy(
             """
               @Foo
-              class Test {
-              }
+              class Test {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void withParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              @Foo()
+              class Test {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void withProperties() {
+        rewriteRun(
+          groovy(
+            """
+              @Foo(value = "A", version = "1.0")
+              class Test {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void withImplicitValueProperty() {
+        rewriteRun(
+          groovy(
+            """
+              @Foo("A")
+              class Test {}
               """
           )
         );
@@ -43,9 +78,8 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              @Foo(bar = @Bar)
-              class Test {
-              }
+              @Foo(bar = @Bar(@Baz(baz = @Qux("1.0"))))
+              class Test {}
               """
           )
         );


### PR DESCRIPTION
## What's changed?
Support for:
- nested annotations with properties, like: `@Foo(bar = @Bar(value = "1.0"))`
- annotations with empty arguments, like `@Foo()`

## What's your motivation?
- fix https://github.com/openrewrite/rewrite/issues/4055

## Any additional context
The [solution](https://github.com/openrewrite/rewrite/pull/4549) of using
```java
public void visitConstantExpression(ConstantExpression expression) {
  ..
  else if (expression instanceof AnnotationConstantExpression) {
    classVisitor.visitAnnotation((AnnotationNode) value);
    return ((Expression) classVisitor.pollQueue()).withPrefix(fmt); // pollQueue returns `J.Annotation`
  }

  return new J.Literal(randomId(), fmt, Markers.EMPTY, value, text, null, jType);
}
```
did not work properly, because it just fooled the compiler (both J.Annotation and J.Literal extend Expression). But in the end all ConstantExpressions are turned into a J.Literal, so the nested annotations were turned to Strings.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
