### PR TITLE
Prevent class cast exception on Unknown annotation type

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/BlockStatementTemplateGenerator.java
@@ -309,7 +309,12 @@ public class BlockStatementTemplateGenerator {
             Optional<Expression> arg = annotation.getArguments().stream().filter(a -> a == prior).findFirst();
             if (arg.isPresent()) {
                 StringBuilder beforeBuffer = new StringBuilder();
-                beforeBuffer.append('@').append(((JavaType.Class) annotation.getType()).getFullyQualifiedName()).append('(');
+                String name = annotation.getType() instanceof JavaType.Class ?
+                        ((JavaType.Class) annotation.getType()).getFullyQualifiedName() :
+                        annotation.getType() instanceof JavaType.FullyQualified ?
+                                ((JavaType.FullyQualified) annotation.getType()).getFullyQualifiedName() :
+                                annotation.getSimpleName();
+                beforeBuffer.append('@').append(name).append('(');
                 before.insert(0, beforeBuffer);
                 after.append(')').append('\n');
 


### PR DESCRIPTION
As seen on https://github.com/finos/spring-bot/blob/4e9ab2d9724125001046cb9131131c006b79372f/libs/teams/teams-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/teams/bot/BotController.java#L85
# Error:
```
"Authorization"
```

# Message:
```
class org.openrewrite.java.tree.JavaType$Unknown cannot be cast to class org.openrewrite.java.tree.JavaType$Class (org.openrewrite.java.tree.JavaType$Unknown and org.openrewrite.java.tree.JavaType$Class are in unnamed module of loader 'app')
```

# Detail:
```
java.lang.ClassCastException: class org.openrewrite.java.tree.JavaType$Unknown cannot be cast to class org.openrewrite.java.tree.JavaType$Class (org.openrewrite.java.tree.JavaType$Unknown and org.openrewrite.java.tree.JavaType$Class are in unnamed module of loader 'app')
org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.contextTemplate(BlockStatementTemplateGenerator.java:312)
org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.contextTemplate(BlockStatementTemplateGenerator.java:570)
org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.lambda$template$0(BlockStatementTemplateGenerator.java:72)
io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:65)
org.openrewrite.java.internal.template.BlockStatementTemplateGenerator.template(BlockStatementTemplateGenerator.java:58)
org.openrewrite.java.internal.template.JavaTemplateParser.lambda$parseExpression$2(JavaTemplateParser.java:113)
org.openrewrite.java.internal.template.JavaTemplateParser.cacheIfContextFree(JavaTemplateParser.java:293)
org.openrewrite.java.internal.template.JavaTemplateParser.parseExpression(JavaTemplateParser.java:112)
org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitExpression(JavaTemplateJavaExtension.java:208)
org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitExpression(JavaTemplateJavaExtension.java:55)
org.openrewrite.java.JavaVisitor.visitLiteral(JavaVisitor.java:804)
org.openrewrite.java.tree.J$Literal.acceptJava(J.java:3331)
org.openrewrite.java.tree.J.accept(J.java:59)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:157)
org.openrewrite.java.JavaTemplate.apply(JavaTemplate.java:115)
...
```