### PR TITLE
Improve discovery of parentheses level for MethodCallExpression

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2484,17 +2484,17 @@ public class GroovyParserVisitor {
     private int determineParenthesisLevel(int childLineNumber, int parentLineNumber, int childColumn, int parentColumn) {
         int saveCursor = cursor;
         whitespace();
-        int childBeginCursor = cursor;
+        int untilCursor = cursor;
         if (childLineNumber > parentLineNumber) {
-            for (int i = 0; i < (childColumn - parentLineNumber); i++) {
-                childBeginCursor = source.indexOf('\n', childBeginCursor);
+            for (int i = 0; i < (childLineNumber - parentLineNumber); i++) {
+                untilCursor = source.indexOf('\n', untilCursor) + 1; // +1; set cursor past `\n`
             }
-            childBeginCursor += childColumn;
+            untilCursor += childColumn - 1; // -1; skip previous `\n`
         } else {
-            childBeginCursor += childColumn - parentColumn;
+            untilCursor += childColumn - parentColumn;
         }
         int count = 0;
-        for (int i = cursor; i < childBeginCursor; i++) {
+        for (int i = cursor; i < untilCursor; i++) {
             if (source.charAt(i) == '(') {
                 count++;
             }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -362,6 +362,25 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/4055")
+    @Test
+    void chainOfMethodInvocations() {
+        rewriteRun(
+          groovy(
+            """
+              Micronaut.build(args)
+                      .banner(false)
+                      .propertySources(PropertySource.of("my-config", [name: "MyApp"]))
+                      .environments("prod") // Only prod
+                      .overrideConfig("custom-config.yml") // Load custom config
+                      .packages("com.company")
+                      .mainClass(Application)
+                      .start()
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2552")
     @Test
     void closureInvocation() {


### PR DESCRIPTION
## What's changed?
Parentheses discovery for method calls did not always work properly.

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4055

Failing parts:

```groovy
Micronaut.build(args)
    .packages('com.edalex')
    .mainClass(Application)
    .start()
```

## Any additional context
The discovery of parentheses is quite hard to grasp. This is the concept behind it. We defined two variables called `parent` and `child`. The parent and child are nodes, which could be visualised like: `<<child>  parent>`. Notice in source code, the nodes could span multiple lines.

To support this, we loop through all the lines of code of the parent and child element:

```
for (int i = 0; i < (childLineNumber - parentLineNumber); i++)
  // move `untilCursor` past next line break every time

// move `untilCursor` after childColumn of last line
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
