### PR TITLE
Add Support for Builder.Default annotation for final vars

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -144,6 +144,30 @@ class LombokTest implements RewriteTest {
     }
 
     @Test
+    void builderWithDefaultAndFinal() {
+        rewriteRun(
+          java(
+            """
+              import lombok.Builder;
+              
+              @Builder
+              class A {
+                  @Builder.Default private final boolean b = false;
+                  @Builder.Default public final int n = 0;
+                  @Builder.Default protected final String s = "Hello, Anshuman!";
+              
+                  void test() {
+                      A x = A.builder().n(1).b(true).s("foo").build();
+                      A y = A.builder().n(1).b(true).build();
+                      A z = A.builder().n(1).build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void tostring() {
         rewriteRun(
           java(


### PR DESCRIPTION
## What's changed?
Added support for the Lombok annotation `@Builder.Default` on final variables.

## What's your motivation?
- In #4823, the `@Builder.Default` annotation was temporarily removed for processing. However, Lombok's HandleBuilder  [skips](https://github.com/projectlombok/lombok/blob/9f5de53e0651142d1fa7a981f221f51a627f41d0/src/core/lombok/javac/handlers/HandleBuilder.java#L281) processing final variables with non-null initialization values unless they include the `@Builder.Default `annotation. To address this, added logic to temporarily remove the final modifier before invoking the annotation processor and restored it afterward.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
