### PR TITLE
HCL - Fixing handling of multi-line empty maps

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -444,10 +444,15 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
             Space tuplePrefix = sourceBefore("{");
             List<HclRightPadded<Expression>> mappedValues = new ArrayList<>();
             List<HCLParser.ObjectelemContext> values = ctx.objectelem();
-            for (int i = 0; i < values.size(); i++) {
-                HCLParser.ObjectelemContext value = values.get(i);
-                mappedValues.add(HclRightPadded.build((Expression) visit(value))
-                        .withAfter(i == values.size() - 1 ? sourceBefore("}") : Space.EMPTY));
+            if (values.isEmpty()) {
+             mappedValues.add(
+                     HclRightPadded.build(new Hcl.Empty(randomId(), sourceBefore("}"), Markers.EMPTY)));
+            } else {
+                for (int i = 0; i < values.size(); i++) {
+                    HCLParser.ObjectelemContext value = values.get(i);
+                    mappedValues.add(HclRightPadded.build((Expression) visit(value))
+                            .withAfter(i == values.size() - 1 ? sourceBefore("}") : Space.EMPTY));
+                }
             }
 
             return new Hcl.ObjectValue(randomId(), Space.format(prefix), Markers.EMPTY,

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -445,8 +445,8 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
             List<HclRightPadded<Expression>> mappedValues = new ArrayList<>();
             List<HCLParser.ObjectelemContext> values = ctx.objectelem();
             if (values.isEmpty()) {
-             mappedValues.add(
-                     HclRightPadded.build(new Hcl.Empty(randomId(), sourceBefore("}"), Markers.EMPTY)));
+                mappedValues.add(
+                        HclRightPadded.build(new Hcl.Empty(randomId(), sourceBefore("}"), Markers.EMPTY)));
             } else {
                 for (int i = 0; i < values.size(); i++) {
                     HCLParser.ObjectelemContext value = values.get(i);

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCollectionValueTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCollectionValueTest.java
@@ -54,4 +54,18 @@ class HclCollectionValueTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyMapInTwoLines() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                known_weird_cases = {
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
A minor fix for handling a special case of empty maps (objects) in HCL.

## What's your motivation?
To fix a print-idempotency issue of:
```
-  known_weird_cases = {
-  }
+  known_weird_cases = {}
```
