### PR TITLE
HCL - UT for expressionOnLeftHandSideOfAMapLiteral

### DIFF
--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclBlockTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclBlockTest.java
@@ -115,4 +115,19 @@ class HclBlockTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void expressionOnLeftHandSideOfAMapLiteral() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                security_groups_to_create = {
+                  (data.aws_security_group.default.id) : "the_default_one"
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Minor thing. Adding a new UT test case for map/object literals which use an expression instead of hard-coded name on the left-hand side of the map entry. HCL spec requires these to be wrapped with parentheses.

## What's your motivation?
To make sure it works.
