### PR TITLE
Fix parsing string literal with line breaks and spaces

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1544,16 +1544,7 @@ public class GroovyParserVisitor {
         @Override
         public void visitGStringExpression(GStringExpression gstring) {
             Space fmt = whitespace();
-            String delimiter;
-            if (source.startsWith("\"\"\"", cursor)) {
-                delimiter = "\"\"\"";
-            } else if (source.startsWith("/", cursor)) {
-                delimiter = "/";
-            } else if (source.startsWith("$/", cursor)) {
-                delimiter = "$/";
-            } else {
-                delimiter = "\"";
-            }
+            String delimiter = getDelimiter();
             skip(delimiter); // Opening delim for GString
 
             NavigableMap<LineColumn, org.codehaus.groovy.ast.expr.Expression> sortedByPosition = new TreeMap<>();

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2415,7 +2415,7 @@ public class GroovyParserVisitor {
     }
 
     /**
-     * Returns a string that is a part of this soure. The substring begins at the specified beginIndex and extends until delimiter.
+     * Returns a string that is a part of this source. The substring begins at the specified beginIndex and extends until delimiter.
      * The cursor will not be moved.
      */
     private String sourceSubstring(int beginIndex, String untilDelim) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
@@ -156,7 +156,7 @@ class AssignmentTest implements RewriteTest {
             """
               def startItem = '|  ', endItem = '  |'
               def repeatLength = startItem.length() + output.length() + endItem.length()
-              println("\\n" + ("-" * repeatLength) + "\\n" + startItem + output + endItem + "\\n" + ("-" * repeatLength))
+              println("\\n" + ("-" * repeatLength) + "\\n|  " + startItem + output + endItem + "  |\\n" + ("-" * repeatLength))
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -267,20 +267,6 @@ class LiteralTest implements RewriteTest {
         );
     }
 
-
-
-    @Test
-    void moreParenthesesStuff() {
-        rewriteRun(
-          groovy(
-            """
-              "  xyz\\n  "
-              """
-          )
-        );
-    }
-    // + '  \n'
-
     @Test
     void differentiateEscapeFromLiteral() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -259,13 +259,27 @@ class LiteralTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-            "\\\\n\\t"
+            "\\n\\t"
             '\\\\n\\t'
             ///\\\\n\\t///
             """
           )
         );
     }
+
+
+
+    @Test
+    void moreParenthesesStuff() {
+        rewriteRun(
+          groovy(
+            """
+              "  xyz\\n  "
+              """
+          )
+        );
+    }
+    // + '  \n'
 
     @Test
     void differentiateEscapeFromLiteral() {
@@ -284,7 +298,7 @@ class LiteralTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              def a = ("-")
+              def a = (       "-")
               """
           ),
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -85,6 +85,17 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void escapedString() {
+        rewriteRun(
+          groovy(
+            """
+              "f\\"o\\\\\\"o"
+              """
+          )
+        );
+    }
+
+    @Test
     void gString() {
         rewriteRun(
           groovy(
@@ -164,6 +175,17 @@ class LiteralTest implements RewriteTest {
           groovy(
             """
               String s = "${ ARTIFACTORY_URL }"
+              """
+          )
+        );
+    }
+
+    @Test
+    void gStringWithEscapedDelimiter() {
+        rewriteRun(
+          groovy(
+            """
+              String s = "<a href=\\"$url\\">${displayName}</a>"
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -259,7 +259,7 @@ class LiteralTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-            "\\n\\t"
+            "\\\\\\\\n\\\\t"
             '\\\\n\\t'
             ///\\\\n\\t///
             """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -298,7 +298,7 @@ class LiteralTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              def a = (       "-")
+              def a = (       "-"  )
               """
           ),
           groovy(


### PR DESCRIPTION
## What's changed?
- Fix: String with line breaks and spaces, like `"\n|  "` are supported as well.
- Cleanup: String literals and the String literals in the GString parser are written in the same way

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
