### PR TITLE
Support pattern operator for groovy

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -79,7 +79,6 @@ class BinaryTest implements RewriteTest {
     }
 
     @Test
-    @ExpectedToFail("Pattern operator is not yet supported") // https://groovy-lang.org/operators.html#_pattern_operator
     void regexPatternOperator() {
         rewriteRun(
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
@@ -28,7 +28,6 @@ import static org.openrewrite.groovy.Assertions.groovy;
 class RealWorldGroovyTest implements RewriteTest {
 
     @Test
-    @ExpectedToFail("Pattern operator is not yet supported") // https://groovy-lang.org/operators.html#_pattern_operator
     @Issue("https://github.com/spring-projects/spring-boot/blob/v3.4.1/settings.gradle")
     void springBootSettingsGradle() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
The pattern operator `~` is parsed correctly.

## What's your motivation?
Support the operator to support Gradle files better. For example the [Spring Boot](https://github.com/spring-projects/spring-boot) project uses it:  [click](https://github.com/spring-projects/spring-boot/blob/183285258d7b5092224eab1600a2cfa8332682d9/settings.gradle#L78).

## Any additional context
I took a shortcut to parse the operator as part of a string, that's exactly the same route as how we parse Regexes:
```groovy
// both are typed as strings
def PATTERN = ~/foo/ // should actually be of type `Pattern`
def REGEX = /\d+/ // should actually be a MethodInvocation of `Pattern.matches(regex, string)`
```

This works, because our groovy parser does not do type checks (like we do for Java). If we ever want to support this, we have to change the groovy parser as well.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
