### PR TITLE
Skip parsing groovy generated transform methods

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -646,7 +646,7 @@ public class GroovyParserVisitor {
                 // The groovy compiler can add or remove annotations for AST transformations.
                 // Because @groovy.transform.Immutable is discarded in favour of other transform annotations, the removed @Immutable annotation must be parsed by hand.
                 String nextParsableElem = source.substring(indexOfNextNonWhitespace(cursor, source));
-                if (nextParsableElem.startsWith("@Immutable") || nextParsableElem.startsWith("@groovy.transform.Immutable") ) {
+                if (nextParsableElem.startsWith("@" + Immutable.class.getSimpleName()) || nextParsableElem.startsWith("@" + Immutable.class.getCanonicalName()) ) {
                     visitAnnotation(new AnnotationNode(new ClassNode(Immutable.class)));
                     paramAnnotations.add(pollQueue());
                 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2728,7 +2728,7 @@ public class GroovyParserVisitor {
 
     /**
      * Sometimes the groovy compiler inserts phantom elements into argument lists and class bodies,
-     * presumably to pass type information around. Other timers the groovy compiler add extra transform annotations.
+     * presumably to pass type information around. Other times the groovy compiler adds extra transform annotations.
      * These elements do not appear in source code and should not be represented in our LST.
      *
      * @param node possible phantom node

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -650,7 +650,7 @@ public class GroovyParserVisitor {
             List<J.Annotation> paramAnnotations = new ArrayList<>(node.getAnnotations().size());
             for (AnnotationNode annotationNode : node.getAnnotations()) {
                 // The groovy compiler can add or remove annotations for AST transformations.
-                // Because @groovy.transform.Immutable is discarded in favour of other transform annotations, the removed @Immutable annotation must be parsed by hand.
+                // Because @groovy.transform.Immutable is discarded in favour of other transform annotations, the removed annotation must be parsed by hand.
                 if (sourceStartsWith("@" + Immutable.class.getSimpleName()) || sourceStartsWith("@" + Immutable.class.getCanonicalName()) ) {
                     visitAnnotation(new AnnotationNode(new ClassNode(Immutable.class)));
                     paramAnnotations.add(pollQueue());

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -481,7 +481,7 @@ public class GroovyParserVisitor {
                                 .collect(toList()),
                         Markers.EMPTY
                 );
-                // rare scenario where annotation does only have non-value implicit properties
+                // Rare scenario where annotation does only have non-value implicit properties
                 if (arguments.getElements().isEmpty()) {
                     arguments = null;
                 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -16,6 +16,7 @@
 package org.openrewrite.groovy;
 
 import groovy.lang.GroovySystem;
+import groovy.transform.Generated;
 import groovyjarjarasm.asm.Opcodes;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -305,7 +306,7 @@ public class GroovyParserVisitor {
                         org.codehaus.groovy.ast.stmt.Statement statement = ((BlockStatement) method.getCode()).getStatements().get(0);
                         sortedByPosition.computeIfAbsent(pos(statement), i -> new ArrayList<>()).add(statement);
                     }
-                } else {
+                } else if (method.getAnnotations(new ClassNode(Generated.class)).isEmpty()) {
                     sortedByPosition.computeIfAbsent(pos(method), i -> new ArrayList<>()).add(method);
                 }
             }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -84,4 +84,21 @@ class AnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4254")
+    @Test
+    void groovyTransformAnnotation() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.transform.ToString
+              import groovy.transform.EqualsAndHashCode
+              
+              @ToString
+              @EqualsAndHashCode
+              class Test {}
+              """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -30,6 +30,21 @@ class AnnotationTest implements RewriteTest {
           groovy(
             """
               @Foo
+              class Test implements Runnable {
+                  @java.lang.Override
+                  void run() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simpleFQN() {
+        rewriteRun(
+          groovy(
+            """
+              @org.springframework.stereotype.Service
               class Test {}
               """
           )
@@ -91,11 +106,45 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              import groovy.transform.ToString
               import groovy.transform.EqualsAndHashCode
+              import groovy.transform.ToString
               
+              @Foo
               @ToString
               @EqualsAndHashCode
+              @Bar
+              class Test {}
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4254")
+    @Test
+    void groovyTransformImmutableAnnotation() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.transform.Immutable
+              //import groovy.transform.TupleConstructor
+              
+              @Foo
+              //@TupleConstructor
+              @Immutable
+              @Bar
+              class Test {}
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4254")
+    @Test
+    void groovyTransformImmutableFQNAnnotation() {
+        rewriteRun(
+          groovy(
+            """
+              @groovy.transform.Immutable
               class Test {}
               """
           )

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -64,6 +64,19 @@ class AnnotationTest implements RewriteTest {
     }
 
     @Test
+    void inline() {
+        rewriteRun(
+          groovy(
+            """
+              @Foo class Test implements Runnable {
+                  @Override void run() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void withProperties() {
         rewriteRun(
           groovy(
@@ -126,10 +139,10 @@ class AnnotationTest implements RewriteTest {
           groovy(
             """
               import groovy.transform.Immutable
-              //import groovy.transform.TupleConstructor
+              import groovy.transform.TupleConstructor
               
               @Foo
-              //@TupleConstructor
+              @TupleConstructor
               @Immutable
               @Bar
               class Test {}


### PR DESCRIPTION
## What's changed?
Generated [transform](https://medium.com/@AlexanderObregon/exploring-groovys-powerful-ast-transformations-enhancing-your-code-at-compile-time-32bdcd8924a3) annotations are parsed.

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4254

## Any additional context
Notice with these fixes the parser just ignores the groovy AST transformations. So you cannot use the 'real' AST as the bytecodes dictate in the groovy recipes. If we want to support that, we would have to do a project like `rewrite-lombok`.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
