### PR TITLE
Support semicolon for groovy packages

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -136,9 +136,8 @@ public class GroovyParserVisitor {
         JRightPadded<J.Package> pkg = null;
         if (ast.getPackage() != null) {
             prefix = whitespace();
-            cursor += "package".length();
-            pkg = JRightPadded.build(new J.Package(randomId(), EMPTY, Markers.EMPTY,
-                    typeTree(null), emptyList()));
+            skip("package");
+            pkg = maybeSemicolon(new J.Package(randomId(), EMPTY, Markers.EMPTY, typeTree(null), emptyList()));
         }
 
         for (ImportNode anImport : ast.getImports()) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -57,6 +57,7 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
         JRightPadded<J.Package> pkg = cu.getPadding().getPackageDeclaration();
         if (pkg != null) {
             visit(pkg.getElement(), p);
+            visitMarkers(pkg.getMarkers(), p);
             visitSpace(pkg.getAfter(), Space.Location.PACKAGE_SUFFIX, p);
         }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -138,6 +138,19 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
+    @Test
+    void hasPackageWithTrailingComma() {
+        rewriteRun(
+          groovy(
+            """ 
+              package org.openrewrite;
+
+              class A{}
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1736")
     @Test
     void parameterizedFieldDoesNotAffectClassType() {


### PR DESCRIPTION
## What's changed?
Packages can have a `;` semicolon

## What's your motivation?
- fixes https://github.com/openrewrite/rewrite/issues/4070

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
