### PR TITLE
Replacing dependency on commons-compress with commons-lang3

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
     api("org.jspecify:jspecify:latest.release")
 
-    implementation("org.apache.commons:commons-compress:latest.release")
+    implementation("org.apache.commons:commons-lang3:latest.release")
 
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("io.github.classgraph:classgraph:latest.release")


### PR DESCRIPTION
## What's changed?
Replacing the dependency on `commons-compress` with just `commons-lang3` in `rewrite-core`.

Here's the `diff` on `./gradlew rewrite-core:dependencies --configuration runtimeClasspath`:
```diff
-+--- org.apache.commons:commons-compress:latest.release -> 1.27.1
-|    +--- commons-codec:commons-codec:1.17.1
-|    +--- commons-io:commons-io:2.16.1
-|    \--- org.apache.commons:commons-lang3:3.16.0
++--- org.apache.commons:commons-lang3:latest.release -> 3.17.0
```
(as you can see we upgrade from 3.16.0 to 3.17.0 as a by-product)

## What's your motivation?
- `commons-compress` doesn't seem needed, we only seem to declare it to bring the subdependency of `commons-lang3`
- removing it hoping to reduce the size of all deliverables depending on `rewrite`

## Checks performed
The only explicit mention of `commons-compress` I could find was in https://github.com/openrewrite/rewrite/tree/main/rewrite-java-test/src/test/resources/dataflow-functional-tests which are test **resources**.