### PR TITLE
HCL - Fixing handling of # or // within multiline comments

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Space.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Space.java
@@ -158,14 +158,14 @@ public class Space {
                 case '#':
                     if (Comment.Style.LINE_SLASH == inLineSlashOrHashComment) {
                         comment.append(c);
+                    } else if (inSingleLineComment) {
+                        comment.append(c);
+                    } else if (inMultiLineComment) {
+                        comment.append(c);
                     } else {
-                        if (inSingleLineComment) {
-                            comment.append(c);
-                        } else {
-                            inSingleLineComment = true;
-                            inLineSlashOrHashComment = Comment.Style.LINE_HASH;
-                            comment = new StringBuilder();
-                        }
+                        inSingleLineComment = true;
+                        inLineSlashOrHashComment = Comment.Style.LINE_HASH;
+                        comment = new StringBuilder();
                     }
                     break;
                 case '/':

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -130,4 +130,49 @@ class HclCommentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void singeLineWithinMultiLineHash() {
+        rewriteRun(
+          hcl(
+            """
+              /*
+              # It's important
+              */
+              locals {
+               Anwil = "Wloclawek"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void singeLineWithinMultiLineSlash() {
+        rewriteRun(
+          hcl(
+            """
+              /*
+              // It's important
+              */
+              locals {
+               Anwil = "Wloclawek"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multilineNotStartingInTheFirstCharacter() {
+        rewriteRun(
+          hcl(
+            """
+                  /* An indented comment
+              */
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Fixing the Whitespace/Comment formatting logic of HCL to not act specially on `#` or `//` characters within the multiline comment (`/* something*/`).

## What's your motivation?
- fixes #4862
