### PR TITLE
fixing comment nesting in positionOfNext()

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -742,8 +742,10 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
 
         int delimIndex = cursor;
         for (; delimIndex < source.length() - untilDelim.length() + 1; delimIndex++) {
-            if (inSingleLineComment && source.charAt(delimIndex) == '\n') {
-                inSingleLineComment = false;
+            if (inSingleLineComment) {
+                if (source.charAt(delimIndex) == '\n') {
+                    inSingleLineComment = false;
+                }
             } else {
                 if (source.length() - untilDelim.length() > delimIndex + 1) {
                     if ('#' == source.charAt(delimIndex)) {

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -175,4 +175,20 @@ class HclCommentTest implements RewriteTest {
         );
     }
 
+    @Test
+    void commentedOutLinesInListLiteral() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                resources = [
+                   "arn:aws:s3:::${var.my_precious_bucket}",
+                   "arn:aws:s3:::${var.waste_bucket}",
+                   #      "arn:aws:s3:::just-some-bucket/*",
+                ]
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Fixing the logic in HCL parser's `positionOfNext` to properly handle `/*` strings within single-line comments. They do **not** start a multi-line comment.

## What's your motivation?
- fixes #4865 
