### PR TITLE
Annotation Matcher with inner Enums as Attribute Values

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
@@ -158,6 +158,7 @@ public class AnnotationMatcher {
                     return false;
                 }
 
+                //todo the problem is, that varType is null for inner Enums even fa.getType() is null
                 JavaType.Variable varType = fa.getName().getFieldType();
                 if (varType != null) {
                     JavaType.FullyQualified owner = TypeUtils.asFullyQualified(varType.getOwner());


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Application Frameworks like Spring often user enums for annotation attributes to restrict the possible values. 
Often these enums are defined within the annotation class itself as inner enums.
Traits canot work 100% in this cases.

## Anything in particular you'd like reviewers to focus on?
There is a new ToDo this line is the problem. 
The root problem seems to be that the type of FieldAccess for inner enums is not set correctly.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
Add adtional checks in the visitor methods.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
