### PR TITLE
fix: create dependencyResourceLoaders in 2 passes

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -249,12 +249,25 @@ public class Environment {
          */
         @SuppressWarnings("unused")
         public Builder scanJar(Path jar, Collection<Path> dependencies, ClassLoader classLoader) {
-            List<ClasspathScanningLoader> list = new ArrayList<>();
+            List<ClasspathScanningLoader> firstPassLoaderList = new ArrayList<>();
             for (Path dep : dependencies) {
                 ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader(dep, properties, emptyList(), classLoader);
-                list.add(classpathScanningLoader);
+                firstPassLoaderList.add(classpathScanningLoader);
             }
-            return load(new ClasspathScanningLoader(jar, properties, list, classLoader), list);
+
+            /*
+             * Second loader creation pass where the firstPassLoaderList is passed as the
+             * dependencyResourceLoaders list to ensure that we can resolve transitive
+             * dependencies using the loaders we just created. This is necessary because
+             * the first pass may have missing recipes since the full list of loaders was
+             * not provided.
+             */
+            List<ClasspathScanningLoader> secondPassLoaderList = new ArrayList<>();
+            for (Path dep : dependencies) {
+                ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader(dep, properties, firstPassLoaderList, classLoader);
+                secondPassLoaderList.add(classpathScanningLoader);
+            }
+            return load(new ClasspathScanningLoader(jar, properties, secondPassLoaderList, classLoader), secondPassLoaderList);
         }
 
         @SuppressWarnings("unused")

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -251,8 +251,7 @@ public class Environment {
         public Builder scanJar(Path jar, Collection<Path> dependencies, ClassLoader classLoader) {
             List<ClasspathScanningLoader> firstPassLoaderList = new ArrayList<>();
             for (Path dep : dependencies) {
-                ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader(dep, properties, emptyList(), classLoader);
-                firstPassLoaderList.add(classpathScanningLoader);
+                firstPassLoaderList.add(new ClasspathScanningLoader(dep, properties, emptyList(), classLoader));
             }
 
             /*
@@ -264,8 +263,7 @@ public class Environment {
              */
             List<ClasspathScanningLoader> secondPassLoaderList = new ArrayList<>();
             for (Path dep : dependencies) {
-                ClasspathScanningLoader classpathScanningLoader = new ClasspathScanningLoader(dep, properties, firstPassLoaderList, classLoader);
-                secondPassLoaderList.add(classpathScanningLoader);
+                secondPassLoaderList.add(new ClasspathScanningLoader(dep, properties, firstPassLoaderList, classLoader));
             }
             return load(new ClasspathScanningLoader(jar, properties, secondPassLoaderList, classLoader), secondPassLoaderList);
         }


### PR DESCRIPTION
## What's changed?
In `scanJar` method in `rewrite-core/src/main/java/org/openrewrite/config/Environment.java`, we are now creating the list of dependencyResourceLoaders in 2 passes to ensure all recipes are resolved. 

## What's your motivation?
Recipe descriptors were missing due to transitive recipes failing to be resolved.
- Shown in this issue: https://github.com/moderneinc/customer-requests/issues/765

## Anything in particular you'd like reviewers to focus on?
Are there any undesirable side effects from this change?

## Anyone you would like to review specifically?
@timtebeek @sambsnyd @kmccarp 
