### PR TITLE
HCL - Fixing empty comment handling

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -750,19 +750,18 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
                 if (source.length() - untilDelim.length() > delimIndex + 1) {
                     if ('#' == source.charAt(delimIndex)) {
                         inSingleLineComment = true;
-                        delimIndex++;
                     } else switch (source.substring(delimIndex, delimIndex + 2)) {
                         case "//":
                             inSingleLineComment = true;
-                            delimIndex += 2;
+                            delimIndex += 1;
                             break;
                         case "/*":
                             inMultiLineComment = true;
-                            delimIndex += 2;
+                            delimIndex += 1;
                             break;
                         case "*/":
                             inMultiLineComment = false;
-                            delimIndex += 2;
+                            delimIndex += 1;
                             break;
                     }
                 }

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -132,7 +132,7 @@ class HclCommentTest implements RewriteTest {
     }
 
     @Test
-    void singeLineWithinMultiLineHash() {
+    void singleLineWithinMultiLineHash() {
         rewriteRun(
           hcl(
             """
@@ -148,7 +148,7 @@ class HclCommentTest implements RewriteTest {
     }
 
     @Test
-    void singeLineWithinMultiLineSlash() {
+    void singleLineWithinMultiLineSlash() {
         rewriteRun(
           hcl(
             """
@@ -186,6 +186,37 @@ class HclCommentTest implements RewriteTest {
                    "arn:aws:s3:::${var.waste_bucket}",
                    #      "arn:aws:s3:::just-some-bucket/*",
                 ]
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyHashCommentJustBeforeCurlyBraceEnd() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                #
+              }
+              module "something" {
+                source = "../else/"
+              }
+              """
+          )
+        );
+    }
+    @Test
+    void emptyDoubleSlashCommentJustBeforeCurlyBraceEnd() {
+        rewriteRun(
+          hcl(
+            """
+              locals {
+                //
+              }
+              module "something" {
+                source = "../else/"
               }
               """
           )

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -207,6 +207,7 @@ class HclCommentTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void emptyDoubleSlashCommentJustBeforeCurlyBraceEnd() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Fixing the handling of empty comments, i.e. just the start of the comment and a newline:
```
//
```

## What's your motivation?
Before this fix, it led to some weird behavior of some of the code being duplicated in the output with slashes removed
```diff
diff --git a/file.tf b/file.tf
index 4f2b4e5..633e863 100644
--- a/file.tf
+++ b/file.tf
@@ -2,5 +2,8 @@ 
   #
 }
 module "something" {
+  source = "..else"
+////}
+module "something" {
   source = "../else/"
 }
```
