### PR TITLE
Avoid UnsupportedOperationException on plaintext parsing

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainTextParser.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainTextParser.java
@@ -52,10 +52,11 @@ public class PlainTextParser implements Parser {
                 .orElseThrow(() -> new IllegalStateException("Failed to parse as plain text"))
                 .withSourcePath(sourceFile.getSourcePath())
                 .withFileAttributes(sourceFile.getFileAttributes())
-                .withCharsetBomMarked(sourceFile.isCharsetBomMarked())
                 .withId(sourceFile.getId());
         if (sourceFile.getCharset() != null) {
-            text = (PlainText) text.withCharset(sourceFile.getCharset());
+            text = (PlainText) text
+                    .withCharset(sourceFile.getCharset())
+                    .withCharsetBomMarked(sourceFile.isCharsetBomMarked());
         }
         return text;
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
withCharsetBomMarked must only be called if there is a known non-null charset.

## What's your motivation?
fixes #4872

## Anything in particular you'd like reviewers to focus on?
I've not been able to test this (company proxy trouble), so please double-check if necessary.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
