### PR TITLE
Add new parameter `oldAttributeValue` to `AddOrUpdateAnnotationAttribute` recipe

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
@@ -25,7 +26,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void addValueAttribute() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", null, null, null)),
           java(
             """
               package org.example;
@@ -56,7 +57,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void addValueAttributeClass() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", null, null, null)),
           java(
             """
               package org.example;
@@ -87,7 +88,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void addValueAttributeFullyQualifiedClass() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "java.math.BigDecimal.class", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "java.math.BigDecimal.class", null, null, null)),
           java(
             """
               package org.example;
@@ -118,7 +119,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void updateValueAttribute() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", null, null, null)),
           java(
             """
               package org.example;
@@ -150,7 +151,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void updateValueAttributeClass() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", null, null, null)),
           java(
             """
               package org.example;
@@ -182,7 +183,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void removeValueAttribute() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, null, null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, null, null, null, null)),
           java(
             """
               package org.example;
@@ -214,7 +215,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void removeValueAttributeClass() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, null, null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, null, null, null, null)),
           java(
             """
               package org.example;
@@ -245,7 +246,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Test
     void addNamedAttribute() {
-        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", "500", null, null)),
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", "500", null, null, null)),
           java(
             """
               package org.junit;
@@ -282,7 +283,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void replaceAttribute() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", "500", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", "500", null, null, null)),
           java(
             """
               package org.junit;
@@ -319,7 +320,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void removeAttribute() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", null, null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", null, null, null, null)),
           java(
             """
               package org.junit;
@@ -356,7 +357,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void preserveExistingAttributes() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", "500", null, null)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "timeout", "500", null, null, null)),
           java(
             """
               package org.junit;
@@ -394,7 +395,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Test
     void implicitValueToExplicitValue() {
-        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null, null)),
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null, null, null)),
           java(
             """
               package org.junit;
@@ -431,7 +432,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Test
     void implicitValueToExplicitValueClass() {
-        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null, null)),
+        rewriteRun(spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null, null, null)),
           java(
             """
               package org.junit;
@@ -469,7 +470,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
     @Test
     void dontChangeWhenSetToAddOnly() {
         rewriteRun(
-          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", true, false)),
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.junit.Test", "other", "1", null, true, false)),
           java(
             """
               package org.junit;
@@ -500,6 +501,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "newTest",
+            null,
             false,
             false)),
           java(
@@ -536,6 +538,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "newTest1,newTest2",
+            null,
             false,
             false)),
           java(
@@ -572,6 +575,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "newTest1,newTest2",
+            null,
             false,
             false)),
           java(
@@ -608,6 +612,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "newTest1,newTest2",
+            null,
             false,
             true)),
           java(
@@ -644,6 +649,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "newTest1,newTest2",
+            null,
             false,
             null)),
           java(
@@ -679,6 +685,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
             "org.example.Foo",
             "array",
+            null,
             null,
             null,
             false)),
@@ -717,6 +724,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "string",
             "test",
             null,
+            null,
             false)),
           java(
             """
@@ -753,6 +761,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "b",
+            null,
             false,
             true)),
           java(
@@ -789,6 +798,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "b,c",
+            null,
             false,
             true)),
           java(
@@ -825,6 +835,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "b,c",
+            null,
             false,
             true)),
           java(
@@ -861,6 +872,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "org.example.Foo",
             "array",
             "b,c",
+            null,
             true,
             true)),
           java(
@@ -901,6 +913,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             "attribute",
             "",
             null,
+            null,
             false)),
           java(
             """
@@ -937,5 +950,123 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Nested
+    class OnMatch {
+        @Test
+        void matchValue() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", "goodbye", null, null)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String value() default "";
+                  }
+                  """
+              ),
+
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo("goodbye")
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo("hello")
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void noMatchValue() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", "hi", null, null)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String value() default "";
+                  }
+                  """
+              ),
+
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo("goodbye")
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void matchClass() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", "Long.class", null, null)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      Class<? extends Number> value();
+                  }
+                  """
+              ),
+
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(Long.class)
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(Integer.class)
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void nomatchClass() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Integer.class", "Double.class", null, null)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      Class<? extends Number> value();
+                  }
+                  """
+              ),
+
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(Long.class)
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -1028,7 +1028,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 "hello",
                 "goodbye",
                 null,
-                null)),
+                true)),
               java(
                 """
                   package org.example;
@@ -1049,7 +1049,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 """
                   import org.example.Foo;
                   
-                  @Foo({"hello", "hi"})
+                  @Foo({"hi", "hello"})
                   public class A {
                   }
                   """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -987,6 +987,71 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
         }
 
         @Test
+        void matchEnumValue() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "Values.TWO", "Values.ONE", null, null)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      Values value() default "";
+                  }
+                  public enum Values {ONE, TWO}
+                  """
+              ),
+
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(Values.ONE)
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(Values.TWO)
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void matchValueInArray() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", "goodbye", null, null)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String[] value() default "";
+                  }
+                  """
+              ),
+
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo({"goodbye", "hi"})
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo({"hello", "hi"})
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void noMatchValue() {
             rewriteRun(
               spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", "hi", null, null)),
@@ -1051,7 +1116,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 """
                   package org.example;
                   public @interface Foo {
-                      Class<? extends Number> value();
+                      Class<?> value();
                   }
                   """
               ),

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -15,9 +15,11 @@
  */
 package org.openrewrite.java;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -964,9 +966,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                   public @interface Foo {
                       String value() default "";
                   }
-                  """
+                  """,
+                SourceSpec::skip
               ),
-
               java(
                 """
                   import org.example.Foo;
@@ -997,9 +999,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                       Values value() default "";
                   }
                   public enum Values {ONE, TWO}
-                  """
+                  """,
+                SourceSpec::skip
               ),
-
               java(
                 """
                   import org.example.Foo;
@@ -1035,9 +1037,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                   public @interface Foo {
                       String[] value() default "";
                   }
-                  """
+                  """,
+                SourceSpec::skip
               ),
-
               java(
                 """
                   import org.example.Foo;
@@ -1067,9 +1069,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                   public @interface Foo {
                       String value() default "";
                   }
-                  """
+                  """,
+                SourceSpec::skip
               ),
-
               java(
                 """
                   import org.example.Foo;
@@ -1092,9 +1094,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                   public @interface Foo {
                       Class<? extends Number> value();
                   }
-                  """
+                  """,
+                SourceSpec::skip
               ),
-
               java(
                 """
                   import org.example.Foo;
@@ -1124,9 +1126,9 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                   public @interface Foo {
                       Class<?> value();
                   }
-                  """
+                  """,
+                SourceSpec::skip
               ),
-
               java(
                 """
                   import org.example.Foo;
@@ -1142,6 +1144,15 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
     @Nested
     class AsValueAttribute {
+
+        @Language("java")
+        private static final String FOO_ANNOTATION_WITH_STRING_ARRAY_VALUE = """
+          package org.example;
+          public @interface Foo {
+              String[] value() default {};
+          }
+          """;
+
         @Test
         void implicitWithNullAttributeName() {
             rewriteRun(
@@ -1153,12 +1164,8 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 false,
                 true)),
               java(
-                """
-                  package org.example;
-                  public @interface Foo {
-                      String[] value() default {};
-                  }
-                  """
+                FOO_ANNOTATION_WITH_STRING_ARRAY_VALUE,
+                SourceSpec::skip
               ),
               java(
                 """
@@ -1190,12 +1197,8 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 false,
                 true)),
               java(
-                """
-                  package org.example;
-                  public @interface Foo {
-                      String[] value() default {};
-                  }
-                  """
+                FOO_ANNOTATION_WITH_STRING_ARRAY_VALUE,
+                SourceSpec::skip
               ),
               java(
                 """
@@ -1227,12 +1230,8 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 false,
                 true)),
               java(
-                """
-                  package org.example;
-                  public @interface Foo {
-                      String[] value() default {};
-                  }
-                  """
+                FOO_ANNOTATION_WITH_STRING_ARRAY_VALUE,
+                SourceSpec::skip
               ),
               java(
                 """
@@ -1264,12 +1263,8 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
                 false,
                 true)),
               java(
-                """
-                  package org.example;
-                  public @interface Foo {
-                      String[] value() default {};
-                  }
-                  """
+                FOO_ANNOTATION_WITH_STRING_ARRAY_VALUE,
+                SourceSpec::skip
               ),
               java(
                 """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -1022,7 +1022,13 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
         @Test
         void matchValueInArray() {
             rewriteRun(
-              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute("org.example.Foo", null, "hello", "goodbye", null, null)),
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+                "org.example.Foo",
+                null,
+                "hello",
+                "goodbye",
+                null,
+                null)),
               java(
                 """
                   package org.example;
@@ -1132,6 +1138,156 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               )
             );
         }
+    }
 
+    @Nested
+    class AsValueAttribute {
+        @Test
+        void implicitWithNullAttributeName() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+                "org.example.Foo",
+                null,
+                "b",
+                null,
+                false,
+                true)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String[] value() default {};
+                  }
+                  """
+              ),
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo({"a"})
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo({"a", "b"})
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void implicitWithAttributeNameValue() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+                "org.example.Foo",
+                null,
+                "b",
+                null,
+                false,
+                true)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String[] value() default {};
+                  }
+                  """
+              ),
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(value = {"a"})
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(value = {"a", "b"})
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void explicitWithNullAttributeName() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+                "org.example.Foo",
+                null,
+                "b",
+                null,
+                false,
+                true)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String[] value() default {};
+                  }
+                  """
+              ),
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(value = {"a"})
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(value = {"a", "b"})
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void explicitWithAttributeNameValue() {
+            rewriteRun(
+              spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+                "org.example.Foo",
+                "value",
+                "b",
+                null,
+                false,
+                true)),
+              java(
+                """
+                  package org.example;
+                  public @interface Foo {
+                      String[] value() default {};
+                  }
+                  """
+              ),
+              java(
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(value = {"a"})
+                  public class A {
+                  }
+                  """,
+                """
+                  import org.example.Foo;
+                  
+                  @Foo(value = {"a", "b"})
+                  public class A {
+                  }
+                  """
+              )
+            );
+        }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -67,6 +67,12 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
     @Nullable
     String attributeValue;
 
+    @Option(displayName = "Old Attribute value",
+            description = "The current value of the attribute, this can be used to filter where the change is applied. Set to `null` for wildcard behavior.",
+            example = "400")
+    @Nullable
+    String oldAttributeValue;
+
     @Option(displayName = "Add only",
             description = "When set to `true` will not change existing annotation attribute values.")
     @Nullable

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -374,9 +374,9 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
         }
         if (oldAttributeValue == null) { // null means wildcard
             return true;
-        } else if (expression instanceof J.Literal) { // 219 & 203
+        } else if (expression instanceof J.Literal) {
             return oldAttributeValue.equals(((J.Literal) expression).getValue());
-        } else if (expression instanceof J.FieldAccess) { // 236
+        } else if (expression instanceof J.FieldAccess) {
             J.FieldAccess fa = (J.FieldAccess) expression;
             String currentValue = ((J.Identifier) fa.getTarget()).getSimpleName() + "." + fa.getSimpleName();
             return oldAttributeValue.equals(currentValue);

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -46,7 +46,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
     @Override
     public String getDescription() {
         return "Some annotations accept arguments. This recipe sets an existing argument to the specified value, " +
-               "or adds the argument if it is not already set.";
+                "or adds the argument if it is not already set.";
     }
 
     @Option(displayName = "Annotation type",
@@ -80,9 +80,9 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
 
     @Option(displayName = "Append array",
             description = "If the attribute is an array, setting this option to `true` will append the value(s). " +
-                          "In conjunction with `addOnly`, it is possible to control duplicates: " +
-                          "`addOnly=true`, always append. " +
-                          "`addOnly=false`, only append if the value is not already present.")
+                    "In conjunction with `addOnly`, it is possible to control duplicates: " +
+                    "`addOnly=true`, always append. " +
+                    "`addOnly=false`, only append if the value is not already present.")
     @Nullable
     Boolean appendArray;
 
@@ -111,7 +111,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                     } else {
                         String newAttributeValueResult = newAttributeValue;
                         if (((JavaType.FullyQualified) Objects.requireNonNull(a.getAnnotationType().getType())).getMethods().stream().anyMatch(method -> method.getReturnType().toString().equals("java.lang.String[]"))) {
-                            String attributeValueCleanedUp = attributeValue.replaceAll("\\s+","").replaceAll("[\\s+{}\"]","");
+                            String attributeValueCleanedUp = attributeValue.replaceAll("\\s+", "").replaceAll("[\\s+{}\"]", "");
                             List<String> attributeList = Arrays.asList(attributeValueCleanedUp.contains(",") ? attributeValueCleanedUp.split(",") : new String[]{attributeValueCleanedUp});
                             newAttributeValueResult = attributeList.stream()
                                     .map(String::valueOf)
@@ -130,9 +130,13 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                         if (it instanceof J.Assignment) {
                             J.Assignment as = (J.Assignment) it;
                             J.Identifier var = (J.Identifier) as.getVariable();
-                            if (attributeName == null || !attributeName.equals(var.getSimpleName())) {
+                            if (attributeName == null && !"value".equals(var.getSimpleName())) {
                                 return it;
                             }
+                            if (attributeName != null && !attributeName.equals(var.getSimpleName())) {
+                                return it;
+                            }
+
                             foundOrSetAttributeWithDesiredValue.set(true);
 
                             if (newAttributeValue == null) {
@@ -141,7 +145,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
 
                             if (as.getAssignment() instanceof J.NewArray) {
                                 List<Expression> jLiteralList = ((J.NewArray) as.getAssignment()).getInitializer();
-                                String attributeValueCleanedUp = attributeValue.replaceAll("\\s+","").replaceAll("[\\s+{}\"]","");
+                                String attributeValueCleanedUp = attributeValue.replaceAll("\\s+", "").replaceAll("[\\s+{}\"]", "");
                                 List<String> attributeList = Arrays.asList(attributeValueCleanedUp.contains(",") ? attributeValueCleanedUp.split(",") : new String[]{attributeValueCleanedUp});
 
                                 if (as.getMarkers().findFirst(AlreadyAppended.class).filter(ap -> ap.getValues().equals(newAttributeValue)).isPresent()) {
@@ -165,16 +169,16 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                             .withMarkers(as.getMarkers().add(new AlreadyAppended(randomId(), newAttributeValue))) : as;
                                 }
                                 int m = 0;
-                                for (int i = 0; i< Objects.requireNonNull(jLiteralList).size(); i++){
-                                    if (i >= attributeList.size()){
+                                for (int i = 0; i < Objects.requireNonNull(jLiteralList).size(); i++) {
+                                    if (i >= attributeList.size()) {
                                         jLiteralList.remove(i);
                                         i--;
                                         continue;
                                     }
 
                                     String newAttributeListValue = maybeQuoteStringArgument(attributeName, attributeList.get(i), finalA);
-                                    if (jLiteralList.size() == i+1){
-                                        m = i+1;
+                                    if (jLiteralList.size() == i + 1) {
+                                        m = i + 1;
                                     }
 
                                     if (newAttributeListValue != null && newAttributeListValue.equals(((J.Literal) jLiteralList.get(i)).getValueSource()) || Boolean.TRUE.equals(addOnly)) {
@@ -186,11 +190,11 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
 
                                     jLiteralList.set(i, ((J.Literal) jLiteralList.get(i)).withValue(newAttributeListValue).withValueSource(newAttributeListValue).withPrefix(jLiteralList.get(i).getPrefix()));
                                 }
-                                if (jLiteralList.size() < attributeList.size() || Boolean.TRUE.equals(addOnly)){
-                                    if (Boolean.TRUE.equals(addOnly)){
+                                if (jLiteralList.size() < attributeList.size() || Boolean.TRUE.equals(addOnly)) {
+                                    if (Boolean.TRUE.equals(addOnly)) {
                                         m = 0;
                                     }
-                                    for (int j = m; j < attributeList.size(); j++){
+                                    for (int j = m; j < attributeList.size(); j++) {
                                         String newAttributeListValue = maybeQuoteStringArgument(attributeName, attributeList.get(j), finalA);
                                         jLiteralList.add(j, new J.Literal(randomId(), jLiteralList.get(j - 1).getPrefix(), Markers.EMPTY, newAttributeListValue, newAttributeListValue, null, JavaType.Primitive.String));
                                     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -125,7 +125,6 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                 } else {
                     // First assume the value exists amongst the arguments and attempt to update it
                     AtomicBoolean foundOrSetAttributeWithDesiredValue = new AtomicBoolean(false);
-                    //String oldAttributeValue = maybeQuoteStringArgument(attributeName, AddOrUpdateAnnotationAttribute.this.oldAttributeValue, a);
                     final J.Annotation finalA = a;
                     List<Expression> newArgs = ListUtils.map(currentArgs, it -> {
                         if (it instanceof J.Assignment) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/recipes/MissingOptionExample.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/recipes/MissingOptionExample.java
@@ -80,7 +80,7 @@ public class MissingOptionExample extends Recipe {
                             }
                         }
 
-                        AddOrUpdateAnnotationAttribute addOrUpdateAnnotationAttribute = new AddOrUpdateAnnotationAttribute(ORG_OPENREWRITE_OPTION, "example", "TODO Provide a usage example for the docs", true, false);
+                        AddOrUpdateAnnotationAttribute addOrUpdateAnnotationAttribute = new AddOrUpdateAnnotationAttribute(ORG_OPENREWRITE_OPTION, "example", "TODO Provide a usage example for the docs", null, true, false);
                         return (J.Annotation) addOrUpdateAnnotationAttribute.getVisitor().visitNonNull(an, ctx, getCursor().getParent());
                     }
                 });


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The `AddOrUpdateAnnotationAttribute` now has the optional ability to only update the value if the provided `oldAttributeValue` matches.

## What's your motivation?
In the Spring 3.4 migration some steps are exchanging annotation attribute values if they have a speicific value.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
A workaround is a specially crafted recipe for every annotation attribute.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
