### PR TITLE
Groovy parser fail with single line comment

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -692,16 +692,18 @@ public class StringUtils {
                 continue;
             } else if (length > cursor + 1) {
                 char next = source.charAt(cursor + 1);
-                if (current == '/' && next == '/') {
+                if (inMultiLineComment) {
+                    if (current == '*' && next == '/') {
+                        inMultiLineComment = false;
+                        cursor++;
+                        continue;
+                    }
+                } else if (current == '/' && next == '/') {
                     inSingleLineComment = true;
                     cursor++;
                     continue;
                 } else if (current == '/' && next == '*') {
                     inMultiLineComment = true;
-                    cursor++;
-                    continue;
-                } else if (current == '*' && next == '/') {
-                    inMultiLineComment = false;
                     cursor++;
                     continue;
                 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
@@ -120,25 +121,18 @@ class JenkinsFileTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/4887")
     @Test
     void jenkinsfileWithComment() {
-        // the Jenkinsfile from https://github.com/jenkinsci/ssh-plugin/blob/158.ve2a_e90fb_7319/Jenkinsfile
+        // the Jenkinsfile adapted from https://github.com/jenkinsci/ssh-plugin/blob/158.ve2a_e90fb_7319/Jenkinsfile
         rewriteRun(
           groovy(
             """
-                #!/usr/bin/env groovy
-
-                /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-                buildPlugin(
-                        useContainerAgent: true,
-                        configurations: [
-                                [platform: 'linux', jdk: 21],
-                                [platform: 'windows', jdk: 17],
-                        ])
+                /* https://github.com */
+                foo()
               """,
             spec -> spec.path("Jenkinsfile")
           )
         );
     }
-
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
@@ -128,8 +128,8 @@ class JenkinsFileTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-                /* https://github.com */
-                foo()
+              /* https://github.com */
+              foo()
               """,
             spec -> spec.path("Jenkinsfile")
           )

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
@@ -119,4 +119,26 @@ class JenkinsFileTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void jenkinsfileWithComment() {
+        // the Jenkinsfile from https://github.com/jenkinsci/ssh-plugin/blob/158.ve2a_e90fb_7319/Jenkinsfile
+        rewriteRun(
+          groovy(
+            """
+                #!/usr/bin/env groovy
+
+                /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+                buildPlugin(
+                        useContainerAgent: true,
+                        configurations: [
+                                [platform: 'linux', jdk: 21],
+                                [platform: 'windows', jdk: 17],
+                        ])
+              """,
+            spec -> spec.path("Jenkinsfile")
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
Just demonstrate a bug that we are facing parsing Jenkinsfile with specific multiline comment on one single line

Raise java.lang.StringIndexOutOfBoundsException: String index out of range: 287

No idea how to fix it but it just highlight the issue

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
