### PR TITLE
Enable `AnnotationMatcher` to match values in `J.NewArray`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
  * {@literal @}java.lang.SuppressWarnings                                 - Matches java.lang.SuppressWarnings with no parameters.
  * {@literal @}myhttp.Get(serviceName="payments", path="recentPayments")  - Matches references to myhttp.Get where the parameters are also matched.
  * {@literal @}myhttp.Get(path="recentPayments", serviceName="payments")  - Exactly the same results from the previous example, order of parameters does not matter.
- * {@literal @}java.lang.SuppressWarnings("deprecation")                  - Matches java.langSuppressWarning with a single parameter.
+ * {@literal @}java.lang.SuppressWarnings("deprecation")                  - Matches java.langSuppressWarning with a parameter "deprecation", values in array initializer match as well.
  * {@literal @}org.junit.runner.RunWith(org.junit.runners.JUnit4.class)   - Matches JUnit4's @RunWith(JUnit4.class)
  * </PRE>
  */

--- a/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
@@ -76,8 +76,8 @@ public class AnnotationMatcher {
 
     public boolean matches(J.Annotation annotation) {
         return matchesAnnotationName(annotation) &&
-               matchesSingleParameter(annotation) &&
-               matchesNamedParameters(annotation);
+                matchesSingleParameter(annotation) &&
+                matchesNamedParameters(annotation);
     }
 
     private boolean matchesAnnotationName(J.Annotation annotation) {
@@ -99,7 +99,7 @@ public class AnnotationMatcher {
                         seenAnnotations = new HashSet<>();
                     }
                     if (seenAnnotations.add(annotation.getFullyQualifiedName()) &&
-                        matchesAnnotationOrMetaAnnotation(annotation, seenAnnotations)) {
+                            matchesAnnotationOrMetaAnnotation(annotation, seenAnnotations)) {
                         return true;
                     }
                 }
@@ -168,10 +168,16 @@ public class AnnotationMatcher {
             }
             if (arg instanceof J.NewArray) {
                 J.NewArray na = (J.NewArray) arg;
-                if (na.getInitializer() == null || na.getInitializer().size() != 1) {
+                if (na.getInitializer() == null) {
                     return false;
                 }
-                return argumentValueMatches("value", na.getInitializer().get(0), matchText);
+                // recursively check each initializer of the array initializer
+                for (Expression expression : na.getInitializer()) {
+                    if (argumentValueMatches(matchOnArgumentName, expression, matchText)) {
+                        return true;
+                    }
+                }
+                return false;
             }
         }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -62,4 +62,44 @@ class AnnotatedTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void checkOnArray() {
+        rewriteRun(
+          spec ->
+            spec.recipe(RewriteTest.toRecipe(() ->
+              annotated("@Example(other=\"World\")")
+                .asVisitor(a -> SearchResult.found(a.getTree()))
+            )),
+          java(
+            //language=java
+            """
+              import java.lang.annotation.ElementType; 
+              import java.lang.annotation.Retention;
+              import java.lang.annotation.RetentionPolicy;
+              import java.lang.annotation.Target;
+              
+              @Target(ElementType.TYPE)
+              @Retention(RetentionPolicy.RUNTIME)
+              @interface Example {
+                  String[] other;
+              }
+              """
+          ),
+          java(
+            //language=java
+            """
+              @Example(other = {"Hello", "World"})
+              class Test {
+              }
+              """,
+            //language=java
+            """
+              /*~~>*/@Example(other = {"Hello", "World"})
+              class Test {
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The `AnnotationMatcher` can now match annotations based on values inside array initializer.

```java
AnnotationMatcher matcher = new AnnotationMatcher("java.lang.SuppressWarnings(\"deprecation\")", false);

J.Annotation anno = // LST of @SuppressWarnings({"deprecation", "unused"});
matcher.match(anno); // true
```

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
With Traits building on top of the Matcher construct they become a central component for Recipes.
Without the ability to match in values inside arrrays it is not possible to use Traits when we target an Annotation with array values.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
An alternative would be to extend the used syntax to enable logical constructs like `X {and/or} Y` and `not X`.
This would need a deeper analysis of the upcomming AspectJ features and additional refactorings.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
