### PR TITLE
Print cursor when tests fail to run a recipe

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -23,10 +23,7 @@ import org.openrewrite.*;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.OptionDescriptor;
-import org.openrewrite.internal.InMemoryDiffEntry;
-import org.openrewrite.internal.RecipeIntrospectionUtils;
-import org.openrewrite.internal.StringUtils;
-import org.openrewrite.internal.WhitespaceValidationService;
+import org.openrewrite.internal.*;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.quark.Quark;
@@ -633,7 +630,13 @@ public interface RewriteTest extends SourceSpecs {
     }
 
     default ExecutionContext defaultExecutionContext(SourceSpec<?>[] sourceSpecs) {
-        InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> fail("Failed to parse sources or run recipe", t));
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
+            if (t instanceof RecipeRunException){
+                RecipeRunException e = (RecipeRunException) t;
+                fail("Failed to run recipe at %s", e.getCursor(), e);
+            }
+            fail("Failed to parse sources or run recipe", t);
+        });
         ParsingExecutionContextView.view(ctx).setCharset(StandardCharsets.UTF_8);
         return ctx;
     }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -632,8 +632,7 @@ public interface RewriteTest extends SourceSpecs {
     default ExecutionContext defaultExecutionContext(SourceSpec<?>[] sourceSpecs) {
         InMemoryExecutionContext ctx = new InMemoryExecutionContext(t -> {
             if (t instanceof RecipeRunException){
-                RecipeRunException e = (RecipeRunException) t;
-                fail("Failed to run recipe at %s", e.getCursor(), e);
+                fail("Failed to run recipe at " + ((RecipeRunException) t).getCursor(), t);
             }
             fail("Failed to parse sources or run recipe", t);
         });


### PR DESCRIPTION
The cursor is added to `RecipeRunException`, and used to add a marker. In tests those markers are not shown however, but it would be helpful to see the cursor position for any exceptions that occur.