### PR TITLE
`LatestRelease` should replace `metadataPattern` as regex, as documented

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -140,9 +140,8 @@ public class LatestRelease implements VersionComparator {
         // parts are the same:
         //
         // HyphenRange [25-28] should include "28-jre" and "28-android" as possible candidates.
-        String normalized1 = metadataPattern == null ? nv1 : nv1.replace(metadataPattern, "");
-        String normalized2 = metadataPattern == null ? nv2 : nv2.replace(metadataPattern, "");
-
+        String normalized1 = metadataPattern == null ? nv1 : nv1.replaceAll(metadataPattern, "");
+        String normalized2 = metadataPattern == null ? nv2 : nv2.replaceAll(metadataPattern, "");
         try {
             for (int i = 1; i <= Math.max(vp1, vp2); i++) {
                 String v1Part = v1Gav.group(i);

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -141,7 +141,7 @@ public class LatestRelease implements VersionComparator {
         //
         // HyphenRange [25-28] should include "28-jre" and "28-android" as possible candidates.
         String normalized1 = metadataPattern == null ? nv1 : nv1.replace(metadataPattern, "");
-        String normalized2 = metadataPattern == null ? nv2 : nv1.replace(metadataPattern, "");
+        String normalized2 = metadataPattern == null ? nv2 : nv2.replace(metadataPattern, "");
 
         try {
             for (int i = 1; i <= Math.max(vp1, vp2); i++) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1016,7 +1016,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/4333")
     void exactVersionWithRegexPattern() {
         rewriteRun(
-          spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "32.1.1", ".*droid")),
+          spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "32.1.1", "-.*?droid")),
           buildGradle(
             """
               plugins {


### PR DESCRIPTION
Hi
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
fixed a (look like) typo in version comparator implementation which results in same version being comprated to itself
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Faced an issue when tried to compare jdk17 to jdk21-chiseled during recipe implemetation

