### PR TITLE
Add `slf4j-nop` transitively through rewrite-test

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     testImplementation(project(":rewrite-test")) {
         // because gradle-api fatjars this implementation already
         exclude("ch.qos.logback", "logback-classic")
+        exclude("org.slf4j", "slf4j-nop")
     }
 
     testImplementation("org.openrewrite.gradle.tooling:model:$latest")

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation("org.assertj:assertj-core:latest.release")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
     implementation("org.slf4j:slf4j-api:1.7.36")
+    implementation("org.slf4j:slf4j-nop:1.7.36")
 
     testImplementation(project(":rewrite-groovy"))
 }


### PR DESCRIPTION
To reduce warnings seen about https://www.slf4j.org/codes.html#StaticLoggerBinder
