### PR TITLE
Add Record pattern matching print idempotency Java21

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -783,8 +783,17 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 convert(node.getType()),
                 node.getPattern() instanceof JCBindingPattern b ?
                         new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
-                                type, typeMapping.variableType(b.var.sym)) : null,
+                                type, typeMapping.variableType(b.var.sym)) :
+                        new J.Identifier(randomId(), mapInstanceOfPatternAsWhitespace(node.getPattern()), Markers.EMPTY, emptyList(), "",
+                        type, null),
                 type);
+    }
+
+    private Space mapInstanceOfPatternAsWhitespace(PatternTree pattern){
+        int saveCursor = cursor;
+        int endCursor = max(endPos(pattern), cursor);
+        cursor = endCursor;
+        return Space.build(source.substring(saveCursor, endCursor), emptyList());
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -785,16 +785,14 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 type);
     }
 
-    private @Nullable J getNodePattern(PatternTree pattern, JavaType type){
-        if (pattern instanceof  JCBindingPattern b) {
+    private J getNodePattern(@Nullable PatternTree pattern, JavaType type) {
+        if (pattern instanceof JCBindingPattern b) {
             return new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
                     type, typeMapping.variableType(b.var.sym));
-        } else if (pattern instanceof JCRecordPattern r) {
-            int endCursor = max(endPos(r), cursor);
+        } else {
+            int endCursor = pattern != null ? max(endPos(pattern), cursor) : cursor;
             cursor = endCursor;
             return new J.Unknown(randomId(), whitespace(), Markers.EMPTY, new J.Unknown.Source(randomId(), whitespace(), Markers.EMPTY, source.substring(cursor, endCursor)));
-        } else {
-            return null;
         }
     }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -790,9 +790,10 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             return new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
                     type, typeMapping.variableType(b.var.sym));
         } else if (pattern instanceof JCRecordPattern r) {
+            int saveCursor = cursor;
             int endCursor = max(endPos(r), cursor);
             cursor = endCursor;
-            return new J.Unknown(randomId(), whitespace(), Markers.EMPTY, new J.Unknown.Source(randomId(), whitespace(), Markers.EMPTY, source.substring(cursor, endCursor)));
+            return new J.Unknown(randomId(), whitespace(), Markers.EMPTY, new J.Unknown.Source(randomId(), whitespace(), Markers.EMPTY, source.substring(saveCursor, endCursor)));
         } else {
             return null;
         }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -790,11 +790,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             return new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
                     type, typeMapping.variableType(b.var.sym));
         } else if (pattern instanceof JCRecordPattern r) {
-            int saveCursor = cursor;
-            int endCursor = max(endPos(pattern), cursor);
+            int endCursor = max(endPos(r), cursor);
             cursor = endCursor;
-            return new J.Identifier(randomId(), Space.build(source.substring(saveCursor, endCursor), emptyList()), Markers.EMPTY, emptyList(), "",
-                    type, null);
+            return new J.Unknown(randomId(), whitespace(), Markers.EMPTY, new J.Unknown.Source(randomId(), whitespace(), Markers.EMPTY, source.substring(cursor, endCursor)));
         } else {
             return null;
         }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -781,19 +781,23 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         return new J.InstanceOf(randomId(), fmt, Markers.EMPTY,
                 convert(node.getExpression(), t -> sourceBefore("instanceof")),
                 convert(node.getType()),
-                node.getPattern() instanceof JCBindingPattern b ?
-                        new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
-                                type, typeMapping.variableType(b.var.sym)) :
-                        new J.Identifier(randomId(), mapInstanceOfPatternAsWhitespace(node.getPattern()), Markers.EMPTY, emptyList(), "",
-                        type, null),
+                getNodePattern(node.getPattern(), type),
                 type);
     }
 
-    private Space mapInstanceOfPatternAsWhitespace(PatternTree pattern){
-        int saveCursor = cursor;
-        int endCursor = max(endPos(pattern), cursor);
-        cursor = endCursor;
-        return Space.build(source.substring(saveCursor, endCursor), emptyList());
+    private @Nullable J getNodePattern(PatternTree pattern, JavaType type){
+        if (pattern instanceof  JCBindingPattern b) {
+            return new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
+                    type, typeMapping.variableType(b.var.sym));
+        } else if (pattern instanceof JCRecordPattern r) {
+            int saveCursor = cursor;
+            int endCursor = max(endPos(pattern), cursor);
+            cursor = endCursor;
+            return new J.Identifier(randomId(), Space.build(source.substring(saveCursor, endCursor), emptyList()), Markers.EMPTY, emptyList(), "",
+                    type, null);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -785,14 +785,16 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 type);
     }
 
-    private J getNodePattern(@Nullable PatternTree pattern, JavaType type) {
-        if (pattern instanceof JCBindingPattern b) {
+    private @Nullable J getNodePattern(PatternTree pattern, JavaType type){
+        if (pattern instanceof  JCBindingPattern b) {
             return new J.Identifier(randomId(), sourceBefore(b.getVariable().getName().toString()), Markers.EMPTY, emptyList(), b.getVariable().getName().toString(),
                     type, typeMapping.variableType(b.var.sym));
-        } else {
-            int endCursor = pattern != null ? max(endPos(pattern), cursor) : cursor;
+        } else if (pattern instanceof JCRecordPattern r) {
+            int endCursor = max(endPos(r), cursor);
             cursor = endCursor;
             return new J.Unknown(randomId(), whitespace(), Markers.EMPTY, new J.Unknown.Source(randomId(), whitespace(), Markers.EMPTY, source.substring(cursor, endCursor)));
+        } else {
+            return null;
         }
     }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordPatternMatchingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordPatternMatchingTest.java
@@ -18,13 +18,19 @@ package org.openrewrite.java.tree;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.MinimumJava21;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
 @MinimumJava21
-@Disabled("To be implemented")
 class RecordPatternMatchingTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.typeValidationOptions(TypeValidation.all().unknown(false));
+    }
 
     @Test
     void shouldParseJava21PatternMatchForRecords() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -74,6 +74,21 @@ public class Assertions {
                             .collect(joining("\n\n")));
                 }
             }
+            if (typeValidation.unknown()) {
+                List<J.Unknown> allUnknown = new JavaIsoVisitor<List<J.Unknown>>() {
+                    @Override
+                    public J.Unknown visitUnknown(J.Unknown unknown, List<J.Unknown> list) {
+                        J.Unknown err = super.visitUnknown(unknown, list);
+                        list.add(err);
+                        return err;
+                    }
+                }.reduce(source, new ArrayList<>());
+                if (!allUnknown.isEmpty()) {
+                    throw new IllegalStateException("LST contains erroneous nodes\n" + allUnknown.stream()
+                            .map(unknown -> unknown.getSource().getText())
+                            .collect(joining("\n\n")));
+                }
+            }
         }
         return source;
     }

--- a/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
@@ -104,6 +104,12 @@ public class TypeValidation {
     private boolean erroneous = true;
 
     /**
+     * Controls whether the LST is validated not to contain any `J.Unknown` elements.
+     */
+    @Builder.Default
+    private boolean unknown = true;
+
+    /**
      * Enable all invariant validation checks.
      */
     public static TypeValidation all() {
@@ -114,7 +120,7 @@ public class TypeValidation {
      * Skip all invariant validation checks.
      */
     public static TypeValidation none() {
-        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false);
+        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false, false);
     }
 
     static TypeValidation before(RecipeSpec testMethodSpec, RecipeSpec testClassSpec) {


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Record pattern matching for Java 21 is not print idempotent (but not yet properly mapped to the LST)
## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @knutwannheden 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
