### PR TITLE
Optionally update maven plugin version in ChangePluginGroupIdAndArtifactId

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
@@ -58,6 +58,13 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
     @Nullable
     String newArtifactId;
 
+    @Option(displayName = "New version",
+            description = "An exact version number or node-style semver selector used to select the version number.",
+            example = "29.X",
+            required = false)
+    @Nullable
+    String newVersion;
+
     @Override
     public String getDisplayName() {
         return "Change Maven plugin group and artifact ID";
@@ -70,7 +77,7 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Change the groupId and/or the artifactId of a specified Maven plugin.";
+        return "Change the groupId and/or the artifactId of a specified Maven plugin.  Optionally update the plugin version.";
     }
 
     @Override
@@ -86,6 +93,9 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
                     }
                     if (newArtifactId != null) {
                         t = changeChildTagValue(t, "artifactId", newArtifactId, ctx);
+                    }
+                    if (newVersion != null) {
+                        t = changeChildTagValue(t, "version", newVersion, ctx);
                     }
                     if (t != tag) {
                         maybeUpdateModel();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
@@ -58,18 +58,6 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
     @Nullable
     String newArtifactId;
 
-    /**
-     * Mistakenly introduced, we restored newArtifactId but let's not break recipes abruptly.
-     */
-    @Option(displayName = "New artifact ID",
-        description = "The new artifact ID to use. Defaults to the existing artifact ID. This property is deprecated, use newArtifactId instead.",
-        example = "my-new-maven-plugin",
-        required = false)
-    @Nullable
-    @Deprecated
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    String newArtifact;
-
     @Override
     public String getDisplayName() {
         return "Change Maven plugin group and artifact ID";
@@ -98,8 +86,6 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
                     }
                     if (newArtifactId != null) {
                         t = changeChildTagValue(t, "artifactId", newArtifactId, ctx);
-                    } else if (newArtifact != null) {
-                        t = changeChildTagValue(t, "artifactId", newArtifact, ctx);
                     }
                     if (t != tag) {
                         maybeUpdateModel();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
@@ -77,7 +77,7 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Change the groupId and/or the artifactId of a specified Maven plugin.  Optionally update the plugin version.";
+        return "Change the groupId and/or the artifactId of a specified Maven plugin. Optionally update the plugin version.";
     }
 
     @Override

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
@@ -196,7 +196,8 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
           )
         );
     }
-@Test
+
+    @Test
     void changePluginGroupIdAndArtifactIdNoChangeWithVersion() {
         rewriteRun(
           spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
@@ -31,85 +31,6 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin",
-            null
-          )),
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>my-app</artifactId>
-                  <version>1</version>
-                  <build>
-                      <plugins>
-                          <plugin>
-                              <groupId>io.quarkus</groupId>
-                              <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                              <version>3.0.0.Beta1</version>
-                          </plugin>
-                      </plugins>
-                  </build>
-                  <profiles>
-                      <profile>
-                          <id>profile</id>
-                          <build>
-                              <plugins>
-                                  <plugin>
-                                      <groupId>io.quarkus</groupId>
-                                      <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-                                      <version>3.0.0.Beta1</version>
-                                  </plugin>
-                              </plugins>
-                          </build>
-                      </profile>
-                  </profiles>
-              </project>
-              """,
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>my-app</artifactId>
-                  <version>1</version>
-                  <build>
-                      <plugins>
-                          <plugin>
-                              <groupId>io.quarkus</groupId>
-                              <artifactId>quarkus-extension-maven-plugin</artifactId>
-                              <version>3.0.0.Beta1</version>
-                          </plugin>
-                      </plugins>
-                  </build>
-                  <profiles>
-                      <profile>
-                          <id>profile</id>
-                          <build>
-                              <plugins>
-                                  <plugin>
-                                      <groupId>io.quarkus</groupId>
-                                      <artifactId>quarkus-extension-maven-plugin</artifactId>
-                                      <version>3.0.0.Beta1</version>
-                                  </plugin>
-                              </plugins>
-                          </build>
-                      </profile>
-                  </profiles>
-              </project>
-              """
-          )
-        );
-    }
-
-    @DocumentExample
-    @Test
-    void changePluginGroupIdAndArtifactIdDeprecatedNewArtifact() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
-            "io.quarkus",
-            "quarkus-bootstrap-maven-plugin",
-            null,
-            null,
             "quarkus-extension-maven-plugin"
           )),
           pomXml(
@@ -186,8 +107,7 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin",
-            null
+            "quarkus-extension-maven-plugin"
           )),
           pomXml(
             """
@@ -232,8 +152,7 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin",
-            null
+            "quarkus-extension-maven-plugin"
           )),
           pomXml(
             """
@@ -343,8 +262,7 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin",
-            null
+            "quarkus-extension-maven-plugin"
           )),
           pomXml(
             """

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactIdTest.java
@@ -31,7 +31,8 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
           )),
           pomXml(
             """
@@ -100,6 +101,56 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
+    @Test
+    void changePluginGroupIdAndArtifactIdWithVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
+            "io.quarkus",
+            "quarkus-bootstrap-maven-plugin",
+            null,
+            "quarkus-extension-maven-plugin",
+            "4.0.0"
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                              <version>3.0.0.Beta1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-extension-maven-plugin</artifactId>
+                              <version>4.0.0</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
     @Test
     void changePluginGroupIdAndArtifactIdNoChange() {
         rewriteRun(
@@ -107,7 +158,53 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-extension-maven-plugin</artifactId>
+                              <version>3.0.0.Beta1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+                  <profiles>
+                      <profile>
+                          <id>profile</id>
+                          <build>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>io.quarkus</groupId>
+                                      <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                      <version>3.0.0.Beta1</version>
+                                  </plugin>
+                              </plugins>
+                          </build>
+                      </profile>
+                  </profiles>
+              </project>
+              """
+          )
+        );
+    }
+@Test
+    void changePluginGroupIdAndArtifactIdNoChangeWithVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
+            "io.quarkus",
+            "quarkus-bootstrap-maven-plugin",
+            null,
+            "quarkus-extension-maven-plugin",
+            "4.0.0"
           )),
           pomXml(
             """
@@ -152,7 +249,8 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
           )),
           pomXml(
             """
@@ -256,13 +354,188 @@ class ChangePluginGroupIdAndArtifactIdTest implements RewriteTest {
     }
 
     @Test
+    void changeManagedPluginGroupIdAndArtifactIdWithVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
+            "io.quarkus",
+            "quarkus-bootstrap-maven-plugin",
+            null,
+            "quarkus-extension-maven-plugin",
+            "4.0.0"
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>io.quarkus</groupId>
+                                  <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                                  <version>3.0.0.Beta1</version>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                              <version>3.0.0.Beta1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+                  <profiles>
+                      <profile>
+                          <id>profile</id>
+                          <build>
+                              <pluginManagement>
+                                  <plugins>
+                                      <plugin>
+                                          <groupId>io.quarkus</groupId>
+                                          <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                                          <version>3.0.0.Beta1</version>
+                                      </plugin>
+                                  </plugins>
+                              </pluginManagement>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>io.quarkus</groupId>
+                                      <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                                  </plugin>
+                              </plugins>
+                          </build>
+                      </profile>
+                  </profiles>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>io.quarkus</groupId>
+                                  <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                  <version>4.0.0</version>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-extension-maven-plugin</artifactId>
+                              <version>4.0.0</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+                  <profiles>
+                      <profile>
+                          <id>profile</id>
+                          <build>
+                              <pluginManagement>
+                                  <plugins>
+                                      <plugin>
+                                          <groupId>io.quarkus</groupId>
+                                          <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                          <version>4.0.0</version>
+                                      </plugin>
+                                  </plugins>
+                              </pluginManagement>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>io.quarkus</groupId>
+                                      <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                  </plugin>
+                              </plugins>
+                          </build>
+                      </profile>
+                  </profiles>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void changeManagedPluginGroupIdAndArtifactIdNoChange() {
         rewriteRun(
           spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
             "io.quarkus",
             "quarkus-bootstrap-maven-plugin",
             null,
-            "quarkus-extension-maven-plugin"
+            "quarkus-extension-maven-plugin",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <build>
+                      <pluginManagement>
+                          <plugins>
+                              <plugin>
+                                  <groupId>io.quarkus</groupId>
+                                  <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                  <version>3.0.0.Beta1</version>
+                              </plugin>
+                          </plugins>
+                      </pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.quarkus</groupId>
+                              <artifactId>quarkus-extension-maven-plugin</artifactId>
+                              <version>3.0.0.Beta1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+                  <profiles>
+                      <profile>
+                          <id>profile</id>
+                          <build>
+                              <pluginManagement>
+                                  <plugins>
+                                      <plugin>
+                                          <groupId>io.quarkus</groupId>
+                                          <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                          <version>3.0.0.Beta1</version>
+                                      </plugin>
+                                  </plugins>
+                              </pluginManagement>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>io.quarkus</groupId>
+                                      <artifactId>quarkus-extension-maven-plugin</artifactId>
+                                  </plugin>
+                              </plugins>
+                          </build>
+                      </profile>
+                  </profiles>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeManagedPluginGroupIdAndArtifactIdNoChangeWithVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePluginGroupIdAndArtifactId(
+            "io.quarkus",
+            "quarkus-bootstrap-maven-plugin",
+            null,
+            "quarkus-extension-maven-plugin",
+            "4.0.0"
           )),
           pomXml(
             """


### PR DESCRIPTION
Fixes #4902 .

## What's changed?
Add an optional parameter to `ChangePluginGroupIdAndArtifactId` that permits the user to specify a `newVersion` Option.  This will update maven plugin version.

## What's your motivation?
- See #4902 .

## Anything in particular you'd like reviewers to focus on?
No.

## Anyone you would like to review specifically?
@timtebeek gave design feedback in #4902 so it may make the most sense to have them review the PR.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
