### PR TITLE
YAML Parser not to take @variables@ in the middle of scalar

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -52,7 +52,7 @@ import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 public class YamlParser implements org.openrewrite.Parser {
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile(":\\s*(@[^\n\r@]+@)");
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile(":\\s+(@[^\n\r@]+@)");
 
     @Override
     public Stream<SourceFile> parse(@Language("yml") String... sources) {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -216,4 +216,20 @@ class YamlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void atSymbols() {
+        rewriteRun(
+          yaml(
+            // BTW, the @ sign is forbidden as the first character of a scalar value by the YAML spec:
+            // https://github.com/yaml/yaml-spec/blob/1b1a1be43bd6e0cfec45caf0e40af3b5d2bb7f8a/spec/1.2.2/spec.md#L1877
+            """
+              root:
+                specifier: npm:@testing-library/vue@5.0.4
+                date: @build.timestamp@
+                version: @project.version@
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Changing the behavior of YAML parser with regards to `@variables@`. The special handling of these is now reduced to only the situations when there's space before `@`.

## What's your motivation?

One of the Moderne customers has reported an edge case of YAML parser corrupting values containing `@` in some cases.

## Context / Thought process on the solution

- These `@variables` are **not** part of the YAML standard
- It seems our support for them has been added in 2021 to address some specific Spring Boot issue - see #509
- As part of the spec, the `@` sign is not allowed to start a scalar value
- Thus I think it's a fine middle ground to continue to support these non-standard variables in a reduced scope, but fix the problem of `@` being used within the values.

## Have you considered any alternatives or workarounds?
- An alternative would be to drop the support for `@variables@` as non-complaint. But that would be hardly helpful.
- Another alternative would be to fine-tune the matching regexp to try to tell apart the variables use-case from just using `@` in the values. But that's hard to get it right and not cause other issues.

The down-side of the current solution is that the following (invalid) YAML:
```
date:@build.timestamp@
```
is **not** handled as a variable anymore (while it used to be). 

```
date: @build.timestamp@
```
continues to be handled the way it used to be.