### PR TITLE
Allow Groovy class to extend `groovy.lang.Script`

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTypeMapping.java
@@ -100,7 +100,7 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
             JavaType.FullyQualified owner = TypeUtils.asFullyQualified(type(node.getOuterClass()));
 
             List<JavaType.Variable> fields = null;
-            if(node.getFields().size() > 0) {
+            if(!node.getFields().isEmpty()) {
                 fields = new ArrayList<>(node.getFields().size());
                 for (FieldNode field : node.getFields()) {
                     if (!field.isSynthetic()) {
@@ -110,9 +110,9 @@ class GroovyTypeMapping implements JavaTypeMapping<ASTNode> {
             }
 
             List<JavaType.Method> methods = null;
-            if(node.getAllDeclaredMethods().size() > 0) {
-                methods = new ArrayList<>(node.getAllDeclaredMethods().size());
-                for (MethodNode method : node.getAllDeclaredMethods()) {
+            if(!node.getMethods().isEmpty()) {
+                methods = new ArrayList<>(node.getMethods().size());
+                for (MethodNode method : node.getMethods()) {
                     if (!method.isSynthetic()) {
                         methods.add(methodType(method));
                     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -88,6 +88,28 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void extendsObject() {
+        rewriteRun(
+          groovy(
+            """
+              class B extends Object {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void extendsScript() {
+        rewriteRun(
+          groovy(
+            """
+              abstract class B extends Script {}
+              """
+          )
+        );
+    }
+
+    @Test
     void interfaceExtendsInterface() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
While a class extending `groovy.lang.Script` typically represents the synthetic class representing the Groovy script as a whole, this is not necessarily the reason.

Additionally, also fix parsing of classes extending `Object` as well as correct type attribution for parsed classes with a super class (the `JavType.Class` should not declare any inherited methods).
