### PR TITLE
Support Groovy methods declaring generic type parameters

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -502,6 +502,17 @@ public class GroovyParserVisitor {
             List<J.Modifier> modifiers = visitModifiers(method.getModifiers());
             boolean isConstructorOfInnerNonStaticClass = false;
             RedundantDef redundantDef = getRedundantDefMarker(method);
+            J.TypeParameters typeParameters = null;
+            if (method.getGenericsTypes() != null) {
+                Space prefix = sourceBefore("<");
+                GenericsType[] genericsTypes = method.getGenericsTypes();
+                List<JRightPadded<J.TypeParameter>> typeParametersList = new ArrayList<>(genericsTypes.length);
+                for (int i = 0; i < genericsTypes.length; i++) {
+                    typeParametersList.add(JRightPadded.build(visitTypeParameter(genericsTypes[i]))
+                            .withAfter(i < genericsTypes.length - 1 ? sourceBefore(",") : sourceBefore(">")));
+                }
+                typeParameters = new J.TypeParameters(randomId(), prefix, Markers.EMPTY, emptyList(), typeParametersList);
+            }
             TypeTree returnType = method instanceof ConstructorNode ? null : visitTypeTree(method.getReturnType());
 
             Space namePrefix = whitespace();
@@ -612,7 +623,7 @@ public class GroovyParserVisitor {
                     redundantDef == null ? Markers.EMPTY : Markers.EMPTY.add(redundantDef),
                     annotations,
                     modifiers,
-                    null,
+                    typeParameters,
                     returnType,
                     new J.MethodDeclaration.IdentifierWithAnnotations(name, emptyList()),
                     JContainer.build(beforeParen, params, Markers.EMPTY),

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeAttributionTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeAttributionTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.groovy.tree.G;
@@ -180,7 +181,7 @@ class GroovyTypeAttributionTest implements RewriteTest {
     }
 
     @SuppressWarnings({"GrPackage", "OptionalGetWithoutIsPresent"})
-    @Disabled
+    @ExpectedToFail
     @Test
     void infersDelegateViaSimilarGradleApi() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/OmitParenthesesForLastArgumentLambdaTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/OmitParenthesesForLastArgumentLambdaTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.groovy.format;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -38,7 +37,6 @@ class OmitParenthesesForLastArgumentLambdaTest implements RewriteTest {
         spec.recipe(new OmitParenthesesForLastArgumentLambda());
     }
 
-    @Disabled("Not yet implemented")
     @Test
     void lastClosureArgument() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -353,7 +353,7 @@ class ClassDeclarationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/pull/4346")
     @Test
-    @Disabled("Known issue; still need to explore a fix")
+    @ExpectedToFail("Known issue; still need to explore a fix")
     void classExtendsGroovyLangScript() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.none()),

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
@@ -70,7 +69,6 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("Fails to parse")
     void implicitPublic() {
         rewriteRun(
           groovy(
@@ -85,7 +83,6 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("Fails to parse")
     void defaultConstructorArguments() {
         rewriteRun(
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/EnumTest.java
@@ -15,15 +15,15 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
 
 class EnumTest implements RewriteTest {
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumDefinition() {
         rewriteRun(
@@ -38,7 +38,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void innerEnum() {
         rewriteRun(
@@ -54,7 +54,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumWithAnnotations() {
         rewriteRun(
@@ -72,7 +72,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void anonymousClassInitializer() {
         rewriteRun(
@@ -99,7 +99,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumConstructor() {
         rewriteRun(
@@ -123,7 +123,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void noArguments() {
         rewriteRun(
@@ -137,7 +137,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumWithParameters() {
         rewriteRun(
@@ -154,7 +154,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumWithoutParameters() {
         rewriteRun(
@@ -164,7 +164,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumUnnecessarilyTerminatedWithSemicolon() {
         rewriteRun(
@@ -174,7 +174,7 @@ class EnumTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void enumWithEmptyParameters() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ForLoopTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ForLoopTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
@@ -148,7 +147,6 @@ class ForLoopTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
     void multiVariableInitialization() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -80,6 +80,19 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void genericTypeParameter() {
+        rewriteRun(
+          groovy(
+            """
+              interface Foo {
+                  <T extends Task> T task(Class<T> type)
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void emptyArguments() {
         rewriteRun(
           groovy("def foo( ) {}")

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TryTest.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -90,7 +90,7 @@ class TryTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1944")
-    @Disabled
+    @ExpectedToFail
     @Test
     void multiCatch() {
         rewriteRun(
@@ -106,7 +106,7 @@ class TryTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1945")
-    @Disabled
+    @ExpectedToFail
     @Test
     void tryWithResource() {
         rewriteRun(
@@ -123,7 +123,7 @@ class TryTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1945")
-    @Disabled
+    @ExpectedToFail
     @Test
     void tryWithResources() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.groovy.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
@@ -129,7 +128,6 @@ class VariableDeclarationsTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
     void singleTypeMultipleVariableDeclaration() {
         rewriteRun(
@@ -137,7 +135,6 @@ class VariableDeclarationsTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
     void multipleTypeMultipleVariableDeclaration() {
         rewriteRun(
@@ -190,7 +187,6 @@ class VariableDeclarationsTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/4702")
-    @Disabled
     @Test
     void nestedTypeParameters() {
         rewriteRun(


### PR DESCRIPTION
Also, using `@ExpectedToFail` I found a bunch of tests which appear to have been fixed. I enabled those and replaced `@Disabled` with `@ExpectedToFail` on others.