### PR TITLE
Fixing YAML handling of multiline literals in some cases

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -194,7 +194,6 @@ public class YamlParser implements org.openrewrite.Parser {
                     }
                     case Scalar: {
                         String fmt = newLine + reader.prefix(lastEnd, event);
-                        newLine = "";
 
                         ScalarEvent scalar = (ScalarEvent) event;
 
@@ -207,6 +206,9 @@ public class YamlParser implements org.openrewrite.Parser {
                         } else {
                             valueStart = lastEnd + fmt.length();
                         }
+                        valueStart = valueStart - newLine.length();
+                        newLine = "";
+
 
                         String scalarValue;
                         switch (scalar.getScalarStyle()) {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -232,4 +232,17 @@ class YamlParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void pipeLiteralInASequenceWithDoubleQuotes() {
+        rewriteRun(
+          yaml(
+            """
+               - "one": |
+                   two
+                 "three": "four"
+               """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing the handling of an edge-case of a YAML with:
- multiline literals using the `|` syntax
- and quoted identifiers.

## What's your motivation?

In some scenarios the YAML parser tends to swallow the first letter of the literal:
```diff
 - "one": |
     two
-  "three": "four"
+  "hree": "four"
] 
```
which is clearly a bug.
