### PR TITLE
Refactoring, renaming visitors not to use Java in their name

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
@@ -52,12 +52,12 @@ public class Autodetect extends NamedStyles {
         private final IndentStatistics indentStatistics = new IndentStatistics();
         private final GeneralFormatStatistics generalFormatStatistics = new GeneralFormatStatistics();
         private final FindIndentXmlVisitor findIndentXmlVisitor = new FindIndentXmlVisitor();
-        private final FindLineFormatJavaVisitor findLineFormatJavaVisitor = new FindLineFormatJavaVisitor();
+        private final FindLineFormatXmlVisitor findLineFormatXmlVisitor = new FindLineFormatXmlVisitor();
 
         public void sample(SourceFile xml) {
             if(xml instanceof Xml.Document) {
                 findIndentXmlVisitor.visit(xml, indentStatistics);
-                findLineFormatJavaVisitor.visit(xml, generalFormatStatistics);
+                findLineFormatXmlVisitor.visit(xml, generalFormatStatistics);
             }
         }
 
@@ -131,7 +131,7 @@ public class Autodetect extends NamedStyles {
         }
     }
 
-    private static class FindLineFormatJavaVisitor extends XmlVisitor<GeneralFormatStatistics> {
+    private static class FindLineFormatXmlVisitor extends XmlVisitor<GeneralFormatStatistics> {
         @Override
         public @Nullable Xml visit(@Nullable Tree tree, GeneralFormatStatistics stats) {
             if (tree instanceof Xml) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/style/Autodetect.java
@@ -35,7 +35,7 @@ public class Autodetect {
     }
 
     public static GeneralFormatStyle generalFormat(Yaml yaml) {
-        FindLineFormatJavaVisitor<Integer> findLineFormat = new FindLineFormatJavaVisitor<>();
+        FindLineFormatYamlVisitor<Integer> findLineFormat = new FindLineFormatYamlVisitor<>();
 
         //noinspection ConstantConditions
         findLineFormat.visit(yaml, 0);
@@ -43,7 +43,7 @@ public class Autodetect {
         return new GeneralFormatStyle(!findLineFormat.isIndentedWithLFNewLines());
     }
 
-    private static class FindLineFormatJavaVisitor<P> extends YamlIsoVisitor<P> {
+    private static class FindLineFormatYamlVisitor<P> extends YamlIsoVisitor<P> {
         private int linesWithCRLFNewLines = 0;
         private int linesWithLFNewLines = 0;
 


### PR DESCRIPTION
## What's changed?

Minor thing. Pure refactoring.
Renaming two visitors not to use Java in their names as they pertain to XML and YAML respectively.

## What's your motivation?

Clean up the code, make it more readable.
The rename has been triggered by 
- https://github.com/openrewrite/rewrite/pull/4916#discussion_r1919757939
