### PR TITLE
Refactoring, introducing getStyleOrDefault and getStyleOrFromAutodetect

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite;
 
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.style.NamedStyles;

--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite;
 
+import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.style.NamedStyles;
@@ -25,6 +26,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static java.util.Collections.singletonList;
 
 public interface SourceFile extends Tree {
 
@@ -77,6 +81,21 @@ public interface SourceFile extends Tree {
     default <S extends Style> S getStyle(Class<S> style, S defaultStyle) {
         S s = getStyle(style);
         return s == null ? defaultStyle : s;
+    }
+
+    default <S extends Style> S getStyleOrDefault(Class<S> style, Supplier<S> defaultStyle) {
+        S s = getStyle(style);
+        return s == null ? defaultStyle.get() : s;
+    }
+
+    default <S extends Style> @NotNull S getStyleOrFromAutodetect(Class<S> style, Supplier<NamedStyles> autodetectedStyle) {
+        S s = getStyle(style);
+        if (s != null) {
+            return s;
+        }
+        S ret = NamedStyles.merge(style, singletonList(autodetectedStyle.get()));
+        assert(ret != null);
+        return ret;
     }
 
     default <P> byte[] printAllAsBytes(P p) {

--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -88,7 +88,7 @@ public interface SourceFile extends Tree {
         return s == null ? defaultStyle.get() : s;
     }
 
-    default <S extends Style> @NotNull S getStyleOrFromAutodetect(Class<S> style, Supplier<NamedStyles> autodetectedStyle) {
+    default <S extends Style> S getStyleOrFromAutodetect(Class<S> style, Supplier<NamedStyles> autodetectedStyle) {
         S s = getStyle(style);
         if (s != null) {
             return s;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
@@ -50,27 +50,23 @@ public class AutoFormatVisitor<P> extends GroovyIsoVisitor<P> {
 
         J t = new NormalizeFormatVisitor<>(stopAfter).visit(tree, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
-                .orElse(IntelliJ.blankLines()), stopAfter)
+        t = new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
-                .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+        t = new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces()),
+                cu.getStyleOrDefault(SpacesStyle.class, IntelliJ::spaces),
                 cu.getStyle(EmptyForInitializerPadStyle.class),
                 cu.getStyle(EmptyForIteratorPadStyle.class),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
@@ -46,20 +46,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         Hcl t = new NormalizeFormatVisitor<>().visit(tree, p, cursor.fork());
 
-        t = new BracketsVisitor<>(Optional.ofNullable(cf.getStyle(BracketsStyle.class))
-                .orElse(BracketsStyle.DEFAULT), stopAfter)
+        t = new BracketsVisitor<>(cf.getStyle(BracketsStyle.class, BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
-                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = new TabsAndIndentsVisitor<>(cf.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new SpacesVisitor<>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
-                .orElse(SpacesStyle.DEFAULT), stopAfter)
+        t = new SpacesVisitor<>(cf.getStyle(SpacesStyle.class, SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Optional.ofNullable(cf.getStyle(BlankLinesStyle.class))
-                .orElse(BlankLinesStyle.DEFAULT), stopAfter)
+        t = new BlankLinesVisitor<>(cf.getStyle(BlankLinesStyle.class, BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         if (t instanceof Hcl.ConfigFile) {
@@ -75,20 +71,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         t = (Hcl.ConfigFile) new NormalizeFormatVisitor<>().visit(t, p);
 
-        t = (Hcl.ConfigFile) new BracketsVisitor<>(Optional.ofNullable(cf.getStyle(BracketsStyle.class))
-                .orElse(BracketsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BracketsVisitor<>(cf.getStyle(BracketsStyle.class, BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
-                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(cf.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new SpacesVisitor<>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
-                .orElse(SpacesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new SpacesVisitor<>(cf.getStyle(SpacesStyle.class, SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(Optional.ofNullable(cf.getStyle(BlankLinesStyle.class))
-                .orElse(BlankLinesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(cf.getStyle(BlankLinesStyle.class, BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
         assert t != null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -57,27 +57,23 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
 
         t = new MinimumViableSpacingVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
-                .orElse(IntelliJ.blankLines()), stopAfter)
+        t = new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
-                .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+        t = new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces()),
+                cu.getStyleOrDefault(SpacesStyle.class, IntelliJ::spaces),
                 cu.getStyle(EmptyForInitializerPadStyle.class),
                 cu.getStyle(EmptyForIteratorPadStyle.class),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))
@@ -101,8 +97,7 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
             }
             JavaSourceFile t = (JavaSourceFile) new RemoveTrailingWhitespaceVisitor<>(stopAfter).visit(cu, p);
 
-            t = (JavaSourceFile) new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
-                    .orElse(IntelliJ.blankLines()), stopAfter)
+            t = (JavaSourceFile) new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
                     .visit(t, p);
 
             t = (JavaSourceFile) new SpacesVisitor<P>(Optional.ofNullable(
@@ -112,16 +107,13 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
                     stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
-                    .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                    .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                    .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
             assert t != null;

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
@@ -45,15 +45,13 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Autodetect autodetectedStyle = Autodetect.detector().sample(doc).build();
         Json js = tree;
 
-        TabsAndIndentsStyle taiStyle = Optional.ofNullable(doc.getStyle(TabsAndIndentsStyle.class))
-                .orElseGet(() -> NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(autodetectedStyle)));
-        assert(taiStyle != null);
-        js = new TabsAndIndentsVisitor<>(taiStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new TabsAndIndentsVisitor<>(
+                doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p, cursor.fork());
 
-        GeneralFormatStyle gfStyle = Optional.ofNullable(doc.getStyle(GeneralFormatStyle.class))
-                        .orElseGet(() -> NamedStyles.merge(GeneralFormatStyle.class, singletonList(autodetectedStyle)));
-        assert(gfStyle != null);
-        js = new NormalizeLineBreaksVisitor<>(gfStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new NormalizeLineBreaksVisitor<>(
+                doc.getStyleOrFromAutodetect(GeneralFormatStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p, cursor.fork());
 
         return js;
     }
@@ -62,15 +60,13 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
     public Json.Document visitDocument(Json.Document js, P p) {
         Autodetect autodetectedStyle = Autodetect.detector().sample(js).build();
 
-        TabsAndIndentsStyle taiStyle = Optional.ofNullable(js.getStyle(TabsAndIndentsStyle.class))
-                .orElseGet(() -> NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(autodetectedStyle)));
-        assert(taiStyle != null);
-        js = (Json.Document) new TabsAndIndentsVisitor<>(taiStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new TabsAndIndentsVisitor<>(
+                js.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p);
 
-        GeneralFormatStyle gfStyle = Optional.ofNullable(js.getStyle(GeneralFormatStyle.class))
-                .orElseGet(() -> NamedStyles.merge(GeneralFormatStyle.class, singletonList(autodetectedStyle)));
-        assert(gfStyle != null);
-        js = (Json.Document) new NormalizeLineBreaksVisitor<>(gfStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new NormalizeLineBreaksVisitor<>(
+                js.getStyleOrFromAutodetect(GeneralFormatStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p);
 
         return js;
     }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -45,11 +45,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends JsonIsoVisitor<ExecutionContext> {
         @Override
         public Json. Document visitDocument(Json.Document docs, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = docs.getStyle(TabsAndIndentsStyle.class);
-            if (style == null) {
-                style = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(Autodetect.detector().sample(docs).build()));
-                assert(style != null);
-            }
+            TabsAndIndentsStyle style = docs.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(docs).build());
             doAfterVisit(new TabsAndIndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
@@ -56,16 +56,10 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
 
         t = new LineBreaksVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
-        TabsAndIndentsStyle tabsStyle = Optional.ofNullable(doc.getStyle(TabsAndIndentsStyle.class))
-                .orElseGet(() -> {
-                    Autodetect.Detector detector = Autodetect.detector();
-                    detector.sample(doc);
-                    return NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(detector.build()));
-                });
-        assert tabsStyle != null;
-
-        t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle, stopAfter)
-                .visit(t, p, cursor.fork());
+        TabsAndIndentsStyle tabsStyle =
+                doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(doc).build());
+        t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle,
+                stopAfter).visit(t, p, cursor.fork());
 
         t = new TabsAndIndentsVisitor<>(tabsStyle, stopAfter)
                 .visit(t, p, cursor.fork());

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
@@ -58,8 +58,8 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
 
         TabsAndIndentsStyle tabsStyle =
                 doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(doc).build());
-        t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle,
-                stopAfter).visit(t, p, cursor.fork());
+        t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle, stopAfter)
+                .visit(t, p, cursor.fork());
 
         t = new TabsAndIndentsVisitor<>(tabsStyle, stopAfter)
                 .visit(t, p, cursor.fork());

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
@@ -42,10 +42,7 @@ public class NormalizeTabsOrSpaces extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class);
-            if (style == null) {
-                style = TabsAndIndentsStyle.DEFAULT;
-            }
+            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new NormalizeTabsOrSpacesVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
@@ -41,10 +41,7 @@ public class TabsAndIndents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class);
-            if (style == null) {
-                style = TabsAndIndentsStyle.DEFAULT;
-            }
+            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new TabsAndIndentsVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
@@ -54,11 +54,12 @@ public class Autodetect extends NamedStyles {
         private final FindIndentXmlVisitor findIndentXmlVisitor = new FindIndentXmlVisitor();
         private final FindLineFormatXmlVisitor findLineFormatXmlVisitor = new FindLineFormatXmlVisitor();
 
-        public void sample(SourceFile xml) {
+        public Detector sample(SourceFile xml) {
             if(xml instanceof Xml.Document) {
                 findIndentXmlVisitor.visit(xml, indentStatistics);
                 findLineFormatXmlVisitor.visit(xml, generalFormatStatistics);
             }
+            return this;
         }
 
         public Autodetect build() {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
@@ -45,12 +45,14 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
 
         y = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p, cursor.fork());
 
-        y = new IndentsVisitor<>(Optional.ofNullable(docs.getStyle(IndentsStyle.class))
-                .orElse(Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())), stopAfter)
+        y = new IndentsVisitor<>(
+                    docs.getStyle(IndentsStyle.class, Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())),
+                    stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
-        y = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(docs.getStyle(GeneralFormatStyle.class))
-                .orElse(Autodetect.generalFormat(docs)), stopAfter)
+        y = new NormalizeLineBreaksVisitor<>(
+                docs.getStyle(GeneralFormatStyle.class, Autodetect.generalFormat(docs)),
+                stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
         return y;
@@ -62,13 +64,15 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
 
         y = (Yaml.Documents) new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p);
 
-        y = (Yaml.Documents) new IndentsVisitor<>(Optional.ofNullable(documents.getStyle(IndentsStyle.class))
-                .orElse(Autodetect.tabsAndIndents(y, YamlDefaultStyles.indents())), stopAfter)
-                .visitNonNull(documents, p);
+        y = (Yaml.Documents) new IndentsVisitor<>(
+                documents.getStyle(IndentsStyle.class, Autodetect.tabsAndIndents(documents, YamlDefaultStyles.indents())),
+                stopAfter)
+                .visitNonNull(y, p);
 
-        y = (Yaml.Documents) new NormalizeLineBreaksVisitor<>(Optional.ofNullable(documents.getStyle(GeneralFormatStyle.class))
-                .orElse(Autodetect.generalFormat(y)), stopAfter)
-                .visitNonNull(documents, p);
+        y = (Yaml.Documents) new NormalizeLineBreaksVisitor<>(
+                documents.getStyle(GeneralFormatStyle.class, Autodetect.generalFormat(documents)),
+                stopAfter)
+                .visitNonNull(y, p);
 
         return y;
     }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
@@ -43,10 +43,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends YamlIsoVisitor<ExecutionContext> {
         @Override
         public Yaml.Documents visitDocuments(Yaml.Documents docs, ExecutionContext ctx) {
-            IndentsStyle style = docs.getStyle(IndentsStyle.class);
-            if (style == null) {
-                style = Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents());
-            }
+            IndentsStyle style = docs.getStyleOrDefault(IndentsStyle.class, () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents()));
             doAfterVisit(new IndentsVisitor<>(style, null));
             return docs;
         }


### PR DESCRIPTION
## What's changed?

Fairly minor refactoring around `Styles` for multiple languages.
Extracting `getStyleOrDefault` or `getStyleOrFromAutodetect` convenience methods.

## What's your motivation?

To DRY the code and align it more against multiple implementations for various languages.

## Anything in particular you'd like reviewers to focus on?

Yes, please review if you consider it an improvement in code readability. I do, but it might be a matter of taste.