### PR TITLE
Map compiler type information for `SwitchExpression`

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1257,7 +1257,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         return new J.SwitchExpression(randomId(), fmt, Markers.EMPTY,
                 convert(node.getExpression()),
                 new J.Block(randomId(), sourceBefore("{"), Markers.EMPTY, new JRightPadded<>(false, EMPTY, Markers.EMPTY),
-                        convertAll(node.getCases(), noDelim, noDelim), sourceBefore("}")));
+                        convertAll(node.getCases(), noDelim, noDelim), sourceBefore("}")), typeMapping.type(node));
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1271,7 +1271,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         return new J.SwitchExpression(randomId(), fmt, Markers.EMPTY,
                 convert(node.getExpression()),
                 new J.Block(randomId(), sourceBefore("{"), Markers.EMPTY, new JRightPadded<>(false, EMPTY, Markers.EMPTY),
-                        convertAll(node.getCases(), noDelim, noDelim), sourceBefore("}")));
+                        convertAll(node.getCases(), noDelim, noDelim), sourceBefore("}")), typeMapping.type(node));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5122,7 +5122,14 @@ public interface J extends Tree {
                 public J visitBlock(Block block, AtomicReference<JavaType> javaType) {
                     if (!block.getStatements().isEmpty()) {
                         Case caze = (Case) block.getStatements().get(0);
-                        javaType.set(caze.getExpressions().get(0).getType());
+                        for (J j : caze.getCaseLabels()) {
+                            if (j instanceof TypedTree) {
+                                if (((TypedTree) j).getType() != null) {
+                                    javaType.set(((TypedTree) j).getType());
+                                    break;
+                                }
+                            }
+                        }
                     }
                     return block;
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -42,7 +42,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
@@ -5114,34 +5113,10 @@ public interface J extends Tree {
         @With
         Block cases;
 
-        @Override
-        @Transient
-        public @Nullable JavaType getType() {
-            return new JavaVisitor<AtomicReference<JavaType>>() {
-                @Override
-                public J visitBlock(Block block, AtomicReference<JavaType> javaType) {
-                    if (!block.getStatements().isEmpty()) {
-                        Case caze = (Case) block.getStatements().get(0);
-                        for (J j : caze.getCaseLabels()) {
-                            if (j instanceof TypedTree) {
-                                if (((TypedTree) j).getType() != null) {
-                                    javaType.set(((TypedTree) j).getType());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    return block;
-                }
-            }.reduce(this, new AtomicReference<>()).get();
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            // a switch expression's type is driven by its case statements
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Nullable
+        @Getter
+        JavaType type;
 
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Switch expressions now map the type information provided by the compiler instead of trying to determine it

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- fixes https://github.com/openrewrite/rewrite/issues/4928

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
