### PR TITLE
TypeTable as a substitute for packing whole jars into `META-INF/rewrite/classpath`

### DIFF
--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -13,9 +13,9 @@ tasks.register<JavaExec>("generateAntlrSources") {
     mainClass.set("org.antlr.v4.Tool")
 
     args = listOf(
-            "-o", "src/main/java/org/openrewrite/java/internal/grammar",
-            "-package", "org.openrewrite.java.internal.grammar",
-            "-visitor"
+        "-o", "src/main/java/org/openrewrite/java/internal/grammar",
+        "-package", "org.openrewrite.java.internal.grammar",
+        "-visitor"
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = antlrGeneration

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -16,34 +16,29 @@
 package org.openrewrite.java;
 
 import io.github.classgraph.ClassGraph;
-import io.github.classgraph.Resource;
-import io.github.classgraph.ResourceList;
-import io.github.classgraph.ScanResult;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.internal.parser.JavaParserClasspathLoader;
+import org.openrewrite.java.internal.parser.RewriteClasspathJarClasspathLoader;
+import org.openrewrite.java.internal.parser.TypeTable;
 import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.style.NamedStyles;
 
-import java.io.*;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static java.util.Objects.requireNonNull;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
@@ -95,7 +90,7 @@ public interface JavaParser extends Parser {
     /**
      * Filters the classpath entries to find paths that match the given artifact name.
      *
-     * @param artifactName    The artifact name to search for.
+     * @param artifactName     The artifact name to search for.
      * @param runtimeClasspath The list of classpath URIs to search within.
      * @return List of Paths that match the artifact name.
      */
@@ -125,94 +120,31 @@ public interface JavaParser extends Parser {
 
     static List<Path> dependenciesFromResources(ExecutionContext ctx, String... artifactNamesWithVersions) {
         if (artifactNamesWithVersions.length == 0) {
-            return Collections.emptyList();
+            return emptyList();
         }
         List<Path> artifacts = new ArrayList<>(artifactNamesWithVersions.length);
-        Set<String> missingArtifactNames = new LinkedHashSet<>(artifactNamesWithVersions.length);
-        missingArtifactNames.addAll(Arrays.asList(artifactNamesWithVersions));
-        File resourceTarget = JavaParserExecutionContextView.view(ctx)
-                .getParserClasspathDownloadTarget();
+        Set<String> missingArtifactNames = new LinkedHashSet<>(Arrays.asList(artifactNamesWithVersions));
 
-        Class<?> caller;
-        try {
-            // StackWalker is only available in Java 15+, but right now we only use classloader isolated
-            // recipe instances in Java 17 environments, so we can safely use StackWalker there.
-            Class<?> options = Class.forName("java.lang.StackWalker$Option");
-            Object retainOption = options.getDeclaredField("RETAIN_CLASS_REFERENCE").get(null);
-
-            Class<?> walkerClass = Class.forName("java.lang.StackWalker");
-            Method getInstance = walkerClass.getDeclaredMethod("getInstance", options);
-            Object walker = getInstance.invoke(null, retainOption);
-            Method getDeclaringClass = Class.forName("java.lang.StackWalker$StackFrame").getDeclaredMethod("getDeclaringClass");
-            caller = (Class<?>) walkerClass.getMethod("walk", Function.class).invoke(walker, (Function<Stream<Object>, Object>) s -> s
-                    .map(f -> {
-                        try {
-                            return (Class<?>) getDeclaringClass.invoke(f);
-                        } catch (IllegalAccessException | InvocationTargetException e) {
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    // Drop anything before the parser or builder class, as well as those classes themselves
-                    .filter(new Predicate<Class<?>>() {
-                        boolean parserOrBuilderFound = false;
-
-                        @Override
-                        public boolean test(Class<?> c1) {
-                            if (c1.getName().equals(JavaParser.class.getName()) ||
-                                c1.getName().equals(Builder.class.getName())) {
-                                parserOrBuilderFound = true;
-                                return false;
-                            }
-                            return parserOrBuilderFound;
-                        }
-                    })
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("Unable to find caller of JavaParser.dependenciesFromResources(..)")));
-        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException |
-                 NoSuchMethodException | InvocationTargetException e) {
-            caller = JavaParser.class;
-        }
-
-        try (ScanResult result = new ClassGraph().acceptPaths("META-INF/rewrite/classpath")
-                .addClassLoader(caller.getClassLoader())
-                .scan()) {
-            ResourceList resources = result.getResourcesWithExtension(".jar");
-
-            for (String artifactName : new ArrayList<>(missingArtifactNames)) {
-                Pattern jarPattern = Pattern.compile(artifactName + "-?.*\\.jar$");
-                for (Resource resource : resources) {
-                    if (jarPattern.matcher(resource.getPath()).find()) {
-                        try {
-                            Path artifact = resourceTarget.toPath().resolve(Paths.get(resource.getPath()).getFileName());
-                            if (!Files.exists(artifact)) {
-                                try {
-                                    InputStream resourceAsStream = requireNonNull(
-                                            caller.getResourceAsStream("/" + resource.getPath()),
-                                            caller.getCanonicalName() + " resource not found: " + resource.getPath());
-                                    Files.copy(resourceAsStream, artifact);
-                                } catch (FileAlreadyExistsException ignore) {
-                                    // can happen when tests run in parallel, for example
-                                }
-                            }
-                            missingArtifactNames.remove(artifactName);
-                            artifacts.add(artifact);
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                        break;
+        try (RewriteClasspathJarClasspathLoader rewriteClasspathJarClasspathLoader = new RewriteClasspathJarClasspathLoader(ctx)) {
+            for (JavaParserClasspathLoader locator : new JavaParserClasspathLoader[]{
+                    new TypeTable(ctx, missingArtifactNames),
+                    rewriteClasspathJarClasspathLoader,
+            }) {
+                for (String missingArtifactName : new ArrayList<>(missingArtifactNames)) {
+                    Path located = locator.load(missingArtifactName);
+                    if (located != null) {
+                        artifacts.add(located);
+                        missingArtifactNames.remove(missingArtifactName);
                     }
                 }
             }
+        }
 
-            if (!missingArtifactNames.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "Unable to find classpath resource dependencies beginning with: " +
-                        missingArtifactNames.stream().map(a -> "'" + a + "'").sorted().collect(joining(", ", "", ".\n")) +
-                        "The caller is of type " + caller.getName() + ".\n" +
-                        "The resources resolvable from the caller's classpath are: " +
-                        resources.stream().map(Resource::getPath).sorted().collect(joining(", "))
-                );
-            }
+        if (!missingArtifactNames.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Unable to find classpath resource dependencies beginning with: " +
+                    missingArtifactNames.stream().map(a -> "'" + a + "'").sorted().collect(joining(", ", "", ".\n"))
+            );
         }
 
         return artifacts;
@@ -324,9 +256,9 @@ public interface JavaParser extends Parser {
 
     @SuppressWarnings("unchecked")
     abstract class Builder<P extends JavaParser, B extends Builder<P, B>> extends Parser.Builder {
-        protected Collection<Path> classpath = Collections.emptyList();
-        protected Collection<String> artifactNames = Collections.emptyList();
-        protected Collection<byte[]> classBytesClasspath = Collections.emptyList();
+        protected Collection<Path> classpath = emptyList();
+        protected Collection<String> artifactNames = emptyList();
+        protected Collection<byte[]> classBytesClasspath = emptyList();
         protected JavaTypeCache javaTypeCache = new JavaTypeCache();
 
         @Nullable
@@ -369,7 +301,7 @@ public interface JavaParser extends Parser {
         }
 
         public B classpath(Collection<Path> classpath) {
-            this.artifactNames = Collections.emptyList();
+            this.artifactNames = emptyList();
             this.classpath = classpath;
             return (B) this;
         }
@@ -388,13 +320,13 @@ public interface JavaParser extends Parser {
 
         public B classpath(String... artifactNames) {
             this.artifactNames = Arrays.asList(artifactNames);
-            this.classpath = Collections.emptyList();
+            this.classpath = emptyList();
             return (B) this;
         }
 
         @SuppressWarnings({"UnusedReturnValue", "unused"})
         public B classpathFromResources(ExecutionContext ctx, String... classpath) {
-            this.artifactNames = Collections.emptyList();
+            this.artifactNames = emptyList();
             this.classpath = dependenciesFromResources(ctx, classpath);
             return (B) this;
         }
@@ -415,7 +347,7 @@ public interface JavaParser extends Parser {
             if (!artifactNames.isEmpty()) {
                 classpath = new ArrayList<>(classpath);
                 classpath.addAll(JavaParser.dependenciesFromClasspath(artifactNames.toArray(new String[0])));
-                artifactNames = Collections.emptyList();
+                artifactNames = emptyList();
             }
             return classpath;
         }
@@ -483,3 +415,4 @@ class RuntimeClasspathCache {
         return runtimeClasspath;
     }
 }
+

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/JavaParserCaller.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/JavaParserCaller.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.parser;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaParser;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * This class is used to find the caller of {@link JavaParser#dependenciesFromResources(ExecutionContext, String...)},
+ * which is used to load classpath resources for {@link JavaParser}.
+ */
+class JavaParserCaller {
+    private JavaParserCaller() {
+    }
+
+    public static Class<?> findCaller() {
+        Class<?> caller;
+        try {
+            // StackWalker is only available in Java 15+, but right now we only use classloader isolated
+            // recipe instances in Java 17 environments, so we can safely use StackWalker there.
+            Class<?> options = Class.forName("java.lang.StackWalker$Option");
+            Object retainOption = options.getDeclaredField("RETAIN_CLASS_REFERENCE").get(null);
+
+            Class<?> walkerClass = Class.forName("java.lang.StackWalker");
+            Method getInstance = walkerClass.getDeclaredMethod("getInstance", options);
+            Object walker = getInstance.invoke(null, retainOption);
+            Method getDeclaringClass = Class.forName("java.lang.StackWalker$StackFrame").getDeclaredMethod("getDeclaringClass");
+            caller = (Class<?>) walkerClass.getMethod("walk", Function.class).invoke(walker, (Function<Stream<Object>, Object>) s -> s
+                    .map(f -> {
+                        try {
+                            return (Class<?>) getDeclaringClass.invoke(f);
+                        } catch (IllegalAccessException | InvocationTargetException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    // Drop anything before the parser or builder class, as well as those classes themselves
+                    .filter(new Predicate<Class<?>>() {
+                        boolean parserOrBuilderFound = false;
+
+                        @Override
+                        public boolean test(Class<?> c1) {
+                            if (c1.getName().equals(JavaParser.class.getName()) ||
+                                c1.getName().equals(JavaParser.Builder.class.getName())) {
+                                parserOrBuilderFound = true;
+                                return false;
+                            }
+                            return parserOrBuilderFound;
+                        }
+                    })
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Unable to find caller of JavaParser.dependenciesFromResources(..)")));
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException |
+                 NoSuchMethodException | InvocationTargetException e) {
+            caller = JavaParser.class;
+        }
+        return caller;
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/JavaParserClasspathLoader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/JavaParserClasspathLoader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.parser;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaParser;
+
+import java.nio.file.Path;
+
+/**
+ * Prepares classpath resources for use by {@link JavaParser}.
+ */
+public interface JavaParserClasspathLoader {
+
+    /**
+     * Load a classpath resource.
+     *
+     * @param artifactName A descriptor for the classpath resource to load.
+     * @return The path a JAR or classes directory that is suitable for use
+     * as a classpath entry in a compilation step.
+     */
+    @Nullable
+    Path load(String artifactName);
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/RewriteClasspathJarClasspathLoader.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/RewriteClasspathJarClasspathLoader.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.parser;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.Resource;
+import io.github.classgraph.ResourceList;
+import io.github.classgraph.ScanResult;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaParserExecutionContextView;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+import static org.openrewrite.java.internal.parser.JavaParserCaller.findCaller;
+
+/**
+ * As of 6.1.0, we are using {@link TypeTable} to include {@link JavaParser} dependencies
+ * as resources in the classpath, because including the whole JAR caused bloat in the size of recipe JARs
+ * and would often get blocked by security scanners that weren't able to recognize that these JAR resources
+ * were only used to parse templats and never executed and so didn't represent a security threat.
+ * <p>
+ * Provided that the type table concept works well, this class and the technique it enables
+ * will be removed in a future release.
+ */
+public class RewriteClasspathJarClasspathLoader implements JavaParserClasspathLoader, AutoCloseable {
+    private final Class<?> caller = findCaller();
+    private final ScanResult result;
+    private final ResourceList resources;
+    private final ExecutionContext ctx;
+
+    public RewriteClasspathJarClasspathLoader(ExecutionContext ctx) {
+        this.ctx = ctx;
+        result = new ClassGraph().acceptPaths("META-INF/rewrite/classpath").scan();
+        resources = result.getResourcesWithExtension(".jar");
+    }
+
+    @Override
+    public @Nullable Path load(String artifactName) {
+        Pattern jarPattern = Pattern.compile(artifactName + "-?.*\\.jar$");
+        for (Resource resource : resources) {
+            if (jarPattern.matcher(resource.getPath()).find()) {
+                try {
+                    Path artifact = getJarsFolder(ctx).resolve(Paths.get(resource.getPath()).getFileName());
+                    if (!Files.exists(artifact)) {
+                        try {
+                            InputStream resourceAsStream = requireNonNull(
+                                    caller.getResourceAsStream("/" + resource.getPath()),
+                                    caller.getCanonicalName() + " resource not found: " + resource.getPath());
+                            Files.copy(resourceAsStream, artifact);
+                        } catch (FileAlreadyExistsException ignore) {
+                            // can happen when tests run in parallel, for example
+                        }
+                    }
+                    return artifact;
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+            return null;
+        }
+
+        return null;
+
+    }
+
+    /**
+     * The /.jars folder will contain JARs that were packed into /META-INF/rewrite/classpath as
+     * part of the original integration to pack parser classpath resources into recipe JARs. Those
+     * JARs existed in /META-INF/rewrite/classpath with just file names of the form
+     * [ARTIFACT]-[VERSION].jar, and so there was always the possibility of collision on JARs
+     * with the same artifact name and different group IDs with this mechanism. As a result, we'll
+     * continue to write those JARs out to the /jars folder, distinct from the way we write out
+     * parser classpath resources from {@link TypeTable} going forward, so that there is no possibility
+     * that we pick up a JAR written from /META-INF/rewrite/classpath that has a more accurate GAV
+     * coordinate fully specified in a type table.
+     *
+     * @param ctx An execution context from which we can determine the root of the JARs folder
+     * @return The path to the /.jars folder
+     */
+    private static Path getJarsFolder(ExecutionContext ctx) {
+        Path jarsFolder = JavaParserExecutionContextView.view(ctx)
+                .getParserClasspathDownloadTarget().toPath().resolve(".jars");
+        if (!Files.exists(jarsFolder) && !jarsFolder.toFile().mkdirs()) {
+            throw new UncheckedIOException(new IOException("Failed to create directory " + jarsFolder));
+        }
+        return jarsFolder;
+    }
+
+    @Override
+    public void close() {
+        resources.close();
+        result.close();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.parser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.objectweb.asm.*;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.java.JavaParserExecutionContextView;
+import org.xerial.snappy.SnappyInputStream;
+import org.xerial.snappy.SnappyOutputStream;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+
+import static org.objectweb.asm.ClassReader.SKIP_CODE;
+import static org.objectweb.asm.Opcodes.V1_8;
+import static org.openrewrite.java.internal.parser.JavaParserCaller.findCaller;
+
+/**
+ * Type tables are written as a TSV file with the following columns:
+ * <ul>
+ *     <li>groupId</li>
+ *     <li>artifactId</li>
+ *     <li>version</li>
+ *     <li>classAccess</li>
+ *     <li>className</li>
+ *     <li>classSignature</li>
+ *     <li>classSuperclassSignature</li>
+ *     <li>classSuperinterfaceSignatures[]</li>
+ *     <li>access</li>
+ *     <li>memberName</li>
+ *     <li>descriptor</li>
+ *     <li>signature</li>
+ *     <li>parameterNames</li>
+ *     <li>exceptions[]</li>
+ * </ul>
+ * <p>
+ * Descriptor and signature are in <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3">JVMS 4.3</a> format.
+ * Because these type tables could get fairly large, the format is optimized for fast record access. TSV was chosen over CSV for its
+ * simplicity and for the reasons cited <a href="https://github.com/eBay/tsv-utils/blob/master/docs/comparing-tsv-and-csv.md">here</a>.
+ * <p>
+ * There is of course a lot of duplication in the class and GAV columns, but compression cuts down on
+ * the disk impact of that and the value is an overall single table representation.
+ */
+@Incubating(since = "8.44.0")
+@Value
+public class TypeTable implements JavaParserClasspathLoader {
+    /**
+     * Verifies that the bytecodes written out for the types represented in a type table
+     * will not be invalid and therefore rejected by the JVM verifier when used in a compilation
+     * step.
+     */
+    public static final String VERIFY_CLASS_WRITING = "org.openrewrite.java.TypeTableClassWritingVerification";
+
+    public static final String DEFAULT_RESOURCE_PATH = "META-INF/rewrite/classpath.tsv.snappy";
+
+    private static final Map<GroupArtifactVersion, Path> classesDirByArtifact = new LinkedHashMap<>();
+
+    public TypeTable(ExecutionContext ctx, Collection<String> artifactNames) {
+        this(ctx, findCaller().getClassLoader().getResourceAsStream(DEFAULT_RESOURCE_PATH), artifactNames);
+    }
+
+    public TypeTable(ExecutionContext ctx, InputStream is, Collection<String> artifactNames) {
+        try (InputStream snappy = new SnappyInputStream(is)) {
+            new Reader(ctx).read(snappy, artifactsNotYetWritten(artifactNames));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Collection<String> artifactsNotYetWritten(Collection<String> artifactNames) {
+        Collection<String> notWritten = new ArrayList<>(artifactNames);
+        for (String artifactName : artifactNames) {
+            for (GroupArtifactVersion groupArtifactVersion : classesDirByArtifact.keySet()) {
+                if (Pattern.compile(artifactName + ".*")
+                        .matcher(groupArtifactVersion.getArtifactId() + "-" + groupArtifactVersion.getVersion())
+                        .matches()) {
+                    notWritten.remove(artifactName);
+                }
+            }
+        }
+        return notWritten;
+    }
+
+    /**
+     * Reads a type table from the classpath, and writes classes directories to disk for matching artifact names.
+     */
+    @RequiredArgsConstructor
+    static class Reader {
+        private final ExecutionContext ctx;
+        private GroupArtifactVersion gav;
+        private final Map<ClassDefinition, List<Member>> membersByClassName = new HashMap<>();
+
+        public void read(InputStream is, Collection<String> artifactNames) throws IOException {
+            if (is != null) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
+                    in.lines().skip(1).map(line -> line.split("\t", -1)).forEach(fields -> {
+                        GroupArtifactVersion rowGav = new GroupArtifactVersion(fields[0], fields[1], fields[2]);
+                        if (!rowGav.equals(gav)) {
+                            writeClassesDir();
+                        }
+
+                        String artifactVersion = fields[1] + "-" + fields[2];
+
+                        for (String artifactName : artifactNames) {
+                            if (Pattern.compile(artifactName + ".*").matcher(artifactVersion).matches()) {
+                                gav = rowGav;
+                                break;
+                            }
+                        }
+
+                        if (gav != null) {
+                            Member member = new Member(
+                                    new ClassDefinition(
+                                            Integer.parseInt(fields[3]),
+                                            fields[4],
+                                            fields[5].isEmpty() ? null : fields[5],
+                                            fields[6].isEmpty() ? null : fields[6],
+                                            fields[7].isEmpty() ? null : fields[7].split("\\|")
+                                    ),
+                                    Integer.parseInt(fields[8]),
+                                    fields[9],
+                                    fields[10],
+                                    fields[11].isEmpty() ? null : fields[11],
+                                    fields[12].isEmpty() ? null : fields[12].split("\\|")
+                            );
+                            membersByClassName
+                                    .computeIfAbsent(member.getClassDefinition(), cd -> new ArrayList<>())
+                                    .add(member);
+                        }
+                    });
+                }
+                writeClassesDir();
+            }
+        }
+
+        private void writeClassesDir() {
+            if (gav == null) {
+                return;
+            }
+
+            Path classesDir = getClassesDir(ctx, gav);
+            classesDirByArtifact.put(gav, classesDir);
+
+            membersByClassName.forEach((classDef, members) -> {
+                Path classFile = classesDir.resolve(classDef.getName() + ".class");
+                if (!Files.exists(classFile.getParent()) && !classFile.getParent().toFile().mkdirs()) {
+                    throw new UncheckedIOException(new IOException("Failed to create directory " + classesDir.getParent()));
+                }
+
+                ClassWriter cw = new ClassWriter(0);
+                ClassVisitor classWriter = ctx.getMessage(VERIFY_CLASS_WRITING, false) ?
+                        cw : new CheckClassAdapter(cw);
+
+                classWriter.visit(
+                        V1_8,
+                        classDef.getAccess(),
+                        classDef.getName(),
+                        classDef.getSignature(),
+                        classDef.getSuperclassSignature(),
+                        classDef.getSuperinterfaceSignatures()
+                );
+
+                Set<ClassDefinition> innerClasses = new HashSet<>();
+                for (ClassDefinition innerClassDef : membersByClassName.keySet()) {
+                    if (innerClassDef.getName().contains("$")) {
+                        innerClasses.add(innerClassDef);
+                    }
+                }
+
+                for (ClassDefinition innerClass : innerClasses) {
+                    classWriter.visitInnerClass(
+                            innerClass.getName(),
+                            classDef.getName(),
+                            innerClass.getName().substring(innerClass.getName().lastIndexOf('$') + 1),
+                            innerClass.getAccess()
+                    );
+                }
+
+                for (Member member : members) {
+                    if (member.getDescriptor().contains("(")) {
+                        classWriter
+                                .visitMethod(
+                                        member.getAccess(),
+                                        member.getName(),
+                                        member.getDescriptor(),
+                                        member.getSignature(),
+                                        member.getExceptions()
+                                )
+                                .visitEnd();
+                    } else {
+                        classWriter
+                                .visitField(
+                                        member.getAccess(),
+                                        member.getName(),
+                                        member.getDescriptor(),
+                                        member.getSignature(),
+                                        null
+                                )
+                                .visitEnd();
+                    }
+                }
+
+                try {
+                    Files.write(classFile, cw.toByteArray());
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+
+            gav = null;
+        }
+    }
+
+    private static Path getClassesDir(ExecutionContext ctx, GroupArtifactVersion gav) {
+        Path jarsFolder = JavaParserExecutionContextView.view(ctx)
+                .getParserClasspathDownloadTarget().toPath().resolve(".tt");
+        if (!Files.exists(jarsFolder) && !jarsFolder.toFile().mkdirs()) {
+            throw new UncheckedIOException(new IOException("Failed to create directory " + jarsFolder));
+        }
+
+        Path classesDir = jarsFolder;
+        for (String g : gav.getGroupId().split("\\.")) {
+            classesDir = classesDir.resolve(g);
+        }
+        classesDir = classesDir.resolve(gav.getArtifactId()).resolve(gav.getVersion());
+
+        if (!Files.exists(classesDir) && !classesDir.toFile().mkdirs()) {
+            throw new UncheckedIOException(new IOException("Failed to create directory " + classesDir));
+        }
+
+        return classesDir;
+    }
+
+    public static Writer newWriter(OutputStream out) {
+        return new Writer(out);
+    }
+
+    @Override
+    public @Nullable Path load(String artifactName) {
+        for (Map.Entry<GroupArtifactVersion, Path> gavAndClassesDir : classesDirByArtifact.entrySet()) {
+            GroupArtifactVersion gav = gavAndClassesDir.getKey();
+            if (Pattern.compile(artifactName + ".*")
+                    .matcher(gav.getArtifactId() + "-" + gav.getVersion())
+                    .matches()) {
+                return gavAndClassesDir.getValue();
+            }
+        }
+        return null;
+    }
+
+    public static class Writer implements AutoCloseable {
+        private final PrintStream out;
+
+        public Writer(OutputStream out) {
+            this.out = new PrintStream(new SnappyOutputStream(out));
+            this.out.println("groupId\tartifactId\tversion\tclassAccess\tclassName\tclassSignature\tclassSuperclassSignature\tclassSuperinterfaceSignatures\taccess\tname\tdescriptor\tsignature\tparameterNames\texceptions");
+        }
+
+        public Jar jar(String groupId, String artifactId, String version) {
+            return new Jar(groupId, artifactId, version);
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+
+        @Value
+        public class Jar {
+            String groupId;
+            String artifactId;
+            String version;
+
+            public void write(Path jar) {
+                try (JarFile jarFile = new JarFile(jar.toFile())) {
+                    Enumeration<JarEntry> entries = jarFile.entries();
+                    while (entries.hasMoreElements()) {
+                        JarEntry entry = entries.nextElement();
+                        if (entry.getName().endsWith(".class")) {
+                            try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                                new ClassReader(inputStream).accept(new ClassVisitor(Opcodes.ASM9) {
+                                    ClassDefinition classDefinition;
+
+                                    @Override
+                                    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                                        classDefinition = classDefinition(access, name, signature, superName, interfaces);
+                                        super.visit(version, access, name, signature, superName, interfaces);
+                                    }
+
+                                    @Override
+                                    public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+                                        classDefinition.writeField(access, name, descriptor, signature);
+                                        return super.visitField(access, name, descriptor, signature, value);
+                                    }
+
+                                    @Override
+                                    public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                                                     String signature, String[] exceptions) {
+                                        classDefinition.writeMethod(access, name, descriptor, signature, null, exceptions);
+                                        return super.visitMethod(access, name, descriptor, signature, exceptions);
+                                    }
+                                }, SKIP_CODE);
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+
+            public ClassDefinition classDefinition(int access, String name, @Nullable String signature,
+                                                   String superclassName, @Nullable String[] superinterfaceSignatures) {
+                return new ClassDefinition(this, access, name, signature, superclassName, superinterfaceSignatures);
+            }
+        }
+
+        @Value
+        public class ClassDefinition {
+            Jar jar;
+            int classAccess;
+            String className;
+            @Nullable
+            String classSignature;
+            String classSuperclassName;
+            @Nullable
+            String[] classSuperinterfaceSignatures;
+
+            public void writeMethod(int access, String name, String descriptor,
+                                    @Nullable String signature,
+                                    @Nullable String[] parameterNames,
+                                    @Nullable String[] exceptions) {
+                if (((Opcodes.ACC_PRIVATE | Opcodes.ACC_SYNTHETIC) & access) == 0) {
+                    out.printf(
+                            "%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s%n",
+                            jar.groupId, jar.artifactId, jar.version,
+                            classAccess, className,
+                            classSignature == null ? "" : classSignature,
+                            classSuperclassName,
+                            classSuperinterfaceSignatures == null ? "" : String.join("|", classSuperinterfaceSignatures),
+                            access, name, descriptor,
+                            signature == null ? "" : signature,
+                            parameterNames == null ? "" : String.join("|", parameterNames),
+                            exceptions == null ? "" : String.join("|", exceptions)
+                    );
+                }
+            }
+
+            public void writeField(int access, String name, String descriptor,
+                                   @Nullable String signature) {
+                if (((Opcodes.ACC_PRIVATE | Opcodes.ACC_SYNTHETIC) & access) == 0) {
+                    // Fits into the same table structure
+                    writeMethod(access, name, descriptor, signature, null, null);
+                }
+            }
+        }
+    }
+
+    @Value
+    private static class GroupArtifactVersion {
+        String groupId;
+        String artifactId;
+        String version;
+    }
+
+    @Value
+    private static class ClassDefinition {
+        int access;
+        String name;
+
+        @Nullable
+        String signature;
+
+        @Nullable
+        String superclassSignature;
+
+        @Nullable
+        String[] superinterfaceSignatures;
+    }
+
+    @Value
+    private static class Member {
+        ClassDefinition classDefinition;
+        int access;
+        String name;
+        String descriptor;
+        String signature;
+        String[] exceptions;
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.parser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaParserExecutionContextView;
+import org.openrewrite.test.RewriteTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.micrometer.core.instrument.util.DoubleFormat.decimalOrNan;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+
+public class TypeTableTest implements RewriteTest {
+    Path tsv;
+    ExecutionContext ctx = new InMemoryExecutionContext();
+
+    @TempDir
+    Path temp;
+
+    @BeforeEach
+    void before() {
+        ctx.putMessage(TypeTable.VERIFY_CLASS_WRITING, true);
+        JavaParserExecutionContextView.view(ctx).setParserClasspathDownloadTarget(temp.toFile());
+        tsv = temp.resolve("types.tsv");
+        System.out.println(tsv);
+    }
+
+    /**
+     * Snappy isn't optimal for compression, but is excellent for portability since it
+     * requires no native libraries or JNI.
+     *
+     * @throws IOException If unable to write.
+     */
+    @Test
+    void writeAllRuntimeClasspathJars() throws IOException {
+        try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsv))) {
+            long jarsSize = 0;
+            for (Path classpath : JavaParser.runtimeClasspath()) {
+                jarsSize += writeJar(classpath, writer);
+            }
+
+            System.out.println("Total size of type table " + humanReadableByteCount(Files.size(tsv)));
+            System.out.println("Total size of jars " + humanReadableByteCount(jarsSize));
+        }
+    }
+
+    @Test
+    void writeReadMicrometer() throws IOException {
+        try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsv))) {
+            for (Path classpath : JavaParser.runtimeClasspath()) {
+                if (classpath.toFile().getName().contains("micrometer")) {
+                    writeJar(classpath, writer);
+                }
+            }
+        }
+
+        TypeTable table = new TypeTable(ctx, Files.newInputStream(tsv), List.of("micrometer"));
+        Path micrometerClassesDir = table.load("micrometer");
+
+        assertThat(micrometerClassesDir).isNotNull();
+
+        // Demonstrate that the bytecode we wrote for the classes in this
+        // JAR is sufficient for the compiler to type attribute code that depends
+        // on them.
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            .classpath(List.of(micrometerClassesDir))),
+          java(
+            """
+              import io.micrometer.core.instrument.Metrics;
+              import io.micrometer.core.instrument.Timer;
+              
+              class Test {
+                  Timer timer = Metrics.timer("my.timer");
+              }
+              """
+          )
+        );
+    }
+
+    private static long writeJar(Path classpath, TypeTable.Writer writer) throws IOException {
+        String fileName = classpath.toFile().getName();
+        if (fileName.endsWith(".jar")) {
+            String[] artifactVersion = fileName.replaceAll(".jar$", "")
+              .split("-(?=\\d)");
+            if (artifactVersion.length > 1) {
+                writer
+                  .jar("unknown", artifactVersion[0], artifactVersion[1])
+                  .write(classpath);
+                System.out.println("  Wrote " + artifactVersion[0] + ":" + artifactVersion[1]);
+            }
+            return Files.size(classpath);
+        }
+        return 0;
+    }
+
+    private String humanReadableByteCount(double bytes) {
+        int unit = 1024;
+        if (bytes < unit || Double.isNaN(bytes)) return decimalOrNan(bytes) + " B";
+        int exp = (int) (Math.log(bytes) / Math.log(unit));
+        String pre = "KMGTPE".charAt(exp - 1) + "i";
+        return decimalOrNan(bytes / Math.pow(unit, exp)) + " " + pre + "B";
+    }
+}


### PR DESCRIPTION
## What's changed?

Introducing a new mechanism for recipes to have resource level dependencies on JARs when they need them for `JavaTemplate` classpaths. Type tables provide an inventory of essentially the ABI of whole classes and JARs, from which we can reconstitute enough bytecodes to be used in a later compilation step (such as a `JavaTemplate` use).

## What's your motivation?

In `rewrite-spring` we've been gradually increasing the size of the recipe JAR over time by including more and more versions . Additionally, we see security scanners sometimes blocking our recipe JARs because they have inlined "vulnerable" JARs into the META-INF directory, even though these JARs would never be executed (the scanners can't tell the difference).

## Anything in particular you'd like reviewers to focus on?

`JavaParser#dependenciesFromResources` will, for a time, still look for whole JARs in the `/META-INF/rewrite/classpath` folder in addition to these type tables.
