### PR TITLE
Add backwards compatibility constructors

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -5130,12 +5130,7 @@ public interface J extends Tree {
         @Deprecated
         @ApiStatus.ScheduledForRemoval(inVersion = "2025-05-01")
         public SwitchExpression(UUID id, Space prefix, Markers markers, ControlParentheses<Expression> selector, Block cases) {
-            this.id = id;
-            this.prefix = prefix;
-            this.markers = markers;
-            this.selector = selector;
-            this.cases = cases;
-            this.type = new JavaVisitor<AtomicReference<@Nullable JavaType>>() {
+            this(id, prefix, markers, selector, cases, new JavaVisitor<AtomicReference<@Nullable JavaType>>() {
                 @Override
                 public J visitBlock(Block block, AtomicReference<@Nullable JavaType> javaType) {
                     if (!block.getStatements().isEmpty()) {
@@ -5144,7 +5139,7 @@ public interface J extends Tree {
                     }
                     return block;
                 }
-            }.reduce(this, new AtomicReference<>()).get();
+            }.reduce(cases, new AtomicReference<>()).get());
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
@@ -42,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
@@ -1111,6 +1113,12 @@ public interface J extends Tree {
             this.guard = guard;
             this.statements = statements;
             this.body = body;
+        }
+
+        @Deprecated
+        @ApiStatus.ScheduledForRemoval(inVersion = "2025-05-01")
+        public Case(UUID id, Space prefix, Markers markers, Type type, @Deprecated @Nullable Expression pattern, JContainer<Expression> expressions, JContainer<Statement> statements, @Nullable JRightPadded<J> body) {
+            this(id, prefix, markers, type, pattern, expressions, null, null, statements, body);
         }
 
         @Override
@@ -5096,6 +5104,7 @@ public interface J extends Tree {
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @Data
+    @RequiredArgsConstructor
     final class SwitchExpression implements J, Expression, TypedTree {
         @With
         @EqualsAndHashCode.Include
@@ -5117,6 +5126,26 @@ public interface J extends Tree {
         @Nullable
         @Getter
         JavaType type;
+
+        @Deprecated
+        @ApiStatus.ScheduledForRemoval(inVersion = "2025-05-01")
+        public SwitchExpression(UUID id, Space prefix, Markers markers, ControlParentheses<Expression> selector, Block cases) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.selector = selector;
+            this.cases = cases;
+            this.type = new JavaVisitor<AtomicReference<@Nullable JavaType>>() {
+                @Override
+                public J visitBlock(Block block, AtomicReference<@Nullable JavaType> javaType) {
+                    if (!block.getStatements().isEmpty()) {
+                        Case caze = (Case) block.getStatements().get(0);
+                        javaType.set(caze.getExpressions().isEmpty() ? null : caze.getExpressions().get(0).getType());
+                    }
+                    return block;
+                }
+            }.reduce(this, new AtomicReference<>()).get();
+        }
 
         @Override
         public <P> J acceptJava(JavaVisitor<P> v, P p) {


### PR DESCRIPTION
For the two recent changes to `J.Case` and `J.SwitchExpression` which both added new fields, the constructor changed and no constructor was added for API backwards compatibility.

This commit adds the corresponding constructors and annotates them both as `@Deprecated` and as `@ScheduledForRemoval` (from the JetBrains annotations). For the latter we provide a date value for the `inVersion` attribute as in `@ScheduledForRemoval(inVersion = "2025-05-01")`. This will allow us to implement some simple tooling to weed these constructors out again, without this chore getting forgotten.
