### PR TITLE
Refactoring, moving getStyle methods to Style.from

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -17,7 +17,6 @@ package org.openrewrite;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.internal.StringUtils;
-import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
 
 import java.nio.charset.Charset;
@@ -25,9 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
-
-import static java.util.Collections.singletonList;
 
 public interface SourceFile extends Tree {
 
@@ -73,28 +69,20 @@ public interface SourceFile extends Tree {
 
     <T extends SourceFile> T withFileAttributes(@Nullable FileAttributes fileAttributes);
 
-    default <S extends Style> @Nullable S getStyle(Class<S> style) {
-        return NamedStyles.merge(style, getMarkers().findAll(NamedStyles.class));
+    /**
+     * @deprecated Use {@link org.openrewrite.style.Style#from(Class, SourceFile)} instead.
+     */
+    @Deprecated
+    default <S extends Style> @Nullable S getStyle(Class<S> styleClass) {
+        return Style.from(styleClass, this);
     }
 
-    default <S extends Style> S getStyle(Class<S> style, S defaultStyle) {
-        S s = getStyle(style);
-        return s == null ? defaultStyle : s;
-    }
-
-    default <S extends Style> S getStyleOrDefault(Class<S> style, Supplier<S> defaultStyle) {
-        S s = getStyle(style);
-        return s == null ? defaultStyle.get() : s;
-    }
-
-    default <S extends Style> S getStyleOrFromAutodetect(Class<S> style, Supplier<NamedStyles> autodetectedStyle) {
-        S s = getStyle(style);
-        if (s != null) {
-            return s;
-        }
-        S ret = NamedStyles.merge(style, singletonList(autodetectedStyle.get()));
-        assert(ret != null);
-        return ret;
+    /**
+     * @deprecated Use {@link org.openrewrite.style.Style#from(Class, SourceFile, S)} instead.
+     */
+    @Deprecated
+    default <S extends Style> S getStyle(Class<S> styleClass, S defaultStyle) {
+        return Style.from(styleClass, this, defaultStyle);
     }
 
     default <P> byte[] printAllAsBytes(P p) {

--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -25,6 +25,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static java.util.Collections.singletonList;
 
 public interface SourceFile extends Tree {
 
@@ -77,6 +80,21 @@ public interface SourceFile extends Tree {
     default <S extends Style> S getStyle(Class<S> style, S defaultStyle) {
         S s = getStyle(style);
         return s == null ? defaultStyle : s;
+    }
+
+    default <S extends Style> S getStyleOrDefault(Class<S> style, Supplier<S> defaultStyle) {
+        S s = getStyle(style);
+        return s == null ? defaultStyle.get() : s;
+    }
+
+    default <S extends Style> S getStyleOrFromAutodetect(Class<S> style, Supplier<NamedStyles> autodetectedStyle) {
+        S s = getStyle(style);
+        if (s != null) {
+            return s;
+        }
+        S ret = NamedStyles.merge(style, singletonList(autodetectedStyle.get()));
+        assert(ret != null);
+        return ret;
     }
 
     default <P> byte[] printAllAsBytes(P p) {

--- a/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/SourceFile.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public interface SourceFile extends Tree {
 
@@ -78,11 +79,11 @@ public interface SourceFile extends Tree {
     }
 
     /**
-     * @deprecated Use {@link org.openrewrite.style.Style#from(Class, SourceFile, S)} instead.
+     * @deprecated Use {@link org.openrewrite.style.Style#from(Class, SourceFile, Supplier)} instead.
      */
     @Deprecated
     default <S extends Style> S getStyle(Class<S> styleClass, S defaultStyle) {
-        return Style.from(styleClass, this, defaultStyle);
+        return Style.from(styleClass, this, () -> defaultStyle);
     }
 
     default <P> byte[] printAllAsBytes(P p) {

--- a/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/NamedStyles.java
@@ -109,4 +109,10 @@ public class NamedStyles implements Marker {
     public Validated<Object> validate() {
         return Validated.none();
     }
+
+    public <S extends Style> S getStyle(Class<S> styleClass) {
+        S ret = merge(styleClass, Collections.singletonList(this));
+        assert(ret != null);
+        return ret;
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/style/Style.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/Style.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.SourceFile;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -52,5 +53,4 @@ public interface Style {
         S s = from(styleClass, sf);
         return s == null ? defaultStyle.get() : s;
     }
-
 }

--- a/rewrite-core/src/main/java/org/openrewrite/style/Style.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/Style.java
@@ -50,11 +50,6 @@ public interface Style {
         return NamedStyles.merge(styleClass, sf.getMarkers().findAll(NamedStyles.class));
     }
 
-    static <S extends Style> @Nullable S from(Class<S> styleClass, SourceFile sf, S defaultValue) {
-        S s = from(styleClass, sf);
-        return s == null ? defaultValue : s;
-    }
-
     static <S extends Style> S from(Class<S> styleClass, SourceFile sf, Supplier<S> defaultStyle) {
         S s = from(styleClass, sf);
         return s == null ? defaultStyle.get() : s;

--- a/rewrite-core/src/main/java/org/openrewrite/style/Style.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/Style.java
@@ -24,8 +24,6 @@ import org.openrewrite.SourceFile;
 
 import java.util.function.Supplier;
 
-import static java.util.Collections.singletonList;
-
 /**
  * Styles represent project-level standards that each source file is expected to follow, e.g.
  * import ordering. They are provided to parser implementations and expected to be stored on
@@ -55,13 +53,4 @@ public interface Style {
         return s == null ? defaultStyle.get() : s;
     }
 
-    static <S extends Style> S fromAutodetect(Class<S> styleClass, SourceFile sf, Supplier<NamedStyles> autodetectedStyle) {
-        S s = from(styleClass, sf);
-        if (s != null) {
-            return s;
-        }
-        S ret = NamedStyles.merge(styleClass, singletonList(autodetectedStyle.get()));
-        assert(ret != null);
-        return ret;
-    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/style/Style.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/Style.java
@@ -53,4 +53,9 @@ public interface Style {
         S s = from(styleClass, sf);
         return s == null ? defaultStyle.get() : s;
     }
+
+    static <S extends Style> S from(Class<S> styleClass, SourceFile sf, Function<Class<S>, S> defaultStyle) {
+        S s = from(styleClass, sf);
+        return s == null ? defaultStyle.apply(styleClass) : s;
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/style/Style.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/Style.java
@@ -53,9 +53,4 @@ public interface Style {
         S s = from(styleClass, sf);
         return s == null ? defaultStyle.get() : s;
     }
-
-    static <S extends Style> S from(Class<S> styleClass, SourceFile sf, Function<Class<S>, S> defaultStyle) {
-        S s = from(styleClass, sf);
-        return s == null ? defaultStyle.apply(styleClass) : s;
-    }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -38,6 +38,7 @@ import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
+import org.openrewrite.style.Style;
 
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -314,7 +315,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
     }
 
     private static String getIndent(G.CompilationUnit cu) {
-        TabsAndIndentsStyle style = cu.getStyle(TabsAndIndentsStyle.class, IntelliJ.tabsAndIndents());
+        TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ.tabsAndIndents());
         if (style.getUseTabCharacter()) {
             return "\t";
         } else {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -315,7 +315,7 @@ public class AddDevelocityGradlePlugin extends Recipe {
     }
 
     private static String getIndent(G.CompilationUnit cu) {
-        TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ.tabsAndIndents());
+        TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents);
         if (style.getUseTabCharacter()) {
             return "\t";
         } else {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -276,8 +276,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
         }
 
         private String getIndent(G.CompilationUnit cu) {
-            TabsAndIndentsStyle defaultValue = IntelliJ.tabsAndIndents();
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, () -> defaultValue);
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents);
             if (style.getUseTabCharacter()) {
                 return "\t";
             } else {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -32,6 +32,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.tree.GroupArtifact;
+import org.openrewrite.style.Style;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -275,7 +276,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
         }
 
         private String getIndent(G.CompilationUnit cu) {
-            TabsAndIndentsStyle style = cu.getStyle(TabsAndIndentsStyle.class, IntelliJ.tabsAndIndents());
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ.tabsAndIndents());
             if (style.getUseTabCharacter()) {
                 return "\t";
             } else {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -276,7 +276,8 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
         }
 
         private String getIndent(G.CompilationUnit cu) {
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ.tabsAndIndents());
+            TabsAndIndentsStyle defaultValue = IntelliJ.tabsAndIndents();
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, () -> defaultValue);
             if (style.getUseTabCharacter()) {
                 return "\t";
             } else {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/style/AutodetectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/style/AutodetectTest.java
@@ -52,7 +52,7 @@ class AutodetectTest implements RewriteTest {
         var styles = detector.build();
         assertThat(styles.getName()).isEqualTo("org.openrewrite.gradle.Autodetect");
 
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = styles.getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(2);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(2);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
@@ -52,23 +52,23 @@ public class AutoFormatVisitor<P> extends GroovyIsoVisitor<P> {
 
         J t = new NormalizeFormatVisitor<>(stopAfter).visit(tree, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, (Supplier<BlankLinesStyle>) IntelliJ::blankLines), stopAfter)
+        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, (Supplier<WrappingAndBracesStyle>) IntelliJ::wrappingAndBraces), stopAfter)
+        t = new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                Style.from(SpacesStyle.class, cu, (Supplier<SpacesStyle>) IntelliJ::spaces),
+                Style.from(SpacesStyle.class, cu, IntelliJ::spaces),
                 cu.getStyle(EmptyForInitializerPadStyle.class),
                 Style.from(EmptyForIteratorPadStyle.class, cu),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
+        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(Style.from(GeneralFormatStyle.class, cu))

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
@@ -50,27 +50,23 @@ public class AutoFormatVisitor<P> extends GroovyIsoVisitor<P> {
 
         J t = new NormalizeFormatVisitor<>(stopAfter).visit(tree, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
-                .orElse(IntelliJ.blankLines()), stopAfter)
+        t = new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
-                .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+        t = new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces()),
+                cu.getStyleOrDefault(SpacesStyle.class, IntelliJ::spaces),
                 cu.getStyle(EmptyForInitializerPadStyle.class),
                 cu.getStyle(EmptyForIteratorPadStyle.class),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/AutoFormatVisitor.java
@@ -24,8 +24,10 @@ import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.openrewrite.java.format.AutodetectGeneralFormatStyle.autodetectGeneralFormatStyle;
 
@@ -50,26 +52,26 @@ public class AutoFormatVisitor<P> extends GroovyIsoVisitor<P> {
 
         J t = new NormalizeFormatVisitor<>(stopAfter).visit(tree, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
+        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, (Supplier<BlankLinesStyle>) IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
+        t = new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, (Supplier<WrappingAndBracesStyle>) IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                cu.getStyleOrDefault(SpacesStyle.class, IntelliJ::spaces),
+                Style.from(SpacesStyle.class, cu, (Supplier<SpacesStyle>) IntelliJ::spaces),
                 cu.getStyle(EmptyForInitializerPadStyle.class),
-                cu.getStyle(EmptyForIteratorPadStyle.class),
+                Style.from(EmptyForIteratorPadStyle.class, cu),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
+        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))
+        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(Style.from(GeneralFormatStyle.class, cu))
                 .orElse(autodetectGeneralFormatStyle(cu)), stopAfter)
                 .visit(t, p, cursor.fork());
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/style/AutodetectTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/style/AutodetectTest.java
@@ -48,7 +48,7 @@ class AutodetectTest implements RewriteTest {
         var styles = detector.build();
         assertThat(styles.getName()).isEqualTo("org.openrewrite.groovy.Autodetect");
 
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = styles.getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclTemplate.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/HclTemplate.java
@@ -24,6 +24,7 @@ import org.openrewrite.hcl.style.SpacesStyle;
 import org.openrewrite.hcl.tree.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.style.Style;
 import org.openrewrite.template.SourceTemplate;
 
 import java.util.List;
@@ -141,7 +142,7 @@ public class HclTemplate implements SourceTemplate<Hcl, HclCoordinates> {
                         );
 
                         Hcl.ConfigFile cf = getCursor().firstEnclosingOrThrow(Hcl.ConfigFile.class);
-                        b = (Hcl.Block) new AttributeSpaceVisitor<Integer>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
+                        b = (Hcl.Block) new AttributeSpaceVisitor<Integer>(Optional.ofNullable(Style.from(SpacesStyle.class, cf))
                                 .orElse(SpacesStyle.DEFAULT)).visit(b, p, getCursor().getParentOrThrow());
                         assert b != null;
                     }

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
@@ -46,20 +46,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         Hcl t = new NormalizeFormatVisitor<>().visit(tree, p, cursor.fork());
 
-        t = new BracketsVisitor<>(Optional.ofNullable(cf.getStyle(BracketsStyle.class))
-                .orElse(BracketsStyle.DEFAULT), stopAfter)
+        t = new BracketsVisitor<>(cf.getStyle(BracketsStyle.class, BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
-                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = new TabsAndIndentsVisitor<>(cf.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new SpacesVisitor<>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
-                .orElse(SpacesStyle.DEFAULT), stopAfter)
+        t = new SpacesVisitor<>(cf.getStyle(SpacesStyle.class, SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Optional.ofNullable(cf.getStyle(BlankLinesStyle.class))
-                .orElse(BlankLinesStyle.DEFAULT), stopAfter)
+        t = new BlankLinesVisitor<>(cf.getStyle(BlankLinesStyle.class, BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         if (t instanceof Hcl.ConfigFile) {
@@ -75,20 +71,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         t = (Hcl.ConfigFile) new NormalizeFormatVisitor<>().visit(t, p);
 
-        t = (Hcl.ConfigFile) new BracketsVisitor<>(Optional.ofNullable(cf.getStyle(BracketsStyle.class))
-                .orElse(BracketsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BracketsVisitor<>(cf.getStyle(BracketsStyle.class, BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(cf.getStyle(TabsAndIndentsStyle.class))
-                .orElse(TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(cf.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new SpacesVisitor<>(Optional.ofNullable(cf.getStyle(SpacesStyle.class))
-                .orElse(SpacesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new SpacesVisitor<>(cf.getStyle(SpacesStyle.class, SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(Optional.ofNullable(cf.getStyle(BlankLinesStyle.class))
-                .orElse(BlankLinesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(cf.getStyle(BlankLinesStyle.class, BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
         assert t != null;

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
@@ -45,16 +45,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         Hcl t = new NormalizeFormatVisitor<>().visit(tree, p, cursor.fork());
 
-        t = new BracketsVisitor<>(Style.from(BracketsStyle.class, cf, BracketsStyle.DEFAULT), stopAfter)
+        t = new BracketsVisitor<>(Style.from(BracketsStyle.class, cf, () -> BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cf, TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cf, () -> TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new SpacesVisitor<>(Style.from(SpacesStyle.class, cf, SpacesStyle.DEFAULT), stopAfter)
+        t = new SpacesVisitor<>(Style.from(SpacesStyle.class, cf, () -> SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cf, BlankLinesStyle.DEFAULT), stopAfter)
+        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cf, () -> BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         if (t instanceof Hcl.ConfigFile) {
@@ -70,16 +70,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         t = (Hcl.ConfigFile) new NormalizeFormatVisitor<>().visit(t, p);
 
-        t = (Hcl.ConfigFile) new BracketsVisitor<>(Style.from(BracketsStyle.class, cf, BracketsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BracketsVisitor<>(Style.from(BracketsStyle.class, cf, () -> BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cf, TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cf, () -> TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new SpacesVisitor<>(Style.from(SpacesStyle.class, cf, SpacesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new SpacesVisitor<>(Style.from(SpacesStyle.class, cf, () -> SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cf, BlankLinesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cf, () -> BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
         assert t != null;

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/format/AutoFormatVisitor.java
@@ -23,8 +23,7 @@ import org.openrewrite.hcl.style.BracketsStyle;
 import org.openrewrite.hcl.style.SpacesStyle;
 import org.openrewrite.hcl.style.TabsAndIndentsStyle;
 import org.openrewrite.hcl.tree.Hcl;
-
-import java.util.Optional;
+import org.openrewrite.style.Style;
 
 public class AutoFormatVisitor<P> extends HclVisitor<P> {
     @Nullable
@@ -46,16 +45,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         Hcl t = new NormalizeFormatVisitor<>().visit(tree, p, cursor.fork());
 
-        t = new BracketsVisitor<>(cf.getStyle(BracketsStyle.class, BracketsStyle.DEFAULT), stopAfter)
+        t = new BracketsVisitor<>(Style.from(BracketsStyle.class, cf, BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(cf.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cf, TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new SpacesVisitor<>(cf.getStyle(SpacesStyle.class, SpacesStyle.DEFAULT), stopAfter)
+        t = new SpacesVisitor<>(Style.from(SpacesStyle.class, cf, SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(cf.getStyle(BlankLinesStyle.class, BlankLinesStyle.DEFAULT), stopAfter)
+        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cf, BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p, cursor.fork());
 
         if (t instanceof Hcl.ConfigFile) {
@@ -71,16 +70,16 @@ public class AutoFormatVisitor<P> extends HclVisitor<P> {
 
         t = (Hcl.ConfigFile) new NormalizeFormatVisitor<>().visit(t, p);
 
-        t = (Hcl.ConfigFile) new BracketsVisitor<>(cf.getStyle(BracketsStyle.class, BracketsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BracketsVisitor<>(Style.from(BracketsStyle.class, cf, BracketsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(cf.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cf, TabsAndIndentsStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new SpacesVisitor<>(cf.getStyle(SpacesStyle.class, SpacesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new SpacesVisitor<>(Style.from(SpacesStyle.class, cf, SpacesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
-        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(cf.getStyle(BlankLinesStyle.class, BlankLinesStyle.DEFAULT), stopAfter)
+        t = (Hcl.ConfigFile) new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cf, BlankLinesStyle.DEFAULT), stopAfter)
                 .visit(t, p);
 
         assert t != null;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RewriteTest;
@@ -50,8 +51,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
@@ -75,8 +75,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getContinuationIndent()).isEqualTo(5);
     }
@@ -97,8 +96,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getMethodDeclarationParameters().getAlignWhenMultiple()).isTrue();
     }
@@ -126,7 +124,7 @@ class AutodetectTest implements RewriteTest {
         cus.forEach(detector::sample);
         var styles = detector.build();
 
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = styles.getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
@@ -162,8 +160,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
@@ -205,8 +202,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(2);
@@ -238,8 +234,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
@@ -265,8 +260,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
@@ -296,8 +290,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
@@ -328,8 +321,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(3);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(3);
@@ -359,8 +351,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
@@ -385,8 +376,7 @@ class AutodetectTest implements RewriteTest {
         );
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
@@ -416,8 +406,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
         assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
@@ -446,8 +435,8 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var importLayout = NamedStyles.merge(ImportLayoutStyle.class, singletonList(styles));
+        var importLayout = detector.build().getStyle(ImportLayoutStyle.class);
+
 
         assertThat(importLayout.getLayout().get(0)).isInstanceOf(ImportLayoutStyle.Block.AllOthers.class);
         assertThat(importLayout.getLayout().get(1)).isInstanceOf(ImportLayoutStyle.Block.BlankLines.class);
@@ -505,8 +494,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var importLayout = NamedStyles.merge(ImportLayoutStyle.class, singletonList(styles));
+        var importLayout = detector.build().getStyle(ImportLayoutStyle.class);
 
         assertThat(importLayout.getLayout().get(0))
           .isInstanceOf(ImportLayoutStyle.Block.ImportPackage.class)
@@ -545,8 +533,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var importLayout = NamedStyles.merge(ImportLayoutStyle.class, singletonList(styles));
+        var importLayout = detector.build().getStyle(ImportLayoutStyle.class);
 
         assertThat(importLayout.getClassCountToUseStarImport()).isEqualTo(6);
     }
@@ -582,8 +569,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var importLayout = NamedStyles.merge(ImportLayoutStyle.class, singletonList(styles));
+        var importLayout = detector.build().getStyle(ImportLayoutStyle.class);
 
         assertThat(importLayout.getClassCountToUseStarImport()).isEqualTo(2147483647);
         assertThat(importLayout.getNameCountToUseStarImport()).isEqualTo(2147483647);
@@ -603,8 +589,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isTrue();
         assertThat(spacesStyle.getOther().getAfterComma()).isFalse();
@@ -624,8 +609,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isFalse();
         assertThat(spacesStyle.getOther().getAfterComma()).isTrue();
@@ -646,8 +630,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeColonInForEach()).isTrue();
     }
@@ -666,8 +649,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getAfterTypeCast()).isTrue();
     }
@@ -687,8 +669,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeForSemicolon()).isFalse();
         assertThat(spacesStyle.getOther().getAfterForSemicolon()).isTrue();
@@ -708,8 +689,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isFalse();
         assertThat(spacesStyle.getOther().getAfterComma()).isTrue();
@@ -729,8 +709,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isFalse();
         assertThat(spacesStyle.getOther().getAfterComma()).isFalse();
@@ -750,8 +729,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isTrue();
         assertThat(spacesStyle.getOther().getAfterComma()).isTrue();
@@ -771,8 +749,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isFalse();
         assertThat(spacesStyle.getOther().getAfterComma()).isTrue();
@@ -796,8 +773,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isFalse();
         assertThat(spacesStyle.getOther().getAfterComma()).isTrue();
@@ -825,8 +801,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getOther().getBeforeComma()).isFalse();
         assertThat(spacesStyle.getOther().getAfterComma()).isTrue();
@@ -849,8 +824,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getWithin().getEmptyMethodCallParentheses()).isFalse();
     }
@@ -870,8 +844,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var spacesStyle = NamedStyles.merge(SpacesStyle.class, singletonList(styles));
+        var spacesStyle = detector.build().getStyle(SpacesStyle.class);
 
         assertThat(spacesStyle.getWithin().getMethodCallParentheses()).isTrue();
     }
@@ -894,8 +867,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var wrappingAndBracesStyle = NamedStyles.merge(WrappingAndBracesStyle.class, singletonList(styles));
+        var wrappingAndBracesStyle = detector.build().getStyle(WrappingAndBracesStyle.class);
 
         assertThat(wrappingAndBracesStyle.getIfStatement().getElseOnNewLine()).isFalse();
     }
@@ -920,8 +892,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var wrappingAndBracesStyle = NamedStyles.merge(WrappingAndBracesStyle.class, singletonList(styles));
+        var wrappingAndBracesStyle = detector.build().getStyle(WrappingAndBracesStyle.class);
 
         assertThat(wrappingAndBracesStyle.getIfStatement().getElseOnNewLine()).isTrue();
     }
@@ -939,8 +910,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var lineFormatStyle = NamedStyles.merge(GeneralFormatStyle.class, singletonList(styles));
+        var lineFormatStyle = detector.build().getStyle(GeneralFormatStyle.class);
 
         assertThat(lineFormatStyle.isUseCRLFNewLines()).isTrue();
     }
@@ -958,8 +928,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var lineFormatStyle = NamedStyles.merge(GeneralFormatStyle.class, singletonList(styles));
+        var lineFormatStyle = detector.build().getStyle(GeneralFormatStyle.class);
 
         assertThat(lineFormatStyle.isUseCRLFNewLines()).isFalse();
     }
@@ -988,8 +957,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(6);
@@ -1039,8 +1007,7 @@ class AutodetectTest implements RewriteTest {
 
         var detector = Autodetect.detector();
         cus.forEach(detector::sample);
-        var styles = detector.build();
-        var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
         assertThat(tabsAndIndents.getUseTabCharacter()).isFalse();
         assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
@@ -1068,8 +1035,7 @@ class AutodetectTest implements RewriteTest {
 
             var detector = Autodetect.detector();
             cus.forEach(detector::sample);
-            var styles = detector.build();
-            var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+            var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
             assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
             assertThat(tabsAndIndents.getContinuationIndent())
@@ -1098,8 +1064,7 @@ class AutodetectTest implements RewriteTest {
 
             var detector = Autodetect.detector();
             cus.forEach(detector::sample);
-            var styles = detector.build();
-            var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+            var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
             assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
             assertThat(tabsAndIndents.getContinuationIndent())
@@ -1127,8 +1092,7 @@ class AutodetectTest implements RewriteTest {
 
             var detector = Autodetect.detector();
             cus.forEach(detector::sample);
-            var styles = detector.build();
-            var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+            var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
             assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
             assertThat(tabsAndIndents.getContinuationIndent())
@@ -1157,8 +1121,7 @@ class AutodetectTest implements RewriteTest {
 
             var detector = Autodetect.detector();
             cus.forEach(detector::sample);
-            var styles = detector.build();
-            var tabsAndIndents = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(styles));
+            var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
 
             assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
             assertThat(tabsAndIndents.getContinuationIndent())

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -155,7 +156,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                 ));
             }
 
-            ImportLayoutStyle layoutStyle = Optional.ofNullable(((SourceFile) cu).getStyle(ImportLayoutStyle.class))
+            ImportLayoutStyle layoutStyle = Optional.ofNullable(Style.from(ImportLayoutStyle.class, ((SourceFile) cu)))
                     .orElse(IntelliJ.importLayout());
 
             List<JavaType.FullyQualified> classpath = cu.getMarkers().findFirst(JavaSourceSet.class)
@@ -181,7 +182,7 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
     }
 
     private List<JRightPadded<J.Import>> checkCRLF(JavaSourceFile cu, List<JRightPadded<J.Import>> newImports) {
-        GeneralFormatStyle generalFormatStyle = Optional.ofNullable(((SourceFile) cu).getStyle(GeneralFormatStyle.class))
+        GeneralFormatStyle generalFormatStyle = Optional.ofNullable(Style.from(GeneralFormatStyle.class, ((SourceFile) cu)))
                 .orElse(autodetectGeneralFormatStyle(cu));
         if (generalFormatStyle.isUseCRLFNewLines()) {
             return ListUtils.map(newImports, rp -> rp.map(

--- a/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/OrderImports.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.style.Style;
 
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +71,7 @@ public class OrderImports extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                ImportLayoutStyle layoutStyle = Optional.ofNullable(cu.getStyle(ImportLayoutStyle.class))
+                ImportLayoutStyle layoutStyle = Optional.ofNullable(Style.from(ImportLayoutStyle.class, cu))
                         .orElse(IntelliJ.importLayout());
 
                 Optional<JavaSourceSet> sourceSet = cu.getMarkers().findFirst(JavaSourceSet.class);

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.style.Style;
 
 import java.time.Duration;
 import java.util.*;
@@ -76,7 +77,7 @@ public class RemoveUnusedImports extends Recipe {
 
         @Override
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-            ImportLayoutStyle layoutStyle = Optional.ofNullable(cu.getStyle(ImportLayoutStyle.class))
+            ImportLayoutStyle layoutStyle = Optional.ofNullable(Style.from(ImportLayoutStyle.class, cu))
                     .orElse(IntelliJ.importLayout());
             String sourcePackage = cu.getPackageDeclaration() == null ? "" :
                     cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()).replaceAll("\\s", "");

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
@@ -43,8 +43,7 @@ public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
             if(cu == null) {
                 style = Checkstyle.unnecessaryParentheses();
             } else {
-                UnnecessaryParenthesesStyle defaultStyle = Checkstyle.unnecessaryParentheses();
-                style = Style.from(UnnecessaryParenthesesStyle.class, ((SourceFile) cu), () -> defaultStyle);
+                style = Style.from(UnnecessaryParenthesesStyle.class, cu, Checkstyle::unnecessaryParentheses);
             }
         }
         return style;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
@@ -44,7 +44,7 @@ public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
                 style = Checkstyle.unnecessaryParentheses();
             } else {
                 UnnecessaryParenthesesStyle defaultStyle = Checkstyle.unnecessaryParentheses();
-                style = Style.from(UnnecessaryParenthesesStyle.class, ((SourceFile) cu), defaultStyle);
+                style = Style.from(UnnecessaryParenthesesStyle.class, ((SourceFile) cu), () -> defaultStyle);
             }
         }
         return style;

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
@@ -16,12 +16,14 @@
 package org.openrewrite.java.cleanup;
 
 import lombok.EqualsAndHashCode;
-import org.openrewrite.*;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.UnwrapParentheses;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.style.UnnecessaryParenthesesStyle;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.style.Style;
 
 @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
@@ -41,7 +43,8 @@ public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
             if(cu == null) {
                 style = Checkstyle.unnecessaryParentheses();
             } else {
-                style = ((SourceFile) cu).getStyle(UnnecessaryParenthesesStyle.class, Checkstyle.unnecessaryParentheses());
+                UnnecessaryParenthesesStyle defaultStyle = Checkstyle.unnecessaryParentheses();
+                style = Style.from(UnnecessaryParenthesesStyle.class, ((SourceFile) cu), defaultStyle);
             }
         }
         return style;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -57,27 +57,23 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
 
         t = new MinimumViableSpacingVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
-                .orElse(IntelliJ.blankLines()), stopAfter)
+        t = new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
-                .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+        t = new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces()),
+                cu.getStyleOrDefault(SpacesStyle.class, IntelliJ::spaces),
                 cu.getStyle(EmptyForInitializerPadStyle.class),
                 cu.getStyle(EmptyForIteratorPadStyle.class),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+        t = new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))
@@ -101,8 +97,7 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
             }
             JavaSourceFile t = (JavaSourceFile) new RemoveTrailingWhitespaceVisitor<>(stopAfter).visit(cu, p);
 
-            t = (JavaSourceFile) new BlankLinesVisitor<>(Optional.ofNullable(cu.getStyle(BlankLinesStyle.class))
-                    .orElse(IntelliJ.blankLines()), stopAfter)
+            t = (JavaSourceFile) new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
                     .visit(t, p);
 
             t = (JavaSourceFile) new SpacesVisitor<P>(Optional.ofNullable(
@@ -112,16 +107,13 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
                     stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(Optional.ofNullable(cu.getStyle(WrappingAndBracesStyle.class))
-                    .orElse(IntelliJ.wrappingAndBraces()), stopAfter)
+            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                    .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(cu.getStyle(TabsAndIndentsStyle.class))
-                    .orElse(IntelliJ.tabsAndIndents()), stopAfter)
+            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
             assert t != null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -24,8 +24,10 @@ import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.java.format.AutodetectGeneralFormatStyle.autodetectGeneralFormatStyle;
@@ -57,26 +59,26 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
 
         t = new MinimumViableSpacingVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
+        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, (Supplier<BlankLinesStyle>) IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
+        t = new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, (Supplier<WrappingAndBracesStyle>) IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                cu.getStyleOrDefault(SpacesStyle.class, IntelliJ::spaces),
-                cu.getStyle(EmptyForInitializerPadStyle.class),
-                cu.getStyle(EmptyForIteratorPadStyle.class),
+                Style.from(SpacesStyle.class, cu, (Supplier<SpacesStyle>) IntelliJ::spaces),
+                Style.from(EmptyForInitializerPadStyle.class, cu),
+                Style.from(EmptyForIteratorPadStyle.class, cu),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
+        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(cu.getStyle(GeneralFormatStyle.class))
+        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(Style.from(GeneralFormatStyle.class, cu))
                 .orElse(autodetectGeneralFormatStyle(cu)), stopAfter)
                 .visit(t, p, cursor.fork());
 
@@ -97,23 +99,23 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
             }
             JavaSourceFile t = (JavaSourceFile) new RemoveTrailingWhitespaceVisitor<>(stopAfter).visit(cu, p);
 
-            t = (JavaSourceFile) new BlankLinesVisitor<>(cu.getStyleOrDefault(BlankLinesStyle.class, IntelliJ::blankLines), stopAfter)
+            t = (JavaSourceFile) new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, (Supplier<BlankLinesStyle>) IntelliJ::blankLines), stopAfter)
                     .visit(t, p);
 
             t = (JavaSourceFile) new SpacesVisitor<P>(Optional.ofNullable(
-                    cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces()),
-                    cu.getStyle(EmptyForInitializerPadStyle.class),
-                    cu.getStyle(EmptyForIteratorPadStyle.class),
+                    Style.from(SpacesStyle.class, cu)).orElse(IntelliJ.spaces()),
+                    Style.from(EmptyForInitializerPadStyle.class, cu),
+                    Style.from(EmptyForIteratorPadStyle.class, cu),
                     stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(cu.getStyleOrDefault(WrappingAndBracesStyle.class, IntelliJ::wrappingAndBraces), stopAfter)
+            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, (Supplier<WrappingAndBracesStyle>) IntelliJ::wrappingAndBraces), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
+            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(cu.getStyleOrDefault(TabsAndIndentsStyle.class, IntelliJ::tabsAndIndents), stopAfter)
+            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
             assert t != null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/AutoFormatVisitor.java
@@ -59,23 +59,23 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
 
         t = new MinimumViableSpacingVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
-        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, (Supplier<BlankLinesStyle>) IntelliJ::blankLines), stopAfter)
+        t = new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, IntelliJ::blankLines), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, (Supplier<WrappingAndBracesStyle>) IntelliJ::wrappingAndBraces), stopAfter)
+        t = new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, IntelliJ::wrappingAndBraces), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new SpacesVisitor<>(
-                Style.from(SpacesStyle.class, cu, (Supplier<SpacesStyle>) IntelliJ::spaces),
+                Style.from(SpacesStyle.class, cu, IntelliJ::spaces),
                 Style.from(EmptyForInitializerPadStyle.class, cu),
                 Style.from(EmptyForIteratorPadStyle.class, cu),
                 stopAfter
         ).visit(t, p, cursor.fork());
 
-        t = new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
+        t = new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
+        t = new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents), stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(Style.from(GeneralFormatStyle.class, cu))
@@ -99,7 +99,7 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
             }
             JavaSourceFile t = (JavaSourceFile) new RemoveTrailingWhitespaceVisitor<>(stopAfter).visit(cu, p);
 
-            t = (JavaSourceFile) new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, (Supplier<BlankLinesStyle>) IntelliJ::blankLines), stopAfter)
+            t = (JavaSourceFile) new BlankLinesVisitor<>(Style.from(BlankLinesStyle.class, cu, IntelliJ::blankLines), stopAfter)
                     .visit(t, p);
 
             t = (JavaSourceFile) new SpacesVisitor<P>(Optional.ofNullable(
@@ -109,13 +109,13 @@ public class AutoFormatVisitor<P> extends JavaIsoVisitor<P> {
                     stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, (Supplier<WrappingAndBracesStyle>) IntelliJ::wrappingAndBraces), stopAfter)
+            t = (JavaSourceFile) new WrappingAndBracesVisitor<>(Style.from(WrappingAndBracesStyle.class, cu, IntelliJ::wrappingAndBraces), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
+            t = (JavaSourceFile) new NormalizeTabsOrSpacesVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, (Supplier<TabsAndIndentsStyle>) IntelliJ::tabsAndIndents), stopAfter)
+            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents), stopAfter)
                     .visit(t, p);
 
             assert t != null;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MethodParamPad.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MethodParamPad.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.style.MethodParamPadStyle;
 import org.openrewrite.java.style.SpacesStyle;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.style.Style;
 
 import java.util.Optional;
 
@@ -62,7 +63,7 @@ public class MethodParamPad extends Recipe {
             if (tree instanceof JavaSourceFile) {
                 SourceFile cu = (SourceFile) requireNonNull(tree);
                 spacesStyle = Optional.ofNullable(cu.getStyle(SpacesStyle.class)).orElse(IntelliJ.spaces());
-                methodParamPadStyle = Optional.ofNullable(cu.getStyle(MethodParamPadStyle.class)).orElse(Checkstyle.methodParamPadStyle());
+                methodParamPadStyle = Optional.ofNullable(Style.from(MethodParamPadStyle.class, cu)).orElse(Checkstyle.methodParamPadStyle());
 
                 spacesStyle = spacesStyle.withBeforeParentheses(
                         spacesStyle.getBeforeParentheses()

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -22,7 +22,10 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.Style;
+
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -63,16 +66,8 @@ public class NoWhitespaceAfter extends Recipe {
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 SourceFile cu = (SourceFile) requireNonNull(tree);
-                if (cu.getStyle(SpacesStyle.class) == null) {
-                    spacesStyle = IntelliJ.spaces();
-                } else {
-                    spacesStyle = cu.getStyle(SpacesStyle.class);
-                }
-                if (cu.getStyle(NoWhitespaceAfterStyle.class) == null) {
-                    noWhitespaceAfterStyle = Checkstyle.noWhitespaceAfterStyle();
-                } else {
-                    noWhitespaceAfterStyle = Style.from(NoWhitespaceAfterStyle.class, cu);
-                }
+                spacesStyle = Style.from(SpacesStyle.class, cu, IntelliJ::spaces);
+                noWhitespaceAfterStyle = Style.from(NoWhitespaceAfterStyle.class, cu, Checkstyle::noWhitespaceAfterStyle);
                 emptyForInitializerPadStyle = Style.from(EmptyForInitializerPadStyle.class, cu);
                 emptyForIteratorPadStyle = Style.from(EmptyForIteratorPadStyle.class, cu);
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.style.Style;
 
 import static java.util.Objects.requireNonNull;
 
@@ -62,10 +63,18 @@ public class NoWhitespaceAfter extends Recipe {
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 SourceFile cu = (SourceFile) requireNonNull(tree);
-                spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
-                noWhitespaceAfterStyle = cu.getStyle(NoWhitespaceAfterStyle.class) == null ? Checkstyle.noWhitespaceAfterStyle() : cu.getStyle(NoWhitespaceAfterStyle.class);
-                emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
-                emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
+                if (cu.getStyle(SpacesStyle.class) == null) {
+                    spacesStyle = IntelliJ.spaces();
+                } else {
+                    spacesStyle = cu.getStyle(SpacesStyle.class);
+                }
+                if (cu.getStyle(NoWhitespaceAfterStyle.class) == null) {
+                    noWhitespaceAfterStyle = Checkstyle.noWhitespaceAfterStyle();
+                } else {
+                    noWhitespaceAfterStyle = Style.from(NoWhitespaceAfterStyle.class, cu);
+                }
+                emptyForInitializerPadStyle = Style.from(EmptyForInitializerPadStyle.class, cu);
+                emptyForIteratorPadStyle = Style.from(EmptyForIteratorPadStyle.class, cu);
             }
             return super.visit(tree, ctx);
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceBefore.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceBefore.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.style.Style;
 
 import static java.util.Objects.requireNonNull;
 
@@ -62,10 +63,18 @@ public class NoWhitespaceBefore extends Recipe {
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 SourceFile cu = (SourceFile) requireNonNull(tree);
-                spacesStyle = cu.getStyle(SpacesStyle.class) == null ? IntelliJ.spaces() : cu.getStyle(SpacesStyle.class);
-                noWhitespaceBeforeStyle = cu.getStyle(NoWhitespaceBeforeStyle.class) == null ? Checkstyle.noWhitespaceBeforeStyle() : cu.getStyle(NoWhitespaceBeforeStyle.class);
-                emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
-                emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
+                if (cu.getStyle(SpacesStyle.class) == null) {
+                    spacesStyle = IntelliJ.spaces();
+                } else {
+                    spacesStyle = cu.getStyle(SpacesStyle.class);
+                }
+                if (cu.getStyle(NoWhitespaceBeforeStyle.class) == null) {
+                    noWhitespaceBeforeStyle = Checkstyle.noWhitespaceBeforeStyle();
+                } else {
+                    noWhitespaceBeforeStyle = Style.from(NoWhitespaceBeforeStyle.class, cu);
+                }
+                emptyForInitializerPadStyle = Style.from(EmptyForInitializerPadStyle.class, cu);
+                emptyForIteratorPadStyle = Style.from(EmptyForIteratorPadStyle.class, cu);
             }
             return super.visit(tree, ctx);
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceBefore.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceBefore.java
@@ -63,16 +63,8 @@ public class NoWhitespaceBefore extends Recipe {
         public J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 SourceFile cu = (SourceFile) requireNonNull(tree);
-                if (cu.getStyle(SpacesStyle.class) == null) {
-                    spacesStyle = IntelliJ.spaces();
-                } else {
-                    spacesStyle = cu.getStyle(SpacesStyle.class);
-                }
-                if (cu.getStyle(NoWhitespaceBeforeStyle.class) == null) {
-                    noWhitespaceBeforeStyle = Checkstyle.noWhitespaceBeforeStyle();
-                } else {
-                    noWhitespaceBeforeStyle = Style.from(NoWhitespaceBeforeStyle.class, cu);
-                }
+                spacesStyle = Style.from(SpacesStyle.class, cu, IntelliJ::spaces);
+                noWhitespaceBeforeStyle = Style.from(NoWhitespaceBeforeStyle.class, cu, Checkstyle::noWhitespaceBeforeStyle);
                 emptyForInitializerPadStyle = Style.from(EmptyForInitializerPadStyle.class, cu);
                 emptyForIteratorPadStyle = Style.from(EmptyForIteratorPadStyle.class, cu);
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/PadEmptyForLoopComponents.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/PadEmptyForLoopComponents.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.style.Style;
 
 import java.util.List;
 
@@ -69,8 +70,8 @@ public class PadEmptyForLoopComponents extends Recipe {
             public J visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof JavaSourceFile) {
                     SourceFile cu = (SourceFile) requireNonNull(tree);
-                    emptyForInitializerPadStyle = cu.getStyle(EmptyForInitializerPadStyle.class);
-                    emptyForIteratorPadStyle = cu.getStyle(EmptyForIteratorPadStyle.class);
+                    emptyForInitializerPadStyle = Style.from(EmptyForInitializerPadStyle.class, cu);
+                    emptyForIteratorPadStyle = Style.from(EmptyForIteratorPadStyle.class, cu);
                 }
                 return super.visit(tree, ctx);
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/Spaces.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/Spaces.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.style.SpacesStyle;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.style.Style;
 
 public class Spaces extends Recipe {
 
@@ -66,7 +67,7 @@ public class Spaces extends Recipe {
         SpacesStyle style = cu.getStyle(SpacesStyle.class);
         //noinspection unchecked
         return (J2) new SpacesVisitor<>(style == null ? IntelliJ.spaces() : style,
-                cu.getStyle(EmptyForInitializerPadStyle.class),
-                cu.getStyle(EmptyForIteratorPadStyle.class)).visitNonNull(j, 0, cursor);
+                Style.from(EmptyForInitializerPadStyle.class, cu),
+                Style.from(EmptyForIteratorPadStyle.class, cu)).visitNonNull(j, 0, cursor);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBraces.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBraces.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.style.WrappingAndBracesStyle;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.style.Style;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -72,8 +73,8 @@ public class WrappingAndBraces extends Recipe {
     }
 
     public static <J2 extends J> J2 formatWrappingAndBraces(J j, Cursor cursor) {
-        WrappingAndBracesStyle style = cursor.firstEnclosingOrThrow(SourceFile.class)
-                .getStyle(WrappingAndBracesStyle.class);
+        SourceFile sourceFile = cursor.firstEnclosingOrThrow(SourceFile.class);
+        WrappingAndBracesStyle style = Style.from(WrappingAndBracesStyle.class, sourceFile);
         //noinspection unchecked
         return (J2) new WrappingAndBracesVisitor<>(style == null ? IntelliJ.wrappingAndBraces() : style)
                 .visitNonNull(j, 0, cursor);

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
@@ -45,15 +45,13 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Autodetect autodetectedStyle = Autodetect.detector().sample(doc).build();
         Json js = tree;
 
-        TabsAndIndentsStyle taiStyle = Optional.ofNullable(doc.getStyle(TabsAndIndentsStyle.class))
-                .orElseGet(() -> NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(autodetectedStyle)));
-        assert(taiStyle != null);
-        js = new TabsAndIndentsVisitor<>(taiStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new TabsAndIndentsVisitor<>(
+                doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p, cursor.fork());
 
-        GeneralFormatStyle gfStyle = Optional.ofNullable(doc.getStyle(GeneralFormatStyle.class))
-                        .orElseGet(() -> NamedStyles.merge(GeneralFormatStyle.class, singletonList(autodetectedStyle)));
-        assert(gfStyle != null);
-        js = new NormalizeLineBreaksVisitor<>(gfStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new NormalizeLineBreaksVisitor<>(
+                doc.getStyleOrFromAutodetect(GeneralFormatStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p, cursor.fork());
 
         return js;
     }
@@ -62,15 +60,13 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
     public Json.Document visitDocument(Json.Document js, P p) {
         Autodetect autodetectedStyle = Autodetect.detector().sample(js).build();
 
-        TabsAndIndentsStyle taiStyle = Optional.ofNullable(js.getStyle(TabsAndIndentsStyle.class))
-                .orElseGet(() -> NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(autodetectedStyle)));
-        assert(taiStyle != null);
-        js = (Json.Document) new TabsAndIndentsVisitor<>(taiStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new TabsAndIndentsVisitor<>(
+                js.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p);
 
-        GeneralFormatStyle gfStyle = Optional.ofNullable(js.getStyle(GeneralFormatStyle.class))
-                .orElseGet(() -> NamedStyles.merge(GeneralFormatStyle.class, singletonList(autodetectedStyle)));
-        assert(gfStyle != null);
-        js = (Json.Document) new NormalizeLineBreaksVisitor<>(gfStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new NormalizeLineBreaksVisitor<>(
+                js.getStyleOrFromAutodetect(GeneralFormatStyle.class, () -> autodetectedStyle),
+                stopAfter).visitNonNull(js, p);
 
         return js;
     }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
@@ -23,7 +23,10 @@ import org.openrewrite.json.style.Autodetect;
 import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.tree.Json;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
+
+import java.util.function.Supplier;
 
 public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
     @Nullable
@@ -42,11 +45,11 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Json js = tree;
 
         js = new TabsAndIndentsVisitor<>(
-                Style.fromAutodetect(TabsAndIndentsStyle.class, doc, () -> autodetectedStyle),
+                Style.from(TabsAndIndentsStyle.class, doc, () -> autodetectedStyle.getStyle(TabsAndIndentsStyle.class)),
                 stopAfter).visitNonNull(js, p, cursor.fork());
 
         js = new NormalizeLineBreaksVisitor<>(
-                Style.fromAutodetect(GeneralFormatStyle.class, doc, () -> autodetectedStyle),
+                Style.from(GeneralFormatStyle.class, doc, () -> autodetectedStyle.getStyle(GeneralFormatStyle.class)),
                 stopAfter).visitNonNull(js, p, cursor.fork());
 
         return js;
@@ -57,11 +60,11 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Autodetect autodetectedStyle = Autodetect.detector().sample(js).build();
 
         js = (Json.Document) new TabsAndIndentsVisitor<>(
-                Style.fromAutodetect(TabsAndIndentsStyle.class, js, () -> autodetectedStyle),
+                Style.from(TabsAndIndentsStyle.class, js, () -> autodetectedStyle.getStyle(TabsAndIndentsStyle.class)),
                 stopAfter).visitNonNull(js, p);
 
         js = (Json.Document) new NormalizeLineBreaksVisitor<>(
-                Style.fromAutodetect(GeneralFormatStyle.class, js, () -> autodetectedStyle),
+                Style.from(GeneralFormatStyle.class, js, () -> autodetectedStyle.getStyle(GeneralFormatStyle.class)),
                 stopAfter).visitNonNull(js, p);
 
         return js;

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
@@ -23,11 +23,7 @@ import org.openrewrite.json.style.Autodetect;
 import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.tree.Json;
 import org.openrewrite.style.GeneralFormatStyle;
-import org.openrewrite.style.NamedStyles;
-
-import java.util.Optional;
-
-import static java.util.Collections.singletonList;
+import org.openrewrite.style.Style;
 
 public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
     @Nullable
@@ -46,11 +42,11 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Json js = tree;
 
         js = new TabsAndIndentsVisitor<>(
-                doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> autodetectedStyle),
+                Style.fromAutodetect(TabsAndIndentsStyle.class, doc, () -> autodetectedStyle),
                 stopAfter).visitNonNull(js, p, cursor.fork());
 
         js = new NormalizeLineBreaksVisitor<>(
-                doc.getStyleOrFromAutodetect(GeneralFormatStyle.class, () -> autodetectedStyle),
+                Style.fromAutodetect(GeneralFormatStyle.class, doc, () -> autodetectedStyle),
                 stopAfter).visitNonNull(js, p, cursor.fork());
 
         return js;
@@ -61,11 +57,11 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Autodetect autodetectedStyle = Autodetect.detector().sample(js).build();
 
         js = (Json.Document) new TabsAndIndentsVisitor<>(
-                js.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> autodetectedStyle),
+                Style.fromAutodetect(TabsAndIndentsStyle.class, js, () -> autodetectedStyle),
                 stopAfter).visitNonNull(js, p);
 
         js = (Json.Document) new NormalizeLineBreaksVisitor<>(
-                js.getStyleOrFromAutodetect(GeneralFormatStyle.class, () -> autodetectedStyle),
+                Style.fromAutodetect(GeneralFormatStyle.class, js, () -> autodetectedStyle),
                 stopAfter).visitNonNull(js, p);
 
         return js;

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -46,7 +46,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends JsonIsoVisitor<ExecutionContext> {
         @Override
         public Json. Document visitDocument(Json.Document docs, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, docs, () -> Autodetect.detector().sample(docs).build().getStyle(TabsAndIndentsStyle.class));
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, docs, Autodetect.detector().sample(docs).build()::getStyle);
             doAfterVisit(new TabsAndIndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -22,7 +22,10 @@ import org.openrewrite.json.JsonIsoVisitor;
 import org.openrewrite.json.style.Autodetect;
 import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.tree.Json;
+import org.openrewrite.style.NamedStyles;
 import org.openrewrite.style.Style;
+
+import java.util.function.Supplier;
 
 public class Indents extends Recipe {
     @Override
@@ -43,7 +46,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends JsonIsoVisitor<ExecutionContext> {
         @Override
         public Json. Document visitDocument(Json.Document docs, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = Style.fromAutodetect(TabsAndIndentsStyle.class, docs, () -> Autodetect.detector().sample(docs).build());
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, docs, () -> Autodetect.detector().sample(docs).build().getStyle(TabsAndIndentsStyle.class));
             doAfterVisit(new TabsAndIndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -22,9 +22,7 @@ import org.openrewrite.json.JsonIsoVisitor;
 import org.openrewrite.json.style.Autodetect;
 import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.tree.Json;
-import org.openrewrite.style.NamedStyles;
-
-import static java.util.Collections.singletonList;
+import org.openrewrite.style.Style;
 
 public class Indents extends Recipe {
     @Override
@@ -45,7 +43,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends JsonIsoVisitor<ExecutionContext> {
         @Override
         public Json. Document visitDocument(Json.Document docs, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = docs.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(docs).build());
+            TabsAndIndentsStyle style = Style.fromAutodetect(TabsAndIndentsStyle.class, docs, () -> Autodetect.detector().sample(docs).build());
             doAfterVisit(new TabsAndIndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -45,11 +45,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends JsonIsoVisitor<ExecutionContext> {
         @Override
         public Json. Document visitDocument(Json.Document docs, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = docs.getStyle(TabsAndIndentsStyle.class);
-            if (style == null) {
-                style = NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(Autodetect.detector().sample(docs).build()));
-                assert(style != null);
-            }
+            TabsAndIndentsStyle style = docs.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(docs).build());
             doAfterVisit(new TabsAndIndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -46,7 +46,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends JsonIsoVisitor<ExecutionContext> {
         @Override
         public Json. Document visitDocument(Json.Document docs, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, docs, Autodetect.detector().sample(docs).build()::getStyle);
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, docs, () -> Autodetect.detector().sample(docs).build().getStyle(TabsAndIndentsStyle.class));
             doAfterVisit(new TabsAndIndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
@@ -169,7 +169,7 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
                 switch (sourcePath) {
                     case "pom.xml":
                         acc.setMavenProject(true);
-                        acc.setUseCRLFNewLines(Style.from(GeneralFormatStyle.class, sourceFile, new GeneralFormatStyle(false))
+                        acc.setUseCRLFNewLines(Style.from(GeneralFormatStyle.class, sourceFile, () -> new GeneralFormatStyle(false))
                                 .isUseCRLFNewLines());
                         break;
                     case EXTENSIONS_XML_PATH:

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDevelocityMavenExtension.java
@@ -37,6 +37,7 @@ import org.openrewrite.semver.LatestRelease;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
 import org.openrewrite.xml.AddToTagVisitor;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlIsoVisitor;
@@ -168,7 +169,7 @@ public class AddDevelocityMavenExtension extends ScanningRecipe<AddDevelocityMav
                 switch (sourcePath) {
                     case "pom.xml":
                         acc.setMavenProject(true);
-                        acc.setUseCRLFNewLines(sourceFile.getStyle(GeneralFormatStyle.class, new GeneralFormatStyle(false))
+                        acc.setUseCRLFNewLines(Style.from(GeneralFormatStyle.class, sourceFile, new GeneralFormatStyle(false))
                                 .isUseCRLFNewLines());
                         break;
                     case EXTENSIONS_XML_PATH:

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
@@ -27,6 +27,7 @@ import org.openrewrite.xml.style.TabsAndIndentsStyle;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static org.openrewrite.xml.format.AutodetectGeneralFormatStyle.autodetectGeneralFormatStyle;
@@ -58,7 +59,8 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
         t = new LineBreaksVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
         TabsAndIndentsStyle tabsStyle =
-                Style.fromAutodetect(TabsAndIndentsStyle.class, doc, () -> Autodetect.detector().sample(doc).build());
+                Style.from(TabsAndIndentsStyle.class, doc,
+                        () -> Autodetect.detector().sample(doc).build().getStyle(TabsAndIndentsStyle.class));
         t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle, stopAfter)
                 .visit(t, p, cursor.fork());
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
@@ -87,11 +87,7 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
         t = (Xml.Document) new LineBreaksVisitor<>(stopAfter).visit(t, p);
 
         TabsAndIndentsStyle tabsStyle = Optional.ofNullable(Style.from(TabsAndIndentsStyle.class, doc))
-                .orElseGet(() -> {
-                    Autodetect.Detector detector = Autodetect.detector();
-                    detector.sample(doc);
-                    return NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(detector.build()));
-                });
+                .orElseGet(() -> Autodetect.detector().sample(doc).build().getStyle(TabsAndIndentsStyle.class));
         assert tabsStyle != null;
 
         t = (Xml.Document) new NormalizeTabsOrSpacesVisitor<>(tabsStyle, stopAfter).visit(t, p);

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
@@ -56,14 +56,8 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
 
         t = new LineBreaksVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
-        TabsAndIndentsStyle tabsStyle = Optional.ofNullable(doc.getStyle(TabsAndIndentsStyle.class))
-                .orElseGet(() -> {
-                    Autodetect.Detector detector = Autodetect.detector();
-                    detector.sample(doc);
-                    return NamedStyles.merge(TabsAndIndentsStyle.class, singletonList(detector.build()));
-                });
-        assert tabsStyle != null;
-
+        TabsAndIndentsStyle tabsStyle =
+                doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(doc).build());
         t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle, stopAfter)
                 .visit(t, p, cursor.fork());
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/AutoFormatVisitor.java
@@ -20,6 +20,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.style.NamedStyles;
+import org.openrewrite.style.Style;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.style.Autodetect;
 import org.openrewrite.xml.style.TabsAndIndentsStyle;
@@ -57,14 +58,14 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
         t = new LineBreaksVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
         TabsAndIndentsStyle tabsStyle =
-                doc.getStyleOrFromAutodetect(TabsAndIndentsStyle.class, () -> Autodetect.detector().sample(doc).build());
+                Style.fromAutodetect(TabsAndIndentsStyle.class, doc, () -> Autodetect.detector().sample(doc).build());
         t = new NormalizeTabsOrSpacesVisitor<>(tabsStyle, stopAfter)
                 .visit(t, p, cursor.fork());
 
         t = new TabsAndIndentsVisitor<>(tabsStyle, stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(doc.getStyle(GeneralFormatStyle.class))
+        t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(Style.from(GeneralFormatStyle.class, doc))
                 .orElse(autodetectGeneralFormatStyle(doc)), stopAfter)
                 .visit(t, p, cursor.fork());
 
@@ -83,7 +84,7 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
 
         t = (Xml.Document) new LineBreaksVisitor<>(stopAfter).visit(t, p);
 
-        TabsAndIndentsStyle tabsStyle = Optional.ofNullable(doc.getStyle(TabsAndIndentsStyle.class))
+        TabsAndIndentsStyle tabsStyle = Optional.ofNullable(Style.from(TabsAndIndentsStyle.class, doc))
                 .orElseGet(() -> {
                     Autodetect.Detector detector = Autodetect.detector();
                     detector.sample(doc);
@@ -95,7 +96,7 @@ public class AutoFormatVisitor<P> extends XmlVisitor<P> {
 
         t = (Xml.Document) new TabsAndIndentsVisitor<>(tabsStyle, stopAfter).visit(t, p);
 
-        t = (Xml.Document) new NormalizeLineBreaksVisitor<>(Optional.ofNullable(doc.getStyle(GeneralFormatStyle.class))
+        t = (Xml.Document) new NormalizeLineBreaksVisitor<>(Optional.ofNullable(Style.from(GeneralFormatStyle.class, doc))
                 .orElse(autodetectGeneralFormatStyle(doc)), stopAfter)
                 .visit(t, p);
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
@@ -18,6 +18,7 @@ package org.openrewrite.xml.format;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.style.Style;
 import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.style.TabsAndIndentsStyle;
 import org.openrewrite.xml.tree.Xml;
@@ -42,7 +43,7 @@ public class NormalizeTabsOrSpaces extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT);
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, document, TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new NormalizeTabsOrSpacesVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
@@ -43,7 +43,7 @@ public class NormalizeTabsOrSpaces extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, document, TabsAndIndentsStyle.DEFAULT);
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, document, () -> TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new NormalizeTabsOrSpacesVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/NormalizeTabsOrSpaces.java
@@ -42,10 +42,7 @@ public class NormalizeTabsOrSpaces extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class);
-            if (style == null) {
-                style = TabsAndIndentsStyle.DEFAULT;
-            }
+            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new NormalizeTabsOrSpacesVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
@@ -42,7 +42,7 @@ public class TabsAndIndents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, document, TabsAndIndentsStyle.DEFAULT);
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, document, () -> TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new TabsAndIndentsVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
@@ -18,6 +18,7 @@ package org.openrewrite.xml.format;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.style.Style;
 import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.style.TabsAndIndentsStyle;
 import org.openrewrite.xml.tree.Xml;
@@ -41,7 +42,7 @@ public class TabsAndIndents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT);
+            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, document, TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new TabsAndIndentsVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndents.java
@@ -41,10 +41,7 @@ public class TabsAndIndents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends XmlIsoVisitor<ExecutionContext> {
         @Override
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class);
-            if (style == null) {
-                style = TabsAndIndentsStyle.DEFAULT;
-            }
+            TabsAndIndentsStyle style = document.getStyle(TabsAndIndentsStyle.class, TabsAndIndentsStyle.DEFAULT);
             return (Xml.Document) new TabsAndIndentsVisitor<>(style).visitNonNull(document, ctx);
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
@@ -54,11 +54,12 @@ public class Autodetect extends NamedStyles {
         private final FindIndentXmlVisitor findIndentXmlVisitor = new FindIndentXmlVisitor();
         private final FindLineFormatXmlVisitor findLineFormatXmlVisitor = new FindLineFormatXmlVisitor();
 
-        public void sample(SourceFile xml) {
+        public Detector sample(SourceFile xml) {
             if(xml instanceof Xml.Document) {
                 findIndentXmlVisitor.visit(xml, indentStatistics);
                 findLineFormatXmlVisitor.visit(xml, generalFormatStatistics);
             }
+            return this;
         }
 
         public Autodetect build() {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/style/AutodetectDebug.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/style/AutodetectDebug.java
@@ -50,7 +50,7 @@ public class AutodetectDebug extends ScanningRecipe<AutodetectDebug.Accumulator>
         private TabsAndIndentsStyle overallProjectStyle;
         TabsAndIndentsStyle overallProjectStyle() {
             if(overallProjectStyle == null) {
-                overallProjectStyle = requireNonNull(NamedStyles.merge(TabsAndIndentsStyle.class, Collections.singletonList(overallDetector.build())));
+                overallProjectStyle = requireNonNull(overallDetector.build().getStyle(TabsAndIndentsStyle.class));
             }
             return overallProjectStyle;
         }
@@ -109,7 +109,7 @@ public class AutodetectDebug extends ScanningRecipe<AutodetectDebug.Accumulator>
             public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
                 Autodetect.Detector detector = new Autodetect.Detector();
                 detector.sample(document);
-                currentDocumentStyle = requireNonNull(NamedStyles.merge(TabsAndIndentsStyle.class, Collections.singletonList(detector.build())));
+                currentDocumentStyle = requireNonNull(detector.build().getStyle(TabsAndIndentsStyle.class));
                 super.visitDocument(document, ctx);
 
                 report.insertRow(ctx, new XmlStyleReport.Row(

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -22,6 +22,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
@@ -73,7 +74,9 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     private String linebreak() {
         if (linebreak == null) {
             linebreak = Optional.ofNullable(getCursor().firstEnclosing(Yaml.Documents.class))
-                    .map(docs -> docs.getStyle(GeneralFormatStyle.class))
+                    .map(docs -> {
+                        return Style.from(GeneralFormatStyle.class, docs);
+                    })
                     .map(format -> format.isUseCRLFNewLines() ? "\r\n" : "\n")
                     .orElse("\n");
         }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -74,9 +74,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     private String linebreak() {
         if (linebreak == null) {
             linebreak = Optional.ofNullable(getCursor().firstEnclosing(Yaml.Documents.class))
-                    .map(docs -> {
-                        return Style.from(GeneralFormatStyle.class, docs);
-                    })
+                    .map(docs -> Style.from(GeneralFormatStyle.class, docs))
                     .map(format -> format.isUseCRLFNewLines() ? "\r\n" : "\n")
                     .orElse("\n");
         }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
@@ -45,12 +45,14 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
 
         y = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p, cursor.fork());
 
-        y = new IndentsVisitor<>(Optional.ofNullable(docs.getStyle(IndentsStyle.class))
-                .orElse(Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())), stopAfter)
+        y = new IndentsVisitor<>(
+                    docs.getStyle(IndentsStyle.class, Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())),
+                    stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
-        y = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(docs.getStyle(GeneralFormatStyle.class))
-                .orElse(Autodetect.generalFormat(docs)), stopAfter)
+        y = new NormalizeLineBreaksVisitor<>(
+                docs.getStyle(GeneralFormatStyle.class, Autodetect.generalFormat(docs)),
+                stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
         return y;
@@ -62,13 +64,15 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
 
         y = (Yaml.Documents) new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p);
 
-        y = (Yaml.Documents) new IndentsVisitor<>(Optional.ofNullable(documents.getStyle(IndentsStyle.class))
-                .orElse(Autodetect.tabsAndIndents(y, YamlDefaultStyles.indents())), stopAfter)
-                .visitNonNull(documents, p);
+        y = (Yaml.Documents) new IndentsVisitor<>(
+                documents.getStyle(IndentsStyle.class, Autodetect.tabsAndIndents(documents, YamlDefaultStyles.indents())),
+                stopAfter)
+                .visitNonNull(y, p);
 
-        y = (Yaml.Documents) new NormalizeLineBreaksVisitor<>(Optional.ofNullable(documents.getStyle(GeneralFormatStyle.class))
-                .orElse(Autodetect.generalFormat(y)), stopAfter)
-                .visitNonNull(documents, p);
+        y = (Yaml.Documents) new NormalizeLineBreaksVisitor<>(
+                documents.getStyle(GeneralFormatStyle.class, Autodetect.generalFormat(documents)),
+                stopAfter)
+                .visitNonNull(y, p);
 
         return y;
     }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
@@ -45,12 +45,12 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
         y = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p, cursor.fork());
 
         y = new IndentsVisitor<>(
-                Style.from(IndentsStyle.class, docs, Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())),
+                Style.from(IndentsStyle.class, docs, () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())),
                     stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
         y = new NormalizeLineBreaksVisitor<>(
-                Style.from(GeneralFormatStyle.class, docs, Autodetect.generalFormat(docs)),
+                Style.from(GeneralFormatStyle.class, docs, () -> Autodetect.generalFormat(docs)),
                 stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
@@ -64,12 +64,12 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
         y = (Yaml.Documents) new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p);
 
         y = (Yaml.Documents) new IndentsVisitor<>(
-                Style.from(IndentsStyle.class, documents, Autodetect.tabsAndIndents(documents, YamlDefaultStyles.indents())),
+                Style.from(IndentsStyle.class, documents, () -> Autodetect.tabsAndIndents(documents, YamlDefaultStyles.indents())),
                 stopAfter)
                 .visitNonNull(y, p);
 
         y = (Yaml.Documents) new NormalizeLineBreaksVisitor<>(
-                Style.from(GeneralFormatStyle.class, documents, Autodetect.generalFormat(documents)),
+                Style.from(GeneralFormatStyle.class, documents, () -> Autodetect.generalFormat(documents)),
                 stopAfter)
                 .visitNonNull(y, p);
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/AutoFormatVisitor.java
@@ -19,13 +19,12 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.style.GeneralFormatStyle;
+import org.openrewrite.style.Style;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.style.Autodetect;
 import org.openrewrite.yaml.style.IndentsStyle;
 import org.openrewrite.yaml.style.YamlDefaultStyles;
 import org.openrewrite.yaml.tree.Yaml;
-
-import java.util.Optional;
 
 public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
     @Nullable
@@ -46,12 +45,12 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
         y = new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p, cursor.fork());
 
         y = new IndentsVisitor<>(
-                    docs.getStyle(IndentsStyle.class, Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())),
+                Style.from(IndentsStyle.class, docs, Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents())),
                     stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
         y = new NormalizeLineBreaksVisitor<>(
-                docs.getStyle(GeneralFormatStyle.class, Autodetect.generalFormat(docs)),
+                Style.from(GeneralFormatStyle.class, docs, Autodetect.generalFormat(docs)),
                 stopAfter)
                 .visitNonNull(y, p, cursor.fork());
 
@@ -65,12 +64,12 @@ public class AutoFormatVisitor<P> extends YamlIsoVisitor<P> {
         y = (Yaml.Documents) new MinimumViableSpacingVisitor<>(stopAfter).visitNonNull(y, p);
 
         y = (Yaml.Documents) new IndentsVisitor<>(
-                documents.getStyle(IndentsStyle.class, Autodetect.tabsAndIndents(documents, YamlDefaultStyles.indents())),
+                Style.from(IndentsStyle.class, documents, Autodetect.tabsAndIndents(documents, YamlDefaultStyles.indents())),
                 stopAfter)
                 .visitNonNull(y, p);
 
         y = (Yaml.Documents) new NormalizeLineBreaksVisitor<>(
-                documents.getStyle(GeneralFormatStyle.class, Autodetect.generalFormat(documents)),
+                Style.from(GeneralFormatStyle.class, documents, Autodetect.generalFormat(documents)),
                 stopAfter)
                 .visitNonNull(y, p);
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
@@ -46,7 +46,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends YamlIsoVisitor<ExecutionContext> {
         @Override
         public Yaml.Documents visitDocuments(Yaml.Documents docs, ExecutionContext ctx) {
-            IndentsStyle style = Style.from(IndentsStyle.class, docs, (Supplier<IndentsStyle>) () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents()));
+            IndentsStyle style = Style.from(IndentsStyle.class, docs, () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents()));
             doAfterVisit(new IndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
@@ -18,11 +18,14 @@ package org.openrewrite.yaml.format;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.style.Style;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.style.Autodetect;
 import org.openrewrite.yaml.style.IndentsStyle;
 import org.openrewrite.yaml.style.YamlDefaultStyles;
 import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.function.Supplier;
 
 public class Indents extends Recipe {
     @Override
@@ -43,7 +46,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends YamlIsoVisitor<ExecutionContext> {
         @Override
         public Yaml.Documents visitDocuments(Yaml.Documents docs, ExecutionContext ctx) {
-            IndentsStyle style = docs.getStyleOrDefault(IndentsStyle.class, () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents()));
+            IndentsStyle style = Style.from(IndentsStyle.class, docs, (Supplier<IndentsStyle>) () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents()));
             doAfterVisit(new IndentsVisitor<>(style, null));
             return docs;
         }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/Indents.java
@@ -43,10 +43,7 @@ public class Indents extends Recipe {
     private static class TabsAndIndentsFromCompilationUnitStyle extends YamlIsoVisitor<ExecutionContext> {
         @Override
         public Yaml.Documents visitDocuments(Yaml.Documents docs, ExecutionContext ctx) {
-            IndentsStyle style = docs.getStyle(IndentsStyle.class);
-            if (style == null) {
-                style = Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents());
-            }
+            IndentsStyle style = docs.getStyleOrDefault(IndentsStyle.class, () -> Autodetect.tabsAndIndents(docs, YamlDefaultStyles.indents()));
             doAfterVisit(new IndentsVisitor<>(style, null));
             return docs;
         }


### PR DESCRIPTION
## What's changed?

Minor refactoring around `Styles` for multiple languages.

- Moving `getStyle*` methods from `SourceFile` super interface to `Style`.
- Introducing `NamedStyles.getStyle` method which merges a single style.
- Adding a convenience method in Style - with supplier - used as static default and to retrieve from autodetect.

## What's your motivation?

- To DRY the code and align it more against multiple implementations for various languages.
- To reduce the `SourceFile` interface.
