### PR TITLE
4634 unit tests reproducing the failure parsing a java record

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -86,4 +86,58 @@ class JavaTemplateAnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void replacesInRecordVisitor() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext p) {
+                        if (annotation.getSimpleName().equals("NotNull")) {
+                            return JavaTemplate.apply("@NonNull", getCursor(), annotation.getCoordinates().replace());
+                        }
+                        return annotation;
+                    }
+                })),
+                java(
+                        """
+                import org.jetbrains.annotations.NotNull;
+    
+                public record Person(
+                    @NotNull String firstName,
+                    @NotNull String lastName
+                ) {}
+                """,
+                        """
+                import lombok.NonNull;
+    
+                public record Person(
+                    @NonNull String firstName,
+                    @NonNull String lastName
+                ) {}
+                """));
+    }
+
+    @Test
+    void replacesInRecord() {
+        rewriteRun(
+                spec -> spec.recipe(new ReplaceAnnotation("@org.jetbrains.annotations.NotNull", "@lombok.NonNull", null)),
+                java(
+                        """
+                import org.jetbrains.annotations.NotNull;
+    
+                public record Person(
+                    @NotNull String firstName,
+                    @NotNull String lastName
+                ) {}
+                """,
+                        """
+                import lombok.NonNull;
+    
+                public record Person(
+                    @NonNull String firstName,
+                    @NonNull String lastName
+                ) {}
+                """));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Unit tests reproducing the issue described in https://github.com/openrewrite/rewrite/issues/4634

## What's your motivation?
Fix the ReplaceAnnotation recipe to work over java records. 

## Anything in particular you'd like reviewers to focus on?
I implemented 2 unit tests, the first trying to replicate the other tests in the class by defining the recipe as an anonymous class overriding visitAnnotation method; the second one by using the ReplaceAnnotation recipe.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?

## Any additional context
https://github.com/openrewrite/rewrite/issues/4634
https://rewriteoss.slack.com/archives/C01A843MWG5/p1737552703678879

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
