### PR TITLE
ChangeDependencyConfiguration should only perform updates when the or…

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleDependency.java
@@ -93,7 +93,7 @@ public class GradleDependency implements Trait<J.MethodInvocation> {
                     return null;
                 }
 
-                if (!(StringUtils.isBlank(configuration) || methodInvocation.getSimpleName().equals(configuration))) {
+                if (!StringUtils.isBlank(configuration) && !methodInvocation.getSimpleName().equals(configuration)) {
                     return null;
                 }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyConfigurationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyConfigurationTest.java
@@ -388,4 +388,69 @@ class ChangeDependencyConfigurationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void onlyIfConfigurationMatches() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyConfiguration("*", "*", "testImplementation", "testRuntimeOnly")),
+          mavenProject("root",
+            settingsGradle(
+              """
+                rootProject.name = "root"
+                
+                include "project1"
+                include "project2"
+                """
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id 'java-library'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation 'org.openrewrite:rewrite-maven:latest.release'
+                    implementation project(':project1')
+                    testRuntimeOnly 'org.openrewrite:rewrite-gradle:latest.release'
+                    testRuntimeOnly project(':project2')
+                }
+                """,
+              """
+                plugins {
+                    id 'java-library'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation 'org.openrewrite:rewrite-maven:latest.release'
+                    implementation project(':project1')
+                    testImplementation 'org.openrewrite:rewrite-gradle:latest.release'
+                    testImplementation project(':project2')
+                }
+                """
+            ),
+            mavenProject("project1",
+              buildGradle(
+                """
+                  plugins {
+                      id "java"
+                  }
+                  """
+              )
+            ),
+            mavenProject("project2",
+              buildGradle(
+                """
+                  plugins {
+                      id "java"
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
Supersedes https://github.com/openrewrite/rewrite/pull/4940.

## Additional Context
Previously, the `GradleDependency.Matcher` was matching on any external dependency while being specific about the configuration being modified. However, this recipe is a little special in that it also needs to be able to update the configuration for dependencies with type `project`, `platform`, or `enforcedPlatform`. As a result of a lax check when the external dependency check failed -- which really only happens for dependencies of the previous types -- then that resulted in any dependency that failed the match to be considered using the more too lax rule and thus was ultimately modified erroneously.

In this PR, I've gone ahead and restricted the matching down to only these other dependency types that should be further interrogated at this early stage which resolves the original overmatching problem that resulted in this issue.