### PR TITLE
Fix bug in `PackageMatcher`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangePackageTest.java
@@ -1767,4 +1767,26 @@ class ChangePackageTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeNonRecursivePackageInYamlKey() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePackage("org.apache.http", "org.apache.hc.core5.http", false)),
+          yaml(
+            """
+              logging:
+                level:
+                  org.apache.hc: debug
+                  org.apache.http: debug
+              """,
+            """
+              logging:
+                level:
+                  org.apache.hc: debug
+                  org.apache.hc.core5.http: debug
+              """,
+            spec -> spec.path("application.yaml")
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/PackageMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/PackageMatcher.java
@@ -54,10 +54,12 @@ public class PackageMatcher implements Reference.Matcher {
 
     String getReplacement(String value, @Nullable String oldValue, String newValue) {
         if (oldValue != null) {
-            if (recursive) {
-                return value.replace(oldValue, newValue);
-            } else if (value.startsWith(oldValue) && Character.isUpperCase(value.charAt(oldValue.length() + 1))) {
-                return value.replace(oldValue, newValue);
+            if (value.equals(oldValue)) {
+                return newValue;
+            } else if (value.startsWith(oldValue)) {
+                if (recursive || value.length() > oldValue.length() + 1 && Character.isUpperCase(value.charAt(oldValue.length() + 1))) {
+                    return newValue + value.substring(oldValue.length());
+                }
             }
         }
         return value;


### PR DESCRIPTION
Found as part of Spring Boot 3.3 migration, when trying to update an `application.yaml` file.
