### PR TITLE
Adding ReplaceLegacyAttributeIndexSyntax

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/ReplaceLegacyAttributeIndexSyntax.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/ReplaceLegacyAttributeIndexSyntax.java
@@ -38,8 +38,8 @@ public class ReplaceLegacyAttributeIndexSyntax extends Recipe {
     public HclVisitor<ExecutionContext> getVisitor() {
         return new HclVisitor<ExecutionContext>() {
             @Override
-            public Hcl.Index visitLegacyIndexAttribute(Hcl.LegacyIndexAttributeAccess legacy, ExecutionContext executionContext) {
-                Hcl.LegacyIndexAttributeAccess ret = (Hcl.LegacyIndexAttributeAccess) super.visitLegacyIndexAttribute(legacy, executionContext);
+            public Hcl.Index visitLegacyIndexAttribute(Hcl.LegacyIndexAttributeAccess legacy, ExecutionContext ctx) {
+                Hcl.LegacyIndexAttributeAccess ret = (Hcl.LegacyIndexAttributeAccess) super.visitLegacyIndexAttribute(legacy, ctx);
                 Hcl.Index.Position position = new Hcl.Index.Position(Tree.randomId(), Space.EMPTY, ret.getIndex().getMarkers(), new HclRightPadded<>(ret.getIndex(), Space.EMPTY, Markers.EMPTY));
                 return new Hcl.Index(Tree.randomId(), ret.getPrefix(), ret.getMarkers(), ret.getBase().getElement(), position);
             }

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/ReplaceLegacyAttributeIndexSyntax.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/ReplaceLegacyAttributeIndexSyntax.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hcl;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.hcl.tree.Hcl;
+import org.openrewrite.hcl.tree.HclRightPadded;
+import org.openrewrite.hcl.tree.Space;
+import org.openrewrite.marker.Markers;
+
+public class ReplaceLegacyAttributeIndexSyntax extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Replace legacy attribute index syntax";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace legacy attribute index syntax (`.0`) with the new syntax (`[0]`).";
+    }
+
+    @Override
+    public HclVisitor<ExecutionContext> getVisitor() {
+        return new HclVisitor<ExecutionContext>() {
+            @Override
+            public Hcl.Index visitLegacyIndexAttribute(Hcl.LegacyIndexAttributeAccess legacy, ExecutionContext executionContext) {
+                Hcl.LegacyIndexAttributeAccess ret = (Hcl.LegacyIndexAttributeAccess) super.visitLegacyIndexAttribute(legacy, executionContext);
+                Hcl.Index.Position position = new Hcl.Index.Position(Tree.randomId(), Space.EMPTY, ret.getIndex().getMarkers(), new HclRightPadded<>(ret.getIndex(), Space.EMPTY, Markers.EMPTY));
+                return new Hcl.Index(Tree.randomId(), ret.getPrefix(), ret.getMarkers(), ret.getBase().getElement(), position);
+            }
+        };
+    }
+}

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/ReplaceLegacyAttributeIndexSyntaxTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/ReplaceLegacyAttributeIndexSyntaxTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.hcl;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.hcl.Assertions.hcl;
+
+class ReplaceLegacyAttributeIndexSyntaxTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void simple() {
+        rewriteRun(
+          spec -> spec.recipe(new ReplaceLegacyAttributeIndexSyntax()),
+          hcl(
+            """
+            locals {
+              dns_record = aws_acm_certificate.google_dot_com.0.resource_record_name
+            }
+            """,
+            """
+            locals {
+              dns_record = aws_acm_certificate.google_dot_com[0].resource_record_name
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Adding a new recipe for HCL called `ReplaceLegacyAttributeIndexSyntax`.
This is to migrate from this syntax which HCL considers legacy (which BTW we have recently added support for in the parser - see #4901):
```
aws_acm_certificate.google_dot_com.0.resource_record_name
```
to the "modern" one doing effectively the same:
```
aws_acm_certificate.google_dot_com[0].resource_record_name
```

## What's your motivation?
To enable HCL users of OpenRewrite to migrate their code to new syntax.
