### PR TITLE
Honoring useCRLF in WrappingAndBracesVisitor

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/style/GeneralFormatStyle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/GeneralFormatStyle.java
@@ -19,5 +19,11 @@ import lombok.Value;
 
 @Value
 public class GeneralFormatStyle implements Style{
+    public static final GeneralFormatStyle DEFAULT = new GeneralFormatStyle(false);
+
     boolean useCRLFNewLines;
+
+    public String newLine() {
+        return useCRLFNewLines ? "\r\n" : "\n";
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/style/LineWrapSetting.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/LineWrapSetting.java
@@ -19,7 +19,7 @@ public enum LineWrapSetting {
     DoNotWrap, WrapAlways;
     // Eventually we would add values like WrapIfTooLong or ChopIfTooLong
 
-    public String delimiter() {
-        return this == DoNotWrap ? "" : "\n";
+    public String delimiter(GeneralFormatStyle generalFormatStyle) {
+        return this == DoNotWrap ? "" : generalFormatStyle.newLine();
     }
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
@@ -50,8 +50,8 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         GeneralFormatStyle generalStyle = Style.from(GeneralFormatStyle.class, doc, () -> autodetectedStyle.getStyle(GeneralFormatStyle.class));
         WrappingAndBracesStyle wrappingStyle = Style.from(WrappingAndBracesStyle.class, doc, () -> autodetectedStyle.getStyle(WrappingAndBracesStyle.class));
 
-        js = new WrappingAndBracesVisitor<>(wrappingStyle, stopAfter).visitNonNull(js, p, cursor.fork());
-        js = new TabsAndIndentsVisitor<>(wrappingStyle, tabsIndentsStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new WrappingAndBracesVisitor<>(wrappingStyle, generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new TabsAndIndentsVisitor<>(wrappingStyle, tabsIndentsStyle, generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
         js = new NormalizeLineBreaksVisitor<>(generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
         return js;
     }
@@ -64,8 +64,8 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         GeneralFormatStyle generalStyle = Style.from(GeneralFormatStyle.class, js, () -> autodetectedStyle.getStyle(GeneralFormatStyle.class));
         WrappingAndBracesStyle wrappingStyle = Style.from(WrappingAndBracesStyle.class, js, () -> autodetectedStyle.getStyle(WrappingAndBracesStyle.class));
 
-        js = (Json.Document) new WrappingAndBracesVisitor<>(wrappingStyle, stopAfter).visitNonNull(js, p);
-        js = (Json.Document) new TabsAndIndentsVisitor<>(wrappingStyle, tabsIndentsStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new WrappingAndBracesVisitor<>(wrappingStyle, generalStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new TabsAndIndentsVisitor<>(wrappingStyle, tabsIndentsStyle, generalStyle, stopAfter).visitNonNull(js, p);
         js = (Json.Document) new NormalizeLineBreaksVisitor<>(generalStyle, stopAfter).visitNonNull(js, p);
 
         return js;

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/Indents.java
@@ -23,6 +23,7 @@ import org.openrewrite.json.style.Autodetect;
 import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.style.WrappingAndBracesStyle;
 import org.openrewrite.json.tree.Json;
+import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.style.Style;
 
 public class Indents extends Recipe {
@@ -47,7 +48,8 @@ public class Indents extends Recipe {
             Autodetect autodetected = Autodetect.detector().sample(docs).build();
             TabsAndIndentsStyle tabsAndIndentsStyle = Style.from(TabsAndIndentsStyle.class, docs, () -> autodetected.getStyle(TabsAndIndentsStyle.class));
             WrappingAndBracesStyle wrappingAndBracesStyle = Style.from(WrappingAndBracesStyle.class, docs, () -> autodetected.getStyle(WrappingAndBracesStyle.class));
-            doAfterVisit(new TabsAndIndentsVisitor<>(wrappingAndBracesStyle, tabsAndIndentsStyle, null));
+            GeneralFormatStyle generalFormatStyle = Style.from(GeneralFormatStyle.class, docs, () -> autodetected.getStyle(GeneralFormatStyle.class));
+            doAfterVisit(new TabsAndIndentsVisitor<>(wrappingAndBracesStyle, tabsAndIndentsStyle, generalFormatStyle,null));
             return docs;
         }
     }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/TabsAndIndentsVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/TabsAndIndentsVisitor.java
@@ -24,6 +24,7 @@ import org.openrewrite.json.style.WrappingAndBracesStyle;
 import org.openrewrite.json.tree.Json;
 import org.openrewrite.json.tree.JsonRightPadded;
 import org.openrewrite.json.tree.Space;
+import org.openrewrite.style.GeneralFormatStyle;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,7 +38,10 @@ public class TabsAndIndentsVisitor<P> extends JsonIsoVisitor<P> {
     @Nullable
     private final Tree stopAfter;
 
-    public TabsAndIndentsVisitor(WrappingAndBracesStyle wrappingAndBracesStyle, TabsAndIndentsStyle tabsAndIndentsStyle, @Nullable Tree stopAfter) {
+    public TabsAndIndentsVisitor(WrappingAndBracesStyle wrappingAndBracesStyle,
+                                 TabsAndIndentsStyle tabsAndIndentsStyle,
+                                 GeneralFormatStyle generalFormatStyle,
+                                 @Nullable Tree stopAfter) {
         this.stopAfter = stopAfter;
 
         if (tabsAndIndentsStyle.getUseTabCharacter()) {
@@ -49,7 +53,7 @@ public class TabsAndIndentsVisitor<P> extends JsonIsoVisitor<P> {
             }
             singleIndent = sb.toString();
         }
-        this.objectsWrappingDelimiter = wrappingAndBracesStyle.getWrapObjects().delimiter();
+        this.objectsWrappingDelimiter = wrappingAndBracesStyle.getWrapObjects().delimiter(generalFormatStyle);
     }
 
     @Override

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBraces.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBraces.java
@@ -18,6 +18,7 @@ package org.openrewrite.json.format;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.json.style.WrappingAndBracesStyle;
+import org.openrewrite.style.GeneralFormatStyle;
 
 public class WrappingAndBraces extends Recipe {
     @Override
@@ -32,6 +33,6 @@ public class WrappingAndBraces extends Recipe {
 
     @Override
     public WrappingAndBracesVisitor<ExecutionContext> getVisitor() {
-        return new WrappingAndBracesVisitor<>(WrappingAndBracesStyle.DEFAULT, null);
+        return new WrappingAndBracesVisitor<>(WrappingAndBracesStyle.DEFAULT, GeneralFormatStyle.DEFAULT, null);
     }
 }


### PR DESCRIPTION
## What's changed?

Continuation of #4931.

Taking the `GeneralFormat.useCRLF` setting in the `WrappingAndBracesVisitor` - part of JSON style autodetection and formatting.

## What's your motivation?
Addressing [this comment](https://github.com/openrewrite/rewrite/pull/4931#discussion_r1928428190) from PR review.
