### PR TITLE
Fix bug parsing Groovy constructor declarations

### DIFF
--- a/rewrite-gradle/src/main/groovy/RewriteGradleProject.groovy
+++ b/rewrite-gradle/src/main/groovy/RewriteGradleProject.groovy
@@ -193,6 +193,8 @@ abstract class RewriteGradleProject extends groovy.lang.Script implements Projec
     abstract Task task(Map<String, ?> options)
     abstract Task task(Map<String, ?> options, Closure configureClosure)
     abstract Task task(String name, Closure configureClosure)
+
+    @Override
     abstract Task task(String name)
     abstract <T extends Task> T task(String name, Class<T> type)
     abstract <T extends Task> T task(String name, Class<T> type, Object... constructorArgs)

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -538,7 +538,7 @@ public class GroovyParserVisitor {
                 See also: https://groovy-lang.org/differences.html#_creating_instances_of_non_static_inner_classes
                 */
                 isConstructorOfInnerNonStaticClass = method.getDeclaringClass() instanceof InnerClassNode && (method.getDeclaringClass().getModifiers() & Modifier.STATIC) == 0;
-                methodName = method.getDeclaringClass().getName().replaceFirst(".*\\$", "");
+                methodName = method.getDeclaringClass().getNameWithoutPackage().replaceFirst(".*\\$", "");
             } else if (source.startsWith(method.getName(), cursor)) {
                 methodName = method.getName();
             } else {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -871,9 +871,10 @@ public class GroovyParserVisitor {
                 name = clazz.getType().getNameWithoutPackage().replace('$', '.');
             }
             skip(name);
-            if (source.startsWith(".class", cursor)) {
-                name += ".class";
-                skip(".class");
+            if (sourceStartsWith(".class")) {
+                String classSuffix = source.substring(cursor, indexOfNextNonWhitespace(cursor, source)) + ".class";
+                name += classSuffix;
+                skip(classSuffix);
             }
             queue.add(TypeTree.build(name)
                     .withType(typeMapping.type(clazz.getType()))

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -260,6 +260,20 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/4705")
+    @Test
+    void constructorWithDef() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  def A() {}
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void constructorForClassInPackage() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassDeclarationTest.java
@@ -260,14 +260,15 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/4705")
     @Test
-    void constructorWithDef() {
+    void constructorForClassInPackage() {
         rewriteRun(
           groovy(
             """
+              package a
+              
               class A {
-                  def A() {}
+                  A() {}
               }
               """
           )

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassExpressionTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassExpressionTest.java
@@ -57,6 +57,24 @@ class ClassExpressionTest implements RewriteTest {
               """
           )
         );
+    }
 
+    @Test
+    void unqualified() {
+        rewriteRun(
+          groovy(
+            """
+              package foo
+              
+              interface MyEntity {
+              }
+              class Foo {
+                  void setUp() {
+                      e = MyEntity.class
+                  }
+              }
+              """
+          )
+        );
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassExpressionTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ClassExpressionTest.java
@@ -77,4 +77,23 @@ class ClassExpressionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void qualified() {
+        rewriteRun(
+          groovy(
+            """
+              package foo
+              
+              interface MyEntity {
+              }
+              class Foo {
+                  void setUp() {
+                      e = foo.MyEntity.class
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -192,7 +192,7 @@ class MethodInvocationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              foo(String.class)
+              foo(String    .class)
               """
           )
         );


### PR DESCRIPTION
When a Groovy class with a constructor is declared within a compilation unit with a package declaration, the parsing fails.
