### PR TITLE
Applying JSON formatting to members of objects and arrays

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/style/LineWrapSetting.java
+++ b/rewrite-core/src/main/java/org/openrewrite/style/LineWrapSetting.java
@@ -19,7 +19,4 @@ public enum LineWrapSetting {
     DoNotWrap, WrapAlways;
     // Eventually we would add values like WrapIfTooLong or ChopIfTooLong
 
-    public String delimiter(GeneralFormatStyle generalFormatStyle) {
-        return this == DoNotWrap ? "" : generalFormatStyle.newLine();
-    }
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormat.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormat.java
@@ -26,7 +26,7 @@ public class AutoFormat extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Indents JSON using the most common indentation size and tabs or space choice in use in the file.";
+        return "Format JSON code using a standard comprehensive set of JSON formatting recipes.";
     }
 
     @Override

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/AutoFormatVisitor.java
@@ -45,12 +45,11 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         Cursor cursor = getCursor().getParentOrThrow();
         Autodetect autodetectedStyle = Autodetect.detector().sample(doc).build();
         Json js = tree;
-
         TabsAndIndentsStyle tabsIndentsStyle = Style.from(TabsAndIndentsStyle.class, doc, () -> autodetectedStyle.getStyle(TabsAndIndentsStyle.class));
         GeneralFormatStyle generalStyle = Style.from(GeneralFormatStyle.class, doc, () -> autodetectedStyle.getStyle(GeneralFormatStyle.class));
         WrappingAndBracesStyle wrappingStyle = Style.from(WrappingAndBracesStyle.class, doc, () -> autodetectedStyle.getStyle(WrappingAndBracesStyle.class));
 
-        js = new WrappingAndBracesVisitor<>(wrappingStyle, generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
+        js = new WrappingAndBracesVisitor<>(wrappingStyle, tabsIndentsStyle, generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
         js = new TabsAndIndentsVisitor<>(wrappingStyle, tabsIndentsStyle, generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
         js = new NormalizeLineBreaksVisitor<>(generalStyle, stopAfter).visitNonNull(js, p, cursor.fork());
         return js;
@@ -64,7 +63,7 @@ public class AutoFormatVisitor<P> extends JsonIsoVisitor<P> {
         GeneralFormatStyle generalStyle = Style.from(GeneralFormatStyle.class, js, () -> autodetectedStyle.getStyle(GeneralFormatStyle.class));
         WrappingAndBracesStyle wrappingStyle = Style.from(WrappingAndBracesStyle.class, js, () -> autodetectedStyle.getStyle(WrappingAndBracesStyle.class));
 
-        js = (Json.Document) new WrappingAndBracesVisitor<>(wrappingStyle, generalStyle, stopAfter).visitNonNull(js, p);
+        js = (Json.Document) new WrappingAndBracesVisitor<>(wrappingStyle, tabsIndentsStyle, generalStyle, stopAfter).visitNonNull(js, p);
         js = (Json.Document) new TabsAndIndentsVisitor<>(wrappingStyle, tabsIndentsStyle, generalStyle, stopAfter).visitNonNull(js, p);
         js = (Json.Document) new NormalizeLineBreaksVisitor<>(generalStyle, stopAfter).visitNonNull(js, p);
 

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBraces.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBraces.java
@@ -17,10 +17,27 @@ package org.openrewrite.json.format;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.style.WrappingAndBracesStyle;
 import org.openrewrite.style.GeneralFormatStyle;
 
 public class WrappingAndBraces extends Recipe {
+    private final WrappingAndBracesStyle wrappingAndBracesStyle;
+    private final TabsAndIndentsStyle tabsAndIndentsStyle;
+    private final GeneralFormatStyle generalFormatStyle;
+
+    public WrappingAndBraces() {
+        this.wrappingAndBracesStyle = WrappingAndBracesStyle.DEFAULT;
+        this.tabsAndIndentsStyle = TabsAndIndentsStyle.DEFAULT;
+        this.generalFormatStyle = GeneralFormatStyle.DEFAULT;
+    }
+
+    public WrappingAndBraces(WrappingAndBracesStyle wrappingAndBracesStyle, TabsAndIndentsStyle tabsAndIndentsStyle, GeneralFormatStyle generalFormatStyle) {
+        this.wrappingAndBracesStyle = wrappingAndBracesStyle;
+        this.tabsAndIndentsStyle = tabsAndIndentsStyle;
+        this.generalFormatStyle = generalFormatStyle;
+    }
+
     @Override
     public String getDisplayName() {
         return "JSON new lines";
@@ -33,6 +50,6 @@ public class WrappingAndBraces extends Recipe {
 
     @Override
     public WrappingAndBracesVisitor<ExecutionContext> getVisitor() {
-        return new WrappingAndBracesVisitor<>(WrappingAndBracesStyle.DEFAULT, GeneralFormatStyle.DEFAULT, null);
+        return new WrappingAndBracesVisitor<>(wrappingAndBracesStyle, tabsAndIndentsStyle, generalFormatStyle, null);
     }
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBracesVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBracesVisitor.java
@@ -98,13 +98,11 @@ public class WrappingAndBracesVisitor<P> extends JsonIsoVisitor<P> {
     }
 
     private <J extends Json> List<JsonRightPadded<J>> ensureCollectionHasIndents(List<JsonRightPadded<J>> elements, LineWrapSetting wrapping) {
-        AtomicBoolean first = new AtomicBoolean(true);
-        return ListUtils.map(elements, elem -> {
-            boolean isFirst = first.getAndSet(false);
+        return ListUtils.map(elements, (Integer idx, JsonRightPadded<J> elem) -> {
             Space prefix = elem.getElement().getPrefix();
             final String newPrefixString;
             String currentAfterNewLine = prefix.getWhitespaceIndent();
-            if (wrapping == LineWrapSetting.DoNotWrap && isFirst) {
+            if (wrapping == LineWrapSetting.DoNotWrap && idx == 0) {
                 newPrefixString = "";
             } else if (wrapping == LineWrapSetting.DoNotWrap) {
                 newPrefixString = " ";
@@ -122,14 +120,10 @@ public class WrappingAndBracesVisitor<P> extends JsonIsoVisitor<P> {
     }
 
     private <JS extends Json> List<JsonRightPadded<JS>> applyWrappingStyleToSuffixes(List<JsonRightPadded<JS>> elements, LineWrapSetting wrapping, String relativeIndent) {
-        AtomicInteger i = new AtomicInteger(0);
-        return ListUtils.map(elements, elem -> {
-            boolean isLast = i.get() == elements.size() - 1;
-            i.incrementAndGet();
-
+        return ListUtils.map(elements, (Integer idx, JsonRightPadded<JS> elem) -> {
             String currentAfter = elem.getAfter().getWhitespace();
             final String newAfter;
-            if (isLast) {
+            if (idx == elements.size() - 1) {
                 if (wrapping == LineWrapSetting.DoNotWrap) {
                     newAfter = "";
                 } else if (wrapping == LineWrapSetting.WrapAlways) {

--- a/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBracesVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/format/WrappingAndBracesVisitor.java
@@ -19,6 +19,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.json.JsonIsoVisitor;
+import org.openrewrite.json.style.TabsAndIndentsStyle;
 import org.openrewrite.json.style.WrappingAndBracesStyle;
 import org.openrewrite.json.tree.Json;
 import org.openrewrite.json.tree.JsonRightPadded;
@@ -28,6 +29,9 @@ import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.style.LineWrapSetting;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
 
@@ -35,39 +39,50 @@ public class WrappingAndBracesVisitor<P> extends JsonIsoVisitor<P> {
     @Nullable
     private final Tree stopAfter;
 
+    private final String singleIndent;
     private final WrappingAndBracesStyle wrappingAndBracesStyle;
     private final GeneralFormatStyle generalFormatStyle;
 
     public WrappingAndBracesVisitor(WrappingAndBracesStyle wrappingAndBracesStyle,
+                                    TabsAndIndentsStyle tabsAndIndentsStyle,
                                     GeneralFormatStyle generalFormatStyle,
                                     @Nullable Tree stopAfter) {
+        this.stopAfter = stopAfter;
+
+        this.singleIndent = tabsAndIndentsStyle.singleIndent();
         this.wrappingAndBracesStyle = wrappingAndBracesStyle;
         this.generalFormatStyle = generalFormatStyle;
-        this.stopAfter = stopAfter;
     }
 
     @Override
     public Json.JsonObject visitObject(Json.JsonObject obj, P p) {
         Json.JsonObject ret = super.visitObject(obj, p);
-        final String possibleNewLine = this.wrappingAndBracesStyle.getWrapObjects().delimiter(generalFormatStyle);
         List<JsonRightPadded<Json>> members = ret.getPadding().getMembers();
-        members = applyWrappingStyleToLastChildSuffix(members, possibleNewLine);
-        members = applyWrappingStyleToPrefixes(members, possibleNewLine);
+        LineWrapSetting wrappingSetting = this.wrappingAndBracesStyle.getWrapObjects();
+
+        members = ensureCollectionHasIndents(members, wrappingSetting);
+        members = applyWrappingStyleToSuffixes(members, wrappingSetting, getCurrentIndent());
         return ret.getPadding().withMembers(members);
     }
 
     @Override
     public Json.Array visitArray(Json.Array array, P p) {
         Json.Array ret = super.visitArray(array, p);
-        final String possibleNewLine = this.wrappingAndBracesStyle.getWrapArrays().delimiter(generalFormatStyle);
         List<JsonRightPadded<JsonValue>> members = ret.getPadding().getValues();
-        members = applyWrappingStyleToLastChildSuffix(members, possibleNewLine);
-        members = applyWrappingStyleToPrefixes(members, possibleNewLine);
+        LineWrapSetting wrappingSetting = this.wrappingAndBracesStyle.getWrapArrays();
+
+        members = ensureCollectionHasIndents(members, wrappingSetting);
+        members = applyWrappingStyleToSuffixes(members, wrappingSetting, getCurrentIndent());
         return ret.getPadding().withValues(members);
     }
 
     @Override
     public @Nullable Json postVisit(Json tree, P p) {
+        if (tree instanceof Json.JsonObject || tree instanceof Json.Array) {
+            String newIndent = getCurrentIndent() + this.singleIndent;
+            getCursor().putMessage("indentToUse", newIndent);
+        }
+
         if (stopAfter != null && stopAfter.isScope(tree)) {
             getCursor().putMessageOnFirstEnclosing(Json.Document.class, "stop", true);
         }
@@ -82,28 +97,67 @@ public class WrappingAndBracesVisitor<P> extends JsonIsoVisitor<P> {
         return super.visit(tree, p);
     }
 
-    private static <JS extends Json> List<JsonRightPadded<JS>> applyWrappingStyleToPrefixes(List<JsonRightPadded<JS>> elements, String possibleNewLine) {
+    private <J extends Json> List<JsonRightPadded<J>> ensureCollectionHasIndents(List<JsonRightPadded<J>> elements, LineWrapSetting wrapping) {
+        AtomicBoolean first = new AtomicBoolean(true);
         return ListUtils.map(elements, elem -> {
-            String oldAfterNewLine = elem.getElement().getPrefix().getWhitespaceIndent();
-            String newPrefix = possibleNewLine + oldAfterNewLine;
-            if (!newPrefix.equals(elem.getElement().getPrefix().getWhitespace())) {
-                return elem.withElement(elem.getElement().withPrefix(Space.build(newPrefix, emptyList())));
+            boolean isFirst = first.getAndSet(false);
+            Space prefix = elem.getElement().getPrefix();
+            final String newPrefixString;
+            String currentAfterNewLine = prefix.getWhitespaceIndent();
+            if (wrapping == LineWrapSetting.DoNotWrap && isFirst) {
+                newPrefixString = "";
+            } else if (wrapping == LineWrapSetting.DoNotWrap) {
+                newPrefixString = " ";
+            } else if (wrapping == LineWrapSetting.WrapAlways) {
+                newPrefixString = this.generalFormatStyle.newLine() + currentAfterNewLine;
+            } else {
+                throw new UnsupportedOperationException("Unknown LineWrapSetting: " + wrapping);
+            }
+            if (!newPrefixString.equals(prefix.getWhitespace())) {
+                return elem.withElement(elem.getElement().withPrefix(prefix.withWhitespace((newPrefixString))));
             } else {
                 return elem;
             }
         });
     }
 
-    private static <JS extends Json> List<JsonRightPadded<JS>> applyWrappingStyleToLastChildSuffix(List<JsonRightPadded<JS>> elements, String possibleNewLine) {
-        return ListUtils.mapLast(elements, last -> {
-            String currentAfterNewLine = last.getAfter().getWhitespaceIndent();
-            String currentAfter = last.getAfter().getWhitespace();
-            String newAfter = possibleNewLine + currentAfterNewLine;
-            if (!newAfter.equals(currentAfter)) {
-                return last.withAfter(Space.build(newAfter, emptyList()));
+    private <JS extends Json> List<JsonRightPadded<JS>> applyWrappingStyleToSuffixes(List<JsonRightPadded<JS>> elements, LineWrapSetting wrapping, String relativeIndent) {
+        AtomicInteger i = new AtomicInteger(0);
+        return ListUtils.map(elements, elem -> {
+            boolean isLast = i.get() == elements.size() - 1;
+            i.incrementAndGet();
+
+            String currentAfter = elem.getAfter().getWhitespace();
+            final String newAfter;
+            if (isLast) {
+                if (wrapping == LineWrapSetting.DoNotWrap) {
+                    newAfter = "";
+                } else if (wrapping == LineWrapSetting.WrapAlways) {
+                    newAfter = this.generalFormatStyle.newLine() + relativeIndent;
+                } else {
+                    throw new UnsupportedOperationException("Unknown LineWrapSetting: " + wrapping);
+                }
             } else {
-                return last;
+                newAfter = "";
+            }
+            if (!newAfter.equals(currentAfter)) {
+                return elem.withAfter(Space.build(newAfter, emptyList()));
+            } else {
+                return elem;
             }
         });
+    }
+
+    private String getCurrentIndent() {
+        String ret = getCursor().getNearestMessage("indentToUse");
+        if (ret == null) {
+            // This is basically the first object we visit, not necessarily the root-level object as we might be
+            // visiting only partial tree.
+            Optional<Json> containingNode = getCursor().getPathAsStream().filter(obj ->
+                    (obj instanceof Json) && ((Json) obj).getPrefix().getWhitespace().contains("\n")
+            ).findFirst().map(obj -> (Json) obj);
+            return containingNode.map(node -> node.getPrefix().getWhitespaceIndent()).orElse("");
+        }
+        return ret;
     }
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/style/Autodetect.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/style/Autodetect.java
@@ -21,6 +21,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.json.JsonVisitor;
 import org.openrewrite.json.tree.Json;
+import org.openrewrite.json.tree.JsonValue;
 import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.style.LineWrapSetting;
 import org.openrewrite.style.NamedStyles;
@@ -261,10 +262,12 @@ public class Autodetect extends NamedStyles {
         }
     }
     private static class ClassifyWrappingJsonVisitor extends JsonVisitor<WrappingStatistics> {
+
+
         @Override
         public Json visitArray(Json.Array array, WrappingStatistics wrappingStatistics) {
-            if (!array.getValues().isEmpty()) {
-                boolean isWrapped = array.getValues().get(0).getPrefix().getWhitespace().contains("\n");
+            for (JsonValue value: array.getValues()) {
+                boolean isWrapped = value.getPrefix().getWhitespace().contains("\n");
                 wrappingStatistics.arraysWrapped.get(isWrapped).incrementAndGet();
             }
             return super.visitArray(array, wrappingStatistics);
@@ -272,8 +275,8 @@ public class Autodetect extends NamedStyles {
 
         @Override
         public Json visitObject(Json.JsonObject obj, WrappingStatistics wrappingStatistics) {
-            if (!obj.getMembers().isEmpty()) {
-                Boolean isWrapped = obj.getMembers().get(0).getPrefix().getWhitespace().contains("\n");
+            for (Json member: obj.getMembers()) {
+                boolean isWrapped = member.getPrefix().getWhitespace().contains("\n");
                 wrappingStatistics.objectsWrapped.get(isWrapped).incrementAndGet();
             }
             return super.visitObject(obj, wrappingStatistics);

--- a/rewrite-json/src/main/java/org/openrewrite/json/style/TabsAndIndentsStyle.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/style/TabsAndIndentsStyle.java
@@ -48,6 +48,18 @@ public class TabsAndIndentsStyle implements JsonStyle {
     // Although IntelliJ settings panel does mention this notion.
     // Integer continuationIndentSize;
 
+    public String singleIndent() {
+        if (getUseTabCharacter()) {
+            return "\t";
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (int j = 0; j < getIndentSize(); j++) {
+                sb.append(" ");
+            }
+            return sb.toString();
+        }
+    }
+
     @Override
     public Style applyDefaults() {
         return StyleHelper.merge(DEFAULT, this);

--- a/rewrite-json/src/main/java/org/openrewrite/json/style/WrappingAndBracesStyle.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/style/WrappingAndBracesStyle.java
@@ -25,6 +25,7 @@ import org.openrewrite.style.StyleHelper;
 @With
 public class WrappingAndBracesStyle implements JsonStyle {
     public static final WrappingAndBracesStyle DEFAULT = new WrappingAndBracesStyle(LineWrapSetting.WrapAlways, LineWrapSetting.WrapAlways);
+    public static final WrappingAndBracesStyle OBJECTS_WRAP_ARRAYS_DONT = new WrappingAndBracesStyle(LineWrapSetting.WrapAlways, LineWrapSetting.DoNotWrap);
 
     LineWrapSetting wrapObjects;
     LineWrapSetting wrapArrays;

--- a/rewrite-json/src/test/java/org/openrewrite/json/format/AutoFormatTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/format/AutoFormatTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.json.format;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -28,11 +29,47 @@ class AutoFormatTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void simple() {
         rewriteRun(
           json(
             """
-            {"a": 3,"b": 5}
+            {   "a": 3,
+            "b": 5,
+                "c": 7}
+            """,
+            """
+            {
+                "a": 3,
+                "b": 5,
+                "c": 7
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void properlyFormattedNoChanges() {
+        rewriteRun(
+          json(
+            """
+            {
+                "a": 3,
+                "b": 5,
+                "c": 7
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void noWrapsObjects() {
+        rewriteRun(
+          json(
+            """
+            {"a": 3, "b": 5}
             """
           )
         );
@@ -61,4 +98,18 @@ class AutoFormatTest implements RewriteTest {
         );
     }
 
+    @Test
+    void noWrapsWithArray() {
+        rewriteRun(
+          json(
+            """
+            { "allowedValues": ["Four", "Three", 6]
+            }
+            """,
+            """
+            {"allowedValues": ["Four", "Three", 6]}
+            """
+          )
+        );
+    }
 }

--- a/rewrite-json/src/test/java/org/openrewrite/json/format/TabsAndIndentsVisitorTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/format/TabsAndIndentsVisitorTest.java
@@ -132,4 +132,3 @@ class TabsAndIndentsVisitorTest implements RewriteTest {
         );
     }
 }
-

--- a/rewrite-json/src/test/java/org/openrewrite/json/format/TabsAndIndentsVisitorTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/format/TabsAndIndentsVisitorTest.java
@@ -70,4 +70,66 @@ class TabsAndIndentsVisitorTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void oneLineArraysAlreadyCompact() {
+        rewriteRun(
+          json(
+            """
+            {
+               "one": [1, 11, 111],
+               "two": [2, 22, 222],
+               "three": [3, 33, 333]
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void wrappedArray() {
+        rewriteRun(
+          json(
+            """
+            {
+               "one": [
+            1,
+               11,
+               111
+               ],
+               "two": [
+            2,
+             22,
+             222
+            ],
+               "three": [
+                3,
+                33,
+                333
+               ]
+            }
+            """,
+            """
+            {
+               "one": [
+                  1,
+                  11,
+                  111
+               ],
+               "two": [
+                  2,
+                  22,
+                  222
+               ],
+               "three": [
+                  3,
+                  33,
+                  333
+               ]
+            }
+            """
+          )
+        );
+    }
 }
+

--- a/rewrite-json/src/test/java/org/openrewrite/json/format/WrappingAndBracesVisitorTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/format/WrappingAndBracesVisitorTest.java
@@ -16,10 +16,13 @@
 package org.openrewrite.json.format;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.json.style.TabsAndIndentsStyle;
+import org.openrewrite.style.GeneralFormatStyle;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.json.Assertions.json;
+import static org.openrewrite.json.style.WrappingAndBracesStyle.OBJECTS_WRAP_ARRAYS_DONT;
 
 class WrappingAndBracesVisitorTest implements RewriteTest {
     @Override
@@ -53,7 +56,7 @@ class WrappingAndBracesVisitorTest implements RewriteTest {
                "x": "x",
                    "key": {
                "a": "b"
-            }
+                   }
             }
             """
           )
@@ -74,7 +77,7 @@ class WrappingAndBracesVisitorTest implements RewriteTest {
                "x": "x",
                "key": {
             "a": "b"
-            }
+               }
             }
             """
           )
@@ -110,7 +113,7 @@ class WrappingAndBracesVisitorTest implements RewriteTest {
             2,
              22,
              222
-            ],
+               ],
                "three": [
                 3,
                 33,
@@ -121,4 +124,30 @@ class WrappingAndBracesVisitorTest implements RewriteTest {
           )
         );
     }
+
+
+
+    @Test
+    void oneLineArrays() {
+        rewriteRun(
+          recipeSpec -> recipeSpec.recipe(new WrappingAndBraces(OBJECTS_WRAP_ARRAYS_DONT, TabsAndIndentsStyle.DEFAULT, GeneralFormatStyle.DEFAULT)),
+          json(
+            """
+            {
+               "one": [1, 11, 111        ],
+               "two": [2, 22         , 222],
+               "three": [3         , 33, 333]
+            }
+            """,
+            """
+            {
+               "one": [1, 11, 111],
+               "two": [2, 22, 222],
+               "three": [3, 33, 333]
+            }
+            """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Continuation of #4931.
Additional step in JSON autoformatting. Taking care of the indents, prefixes and suffixes around object and array members.

## What's your motivation?
To provide more complete support for JSON style autodetection and autoformatting.

## Anything in particular you'd like reviewers to focus on?
As indicated in Github comments.
