### PR TITLE
Merge provided and built MavenSettings

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
@@ -72,8 +72,9 @@ public class MavenDependency implements Trait<Xml.Tag> {
             MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
             MavenMetadata mavenMetadata = metadataFailures.insertRows(ctx, () -> new MavenPomDownloader(
                     emptyMap(), ctx,
-                    Optional.ofNullable(mctx.getSettings())
-                            .orElse(mrr.getMavenSettings()),
+                    mctx.getSettings() == null ? mrr.getMavenSettings() :
+                            mrr.getMavenSettings() == null ? mctx.getSettings() :
+                                    mctx.getSettings().merge(mrr.getMavenSettings()),
                     Optional.ofNullable(mctx.getSettings())
                             .map(MavenSettings::getActiveProfiles)
                             .map(MavenSettings.ActiveProfiles::getActiveProfiles)


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
At Maven resolution time, if a `MavenSettings` is provided both as part of the `ExecutionContext` and also as part of the `MavenResolutionResult` (created during LST build time), rather than let one override the other, we want to merge them.

## What's your motivation?
There are cases that require adding additional repositories for performance reasons.

## Anything in particular you'd like reviewers to focus on?
Making sure the merge logic is in the correct direction.

## Anyone you would like to review specifically?
@sambsnyd @jkschneider 

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
