### PR TITLE
Fix bug in handling default case in switch statement

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -350,7 +350,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 null,
                 null,
                 JContainer.build(
-                        node.getLabels().isEmpty() ? EMPTY : sourceBefore("case"),
+                        node.getLabels().isEmpty() || node.getLabels().getFirst() instanceof DefaultCaseLabelTree ?
+                                EMPTY : sourceBefore("case"),
                         node.getLabels().isEmpty() || node.getLabels().getFirst() instanceof DefaultCaseLabelTree ?
                                 List.of(JRightPadded.build(new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), skip("default"), null, null))) :
                                 convertAll(node.getLabels(), commaDelim, ignored -> node.getGuard() != null ? sourceBefore("when", '-') : EMPTY),

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -373,4 +373,30 @@ class JavaParserTest implements RewriteTest {
         assertThat(JavaParser.filterArtifacts("rewrite-java", classpath))
           .containsOnly(Paths.get("/.m2/repository/org/openrewrite/rewrite-java/8.41.1/rewrite-java-8.41.1.jar"));
     }
+
+    @Test
+    void multipleSwitchStatements() {
+        rewriteRun(
+          java(
+            """
+              class A {
+                  void test(int i) {
+                      switch (i) {
+                          case 1:
+                              System.out.println("1");
+                          default:
+                              throw new IllegalStateException("Unexpected value: " + i);
+                      }
+                      switch (i) {
+                          case 1:
+                              System.out.println("1");
+                          default:
+                              throw new IllegalStateException("Unexpected value: " + i);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
fixes: #4959 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
