### PR TITLE
Exclude parenthese determination from comments and string literals

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1340,8 +1340,8 @@ public class GroovyParserVisitor {
                         Delimiter delimiter = getDelimiter(cursor);
                         if (delimiter != null) {
                             // Get the string literal from the source, so escaping of newlines and the like works out of the box
-                            value = sourceSubstring(cursor + delimiter.start.length(), delimiter.end);
-                            text = delimiter.start + value + delimiter.end;
+                            value = sourceSubstring(cursor + delimiter.open.length(), delimiter.close);
+                            text = delimiter.open + value + delimiter.close;
                         }
                     }
                 } else if (expression.isNullExpression()) {
@@ -1596,7 +1596,7 @@ public class GroovyParserVisitor {
         public void visitGStringExpression(GStringExpression gstring) {
             Space fmt = whitespace();
             Delimiter delimiter = getDelimiter(cursor);
-            skip(delimiter.start); // Opening delim for GString
+            skip(delimiter.open);
 
             NavigableMap<LineColumn, org.codehaus.groovy.ast.expr.Expression> sortedByPosition = new TreeMap<>();
             for (ConstantExpression e : gstring.getStrings()) {
@@ -1627,7 +1627,7 @@ public class GroovyParserVisitor {
                     }
                 } else if (e instanceof ConstantExpression) {
                     // Get the string literal from the source, so escaping of newlines and the like works out of the box
-                    String value = sourceSubstring(cursor, delimiter.end);
+                    String value = sourceSubstring(cursor, delimiter.close);
                     // There could be a closer GString before the end of the closing delimiter, so shorten the string if needs be
                     int indexNextSign = source.indexOf("$", cursor);
                     if (indexNextSign != -1 && indexNextSign < (cursor + value.length())) {
@@ -1641,8 +1641,8 @@ public class GroovyParserVisitor {
                 }
             }
 
-            queue.add(new G.GString(randomId(), fmt, Markers.EMPTY, delimiter.start, strings, typeMapping.type(gstring.getType())));
-            skip(delimiter.end); // Closing delim for GString
+            queue.add(new G.GString(randomId(), fmt, Markers.EMPTY, delimiter.open, strings, typeMapping.type(gstring.getType())));
+            skip(delimiter.close);
         }
 
         @Override
@@ -2548,8 +2548,8 @@ public class GroovyParserVisitor {
                         count--;
                     }
                 }
-            } else if (delimiter.end.equals(source.substring(i, Math.min(i + delimiter.end.length(), source.length())))) {
-                i += delimiter.end.length() - 1; // skip the next chars for the rest of the delimiter
+            } else if (delimiter.close.equals(source.substring(i, Math.min(i + delimiter.close.length(), source.length())))) {
+                i += delimiter.close.length() - 1; // skip the next chars for the rest of the delimiter
                 delimiter = null;
             }
         }
@@ -2592,8 +2592,8 @@ public class GroovyParserVisitor {
         SINGLE_LINE_COMMENT("//", "\n"),
         MULTILINE_COMMENT("/*", "*/");
 
-        private final String start;
-        private final String end;
+        private final String open;
+        private final String close;
     }
 
     private TypeTree visitTypeTree(ClassNode classNode) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2550,7 +2550,7 @@ public class GroovyParserVisitor {
                 } else {
                     i += delimiter.open.length() - 1; // skip the next chars for the rest of the delimiter
                 }
-            } else if (delimiter.close.equals(source.substring(i, Math.min(i + delimiter.close.length(), source.length())))) {
+            } else if (source.startsWith(delimiter.close, i)) {
                 i += delimiter.close.length() - 1; // skip the next chars for the rest of the delimiter
                 delimiter = null;
             }
@@ -2559,24 +2559,23 @@ public class GroovyParserVisitor {
     }
 
     private @Nullable Delimiter getDelimiter(int cursor) {
-        String maybeDelimiter = source.substring(cursor, Math.min(cursor + 3, source.length()));
-        if (maybeDelimiter.startsWith("$/")) {
+        if (source.startsWith("$/", cursor)) {
             return DOLLAR_SLASHY_STRING;
-        } else if (maybeDelimiter.startsWith("\"\"\"")) {
+        } else if (source.startsWith("\"\"\"", cursor)) {
             return TRIPLE_DOUBLE_QUOTE;
-        } else if (maybeDelimiter.startsWith("'''")) {
+        } else if (source.startsWith("'''", cursor)) {
             return TRIPLE_SINGLE_QUOTE;
-        } else if (maybeDelimiter.startsWith("~/")) {
+        } else if (source.startsWith("~/", cursor)) {
             return PATTERN_OPERATOR;
-        } else if (maybeDelimiter.startsWith("//")) {
+        } else if (source.startsWith("//", cursor)) {
             return SINGLE_LINE_COMMENT;
-        } else if (maybeDelimiter.startsWith("/*")) {
+        } else if (source.startsWith("/*", cursor)) {
             return MULTILINE_COMMENT;
-        } else if (maybeDelimiter.startsWith("/")) {
+        } else if (source.startsWith("/", cursor)) {
             return SLASHY;
-        } else if (maybeDelimiter.startsWith("\"")) {
+        } else if (source.startsWith("\"", cursor)) {
             return DOUBLE_QUOTE;
-        } else if (maybeDelimiter.startsWith("'")) {
+        } else if (source.startsWith("'", cursor)) {
             return SINGLE_QUOTE;
         }
         return null;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2537,13 +2537,30 @@ public class GroovyParserVisitor {
         int start = sourceLineNumberOffsets[startingLineNumber - 1] + startingColumn - 1;
         int end = sourceLineNumberOffsets[endingLineNumber - 1] + endingColumn - 1;
 
-        // Determine level of parentheses by going through the source
+        // Determine level of parentheses by going through the source, don't count parentheses in comments
         int count = 0;
+        boolean inSingleLineComment = false;
+        boolean inMultilineComment = false;
         for (int i = start; i < end; i++) {
-            if (source.charAt(i) == '(') {
-                count++;
-            } else if (source.charAt(i) == ')') {
-                count--;
+            if (source.charAt(i) == '/' && (end - 1) != i && source.charAt(i + 1) == '/') {
+                inSingleLineComment = true;
+            }
+            if (source.charAt(i) == '/' && (end - 1) != i && source.charAt(i + 1) == '*') {
+                inMultilineComment = true;
+            }
+            if (inSingleLineComment && source.charAt(i) == '\n') {
+                inSingleLineComment = false;
+            }
+            if (inMultilineComment && source.charAt(i) == '*' && (end - 1) != i && source.charAt(i + 1) == '/') {
+                inMultilineComment = false;
+            }
+
+            if (!inSingleLineComment && !inMultilineComment) {
+                if (source.charAt(i) == '(') {
+                    count++;
+                } else if (source.charAt(i) == ')') {
+                    count--;
+                }
             }
         }
         return Math.max(count, 0);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -32,6 +32,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.FileAttributes;
+import org.openrewrite.groovy.internal.Delimiter;
 import org.openrewrite.groovy.marker.*;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.EncodingDetectingInputStream;
@@ -63,7 +64,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.groovy.GroovyParserVisitor.Delimiter.*;
+import static org.openrewrite.groovy.internal.Delimiter.*;
 import static org.openrewrite.internal.StringUtils.indexOfNextNonWhitespace;
 import static org.openrewrite.java.tree.Space.EMPTY;
 import static org.openrewrite.java.tree.Space.format;
@@ -2562,9 +2563,9 @@ public class GroovyParserVisitor {
         if (source.startsWith("$/", cursor)) {
             return DOLLAR_SLASHY_STRING;
         } else if (source.startsWith("\"\"\"", cursor)) {
-            return TRIPLE_DOUBLE_QUOTE;
+            return TRIPLE_DOUBLE_QUOTE_STRING;
         } else if (source.startsWith("'''", cursor)) {
-            return TRIPLE_SINGLE_QUOTE;
+            return TRIPLE_SINGLE_QUOTE_STRING;
         } else if (source.startsWith("~/", cursor)) {
             return PATTERN_OPERATOR;
         } else if (source.startsWith("//", cursor)) {
@@ -2572,29 +2573,13 @@ public class GroovyParserVisitor {
         } else if (source.startsWith("/*", cursor)) {
             return MULTILINE_COMMENT;
         } else if (source.startsWith("/", cursor)) {
-            return SLASHY;
+            return SLASHY_STRING;
         } else if (source.startsWith("\"", cursor)) {
-            return DOUBLE_QUOTE;
+            return DOUBLE_QUOTE_STRING;
         } else if (source.startsWith("'", cursor)) {
-            return SINGLE_QUOTE;
+            return SINGLE_QUOTE_STRING;
         }
         return null;
-    }
-
-    @RequiredArgsConstructor
-    enum Delimiter {
-        SINGLE_QUOTE("'", "'"),
-        DOUBLE_QUOTE("\"", "\""),
-        TRIPLE_SINGLE_QUOTE("'''", "'''"),
-        TRIPLE_DOUBLE_QUOTE("\"\"\"", "\"\"\""),
-        SLASHY("/", "/"),
-        DOLLAR_SLASHY_STRING("$/", "/$"),
-        PATTERN_OPERATOR("~/", "/"),
-        SINGLE_LINE_COMMENT("//", "\n"),
-        MULTILINE_COMMENT("/*", "*/");
-
-        private final String open;
-        private final String close;
     }
 
     private TypeTree visitTypeTree(ClassNode classNode) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2547,6 +2547,8 @@ public class GroovyParserVisitor {
                     } else if (source.charAt(i) == ')') {
                         count--;
                     }
+                } else {
+                    i += delimiter.open.length() - 1; // skip the next chars for the rest of the delimiter
                 }
             } else if (delimiter.close.equals(source.substring(i, Math.min(i + delimiter.close.length(), source.length())))) {
                 i += delimiter.close.length() - 1; // skip the next chars for the rest of the delimiter

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1595,8 +1595,8 @@ public class GroovyParserVisitor {
         @Override
         public void visitGStringExpression(GStringExpression gstring) {
             Space fmt = whitespace();
-            String delimiter = getDelimiter(cursor).start;
-            skip(delimiter); // Opening delim for GString
+            Delimiter delimiter = getDelimiter(cursor);
+            skip(delimiter.start); // Opening delim for GString
 
             NavigableMap<LineColumn, org.codehaus.groovy.ast.expr.Expression> sortedByPosition = new TreeMap<>();
             for (ConstantExpression e : gstring.getStrings()) {
@@ -1627,7 +1627,7 @@ public class GroovyParserVisitor {
                     }
                 } else if (e instanceof ConstantExpression) {
                     // Get the string literal from the source, so escaping of newlines and the like works out of the box
-                    String value = sourceSubstring(cursor, ("~/".equals(delimiter) ? "/" : delimiter));
+                    String value = sourceSubstring(cursor, delimiter.end);
                     // There could be a closer GString before the end of the closing delimiter, so shorten the string if needs be
                     int indexNextSign = source.indexOf("$", cursor);
                     if (indexNextSign != -1 && indexNextSign < (cursor + value.length())) {
@@ -1641,8 +1641,8 @@ public class GroovyParserVisitor {
                 }
             }
 
-            queue.add(new G.GString(randomId(), fmt, Markers.EMPTY, delimiter, strings, typeMapping.type(gstring.getType())));
-            skip(delimiter); // Closing delim for GString
+            queue.add(new G.GString(randomId(), fmt, Markers.EMPTY, delimiter.start, strings, typeMapping.type(gstring.getType())));
+            skip(delimiter.end); // Closing delim for GString
         }
 
         @Override

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -19,6 +19,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
+import org.openrewrite.groovy.internal.Delimiter;
 import org.openrewrite.groovy.marker.*;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.groovy.tree.GContainer;
@@ -33,6 +34,8 @@ import org.openrewrite.marker.Markers;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
+
+import static org.openrewrite.groovy.internal.Delimiter.DOUBLE_QUOTE_STRING;
 
 public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
     private final GroovyJavaPrinter delegate = new GroovyJavaPrinter();
@@ -73,18 +76,14 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
     @Override
     public J visitGString(G.GString gString, PrintOutputCapture<P> p) {
         beforeSyntax(gString, GSpace.Location.GSTRING, p);
-        String delimiter = gString.getDelimiter();
+        Delimiter delimiter = Delimiter.of(gString.getDelimiter());
         if (delimiter == null) {
             // For backwards compatibility with ASTs before we collected this field
-            delimiter = "\"";
+            delimiter = DOUBLE_QUOTE_STRING;
         }
-        p.append(delimiter);
+        p.append(delimiter.open);
         visit(gString.getStrings(), p);
-        if ("$/".equals(delimiter)) {
-            p.append("/$");
-        } else {
-            p.append(delimiter);
-        }
+        p.append(delimiter.close);
         afterSyntax(gString, p);
         return gString;
     }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.groovy.internal;
 
 import lombok.RequiredArgsConstructor;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
@@ -1,0 +1,29 @@
+package org.openrewrite.groovy.internal;
+
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@RequiredArgsConstructor
+public enum Delimiter {
+    SINGLE_QUOTE_STRING("'", "'"),
+    DOUBLE_QUOTE_STRING("\"", "\""),
+    TRIPLE_SINGLE_QUOTE_STRING("'''", "'''"),
+    TRIPLE_DOUBLE_QUOTE_STRING("\"\"\"", "\"\"\""),
+    SLASHY_STRING("/", "/"),
+    DOLLAR_SLASHY_STRING("$/", "/$"),
+    PATTERN_OPERATOR("~/", "/"),
+    SINGLE_LINE_COMMENT("//", "\n"),
+    MULTILINE_COMMENT("/*", "*/");
+
+    public final String open;
+    public final String close;
+
+    public static @Nullable Delimiter of(String open) {
+        for (Delimiter delim : Delimiter.values()) {
+            if (delim.open.equals(open)) {
+                return delim;
+            }
+        }
+        return null;
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -313,6 +313,11 @@ class LiteralTest implements RewriteTest {
             """
               def a = (("-"))
               """
+          ),
+          groovy(
+            """
+              from(":-)").via(''':-|(''').via(":-)").to(':-(')
+              """
           )
         );
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -192,6 +192,17 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void gStringWithStringLiteralsWithParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              "Hello ${from(":-)").via(''':-|(''').via(":-)").to(':-(')}!"
+              """
+          )
+        );
+    }
+
+    @Test
     void mapLiteral() {
         rewriteRun(
           groovy(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -506,4 +506,19 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void insideFourParenthesesAndEntersWithCommentWithParentheses() {
+        rewriteRun(
+          groovy(
+            """
+              ((/* comment :-) ((
+              */((
+                // :-((
+                something(a)
+              ))))
+              """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -515,7 +515,7 @@ class MethodInvocationTest implements RewriteTest {
               ((/* comment :-) ((
               */((
                 // :-((
-                something(a)
+                /*)*/something(a)
               ))))
               """
           )


### PR DESCRIPTION
## What's changed?
Exclude parentheses handling for comments and string literals.

## What's your motivation?
Improvement to
- https://github.com/openrewrite/rewrite/pull/4951

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
