### PR TITLE
Add failing test for maven settings deserialization

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenSettingsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.maven;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
@@ -868,9 +869,8 @@ class MavenSettingsTest {
     void failingDeserialization() throws JsonProcessingException {
         //language=xml
         String xml = """
-          <settings>
-          </settings>
+          <settings></settings>
           """;
-        MavenSettings settings = MavenXmlMapper.writeMapper().readValue(xml, MavenSettings.class);
+        MavenSettings settings = MavenXmlMapper.writeMapper().registerModule(new ParameterNamesModule()).readValue(xml, MavenSettings.class);
     }
 }


### PR DESCRIPTION
The exception:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Invalid type definition for type `org.openrewrite.maven.MavenSettings`: Argument #0 of constructor [constructor for `org.openrewrite.maven.MavenSettings` (5 args), annotations: {interface com.fasterxml.jackson.annotation.JsonCreator=@com.fasterxml.jackson.annotation.JsonCreator(mode=DEFAULT)} has no property name (and is not Injectable): can not use as property-based Creator
 at [Source: (StringReader); line: 1, column: 1]

	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:62)
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadTypeDefinition(DeserializationContext.java:1865)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._validateNamedPropertyParameter(BasicDeserializerFactory.java:1165)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._addExplicitPropertyCreator(BasicDeserializerFactory.java:882)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._addExplicitAnyCreator(BasicDeserializerFactory.java:929)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._addExplicitConstructorCreators(BasicDeserializerFactory.java:466)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory._constructDefaultValueInstantiator(BasicDeserializerFactory.java:293)
	at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory.findValueInstantiator(BasicDeserializerFactory.java:222)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.buildBeanDeserializer(BeanDeserializerFactory.java:262)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:151)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer2(DeserializerCache.java:450)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:394)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:295)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:273)
	at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:173)
	at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:669)
	at com.fasterxml.jackson.databind.ObjectMapper._findRootDeserializer(ObjectMapper.java:5036)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4906)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3848)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3816)
	at org.openrewrite.maven.MavenSettingsTest.serialization(MavenSettingsTest.java:875)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```