### PR TITLE
Using withToolingApiUsingModulesCaching in rewrite-gradle tests

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.groovy.Assertions.srcMainGroovy;
 import static org.openrewrite.java.Assertions.java;
@@ -48,7 +48,7 @@ import static org.openrewrite.properties.Assertions.properties;
 class AddDependencyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api", "guava", "jackson-databind", "jackson-core", "lombok"));
     }
 
@@ -1124,7 +1124,7 @@ class AddDependencyTest implements RewriteTest {
     void addDynamicVersionDependency() {
         rewriteRun(
           spec -> spec
-            .beforeRecipe(withToolingApi())
+            .beforeRecipe(withToolingApiUsingModulesCaching())
             .recipe(addDependency("org.openrewrite:rewrite-core:7.39.X", "java.util.Date", "implementation")),
           mavenProject("project",
             srcMainGroovy(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddJUnitPlatformLauncherTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddJUnitPlatformLauncherTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.java.Assertions.*;
 
 class AddJUnitPlatformLauncherTest implements RewriteTest {
@@ -31,7 +31,7 @@ class AddJUnitPlatformLauncherTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .beforeRecipe(withToolingApi())
+          .beforeRecipe(withToolingApiUsingModulesCaching())
           .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api"))
           .recipeFromResources("org.openrewrite.gradle.AddJUnitPlatformLauncher");
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyArtifactIdTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyArtifactIdTest.java
@@ -26,13 +26,13 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangeDependencyArtifactIdTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyClassifierTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyClassifierTest.java
@@ -23,13 +23,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangeDependencyClassifierTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyConfigurationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyConfigurationTest.java
@@ -24,14 +24,14 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.java.Assertions.mavenProject;
 
 class ChangeDependencyConfigurationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyExtensionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyExtensionTest.java
@@ -23,13 +23,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangeDependencyExtensionTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyGroupIdTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyGroupIdTest.java
@@ -26,13 +26,13 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangeDependencyGroupIdTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -21,12 +21,12 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangeDependencyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseMapNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseMapNotationTest.java
@@ -22,13 +22,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class DependencyUseMapNotationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new DependencyUseMapNotation());
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -21,13 +21,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class DependencyUseStringNotationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new DependencyUseStringNotation());
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -28,14 +28,14 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.java.Assertions.mavenProject;
 
 class RemoveDependencyTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new RemoveDependency("org.springframework.boot", "spring-boot*", null));
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
@@ -21,12 +21,12 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new RemoveRedundantDependencyVersions(null, null, null, null));
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.gradle.util.GradleWrapper.*;
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.test.SourceSpecs.*;
@@ -67,7 +67,7 @@ class UpdateGradleWrapperTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UpdateGradleWrapper("7.4.2", null, null, null, null))
-          .beforeRecipe(withToolingApi());
+          .beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @Test

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -31,14 +31,14 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.properties.Assertions.properties;
 
 class UpgradeDependencyVersionTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "30.x", "-jre"));
     }
 
@@ -102,7 +102,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Test
     void mockitoTestImplementation() {
         rewriteRun(recipeSpec -> {
-              recipeSpec.beforeRecipe(withToolingApi())
+              recipeSpec.beforeRecipe(withToolingApiUsingModulesCaching())
                 .recipe(new UpgradeDependencyVersion("org.mockito", "*", "4.11.0", null));
           },
           buildGradle(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -24,14 +24,14 @@ import org.openrewrite.test.RewriteTest;
 import java.util.List;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .beforeRecipe(withToolingApi())
+          .beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new UpgradeTransitiveDependencyVersion(
             "com.fasterxml*", "jackson-core", "2.12.5", null, "CVE-2024-BAD", null));
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
@@ -23,12 +23,12 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class AddBuildPluginTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePluginTest.java
@@ -35,14 +35,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.test.SourceSpecs.dir;
 
 class AddDevelocityGradlePluginTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new AddDevelocityGradlePlugin("3.x", null, null, null, null, null));
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddSettingsPluginTest.java
@@ -28,12 +28,12 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class AddSettingsPluginTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null, null, null));
     }
 
@@ -131,7 +131,7 @@ class AddSettingsPluginTest implements RewriteTest {
     @Test
     void addPluginApplyFalse() {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi())
+          spec -> spec.beforeRecipe(withToolingApiUsingModulesCaching())
             .recipe(new AddSettingsPlugin("com.gradle.enterprise", "3.11.x", null, false, null)),
           settingsGradle(
             "",

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginTest.java
@@ -31,12 +31,12 @@ import java.util.regex.Pattern;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangePluginTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new ChangePlugin("org.openrewrite.rewrite", "io.moderne.rewrite", "0.x"));
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/ChangePluginVersionTest.java
@@ -21,13 +21,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class ChangePluginVersionTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocityTest.java
@@ -22,13 +22,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class MigrateGradleEnterpriseToDevelocityTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new MigrateGradleEnterpriseToDevelocity("3.17.x"))
-          .beforeRecipe(withToolingApi());
+          .beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @Test

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveDevelocityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveDevelocityTest.java
@@ -21,13 +21,13 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 
 class RemoveDevelocityTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .beforeRecipe(withToolingApi())
+          .beforeRecipe(withToolingApiUsingModulesCaching())
           .recipeFromResource("/META-INF/rewrite/gradle.yml", "org.openrewrite.gradle.plugins.RemoveDevelocity");
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -29,13 +29,13 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.properties.Assertions.properties;
 
 class UpgradePluginVersionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi());
+        spec.beforeRecipe(withToolingApiUsingModulesCaching());
     }
 
     @DocumentExample("Upgrading a build plugin")

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -23,14 +23,14 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 class DependencyInsightTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.beforeRecipe(withToolingApi())
+        spec.beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(new DependencyInsight("com.google.guava", "failureaccess", null, null));
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindGradleProjectTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindGradleProjectTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.test.SourceSpecs.text;
 
@@ -38,7 +38,7 @@ class FindGradleProjectTest implements RewriteTest {
     @EnumSource(FindGradleProject.SearchCriteria.class)
     void isGradleGroovyProject(FindGradleProject.SearchCriteria criteria) {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi())
+          spec -> spec.beforeRecipe(withToolingApiUsingModulesCaching())
             .recipe(new FindGradleProject(criteria)),
           buildGradle(
             """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindPluginsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindPluginsTest.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.settingsGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.test.SourceSpecs.text;
 
@@ -41,7 +41,7 @@ class FindPluginsTest implements RewriteTest {
     @Test
     void findPlugin() {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
+          spec -> spec.beforeRecipe(withToolingApiUsingModulesCaching()),
           buildGradle(
             """
               plugins {
@@ -68,7 +68,7 @@ class FindPluginsTest implements RewriteTest {
     @Test
     void settingsResolutionStrategy() {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
+          spec -> spec.beforeRecipe(withToolingApiUsingModulesCaching()),
           settingsGradle(
               """
             pluginManagement {
@@ -107,7 +107,7 @@ class FindPluginsTest implements RewriteTest {
     @Test
     void property() {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
+          spec -> spec.beforeRecipe(withToolingApiUsingModulesCaching()),
           properties("rewritePluginVersion=6.22.0", spec -> spec.path("gradle.properties")),
           buildGradle(
             """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependencyTest.java
@@ -22,14 +22,14 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApiUsingModulesCaching;
 import static org.openrewrite.gradle.trait.Traits.gradleDependency;
 
 class GradleDependencyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .beforeRecipe(withToolingApi())
+          .beforeRecipe(withToolingApiUsingModulesCaching())
           .recipe(RewriteTest.toRecipe(() -> gradleDependency().asVisitor(dep ->
             SearchResult.found(dep.getTree(), dep.getResolvedDependency().getGav().toString()))));
     }


### PR DESCRIPTION
## What's changed?
Using `withToolingApiUsingModulesCaching` added in https://github.com/openrewrite/rewrite-gradle-tooling-model/pull/33.
Following the advice by @shanman190 at: https://github.com/openrewrite/rewrite/pull/4965#discussion_r1934073362

## What's your motivation?
To speed up CI in this project, specifically the duration of `rewrite-gradle` tests.

EDIT: Adding some non-scientific measurements:

| What | Without this change | With this change |
|------|--------------------|-----------------|
| `./gradlew rewrite-gradle:test` on my laptop | [13m 18s](https://ge.openrewrite.org/s/cvtnsj4koaljw) | [2m 6s](https://ge.openrewrite.org/s/xouyjhlxlyh7g) |
| CI on some other PR touching `rewrite-gradle` only | some PR a few days ago: [9m 43s](https://ge.openrewrite.org/s/27wxickd3r3cw) | this PR: [8m 21s](https://ge.openrewrite.org/s/xyk2hh2c6iwf2) |
| CI on a PR touching `rewrite-core` | [19m 17s](https://ge.openrewrite.org/s/ixitf4ctzeuvs) | [17m 59s](https://ge.openrewrite.org/s/rirclc3feblm4) |

(So it seems like the biggest win is for people living far away from Maven Central servers in terms of network latency)