### PR TITLE
Preserve spacing when merging flow style YAML

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/MinimumViableSpacingVisitor.java
@@ -44,6 +44,10 @@ public class MinimumViableSpacingVisitor<P> extends YamlIsoVisitor<P> {
                     return e;
                 }
             }
+
+        if (" ".equals(e.getPrefix())) {
+            return e;
+        }
             return e.withPrefix("\n");
         }
         return e;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/MinimumViableSpacingVisitor.java
@@ -45,9 +45,9 @@ public class MinimumViableSpacingVisitor<P> extends YamlIsoVisitor<P> {
                 }
             }
 
-        if (" ".equals(e.getPrefix())) {
-            return e;
-        }
+            if (" ".equals(e.getPrefix())) {
+                return e;
+            }
             return e.withPrefix("\n");
         }
         return e;

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1688,4 +1688,101 @@ class MergeYamlTest implements RewriteTest {
               """)
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4958")
+    @Test
+    void preserveSpacingWhenMergingFlowStyle() {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$.jobs[?(@.name=='test')].plan[?(@.task=='sonar')]",
+              // language=yaml
+              "vars: { version: 10.3 }",
+              false,
+              null,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              jobs:
+              - name: test
+                plan:
+                - task: sonar
+              """,
+            // language=yaml
+            """
+              jobs:
+              - name: test
+                plan:
+                - task: sonar
+                  vars: { version: 10.3 }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4958")
+    @Test
+    void preserveSpacingWhenMergingFlowStyleAttempt2() {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$.jobs[?(@.name=='test')].plan[?(@.task=='sonar')]",
+              // language=yaml
+              "vars: { mapping: { version: 10.3 } }",
+              false,
+              null,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              jobs:
+              - name: test
+                plan:
+                - task: sonar
+              """,
+            // language=yaml
+            """
+              jobs:
+              - name: test
+                plan:
+                - task: sonar
+                  vars: { mapping: { version: 10.3 } }
+              """
+          ));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4958")
+    @Test
+    void preserveSpacingWhenMergingFlowStyleAttempt3() {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$.jobs[?(@.name=='test')].plan[?(@.task=='sonar')]",
+              // language=yaml
+              """
+                vars: {
+                  version: 10.3 }
+                """,
+              false,
+              null,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              jobs:
+              - name: test
+                plan:
+                - task: sonar
+              """,
+            // language=yaml
+            """
+              jobs:
+              - name: test
+                plan:
+                - task: sonar
+                  vars: {
+                    version: 10.3 }
+              """
+          ));
+    }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1685,7 +1685,8 @@ class MergeYamlTest implements RewriteTest {
                   script: >-
                     #!/bin/bash
                     echo "hello"
-              """)
+              """
+          )
         );
     }
 
@@ -1717,12 +1718,13 @@ class MergeYamlTest implements RewriteTest {
                 - task: sonar
                   vars: { version: 10.3 }
               """
-          ));
+          )
+        );
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/4958")
     @Test
-    void preserveSpacingWhenMergingFlowStyleAttempt2() {
+    void preserveSpacingWhenMergingFlowStyleNested() {
         rewriteRun(spec -> spec
             .recipe(new MergeYaml(//language=jsonpath
               "$.jobs[?(@.name=='test')].plan[?(@.task=='sonar')]",
@@ -1748,12 +1750,13 @@ class MergeYamlTest implements RewriteTest {
                 - task: sonar
                   vars: { mapping: { version: 10.3 } }
               """
-          ));
+          )
+        );
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/4958")
     @Test
-    void preserveSpacingWhenMergingFlowStyleAttempt3() {
+    void preserveSpacingWhenMergingFlowStyleWithNewline() {
         rewriteRun(spec -> spec
             .recipe(new MergeYaml(//language=jsonpath
               "$.jobs[?(@.name=='test')].plan[?(@.task=='sonar')]",
@@ -1783,6 +1786,7 @@ class MergeYamlTest implements RewriteTest {
                   vars: {
                     version: 10.3 }
               """
-          ));
+          )
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fixing the unwanted carriage return when merging yaml values that are written in flow style

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- Resolves #4958

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
