### PR TITLE
Support duplicate static star imports for Groovy

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2786,7 +2786,7 @@ public class GroovyParserVisitor {
     /**
      * Duplicate imports do work out of the box for import, star-import and static-import.
      * For static-star-import, this does work though.
-     * The groovy compiler does only save the last duplicate import instead of all, so parse all static star imports by hand.
+     * The groovy compiler does only memoize the last duplicate import instead of all, so retrieve all static star imports by hand.
      */
     private List<ImportNode> getStaticStarImports(ModuleNode ast) {
         List<ImportNode> completeStaticStarImports = new ArrayList<>();
@@ -2822,8 +2822,7 @@ public class GroovyParserVisitor {
                     }
 
                     if (packageEnd < line.length() && line.charAt(packageEnd) == '*') {
-                        ImportNode orginalImportNode = staticStarImports.get(line.substring(packageBegin, packageEnd - 1));
-                        ImportNode node = new ImportNode(orginalImportNode.getType());
+                        ImportNode node = new ImportNode(staticStarImports.get(line.substring(packageBegin, packageEnd - 1)).getType());
                         node.setLineNumber(i + 1);
                         node.setColumnNumber(importIndex + 1);
                         completeStaticStarImports.add(node);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2245,11 +2245,11 @@ public class GroovyParserVisitor {
         } else if (node instanceof ImportNode) {
             ImportNode importNode = (ImportNode) node;
             Space prefix = sourceBefore("import");
-            JLeftPadded<Boolean> static_;
+            JLeftPadded<Boolean> statik;
             if (importNode.isStatic()) {
-                static_ = padLeft(sourceBefore("static"), true);
+                statik = padLeft(sourceBefore("static"), true);
             } else {
-                static_ = padLeft(EMPTY, false);
+                statik = padLeft(EMPTY, false);
             }
             String packageName = importNode.getPackageName();
             J.FieldAccess qualid;
@@ -2276,7 +2276,7 @@ public class GroovyParserVisitor {
                 alias = padLeft(sourceBefore("as"), new J.Identifier(randomId(), sourceBefore(simpleName), Markers.EMPTY, emptyList(), simpleName, null, null));
             }
 
-            J.Import anImport = new J.Import(randomId(), prefix, Markers.EMPTY, static_, qualid, alias);
+            J.Import anImport = new J.Import(randomId(), prefix, Markers.EMPTY, statik, qualid, alias);
             return maybeSemicolon(anImport);
         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -162,7 +162,7 @@ public class GroovyParserVisitor {
         }
 
         // Duplicate imports do work out of the box for import, star-import and static-import.
-        // For static-star-import, this does work though.
+        // For static-star-import, this does not work though.
         // The groovy compiler does only save the last duplicate import instead of all, so parse all static star imports by hand.
         Map<String, ImportNode> staticStarImports = ast.getStaticStarImports();
         if (!staticStarImports.isEmpty()) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2228,9 +2228,7 @@ public class GroovyParserVisitor {
             J.FieldAccess qualid = TypeTree.build(name()).withPrefix(space);
             JLeftPadded<J.Identifier> alias = null;
             if (sourceStartsWith("as")) {
-                Space beforeAs = sourceBefore("as");
-                Space prefixIdentifier = whitespace();
-                alias = padLeft(beforeAs, new J.Identifier(randomId(), prefixIdentifier, Markers.EMPTY, emptyList(), name(), null, null));
+                alias = padLeft(sourceBefore("as"), new J.Identifier(randomId(), whitespace(), Markers.EMPTY, emptyList(), name(), null, null));
             }
             return maybeSemicolon(new J.Import(randomId(), importPrefix, Markers.EMPTY, statik, qualid, alias));
         }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -160,9 +160,9 @@ public class GroovyParserVisitor {
             sortedByPosition.computeIfAbsent(pos(anImport), i -> new ArrayList<>()).add(anImport);
         }
 
-        // Duplicate imports do work out of the box for import/star-import/static-import.
-        // For static-star-import, the groovy compiler does only save the last duplicate import instead of all,
-        // so restore all static star imports by hand.
+        // Duplicate imports do work out of the box for import, star-import and static-import.
+        // For static-star-import, this does work though.
+        // The groovy compiler does only save the last duplicate import instead of all, so parse all static star imports by hand.
         Map<String, ImportNode> staticStarImports = ast.getStaticStarImports();
         if (!staticStarImports.isEmpty()) {
             // Take source code until last static star import for performance reasons

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -160,10 +160,7 @@ public class GroovyParserVisitor {
         for (ImportNode anImport : ast.getStaticImports().values()) {
             sortedByPosition.computeIfAbsent(pos(anImport), i -> new ArrayList<>()).add(anImport);
         }
-
-        // Duplicate imports do work out of the box for import, star-import and static-import.
-        // For static-star-import, this does not work though.
-        // The groovy compiler does only save the last duplicate import instead of all, so parse all static star imports by hand.
+        // The groovy compiler does not memoize duplicate static star imports, thus walk through the source code and create all ImportNodes by hand
         Map<String, ImportNode> staticStarImports = ast.getStaticStarImports();
         if (!staticStarImports.isEmpty()) {
             // Take source code until last static star import for performance reasons
@@ -2265,40 +2262,17 @@ public class GroovyParserVisitor {
             return JRightPadded.build(classVisitor.pollQueue());
         } else if (node instanceof ImportNode) {
             ImportNode importNode = (ImportNode) node;
-            Space prefix = sourceBefore("import");
-            JLeftPadded<Boolean> statik;
-            if (importNode.isStatic()) {
-                statik = padLeft(sourceBefore("static"), true);
-            } else {
-                statik = padLeft(EMPTY, false);
-            }
-            String packageName = importNode.getPackageName();
-            J.FieldAccess qualid;
-            if (packageName == null) {
-                String type = importNode.getType().getName().replace('$', '.');
-                if (importNode.isStar()) {
-                    type += ".*";
-                } else if (importNode.getFieldName() != null) {
-                    type += "." + importNode.getFieldName();
-                }
-                Space space = sourceBefore(type);
-                qualid = TypeTree.build(type).withPrefix(space);
-            } else {
-                if (importNode.isStar()) {
-                    packageName += "*";
-                }
-                qualid = TypeTree.build(packageName).withPrefix(sourceBefore(packageName));
-            }
-
+            Space importPrefix = sourceBefore("import");
+            JLeftPadded<Boolean> statik = importNode.isStatic() ? padLeft(sourceBefore("static"), true) : padLeft(EMPTY, false);
+            Space space = whitespace();
+            J.FieldAccess qualid = TypeTree.build(name()).withPrefix(space);
             JLeftPadded<J.Identifier> alias = null;
-            int endOfWhitespace = indexOfNextNonWhitespace(cursor, source);
-            if (endOfWhitespace + 2 <= source.length() && "as".equals(source.substring(endOfWhitespace, endOfWhitespace + 2))) {
-                String simpleName = importNode.getAlias();
-                alias = padLeft(sourceBefore("as"), new J.Identifier(randomId(), sourceBefore(simpleName), Markers.EMPTY, emptyList(), simpleName, null, null));
+            if (sourceStartsWith("as")) {
+                Space beforeAs = sourceBefore("as");
+                Space prefixIdentifier = whitespace();
+                alias = padLeft(beforeAs, new J.Identifier(randomId(), prefixIdentifier, Markers.EMPTY, emptyList(), name(), null, null));
             }
-
-            J.Import anImport = new J.Import(randomId(), prefix, Markers.EMPTY, statik, qualid, alias);
-            return maybeSemicolon(anImport);
+            return maybeSemicolon(new J.Import(randomId(), importPrefix, Markers.EMPTY, statik, qualid, alias));
         }
 
         RewriteGroovyVisitor groovyVisitor = new RewriteGroovyVisitor(node, new RewriteGroovyClassVisitor(unit));

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -174,14 +174,14 @@ public class GroovyParserVisitor {
 
             // Create a node for each `import static`
             String[] lines = importSource.split("\n");
-            Pattern pattern = Pattern.compile("\\bimport\\s+static\\s+([a-zA-Z_][\\w.]*)\\.\\*");
+            Pattern pattern = Pattern.compile("import\\s+static\\s+([\\w.]*)\\.\\*");
             for (int i = 0; i < lines.length; i++) {
                 Matcher matcher = pattern.matcher(lines[i]);
                 while (matcher.find()) {
-                    ImportNode anImportCopy = new ImportNode(staticStarImports.get(matcher.group(1)).getType());
-                    anImportCopy.setLineNumber(i + 1);
-                    anImportCopy.setColumnNumber(matcher.start() + 1);
-                    sortedByPosition.computeIfAbsent(pos(anImportCopy), ii -> new ArrayList<>()).add(anImportCopy);
+                    ImportNode node = new ImportNode(staticStarImports.get(matcher.group(1)).getType());
+                    node.setLineNumber(i + 1);
+                    node.setColumnNumber(matcher.start() + 1);
+                    sortedByPosition.computeIfAbsent(pos(node), ii -> new ArrayList<>()).add(node);
                 }
             }
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -57,34 +57,10 @@ class ImportTest implements RewriteTest {
     }
 
     @Test
-    void duplicateStarImport() {
-        rewriteRun(
-          groovy(
-            """
-              import java.util.*
-              import java.util.*
-              """
-          )
-        );
-    }
-
-    @Test
     void staticImport() {
         rewriteRun(
           groovy(
             """
-              import static java.util.Collections.singletonList
-              """
-          )
-        );
-    }
-
-    @Test
-    void duplicateStaticImport() {
-        rewriteRun(
-          groovy(
-            """
-              import static java.util.Collections.singletonList
               import static java.util.Collections.singletonList
               """
           )
@@ -97,21 +73,6 @@ class ImportTest implements RewriteTest {
           groovy(
             """
               import static java.util.Collections.*
-              """
-          )
-        );
-    }
-
-    @Test
-    void duplicateStaticStarImport() {
-        rewriteRun(
-          groovy(
-            """
-                    import static      java.util.Collections.*    ;     import               static      java.util.Collections.*
-              import java.util.Collections.*  ; import static java.util.Collections.*
-              import java.util.Collections.*
-              import static java.util.Collections.*;import static java.util.Collections.*
-              import java.util.Collections.*
               """
           )
         );
@@ -137,6 +98,23 @@ class ImportTest implements RewriteTest {
               import static java.util.Collections.singletonList as listOf
               """,
             spec -> spec.afterRecipe(cu -> assertThat(cu.getEof()).isEqualTo(Space.EMPTY))
+          )
+        );
+    }
+
+    @Test
+    void duplicateImports() {
+        rewriteRun(
+          groovy(
+            """
+                    import static      java.util.Collections.*    ;     import               static      java.util.Collections.*
+              import java.util.Collections.*  ; import static java.util.Collections.*
+              import java.util.Collections.*
+              import static java.util.Collections.singletonList as listOf
+              import static java.util.Collections.singletonList as listOf
+              import static java.util.Collections.singletonList;import static java.util.Collections.*
+              import java.util.Collections.*
+              """
           )
         );
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -107,10 +107,11 @@ class ImportTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              import static java.util.Collections.*
-              import java.util.*
-              import java.util.*
-              import static java.util.Collections.*
+                    import static      java.util.Collections.*    ;     import               static      java.util.Collections.*
+              import java.util.Collections.*
+              import java.util.Collections.*
+              import static java.util.Collections.*;import static java.util.Collections.*
+              import java.util.Collections.*
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -35,10 +35,33 @@ class ImportTest implements RewriteTest {
     }
 
     @Test
+    void multipleImportsOnOneLine() {
+        rewriteRun(
+          groovy(
+            """
+              import java.util.List;import java.util.Set
+              """
+          )
+        );
+    }
+
+    @Test
     void starImport() {
         rewriteRun(
           groovy(
             """
+              import java.util.*
+              """
+          )
+        );
+    }
+
+    @Test
+    void duplicateStarImport() {
+        rewriteRun(
+          groovy(
+            """
+              import java.util.*
               import java.util.*
               """
           )
@@ -57,10 +80,36 @@ class ImportTest implements RewriteTest {
     }
 
     @Test
+    void duplicateStaticImport() {
+        rewriteRun(
+          groovy(
+            """
+              import static java.util.Collections.singletonList
+              import static java.util.Collections.singletonList
+              """
+          )
+        );
+    }
+
+    @Test
     void staticStarImport() {
         rewriteRun(
           groovy(
             """
+              import static java.util.Collections.*
+              """
+          )
+        );
+    }
+
+    @Test
+    void duplicateStaticStarImport() {
+        rewriteRun(
+          groovy(
+            """
+              import static java.util.Collections.*
+              import java.util.*
+              import java.util.*
               import static java.util.Collections.*
               """
           )

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -108,7 +108,7 @@ class ImportTest implements RewriteTest {
           groovy(
             """
                     import static      java.util.Collections.*    ;     import               static      java.util.Collections.*
-              import java.util.Collections.*
+              import java.util.Collections.*  ; import static java.util.Collections.*
               import java.util.Collections.*
               import static java.util.Collections.*;import static java.util.Collections.*
               import java.util.Collections.*


### PR DESCRIPTION
## What's changed?
- Duplicate static star imports work as well.
- Shorten the parser code for ImportNode (we have now methods like `sourceStartsWith`)

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4068

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
