### PR TITLE
Disable parentheses level discovery for method calls for groovy 2

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2458,7 +2458,8 @@ public class GroovyParserVisitor {
         } else if (rawIpl instanceof Integer) {
             // On Java 8 _INSIDE_PARENTHESES_LEVEL is a regular Integer
             return (Integer) rawIpl;
-        } else if (node instanceof MethodCallExpression) {
+        } else if (node instanceof MethodCallExpression && !isOlderThanGroovy3()) {
+            // Only for groovy 3+, because lower versions do always return `-1` for objectExpression.lineNumber / objectExpression.columnNumber
             MethodCallExpression expr = (MethodCallExpression) node;
             return determineParenthesisLevel(expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
         } else if (node instanceof BinaryExpression) {


### PR DESCRIPTION
## What's changed?
Disable parentheses level discovery for methods for Groovy 2.

## What's your motivation?
Groovy 2 does not contain the information we need, it always return -1 for the method calls object-expression. In older version of the groovy-parser this did not cause any exceptions, but since
- https://github.com/openrewrite/rewrite/pull/4951

it does.

Notice before PR #4951, the parser did also not support parentheses level discovery for methods for Groovy 2, but I did not throw an errors by chance.

## Any additional context
Would  be nice to have a real working solution for Groovy 2 as well. But let's focus on that at a later stage.