### PR TITLE
fix: handle comment at the end of a method declaration

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1840,9 +1840,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         if (t instanceof JCMethodDecl) {
             JCMethodDecl m = (JCMethodDecl) t;
             if (m.body == null || m.defaultValue != null) {
-                String suffix = source.substring(cursor, positionOfNext(";", null));
-                int idx = findFirstNonWhitespaceChar(suffix);
-                return sourceBefore(idx >= 0 ? "" : ";");
+                return sourceBefore(";");
             } else {
                 return sourceBefore("");
             }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1920,9 +1920,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             case METHOD:
                 JCMethodDecl m = (JCMethodDecl) t;
                 if (m.body == null || m.defaultValue != null) {
-                    String suffix = source.substring(cursor, positionOfNext(";", null));
-                    int idx = findFirstNonWhitespaceChar(suffix);
-                    return sourceBefore(idx >= 0 ? "" : ";");
+                    return sourceBefore(";");
                 } else {
                     return sourceBefore("");
                 }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1953,9 +1953,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             case METHOD:
                 JCMethodDecl m = (JCMethodDecl) t;
                 if (m.body == null || m.defaultValue != null) {
-                    String suffix = source.substring(cursor, positionOfNext(";", null));
-                    int idx = findFirstNonWhitespaceChar(suffix);
-                    return sourceBefore(idx >= 0 ? "" : ";");
+                    return sourceBefore(";");
                 } else {
                     return sourceBefore("");
                 }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1833,9 +1833,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         if (t instanceof JCMethodDecl) {
             JCMethodDecl m = (JCMethodDecl) t;
             if (m.body == null || m.defaultValue != null) {
-                String suffix = source.substring(cursor, positionOfNext(";", null));
-                int idx = findFirstNonWhitespaceChar(suffix);
-                return sourceBefore(idx >= 0 ? "" : ";");
+                return sourceBefore(";");
             } else {
                 return sourceBefore("");
             }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -45,6 +46,20 @@ class CommentTest implements RewriteTest {
           java(
             """
               class Test {// /*
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4995")
+    @Test
+    void trailingComment() {
+        rewriteRun(
+          java(
+            """
+              abstract class Test {
+                void alert(String msg) /*-{ $wnd.alert(msg); }-*/;
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -196,7 +196,7 @@ class JavaParserTest implements RewriteTest {
         package com.example.demo;
         class FooBar {
             public void test(int num string msg) {
-              String a; this.ownerR
+              String a;
               System.out.println();
             }
         }
@@ -204,7 +204,7 @@ class JavaParserTest implements RewriteTest {
       """
         package com.example.demo;
         class FooBar {
-            public void test(int num string s, int b) {
+            public void test() {
               String a; this.ownerR
               System.out.println();
             }


### PR DESCRIPTION
Multi line comment is allowed at almost any part of the Java source code
where whitespace is allowed. The reloadable Java parser visitor however
swallows multi line comment at the end of a method declaration, which
happens to be a common pattern in GWT in order to embed JavaScript in a
Java class.

- Note that this effectively is a partial revert of https://github.com/openrewrite/rewrite/pull/4412
(commit https://github.com/openrewrite/rewrite/commit/ac32851e09c9b76aed56c898844e217fa9e61367).

- Fixes https://github.com/openrewrite/rewrite/issues/4995