### PR TITLE
Don't include diff in exception in `Result`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -76,12 +76,9 @@ public class Result {
     public Result(@Nullable SourceFile before, SourceFile after) {
         this(before, after, after.getMarkers()
                 .findFirst(RecipesThatMadeChanges.class)
-                .orElseThrow(() -> new IllegalStateException(
-                        String.format(
-                                "Source file changed but no recipe " +
-                                "reported making a change. %s",
-                                explainWhatChanged(before, after)
-                        )
+                .orElseThrow(() -> new UnknownSourceFileChangeException(
+                        after,
+                        explainWhatChanged(before, after)
                 ))
                 .getRecipes());
     }

--- a/rewrite-core/src/main/java/org/openrewrite/UnknownSourceFileChangeException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/UnknownSourceFileChangeException.java
@@ -24,9 +24,9 @@ public class UnknownSourceFileChangeException extends RecipeException {
     SourceFile sourceFile;
     String diff;
 
-    @Override
-    public String getMessage() {
-        return "Source file changed but no recipe " +
-               "reported making a change.";
+    public UnknownSourceFileChangeException(SourceFile sourceFile, String diff) {
+        super("Source file changed but no recipe reported making a change.");
+        this.sourceFile = sourceFile;
+        this.diff = diff;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/UnknownSourceFileChangeException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/UnknownSourceFileChangeException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UnknownSourceFileChangeException extends RecipeException {
+    SourceFile sourceFile;
+    String diff;
+
+    @Override
+    public String getMessage() {
+        return "Source file changed but no recipe " +
+               "reported making a change.";
+    }
+}


### PR DESCRIPTION


## What's changed? / What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
In order to allow clients of OpenRewrite to decide whether to include (or not) the diff text when a source file changed but no changes were reported, extract the logic to a new `Exception`, `UnknownSourceFileChangeException`, passing in the `SourceFile` and diff.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
N/A

## Anyone you would like to review specifically?
N/A

## Have you considered any alternatives or workarounds?
The workaround would be to read the text of the error message, which is error- and change-prone.

## Any additional context
N/A

### Checklist
~- [ ] I've added unit tests to cover both positive and negative cases~
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
