### PR TITLE
Use `pattern` operator for all possible string kinds

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2526,25 +2526,33 @@ public class GroovyParserVisitor {
         return Math.max(count, 0);
     }
 
+    /**
+     * Grabs a {@link Delimiter} from source if cursor is right in front of a delimiter.
+     * Whitespace characters are NOT excluded, the cursor will not be moved.
+     */
     private @Nullable Delimiter getDelimiter(int cursor) {
-        if (source.startsWith("$/", cursor)) {
-            return DOLLAR_SLASHY_STRING;
-        } else if (source.startsWith("\"\"\"", cursor)) {
-            return TRIPLE_DOUBLE_QUOTE_STRING;
-        } else if (source.startsWith("'''", cursor)) {
-            return TRIPLE_SINGLE_QUOTE_STRING;
-        } else if (source.startsWith("~/", cursor)) {
-            return PATTERN_OPERATOR;
-        } else if (source.startsWith("//", cursor)) {
+        boolean isPatternOperator = source.startsWith("~", cursor);
+        int c = cursor;
+        if (isPatternOperator) {
+            c = cursor + 1;
+        }
+
+        if (source.startsWith("$/", c)) {
+            return isPatternOperator ? PATTERN_DOLLAR_SLASHY_STRING : DOLLAR_SLASHY_STRING;
+        } else if (source.startsWith("\"\"\"", c)) {
+            return isPatternOperator ? PATTERN_TRIPLE_DOUBLE_QUOTE_STRING : TRIPLE_DOUBLE_QUOTE_STRING;
+        } else if (source.startsWith("'''", c)) {
+            return isPatternOperator ? PATTERN_TRIPLE_SINGLE_QUOTE_STRING : TRIPLE_SINGLE_QUOTE_STRING;
+        } else if (source.startsWith("//", c)) {
             return SINGLE_LINE_COMMENT;
-        } else if (source.startsWith("/*", cursor)) {
+        } else if (source.startsWith("/*", c)) {
             return MULTILINE_COMMENT;
-        } else if (source.startsWith("/", cursor)) {
-            return SLASHY_STRING;
-        } else if (source.startsWith("\"", cursor)) {
-            return DOUBLE_QUOTE_STRING;
-        } else if (source.startsWith("'", cursor)) {
-            return SINGLE_QUOTE_STRING;
+        } else if (source.startsWith("/", c)) {
+            return isPatternOperator ? PATTERN_SLASHY_STRING : SLASHY_STRING;
+        } else if (source.startsWith("\"", c)) {
+            return isPatternOperator ? PATTERN_DOUBLE_QUOTE_STRING : DOUBLE_QUOTE_STRING;
+        } else if (source.startsWith("'", c)) {
+            return isPatternOperator ? PATTERN_SINGLE_QUOTE_STRING : SINGLE_QUOTE_STRING;
         }
         return null;
     }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
@@ -26,7 +26,12 @@ public enum Delimiter {
     TRIPLE_DOUBLE_QUOTE_STRING("\"\"\"", "\"\"\""),
     SLASHY_STRING("/", "/"),
     DOLLAR_SLASHY_STRING("$/", "/$"),
-    PATTERN_OPERATOR("~/", "/"),
+    PATTERN_SINGLE_QUOTE_STRING("~'", "'"),
+    PATTERN_DOUBLE_QUOTE_STRING("~\"", "\""),
+    PATTERN_TRIPLE_SINGLE_QUOTE_STRING("'''", "'''"),
+    PATTERN_TRIPLE_DOUBLE_QUOTE_STRING("\"\"\"", "\"\"\""),
+    PATTERN_SLASHY_STRING("~/", "/"),
+    PATTERN_DOLLAR_SLASHY_STRING("~$/", "$/"),
     SINGLE_LINE_COMMENT("//", "\n"),
     MULTILINE_COMMENT("/*", "*/");
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -78,18 +78,6 @@ class BinaryTest implements RewriteTest {
         );
     }
 
-    @Test
-    void regexPatternOperator() {
-        rewriteRun(
-          groovy(
-            """
-              def PATTERN = ~/foo/
-              def result = PATTERN.matcher('4711').matches()
-              """
-          )
-        );
-    }
-
     @Issue("https://github.com/openrewrite/rewrite/issues/1531")
     @Test
     void regexFindOperator() {
@@ -117,6 +105,8 @@ class BinaryTest implements RewriteTest {
           )
         );
     }
+
+
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1520")
     @Test

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -40,9 +40,46 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
-    void string() {
+    void singleQuoteString() {
         rewriteRun(
-          groovy("'hello'")
+          groovy(
+            """
+              'hello'
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexPatternSingleQuoteString() {
+        rewriteRun(
+          groovy(
+            """
+              ~"hello"
+              """
+          )
+        );
+    }
+
+    @Test
+    void doubleQuoteString() {
+        rewriteRun(
+          groovy(
+            """
+              "hello"
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexPatternDoubleQuoteString() {
+        rewriteRun(
+          groovy(
+            """
+              ~"hello"
+              """
+          )
         );
     }
 
@@ -74,11 +111,35 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void regexPatterQuotedString() {
+        rewriteRun(
+          groovy(
+            """
+              ~\"""
+                  " Hi "
+              \"""
+              """
+          )
+        );
+    }
+
+    @Test
     void slashString() {
         rewriteRun(
           groovy(
             """
               /.*"foo".*/
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexPatternSlashString() {
+        rewriteRun(
+          groovy(
+            """
+              ~/foo/
               """
           )
         );
@@ -101,6 +162,17 @@ class LiteralTest implements RewriteTest {
           groovy(
             """
               " uid: ${ UUID.randomUUID() } "
+              """
+          )
+        );
+    }
+
+    @Test
+    void regexPatternGString() {
+        rewriteRun(
+          groovy(
+            """
+              ~"${ UUID.randomUUID() }"
               """
           )
         );


### PR DESCRIPTION
## What's changed?
The pattern operator is supported for all possible string kinds. 

## What's your motivation?
The parser did only support the pattern operator for slashy strings (`~/<pattern>/)`. Though by convention slashy strings are used most for the patten operator, you can use every kind of string: 

> The pattern operator (~) provides a simple way to create a java.util.regex.Pattern instance. While in general, you find the pattern operator with an expression in a slashy-string, it can be used with any kind of String in Groovy - [docs](https://groovy-lang.org/operators.html#_pattern_operator)
