### PR TITLE
Groovy parser does not support annotations on variable declarations

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -226,7 +226,7 @@ public class GroovyParserVisitor {
     }
 
     @RequiredArgsConstructor
-    class RewriteGroovyClassVisitor extends ClassCodeVisitorSupport {
+    private class RewriteGroovyClassVisitor extends ClassCodeVisitorSupport {
         @Getter
         private final SourceUnit sourceUnit;
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -64,6 +64,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.lang.Character.isJavaIdentifierPart;
+import static java.lang.Character.isWhitespace;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -1225,9 +1226,20 @@ public class GroovyParserVisitor {
             // The groovy compiler can add or remove annotations for AST transformations.
             // Because @groovy.transform.Field is transformed to a ConstantExpression, we need to restore the original DeclarationExpression
             if (sourceStartsWith("@" + Field.class.getSimpleName()) || sourceStartsWith("@" + Field.class.getCanonicalName())) {
-                VariableExpression left = new VariableExpression("a");
+                String str = source.substring(cursor);
+                int equalsIndex = str.indexOf("=");
+
+                int end = equalsIndex - 1;
+                while (end >= 0 && isWhitespace(str.charAt(end))) {
+                    end--;
+                }
+                int start = end;
+                while (start >= 0 && !isWhitespace(str.charAt(start))) {
+                    start--;
+                }
+                VariableExpression left = new VariableExpression(str.substring(start + 1, end + 1));
                 Token operation = new Token(Types.EQUAL, "=", -1, -1);
-                VariableExpression right = new VariableExpression("a");
+                ConstantExpression right = new ConstantExpression("[1, 2, 3]");
                 DeclarationExpression declarationExpression = new DeclarationExpression(left, operation, right);
                 declarationExpression.addAnnotations(singletonList(new AnnotationNode(new ClassNode(Field.class))));
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1237,9 +1237,24 @@ public class GroovyParserVisitor {
                 while (start >= 0 && !isWhitespace(str.charAt(start))) {
                     start--;
                 }
+
+                int startX = indexOfNextNonWhitespace( equalsIndex + 1, str);
+                int endX = startX;
+                if (str.charAt(endX) == '[') {
+                    endX = str.indexOf(']');
+                } else if (getDelimiter(endX) != null) {
+                    Delimiter delim = getDelimiter(endX);
+                    endX = str.indexOf(delim.close, endX + delim.open.length());
+                } else {
+                    while (isJavaIdentifierPart(str.charAt(endX)) || str.charAt(endX) == ',') {
+                        endX++;
+                    }
+                }
+
+
                 VariableExpression left = new VariableExpression(str.substring(start + 1, end + 1));
                 Token operation = new Token(Types.EQUAL, "=", -1, -1);
-                ConstantExpression right = new ConstantExpression("[1, 2, 3]");
+                ConstantExpression right = new ConstantExpression(str.substring(startX, endX + 1));
                 DeclarationExpression declarationExpression = new DeclarationExpression(left, operation, right);
                 declarationExpression.addAnnotations(singletonList(new AnnotationNode(new ClassNode(Field.class))));
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/Delimiter.java
@@ -33,7 +33,8 @@ public enum Delimiter {
     PATTERN_SLASHY_STRING("~/", "/"),
     PATTERN_DOLLAR_SLASHY_STRING("~$/", "$/"),
     SINGLE_LINE_COMMENT("//", "\n"),
-    MULTILINE_COMMENT("/*", "*/");
+    MULTILINE_COMMENT("/*", "*/"),
+    ARRAY("[", "]");
 
     public final String open;
     public final String close;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -181,19 +181,43 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              @groovy.transform.Field def a =    / a strig /
+              import groovy.transform.Field
+              
+              @Field def a = [1, 2, 3]
               """
           )
         );
     }
 
     @Test
-    void groovyTransformFieldAnnotationOnVariableWithReference() {
+    void groovyTransformFieldFQNAnnotationOnVariable() {
+        rewriteRun(
+          groovy(
+            """
+              @groovy.transform.Field def a = [1, 2, 3]
+              """
+          )
+        );
+    }
+
+    @Test
+    void groovyTransformFieldFQNAnnotationOnVariableWithReference() {
         rewriteRun(
           groovy(
             """
               def z = 1 + 2
               @groovy.transform.Field def a = z
+              """
+          )
+        );
+    }
+
+    @Test
+    void groovyTransformFieldFQNAnnotationOnVariableWithMethodInvocation() {
+        rewriteRun(
+          groovy(
+            """
+              @groovy.transform.Field def a = callSomething()
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -181,8 +181,7 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              @groovy.transform.Field
-              def a = "a"
+              @groovy.transform.Field def a = "a"
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -181,7 +181,19 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              @groovy.transform.Field def a = "a"
+              @groovy.transform.Field def a = [1, 2, 3]
+              """
+          )
+        );
+    }
+
+    @Test
+    void groovyTransformFieldAnnotationOnVariableWithReference() {
+        rewriteRun(
+          groovy(
+            """
+              def z = 1 + 2
+              @groovy.transform.Field def a = z
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -181,7 +181,7 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              @groovy.transform.Field def a = [1, 2, 3]
+              @groovy.transform.Field def a =    / a strig /
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AnnotationTest.java
@@ -163,4 +163,28 @@ class AnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4853")
+    @Test
+    void annotationOnVariable() {
+        rewriteRun(
+          groovy(
+            """
+              @Foo def a = "a"
+              """
+          )
+        );
+    }
+
+    @Test
+    void groovyTransformFieldAnnotationOnVariable() {
+        rewriteRun(
+          groovy(
+            """
+              @groovy.transform.Field
+              def a = "a"
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Annotations on variables are supported as well.

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4853

## Any additional context
The `@groovy.transform.Field` annotation is a transformer annotation, it changes the scope of a variable within a script to the class level for the script (see [javadoc](https://docs.groovy-lang.org/latest/html/gapi/groovy/transform/Field.html)). This means that the original DeclarationExpression is gone, but the Groovy Compiler replaced it by a semi empty  ConstantExpression.

I put in some work to make it work again, by recreating a DeclarationExpression. This is done very roughly, so the code is neither beautiful nor does restore all type information. At least we can parse `@Field` annotation now, instead of failing. If you have a better idea how to handle this, my ears are open!
