### PR TITLE
Disable Lombok again

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -124,7 +124,8 @@ public class ReloadableJava11Parser implements JavaParser {
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
         LOMBOK:
-        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
+        if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
+                classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             Processor lombokProcessor = null;
             try {
                 // https://projectlombok.org/contributing/lombok-execution-path

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -122,7 +122,8 @@ public class ReloadableJava17Parser implements JavaParser {
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
         LOMBOK:
-        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
+        if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
+                classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             Processor lombokProcessor = null;
             try {
                 // https://projectlombok.org/contributing/lombok-execution-path

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
@@ -122,7 +122,8 @@ public class ReloadableJava21Parser implements JavaParser {
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
         LOMBOK:
-        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
+        if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
+                classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             Processor lombokProcessor = null;
             try {
                 // https://projectlombok.org/contributing/lombok-execution-path

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -40,7 +40,6 @@ class LombokTest implements RewriteTest {
 
     @BeforeAll
     static void setUp() {
-        // Only needed for Java 8, until enabled by default there
         System.setProperty("rewrite.lombok", "true");
     }
 


### PR DESCRIPTION
## What's changed?
Default Lombok is disabled again.

## What's your motivation?
There are still issues with Lombok, which  causes wrong positions in the AST. The parsers will break when the positions are off.
