### PR TITLE
Fixing JavaTemplateParser wrt method arguments replacement - removing extra semicolon

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
@@ -16,18 +16,12 @@
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.*;
-import org.openrewrite.config.Environment;
-import org.openrewrite.java.tree.Expression;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateSubstitutionsTest.java
@@ -52,7 +52,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                   void test(int n) {
                       value();
                   }
-
+              
                   int value() {
                       return 0;
                   }
@@ -63,7 +63,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                   void test(int n) {
                       test(value());
                   }
-
+              
                   int value() {
                       return 0;
                   }
@@ -96,7 +96,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                   void test(int[][] n) {
                       array();
                   }
-
+              
                   int[][] array() {
                       return new int[0][0];
                   }
@@ -107,7 +107,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
                   void test(int[][] n) {
                       test(array());
                   }
-
+              
                   int[][] array() {
                       return new int[0][0];
                   }
@@ -404,7 +404,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
             """
               abstract class Test {
                   abstract String[] array();
-
+              
                   void test(boolean condition) {
                       Object any = condition ? array() : new String[]{"Hello!"};
                   }
@@ -493,21 +493,23 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(toRecipe(BigDecimalSetScaleVisitor::new)),
           java(
-          """
-            import java.math.BigDecimal;
-
-            class A {
-                static String s = String.valueOf("Value: " + BigDecimal.ONE.setScale(0, BigDecimal.ROUND_DOWN));
-            }
-          """,
-          """
-          import java.math.BigDecimal;
-          import java.math.RoundingMode;
-
-          class A {
-              static String s = String.valueOf("Value: " + BigDecimal.ONE.setScale(0, RoundingMode.DOWN));
-          }
-          """));
+            """
+              import java.math.BigDecimal;
+              
+              class A {
+                  static String s = String.valueOf("Value: " + BigDecimal.ONE.setScale(0, BigDecimal.ROUND_DOWN));
+              }
+              """,
+            """
+              import java.math.BigDecimal;
+              import java.math.RoundingMode;
+              
+              class A {
+                  static String s = String.valueOf("Value: " + BigDecimal.ONE.setScale(0, RoundingMode.DOWN));
+              }
+              """
+          )
+        );
     }
 
     @Test
@@ -517,23 +519,25 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
           java(
             """
               import java.math.BigDecimal;
-
+              
               class A {
                   public static void b() {
                       BigDecimal.ONE.setScale(0, BigDecimal.ROUND_DOWN);
                   }
               }
-            """,
+              """,
             """
-            import java.math.BigDecimal;
-            import java.math.RoundingMode;
-
-            class A {
-                public static void b() {
-                    BigDecimal.ONE.setScale(0, RoundingMode.DOWN);
-                }
-            }
-            """));
+              import java.math.BigDecimal;
+              import java.math.RoundingMode;
+              
+              class A {
+                  public static void b() {
+                      BigDecimal.ONE.setScale(0, RoundingMode.DOWN);
+                  }
+              }
+              """
+          )
+        );
     }
 
     private static class BigDecimalSetScaleVisitor extends JavaVisitor<ExecutionContext> {
@@ -541,7 +545,7 @@ class JavaTemplateSubstitutionsTest implements RewriteTest {
         @Override
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-            if ("setScale".equals(m.getName().getSimpleName()) ) {
+            if ("setScale".equals(m.getName().getSimpleName())) {
                 J.FieldAccess secondArgument = (J.FieldAccess) m.getArguments().get(1);
                 if (secondArgument.getName().getSimpleName().equals("ROUND_DOWN")) {
                     maybeAddImport("java.math.RoundingMode");

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -200,9 +200,6 @@ public class JavaTemplateParser {
         J.MethodInvocation method = cursor.getValue();
         String methodWithReplacementArgs = method.withArguments(Collections.emptyList()).printTrimmed(cursor.getParentOrThrow())
                 .replaceAll("\\)$", template + ")");
-        if (!(cursor.getParentTreeCursor().getValue() instanceof J.MethodInvocation)) {
-            methodWithReplacementArgs += ';';
-        }
         // TODO: The stub string includes the scoped elements of each original AST, and therefore is not a good
         //       cache key. There are virtual no cases where a stub key will result in re-use. If we can come up with
         //       a safe, reusable key, we can consider using the cache for block statements.


### PR DESCRIPTION
## What's changed?

Fixing JavaTemplateParser not to add a semicolon when doing a method arguments replacement.

## What's your motivation?

To address an issue reported by an openrewrite user. The issue symptoms were:
```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
org.openrewrite.internal.RecipeRunException: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:290)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:157)
	at org.openrewrite.java.JavaTemplate.apply(JavaTemplate.java:115)
	at org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums$1.visitMethodInvocation(BigDecimalRoundingConstantsToEnums.java:93)
	at org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums$1.visitMethodInvocation(BigDecimalRoundingConstantsToEnums.java:62)
```
when running `BigDecimalRoundingConstantsToEnums`.

## Anything in particular you'd like reviewers to focus on?

Yes. This basically undoes the fix added in https://github.com/openrewrite/rewrite/pull/4709, so this should cause a regression, but I have a hard time establishing what is what we lose:
- I've asked the PR author (@timtebeek) for possible context
- I've tried running the modified code against the https://github.com/openrewrite/rewrite-logging-frameworks (where the original problem was reported back in 2024), but all the tests worked. Incl. the one reported by the user in [issue #185](https://github.com/openrewrite/rewrite-logging-frameworks/issues/185).
- I tried guessing what would be the scenario where adding the trailing semicolon would be needed. Tried a few cases, but none of them seemed to pinpoint anything special. This PR adds one of them.

## Anyone you would like to review specifically?
@timtebeek 
