### PR TITLE
Declaring Maven Central as first repository for some of the tests

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -128,6 +128,11 @@ class ChangeParentPomTest implements RewriteTest {
                  </dependencies>
                   <repositories>
                       <repository>
+                        <id>central</id>
+                        <name>Central Repository</name>
+                        <url>https://repo.maven.apache.org/maven2</url>
+                      </repository>
+                      <repository>
                           <id>repo.jenkins-ci.org</id>
                           <url>https://repo.jenkins-ci.org/public/</url>
                       </repository>
@@ -166,6 +171,11 @@ class ChangeParentPomTest implements RewriteTest {
                      </dependency>
                  </dependencies>
                   <repositories>
+                      <repository>
+                        <id>central</id>
+                        <name>Central Repository</name>
+                        <url>https://repo.maven.apache.org/maven2</url>
+                      </repository>
                       <repository>
                           <id>repo.jenkins-ci.org</id>
                           <url>https://repo.jenkins-ci.org/public/</url>
@@ -1553,6 +1563,11 @@ class ChangeParentPomTest implements RewriteTest {
                       <jenkins.version>2.387.3</jenkins.version>
                   </properties>
                   <repositories>
+                    <repository>
+                        <id>central</id>
+                        <name>Central Repository</name>
+                        <url>https://repo.maven.apache.org/maven2</url>
+                    </repository>
                       <repository>
                           <id>repo.jenkins-ci.org</id>
                           <url>https://repo.jenkins-ci.org/public/</url>
@@ -1597,6 +1612,11 @@ class ChangeParentPomTest implements RewriteTest {
                       <jenkins.version>2.387.3</jenkins.version>
                   </properties>
                   <repositories>
+                    <repository>
+                        <id>central</id>
+                        <name>Central Repository</name>
+                        <url>https://repo.maven.apache.org/maven2</url>
+                    </repository>
                       <repository>
                           <id>repo.jenkins-ci.org</id>
                           <url>https://repo.jenkins-ci.org/public/</url>


### PR DESCRIPTION
## What's changed?
Changing two test cases of `ChangeParentPomTest`. Specifically the `pom.xml` they define.
Adding explicit Maven Central repository as the first one, before the Jenkins one (the Maven Central repository is present by default in Maven anyway, it just defaults to being the last one as per this [StackOverflow post](https://stackoverflow.com/a/51792634)).

## Observations

I've observed the `ChangeParentPomTest` spends a lot of time sending requests to various artifacts in the `jenkins-ci.org` Maven repo. The requests are:
- slow (~600ms vs. ~40ms to Maven Central) where I live
- and they 404 anyway as the Jenkins repo doesn't provide all versions of these standard Java libraries like Jetty or commons-logging

## What's your motivation?

To speed up the CI of this project.

Non-scientific measurement on my laptop for the single test case of `ChangeParentPomTest#shouldNotAddToDependencyManagement`:
- before this change: ~3m33s
- after this change: ~43s
