### PR TITLE
JMH Gradle plugin 0.7.3

### DIFF
--- a/rewrite-benchmarks/build.gradle.kts
+++ b/rewrite-benchmarks/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("org.openrewrite.build.java-base")
     id("org.openrewrite.build.recipe-repositories")
-    id("me.champeau.gradle.jmh") version "0.5.2"
+    id("me.champeau.jmh") version "0.7.3"
 }
 
 dependencies {


### PR DESCRIPTION
## What's changed?
Upgrading the JMH Gradle plugin to the latest available version (0.7.3).

## What's your motivation?
- It started with me seeing a `Space-assignment syntax in Groovy DSL has been deprecated.` warning in an unrelated Gradle build
- then I noticed we are using an old version, and the old version is violating the minimal plugin version as per https://github.com/melix/jmh-gradle-plugin/blob/493a4f0ca583d95ee5a61f20ae840d8d83eaa108/README.adoc#L38
- and then I tried running the JMH benchmarks locally and without the change they failed with the following error (which goes away after the upgrade):
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rewrite-benchmarks:jmhRunBytecodeGenerator'.
> 'void org.gradle.workers.WorkerExecutor.submit(java.lang.Class, org.gradle.api.Action)'
```
