### PR TITLE
Add `ResolutionEventListener` event whenever a repository normalization attempt is skipped

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -219,7 +219,7 @@ public class MavenPomDownloader {
                 .normalize();
         Pom parentPom = projectPoms.get(parentPath);
         return parentPom != null && parentPom.getGav().getGroupId().equals(parent.getGav().getGroupId()) &&
-                parentPom.getGav().getArtifactId().equals(parent.getGav().getArtifactId()) ? parentPom : null;
+               parentPom.getGav().getArtifactId().equals(parent.getGav().getArtifactId()) ? parentPom : null;
     }
 
     public MavenMetadata downloadMetadata(GroupArtifact groupArtifact, @Nullable ResolvedPom containingPom, List<MavenRepository> repositories) throws MavenDownloadingException {
@@ -259,9 +259,9 @@ public class MavenPomDownloader {
                 try {
                     String scheme = URI.create(repo.getUri()).getScheme();
                     String baseUri = repo.getUri() + (repo.getUri().endsWith("/") ? "" : "/") +
-                            requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
-                            gav.getArtifactId() + '/' +
-                            (gav.getVersion() == null ? "" : gav.getVersion() + '/');
+                                     requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
+                                     gav.getArtifactId() + '/' +
+                                     (gav.getVersion() == null ? "" : gav.getVersion() + '/');
 
                     if ("file".equals(scheme)) {
                         // A maven repository can be expressed as a URI with a file scheme
@@ -356,8 +356,8 @@ public class MavenPomDownloader {
 
         String scheme = URI.create(repo.getUri()).getScheme();
         String uri = repo.getUri() + (repo.getUri().endsWith("/") ? "" : "/") +
-                requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
-                gav.getArtifactId() + '/';
+                     requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
+                     gav.getArtifactId() + '/';
 
         try {
             MavenMetadata.Versioning versioning;
@@ -496,7 +496,7 @@ public class MavenPomDownloader {
         // The requested gav might itself have an unresolved placeholder in the version, so also check raw values
         for (Pom projectPom : projectPoms.values()) {
             if (!projectPom.getGroupId().equals(gav.getGroupId()) ||
-                    !projectPom.getArtifactId().equals(gav.getArtifactId())) {
+                !projectPom.getArtifactId().equals(gav.getArtifactId())) {
                 continue;
             }
 
@@ -512,7 +512,7 @@ public class MavenPomDownloader {
         }
 
         if (containingPom != null && containingPom.getRequested().getSourcePath() != null &&
-                !StringUtils.isBlank(relativePath) && !relativePath.contains(":")) {
+            !StringUtils.isBlank(relativePath) && !relativePath.contains(":")) {
             Path folderContainingPom = containingPom.getRequested().getSourcePath().getParent();
             if (folderContainingPom != null) {
                 Pom maybeLocalPom = projectPoms.get(folderContainingPom.resolve(Paths.get(relativePath, "pom.xml"))
@@ -521,9 +521,9 @@ public class MavenPomDownloader {
                 // So double check that the GAV coordinates match so that we don't get a relative path from a remote
                 // pom like ".." or "../.." which coincidentally _happens_ to have led to an unrelated pom on the local filesystem
                 if (maybeLocalPom != null &&
-                        gav.getGroupId().equals(maybeLocalPom.getGroupId()) &&
-                        gav.getArtifactId().equals(maybeLocalPom.getArtifactId()) &&
-                        gav.getVersion().equals(maybeLocalPom.getVersion())) {
+                    gav.getGroupId().equals(maybeLocalPom.getGroupId()) &&
+                    gav.getArtifactId().equals(maybeLocalPom.getArtifactId()) &&
+                    gav.getVersion().equals(maybeLocalPom.getVersion())) {
                     return maybeLocalPom;
                 }
             }
@@ -552,10 +552,10 @@ public class MavenPomDownloader {
 
             if (result == null) {
                 URI uri = URI.create(repo.getUri() + (repo.getUri().endsWith("/") ? "" : "/") +
-                        requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
-                        gav.getArtifactId() + '/' +
-                        gav.getVersion() + '/' +
-                        gav.getArtifactId() + '-' + versionMaybeDatedSnapshot + ".pom");
+                                     requireNonNull(gav.getGroupId()).replace('.', '/') + '/' +
+                                     gav.getArtifactId() + '/' +
+                                     gav.getVersion() + '/' +
+                                     gav.getArtifactId() + '-' + versionMaybeDatedSnapshot + ".pom");
                 uris.add(uri.toString());
                 if ("file".equals(uri.getScheme())) {
                     Path inputPath = Paths.get(gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
@@ -688,9 +688,9 @@ public class MavenPomDownloader {
         if (gav.getVersion() != null && gav.getVersion().endsWith("-SNAPSHOT")) {
             for (ResolvedGroupArtifactVersion pinnedSnapshotVersion : new MavenExecutionContextView(ctx).getPinnedSnapshotVersions()) {
                 if (pinnedSnapshotVersion.getDatedSnapshotVersion() != null &&
-                        pinnedSnapshotVersion.getGroupId().equals(gav.getGroupId()) &&
-                        pinnedSnapshotVersion.getArtifactId().equals(gav.getArtifactId()) &&
-                        pinnedSnapshotVersion.getVersion().equals(gav.getVersion())) {
+                    pinnedSnapshotVersion.getGroupId().equals(gav.getGroupId()) &&
+                    pinnedSnapshotVersion.getArtifactId().equals(gav.getArtifactId()) &&
+                    pinnedSnapshotVersion.getVersion().equals(gav.getVersion())) {
                     return pinnedSnapshotVersion.getDatedSnapshotVersion();
                 }
             }
@@ -811,6 +811,8 @@ public class MavenPomDownloader {
 
                 mavenCache.putNormalizedRepository(repository, normalized);
                 result = Optional.ofNullable(normalized);
+            } else if(!result.isPresent()) {
+                ctx.getResolutionListener().repositoryAccessFailedPreviously(repository.getUri());
             }
         } catch (Exception e) {
             ctx.getResolutionListener().repositoryAccessFailed(repository.getUri(), e);
@@ -912,7 +914,7 @@ public class MavenPomDownloader {
             } catch (FailsafeException failsafeException) {
                 Throwable cause = failsafeException.getCause();
                 if (cause instanceof HttpSenderResponseException && hasCredentials(repo) &&
-                        ((HttpSenderResponseException) cause).isClientSideException()) {
+                    ((HttpSenderResponseException) cause).isClientSideException()) {
                     return Failsafe.with(retryPolicy).get(() -> {
                         HttpSender.Request unauthenticated = httpSender.get(jarUrl).build();
                         try (HttpSender.Response response = httpSender.send(unauthenticated)) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolutionEventListener.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolutionEventListener.java
@@ -64,4 +64,13 @@ public interface ResolutionEventListener {
 
     default void repositoryAccessFailed(String uri, Throwable e) {
     }
+
+    /**
+     * This is called if a previous failure to access a repository was cached and used.
+     * Useful to log when a persistent maven cache is used to debug issues where repositories are not being attempted for downloads.
+      * @param uri The repository URI which was not attempted to access
+     */
+    default void repositoryAccessFailedPreviously(String uri) {
+    }
+
 }


### PR DESCRIPTION
When a normalization attempt fails, the repository gets cached as `null` and any subsequent normalization attempts are skipped. When this cache is persisted we lose any such information in subsequent runs. Adding this event can give a hint as to why repositories are not attempted for downloading.

## What's changed?
New event added and used

## What's your motivation?
Not knowing why a repository is not attempted to be used for downloading

## Have you considered any alternatives or workarounds?
It would be even nicer of downloadError could list all the repositories NOT attempted (with reasons), but that would be a much bigger change.
