### PR TITLE
Removing `rewrite-java-test` dependency on `:rewrite-maven`

### DIFF
--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     testRuntimeOnly("org.mapstruct:mapstruct:latest.release")
     testRuntimeOnly("org.projectlombok:lombok:latest.release")
     testRuntimeOnly(project(":rewrite-yaml"))
-    testImplementation(project(":rewrite-maven"))
     testImplementation(project(":rewrite-properties"))
     testImplementation(project(":rewrite-xml"))
 }


### PR DESCRIPTION
## What's changed?
Removing `rewrite-java-test` dependency on `rewrite-maven`.

## What's your motivation?

To speed up the CI of this project.
I've observed a few Gradle scans which spent excessive time running various flavours of compatibility tests for what seems no actual purpose.
E.g. [the Gradle scan for the PR 5023](https://ge.openrewrite.org/s/junoxzkh6h7fg/timeline) has:

![image](https://github.com/user-attachments/assets/32a01864-6a43-4d88-991c-eef83c6bd467)

## Research

The dependency seems to have been added in https://github.com/openrewrite/rewrite/commit/bba8b92fd85ae27b8bb2d5b2a7bfb8bafc2449ad
After that, the actual class needed got moved, but the dependency remained.
