### PR TITLE
Centralize Lombok initialization logic

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -9,7 +9,7 @@ val javaTck = configurations.create("javaTck") {
 dependencies {
     api(project(":rewrite-core"))
     api(project(":rewrite-java"))
-    runtimeOnly(project(":rewrite-java-lombok"))
+    implementation(project(":rewrite-java-lombok"))
 
     compileOnly("org.slf4j:slf4j-api:1.7.+")
 

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -35,11 +35,10 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.MetricsHelper;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaParsingException;
 import org.openrewrite.java.internal.JavaTypeCache;
-import org.openrewrite.java.lombok.Lombok;
+import org.openrewrite.java.lombok.LombokSupport;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -123,7 +122,7 @@ public class ReloadableJava11Parser implements JavaParser {
         annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             try {
-                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
+                Processor lombokProcessor = LombokSupport.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
                     annotationProcessors.add(lombokProcessor);

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -39,6 +39,7 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaParsingException;
 import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.lombok.Lombok;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -53,12 +54,9 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardLocation;
 import java.io.*;
-import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -123,59 +121,19 @@ public class ReloadableJava11Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
-        LOMBOK:
-        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok-1.18.37"))) {
+        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             Processor lombokProcessor = null;
             try {
-                // https://projectlombok.org/contributing/lombok-execution-path
-                List<String> overrideClasspath = new ArrayList<>();
-                for (Path part : classpath) {
-                    if (part.toString().contains("lombok-1.18.37") || part.toString().contains("rewrite-java-lombok")) {
-                        overrideClasspath.add(part.toString());
-                    }
-                }
-                // make sure the rewrite-java-lombok dependency comes first
-                boolean found = false;
-                for (int i = 0; i < overrideClasspath.size(); i++) {
-                    if (overrideClasspath.get(i).contains("rewrite-java-lombok")) {
-                        overrideClasspath.add(0, overrideClasspath.remove(i));
-                        found = true;
-                    }
-                }
-                if (!found) {
-                    // try to find `rewrite-java-lombok` using class loader
-                    URL resource = getClass().getClassLoader().getResource("org/openrewrite/java/lombok/OpenRewriteConfigurationKeysLoader.class");
-                    if (resource != null && resource.getProtocol().equals("jar") && resource.getPath().startsWith("file:")) {
-                        String path = Paths.get(URI.create(resource.getPath().substring(0, resource.getPath().indexOf("!")))).toString();
-                        overrideClasspath.add(0, path);
-                    } else {
-                        break LOMBOK;
-                    }
-                }
-                System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
-
-                Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, getClass().getClassLoader());
-                Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
-                        Class.forName("java.lang.ClassLoader"),
-                        Class.forName("java.lang.String"),
-                        Class.forName("java.lang.String"),
-                        Class.forName("java.util.List"),
-                        Class.forName("java.util.List"));
-                shadowLoaderConstructor.setAccessible(true);
-
-                ClassLoader lombokShadowLoader = (ClassLoader) shadowLoaderConstructor.newInstance(
-                        getClass().getClassLoader(),
-                        "lombok",
-                        null,
-                        emptyList(),
-                        singletonList("lombok.patcher.Symbols")
-                );
-                lombokProcessor = (Processor) lombokShadowLoader.loadClass("lombok.core.AnnotationProcessor").getDeclaredConstructor().newInstance();
-                Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
             } catch (ReflectiveOperationException ignore) {
                 // Lombok was not found or could not be initialized
             } finally {
-                annotationProcessors = lombokProcessor != null ? singletonList(lombokProcessor) : emptyList();
+                if (lombokProcessor != null) {
+                    Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+                    annotationProcessors = singletonList(lombokProcessor);
+                } else {
+                    annotationProcessors = emptyList();
+                }
             }
         } else {
             annotationProcessors = emptyList();

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -64,7 +64,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -121,22 +120,17 @@ public class ReloadableJava11Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
+        annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
-            Processor lombokProcessor = null;
             try {
-                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
-            } catch (ReflectiveOperationException ignore) {
-                // Lombok was not found or could not be initialized
-            } finally {
+                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
-                    annotationProcessors = singletonList(lombokProcessor);
-                } else {
-                    annotationProcessors = emptyList();
+                    annotationProcessors.add(lombokProcessor);
                 }
+            } catch (ReflectiveOperationException ignore) {
+                // Lombok was not found or could not be initialized
             }
-        } else {
-            annotationProcessors = emptyList();
         }
 
         // MUST be created ahead of compiler construction

--- a/rewrite-java-17/build.gradle.kts
+++ b/rewrite-java-17/build.gradle.kts
@@ -14,7 +14,7 @@ val javaTck = configurations.create("javaTck") {
 dependencies {
     api(project(":rewrite-core"))
     api(project(":rewrite-java"))
-    runtimeOnly(project(":rewrite-java-lombok"))
+    implementation(project(":rewrite-java-lombok"))
 
     compileOnly("org.slf4j:slf4j-api:1.7.+")
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -62,7 +62,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -119,22 +118,17 @@ public class ReloadableJava17Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
+        annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
-            Processor lombokProcessor = null;
             try {
-                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
-            } catch (ReflectiveOperationException ignore) {
-                // Lombok was not found or could not be initialized
-            } finally {
+                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
-                    annotationProcessors = singletonList(lombokProcessor);
-                } else {
-                    annotationProcessors = emptyList();
+                    annotationProcessors.add(lombokProcessor);
                 }
+            } catch (ReflectiveOperationException ignore) {
+                // Lombok was not found or could not be initialized
             }
-        } else {
-            annotationProcessors = emptyList();
         }
 
         // MUST be created (registered with the context) after pfm and compilerLog

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -38,7 +38,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaParsingException;
 import org.openrewrite.java.internal.JavaTypeCache;
-import org.openrewrite.java.lombok.Lombok;
+import org.openrewrite.java.lombok.LombokSupport;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -121,7 +121,7 @@ public class ReloadableJava17Parser implements JavaParser {
         annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             try {
-                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
+                Processor lombokProcessor = LombokSupport.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
                     annotationProcessors.add(lombokProcessor);

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -38,6 +38,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaParsingException;
 import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.lombok.Lombok;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -52,12 +53,9 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardLocation;
 import java.io.*;
-import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -121,59 +119,19 @@ public class ReloadableJava17Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
-        LOMBOK:
-        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok-1.18.37"))) {
+        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             Processor lombokProcessor = null;
             try {
-                // https://projectlombok.org/contributing/lombok-execution-path
-                List<String> overrideClasspath = new ArrayList<>();
-                for (Path part : classpath) {
-                    if (part.toString().contains("lombok-1.18.37") || part.toString().contains("rewrite-java-lombok")) {
-                        overrideClasspath.add(part.toString());
-                    }
-                }
-                // make sure the rewrite-java-lombok dependency comes first
-                boolean found = false;
-                for (int i = 0; i < overrideClasspath.size(); i++) {
-                    if (overrideClasspath.get(i).contains("rewrite-java-lombok")) {
-                        overrideClasspath.add(0, overrideClasspath.remove(i));
-                        found = true;
-                    }
-                }
-                if (!found) {
-                    // try to find `rewrite-java-lombok` using class loader
-                    URL resource = getClass().getClassLoader().getResource("org/openrewrite/java/lombok/OpenRewriteConfigurationKeysLoader.class");
-                    if (resource != null && resource.getProtocol().equals("jar") && resource.getPath().startsWith("file:")) {
-                        String path = Paths.get(URI.create(resource.getPath().substring(0, resource.getPath().indexOf("!")))).toString();
-                        overrideClasspath.add(0, path);
-                    } else {
-                        break LOMBOK;
-                    }
-                }
-                System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
-
-                Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, getClass().getClassLoader());
-                Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
-                        Class.forName("java.lang.ClassLoader"),
-                        Class.forName("java.lang.String"),
-                        Class.forName("java.lang.String"),
-                        Class.forName("java.util.List"),
-                        Class.forName("java.util.List"));
-                shadowLoaderConstructor.setAccessible(true);
-
-                ClassLoader lombokShadowLoader = (ClassLoader) shadowLoaderConstructor.newInstance(
-                        getClass().getClassLoader(),
-                        "lombok",
-                        null,
-                        emptyList(),
-                        singletonList("lombok.patcher.Symbols")
-                );
-                lombokProcessor = (Processor) lombokShadowLoader.loadClass("lombok.core.AnnotationProcessor").getDeclaredConstructor().newInstance();
-                Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
             } catch (ReflectiveOperationException ignore) {
                 // Lombok was not found or could not be initialized
             } finally {
-                annotationProcessors = lombokProcessor != null ? singletonList(lombokProcessor) : emptyList();
+                if (lombokProcessor != null) {
+                    Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+                    annotationProcessors = singletonList(lombokProcessor);
+                } else {
+                    annotationProcessors = emptyList();
+                }
             }
         } else {
             annotationProcessors = emptyList();

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -17,7 +17,7 @@ val javaTck = configurations.create("javaTck") {
 dependencies {
     api(project(":rewrite-core"))
     api(project(":rewrite-java"))
-    runtimeOnly(project(":rewrite-java-lombok"))
+    implementation(project(":rewrite-java-lombok"))
 
     compileOnly("org.slf4j:slf4j-api:1.7.+")
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
@@ -38,7 +38,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaParsingException;
 import org.openrewrite.java.internal.JavaTypeCache;
-import org.openrewrite.java.lombok.Lombok;
+import org.openrewrite.java.lombok.LombokSupport;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -121,7 +121,7 @@ public class ReloadableJava21Parser implements JavaParser {
         annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             try {
-                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
+                Processor lombokProcessor = LombokSupport.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
                     annotationProcessors.add(lombokProcessor);

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
@@ -62,7 +62,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -119,22 +118,17 @@ public class ReloadableJava21Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
+        annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
-            Processor lombokProcessor = null;
             try {
-                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
-            } catch (ReflectiveOperationException ignore) {
-                // Lombok was not found or could not be initialized
-            } finally {
+                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
-                    annotationProcessors = singletonList(lombokProcessor);
-                } else {
-                    annotationProcessors = emptyList();
+                    annotationProcessors.add(lombokProcessor);
                 }
+            } catch (ReflectiveOperationException ignore) {
+                // Lombok was not found or could not be initialized
             }
-        } else {
-            annotationProcessors = emptyList();
         }
 
         // MUST be created (registered with the context) after pfm and compilerLog

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     compileOnly("org.slf4j:slf4j-api:1.7.+")
 
     implementation(project(":rewrite-java"))
-    runtimeOnly(project(":rewrite-java-lombok"))
+    implementation(project(":rewrite-java-lombok"))
     implementation("org.ow2.asm:asm:latest.release")
 
     implementation("io.micrometer:micrometer-core:1.9.+")

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -57,7 +57,6 @@ import java.util.stream.StreamSupport;
 
 import static com.sun.tools.javac.util.List.nil;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 class ReloadableJava8Parser implements JavaParser {
@@ -111,22 +110,17 @@ class ReloadableJava8Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
+        annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
-            Processor lombokProcessor = null;
             try {
-                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
-            } catch (ReflectiveOperationException ignore) {
-                // Lombok was not found or could not be initialized
-            } finally {
+                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
-                    annotationProcessors = singletonList(lombokProcessor);
-                } else {
-                    annotationProcessors = emptyList();
+                    annotationProcessors.add(lombokProcessor);
                 }
+            } catch (ReflectiveOperationException ignore) {
+                // Lombok was not found or could not be initialized
             }
-        } else {
-            annotationProcessors = emptyList();
         }
 
         // MUST be created (registered with the context) after pfm and compilerLog

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -17,7 +17,6 @@ package org.openrewrite.java;
 
 import com.sun.tools.javac.comp.Check;
 import com.sun.tools.javac.comp.Enter;
-import com.sun.tools.javac.comp.Todo;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.main.Option;
@@ -35,7 +34,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.internal.JavaTypeCache;
-import org.openrewrite.java.lombok.Lombok;
+import org.openrewrite.java.lombok.LombokSupport;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -56,7 +55,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static com.sun.tools.javac.util.List.nil;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 class ReloadableJava8Parser implements JavaParser {
@@ -113,7 +111,7 @@ class ReloadableJava8Parser implements JavaParser {
         annotationProcessors = new ArrayList<>(1);
         if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             try {
-                Processor lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
+                Processor lombokProcessor = LombokSupport.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {
                     Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
                     annotationProcessors.add(lombokProcessor);

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -35,6 +35,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.lombok.Lombok;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.NamedStyles;
@@ -46,12 +47,9 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.processing.Processor;
 import javax.tools.*;
 import java.io.*;
-import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -113,60 +111,19 @@ class ReloadableJava8Parser implements JavaParser {
         // for all other source files and unaffected nodes within the same file.
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
-        LOMBOK:
-        if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
-                classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok-1.18.37"))) {
+        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             Processor lombokProcessor = null;
             try {
-                // https://projectlombok.org/contributing/lombok-execution-path
-                List<String> overrideClasspath = new ArrayList<>();
-                for (Path part : classpath) {
-                    if (part.toString().contains("lombok-1.18.37") || part.toString().contains("rewrite-java-lombok")) {
-                        overrideClasspath.add(part.toString());
-                    }
-                }
-                // make sure the rewrite-java-lombok dependency comes first
-                boolean found = false;
-                for (int i = 0; i < overrideClasspath.size(); i++) {
-                    if (overrideClasspath.get(i).contains("rewrite-java-lombok")) {
-                        overrideClasspath.add(0, overrideClasspath.remove(i));
-                        found = true;
-                    }
-                }
-                if (!found) {
-                    // try to find `rewrite-java-lombok` using class loader
-                    URL resource = getClass().getClassLoader().getResource("org/openrewrite/java/lombok/OpenRewriteConfigurationKeysLoader.class");
-                    if (resource != null && resource.getProtocol().equals("jar") && resource.getPath().startsWith("file:")) {
-                        String path = Paths.get(URI.create(resource.getPath().substring(0, resource.getPath().indexOf("!")))).toString();
-                        overrideClasspath.add(0, path);
-                    } else {
-                        break LOMBOK;
-                    }
-                }
-                System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
-
-                Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, getClass().getClassLoader());
-                Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
-                        Class.forName("java.lang.ClassLoader"),
-                        Class.forName("java.lang.String"),
-                        Class.forName("java.lang.String"),
-                        Class.forName("java.util.List"),
-                        Class.forName("java.util.List"));
-                shadowLoaderConstructor.setAccessible(true);
-
-                ClassLoader lombokShadowLoader = (ClassLoader) shadowLoaderConstructor.newInstance(
-                        getClass().getClassLoader(),
-                        "lombok",
-                        null,
-                        emptyList(),
-                        singletonList("lombok.patcher.Symbols")
-                );
-                lombokProcessor = (Processor) lombokShadowLoader.loadClass("lombok.core.AnnotationProcessor").getDeclaredConstructor().newInstance();
-                Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+                lombokProcessor = Lombok.createLombokProcessor(getClass().getClassLoader());
             } catch (ReflectiveOperationException ignore) {
                 // Lombok was not found or could not be initialized
             } finally {
-                annotationProcessors = lombokProcessor != null ? singletonList(lombokProcessor) : emptyList();
+                if (lombokProcessor != null) {
+                    Options.instance(context).put(Option.PROCESSOR, "lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+                    annotationProcessors = singletonList(lombokProcessor);
+                } else {
+                    annotationProcessors = emptyList();
+                }
             }
         } else {
             annotationProcessors = emptyList();

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -109,7 +109,8 @@ class ReloadableJava8Parser implements JavaParser {
         Options.instance(context).put("should-stop.ifError", "GENERATE");
 
         annotationProcessors = new ArrayList<>(1);
-        if (classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
+        if (System.getenv().getOrDefault("REWRITE_LOMBOK", System.getProperty("rewrite.lombok")) != null &&
+            classpath != null && classpath.stream().anyMatch(it -> it.toString().contains("lombok"))) {
             try {
                 Processor lombokProcessor = LombokSupport.createLombokProcessor(getClass().getClassLoader());
                 if (lombokProcessor != null) {

--- a/rewrite-java-lombok/build.gradle.kts
+++ b/rewrite-java-lombok/build.gradle.kts
@@ -53,7 +53,7 @@ val compiler = javaToolchains.compilerFor {
 val tools = compiler.get().metadata.installationPath.file("lib/tools.jar")
 
 dependencies {
-    implementation("org.jspecify:jspecify:latest.release")
+    implementation(project(":rewrite-core"))
     //runtimeOnly("org.projectlombok:lombok:latest.release")
     runtimeOnly("org.openrewrite.tools:lombok:latest.release") // Temporary pending the next stable release of lombok
 

--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/Lombok.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/Lombok.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.lombok;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.internal.ReflectionUtils;
+
+import javax.annotation.processing.Processor;
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class Lombok {
+
+    public static @Nullable Processor createLombokProcessor(ClassLoader classLoader) throws ReflectiveOperationException {
+        // https://projectlombok.org/contributing/lombok-execution-path
+        List<String> overrideClasspath = new ArrayList<>();
+        for (Path entry : ReflectionUtils.findClassPathEntriesFor("lombok/Getter.class", classLoader)) {
+            if (entry.getFileName().toString().contains("lombok-1.18.37") && !overrideClasspath.contains(entry.toString())) {
+                overrideClasspath.add(entry.toString());
+            }
+        }
+
+        // try to find `rewrite-java-lombok` using class loader
+        for (Path entry : ReflectionUtils.findClassPathEntriesFor("org/openrewrite/java/lombok/OpenRewriteConfigurationKeysLoader.class", classLoader)) {
+            if (!overrideClasspath.contains(entry.toString())) {
+                // make sure the rewrite-java-lombok dependency comes first
+                overrideClasspath.add(0, entry.toString());
+            }
+        }
+        for (Path entry : ReflectionUtils.findClassPathEntriesFor("META-INF/services/lombok.core.configuration.ConfigurationKeysLoader", classLoader)) {
+            if (!overrideClasspath.contains(entry.toString())) {
+                // make sure the rewrite-java-lombok dependency comes first
+                overrideClasspath.add(0, entry.toString());
+            }
+        }
+
+        if (overrideClasspath.isEmpty()) {
+            return null;
+        }
+
+        System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
+
+        Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, classLoader);
+        Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
+                Class.forName("java.lang.ClassLoader"),
+                Class.forName("java.lang.String"),
+                Class.forName("java.lang.String"),
+                Class.forName("java.util.List"),
+                Class.forName("java.util.List"));
+        shadowLoaderConstructor.setAccessible(true);
+
+        ClassLoader lombokShadowLoader = (ClassLoader) shadowLoaderConstructor.newInstance(
+                classLoader,
+                "lombok",
+                null,
+                emptyList(),
+                singletonList("lombok.patcher.Symbols")
+        );
+        return (Processor) lombokShadowLoader.loadClass("lombok.core.AnnotationProcessor").getDeclaredConstructor().newInstance();
+    }
+}

--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
@@ -28,12 +28,12 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-public class Lombok {
+public class LombokSupport {
 
-    public static @Nullable Processor createLombokProcessor(ClassLoader classLoader) throws ReflectiveOperationException {
+    public static @Nullable Processor createLombokProcessor(ClassLoader parserClassLoader) throws ReflectiveOperationException {
         // https://projectlombok.org/contributing/lombok-execution-path
         List<String> overrideClasspath = new ArrayList<>();
-        for (Path entry : ReflectionUtils.findClassPathEntriesFor("lombok/Getter.class", classLoader)) {
+        for (Path entry : ReflectionUtils.findClassPathEntriesFor("lombok/Getter.class", parserClassLoader)) {
             // FIXME remove hardcoded version once Lombok proper 1.18.37 is released
             if (entry.getFileName().toString().contains("lombok-1.18.37") && !overrideClasspath.contains(entry.toString())) {
                 overrideClasspath.add(entry.toString());
@@ -41,14 +41,14 @@ public class Lombok {
         }
 
         // try to find `rewrite-java-lombok` using class loader
-        for (Path entry : ReflectionUtils.findClassPathEntriesFor("org/openrewrite/java/lombok/OpenRewriteConfigurationKeysLoader.class", classLoader)) {
+        for (Path entry : ReflectionUtils.findClassPathEntriesFor("org/openrewrite/java/lombok/OpenRewriteConfigurationKeysLoader.class", parserClassLoader)) {
             if (!overrideClasspath.contains(entry.toString())) {
                 // make sure the rewrite-java-lombok dependency comes first
                 overrideClasspath.add(0, entry.toString());
             }
         }
         // for IDE support, where the `rewrite-java-lombok` classes and resources could be in separate folders
-        for (Path entry : ReflectionUtils.findClassPathEntriesFor("META-INF/services/lombok.core.configuration.ConfigurationKeysLoader", classLoader)) {
+        for (Path entry : ReflectionUtils.findClassPathEntriesFor("META-INF/services/lombok.core.configuration.ConfigurationKeysLoader", parserClassLoader)) {
             if (!overrideClasspath.contains(entry.toString())) {
                 // make sure the rewrite-java-lombok dependency comes first
                 overrideClasspath.add(0, entry.toString());
@@ -61,7 +61,7 @@ public class Lombok {
 
         String oldValue = System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
         try {
-            Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, classLoader);
+            Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader);
             Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
                     Class.forName("java.lang.ClassLoader"),
                     Class.forName("java.lang.String"),
@@ -71,7 +71,7 @@ public class Lombok {
             shadowLoaderConstructor.setAccessible(true);
 
             ClassLoader lombokShadowLoader = (ClassLoader) shadowLoaderConstructor.newInstance(
-                    classLoader,
+                    parserClassLoader,
                     "lombok",
                     null,
                     emptyList(),


### PR DESCRIPTION
The logic to initialize the Lombok annotation processor is now moved to the `rewrite-java-lombok` project and used by all Java parsers.
