### PR TITLE
Use defined `ClassLoader` in `ServiceLoader` 

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
@@ -104,8 +104,8 @@ public class PlainText implements SourceFileWithReferences, Tree {
     }
 
     @Override
-    public References getReferences() {
-        this.references = build(this.references);
+    public References getReferences(ClassLoader classLoader) {
+        this.references = build(this.references, getClass().getClassLoader());
         return Objects.requireNonNull(this.references.get());
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -17,17 +17,22 @@ package org.openrewrite.gradle;
 
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.openrewrite.Issue;
+import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +66,46 @@ class AddDependencyTest implements RewriteTest {
                 }
             }
       """;
+
+   public static class TSTRecipe extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "A";
+        }
+
+        @Override
+        public String getDescription() {
+            return "B.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaVisitor<>(){
+
+                @Override
+                public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+                    return super.visitMethodDeclaration(method, executionContext);
+                }
+            };
+        }
+    }
+
+    @Disabled
+    @Test
+    void tsts() {
+        rewriteRun(
+          spec -> spec.recipe(new TSTRecipe()),
+          java("""
+            import java.util.List;
+            class A {
+                void tst() {
+                    List.of("A", "B");
+                }
+            }
+            """
+          )
+        );
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"com.google.common.math.*", "com.google.common.math.IntMath"})

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangePackage.java
@@ -118,7 +118,7 @@ public class ChangePackage extends Recipe {
                     SourceFileWithReferences cu = (SourceFileWithReferences) tree;
                     boolean recursive = Boolean.TRUE.equals(ChangePackage.this.recursive);
                     String recursivePackageNamePrefix = oldPackageName + ".";
-                    for (Reference ref : cu.getReferences().getReferences()) {
+                    for (Reference ref : cu.getReferences(getClass().getClassLoader()).getReferences()) {
                         if (ref.getValue().equals(oldPackageName) || recursive && ref.getValue().startsWith(recursivePackageNamePrefix)) {
                             return SearchResult.found(cu);
                         }
@@ -141,7 +141,7 @@ public class ChangePackage extends Recipe {
                     return new JavaChangePackageVisitor().visit(tree, ctx, requireNonNull(getCursor().getParent()));
                 } else if (tree instanceof SourceFileWithReferences) {
                     SourceFileWithReferences sourceFile = (SourceFileWithReferences) tree;
-                    SourceFileWithReferences.References references = sourceFile.getReferences();
+                    SourceFileWithReferences.References references = sourceFile.getReferences(getClass().getClassLoader());
                     boolean recursive = Boolean.TRUE.equals(ChangePackage.this.recursive);
                     PackageMatcher matcher = new PackageMatcher(oldPackageName, recursive);
                     Map<Tree, Reference> matches = new HashMap<>();

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -111,7 +111,7 @@ public class ChangeType extends Recipe {
                     return new JavaChangeTypeVisitor(oldFullyQualifiedTypeName, newFullyQualifiedTypeName, ignoreDefinition).visit(tree, ctx, requireNonNull(getCursor().getParent()));
                 } else if (tree instanceof SourceFileWithReferences) {
                     SourceFileWithReferences sourceFile = (SourceFileWithReferences) tree;
-                    SourceFileWithReferences.References references = sourceFile.getReferences();
+                    SourceFileWithReferences.References references = sourceFile.getReferences(getClass().getClassLoader());
                     TypeMatcher matcher = new TypeMatcher(oldFullyQualifiedTypeName);
                     Map<Tree, Reference> matches = new HashMap<>();
                     for (Reference ref : references.findMatches(matcher)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -77,7 +77,7 @@ public class FindTypes extends Recipe {
                     return new JavaSourceFileVisitor(fullyQualifiedType).visit(tree, ctx);
                 } else if (tree instanceof SourceFileWithReferences) {
                     SourceFileWithReferences sourceFile = (SourceFileWithReferences) tree;
-                    SourceFileWithReferences.References references = sourceFile.getReferences();
+                    SourceFileWithReferences.References references = sourceFile.getReferences(getClass().getClassLoader());
                     TypeMatcher matcher = new TypeMatcher(fullyQualifiedTypeName);
                     Set<Tree> matches = references.findMatches(matcher).stream().map(Trait::getTree).collect(Collectors.toSet());
                     return new ReferenceVisitor(matches).visit(tree, ctx);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
@@ -121,7 +121,7 @@ public class UsesType<P> extends TreeVisitor<Tree, P> {
             }
         } else if (tree instanceof SourceFileWithReferences) {
             SourceFileWithReferences sourceFile = (SourceFileWithReferences) tree;
-            SourceFileWithReferences.References references = sourceFile.getReferences();
+            SourceFileWithReferences.References references = sourceFile.getReferences(getClass().getClassLoader());
             TypeMatcher matcher = typeMatcher != null ? typeMatcher : new TypeMatcher(fullyQualifiedType);
             for (Reference ignored : references.findMatches(matcher)) {
                 return SearchResult.found(sourceFile);

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/tree/Properties.java
@@ -118,8 +118,8 @@ public interface Properties extends Tree {
         transient SoftReference<References> references;
 
         @Override
-        public References getReferences() {
-            this.references = build(this.references);
+        public References getReferences(ClassLoader classLoader) {
+            this.references = build(this.references, getClass().getClassLoader());
             return Objects.requireNonNull(this.references.get());
         }
     }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/trait/PropertiesReferenceTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/trait/PropertiesReferenceTest.java
@@ -44,7 +44,7 @@ class PropertiesReferenceTest implements RewriteTest {
           properties(
             PROPERTIES,
             spec -> spec.path(filename).afterRecipe(doc ->
-              assertThat(doc.getReferences().getReferences())
+              assertThat(doc.getReferences(getClass().getClassLoader()).getReferences())
                 .satisfiesExactlyInAnyOrder(
                   ref -> {
                       assertThat(ref.getKind()).isEqualTo(Reference.Kind.TYPE);
@@ -72,7 +72,7 @@ class PropertiesReferenceTest implements RewriteTest {
         rewriteRun(
           properties(
             PROPERTIES,
-            spec -> spec.path(filename).afterRecipe(doc -> assertThat(doc.getReferences().getReferences()).isEmpty())
+            spec -> spec.path(filename).afterRecipe(doc -> assertThat(doc.getReferences(getClass().getClassLoader()).getReferences()).isEmpty())
           )
         );
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -168,8 +168,8 @@ public interface Xml extends Tree {
         transient SoftReference<References> references;
 
         @Override
-        public References getReferences() {
-            this.references = build(this.references);
+        public References getReferences(ClassLoader classLoader) {
+            this.references = build(this.references, getClass().getClassLoader());
             return Objects.requireNonNull(this.references.get());
         }
     }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -145,9 +145,9 @@ class XmlParserTest implements RewriteTest {
               </beans>
               """,
             spec -> spec.afterRecipe(doc -> {
-                assertThat(doc.getReferences().getReferences().stream().anyMatch(typeRef -> typeRef.getValue().equals("java.lang.String"))).isTrue();
-                assertThat(doc.getReferences().getReferences().stream().anyMatch(typeRef -> typeRef.getKind() == Reference.Kind.TYPE)).isTrue();
-                assertThat(doc.getReferences().getReferences().stream().anyMatch(typeRef -> typeRef.getKind() == Reference.Kind.PACKAGE)).isTrue();
+                assertThat(doc.getReferences(getClass().getClassLoader()).getReferences().stream().anyMatch(typeRef -> typeRef.getValue().equals("java.lang.String"))).isTrue();
+                assertThat(doc.getReferences(getClass().getClassLoader()).getReferences().stream().anyMatch(typeRef -> typeRef.getKind() == Reference.Kind.TYPE)).isTrue();
+                assertThat(doc.getReferences(getClass().getClassLoader()).getReferences().stream().anyMatch(typeRef -> typeRef.getKind() == Reference.Kind.PACKAGE)).isTrue();
             })
           )
         );

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
@@ -136,8 +136,8 @@ public interface Yaml extends Tree {
         transient SoftReference<References> references;
 
         @Override
-        public References getReferences() {
-            this.references = build(this.references);
+        public References getReferences(ClassLoader classLoader) {
+            this.references = build(this.references, getClass().getClassLoader());
             return Objects.requireNonNull(this.references.get());
         }
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/trait/YamlReferenceTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/trait/YamlReferenceTest.java
@@ -53,7 +53,7 @@ class YamlReferenceTest implements RewriteTest {
           yaml(
             YAML,
             spec -> spec.path(filename).afterRecipe(doc ->
-              assertThat(doc.getReferences().getReferences()).satisfiesExactlyInAnyOrder(
+              assertThat(doc.getReferences(getClass().getClassLoader()).getReferences()).satisfiesExactlyInAnyOrder(
                 ref -> {
                     assertThat(ref.getKind()).isEqualTo(Reference.Kind.TYPE);
                     assertThat(ref.getValue()).isEqualTo("java.lang.String");
@@ -90,7 +90,7 @@ class YamlReferenceTest implements RewriteTest {
         rewriteRun(
           yaml(
             YAML,
-            spec -> spec.path(filename).afterRecipe(doc -> assertThat(doc.getReferences().getReferences()).isEmpty())
+            spec -> spec.path(filename).afterRecipe(doc -> assertThat(doc.getReferences(getClass().getClassLoader()).getReferences()).isEmpty())
           )
         );
     }
@@ -108,7 +108,7 @@ class YamlReferenceTest implements RewriteTest {
               """,
             spec -> spec
               .path("application.yml")
-              .afterRecipe(doc -> assertThat(doc.getReferences().getReferences()).singleElement().satisfies(
+              .afterRecipe(doc -> assertThat(doc.getReferences(getClass().getClassLoader()).getReferences()).singleElement().satisfies(
                 ref -> {
                     assertThat(ref.getKind()).isEqualTo(Reference.Kind.TYPE);
                     assertThat(ref.getValue()).isEqualTo("org.openrewrite.java.DoSomething");


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Forward ClassLoader to SourceFileWithReferences to enbale the used ServiceLoader to load classes from the recipe classpath.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Make Providers available that are defined in external recipe artifacts loaded at runtime.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
