### PR TITLE
Improve MergeYaml recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
@@ -351,6 +352,37 @@ public final class ListUtils {
     @Contract("null, _ -> null; !null, _ -> !null")
     public static <T> @Nullable List<T> flatMap(@Nullable List<T> ls, Function<T, Object> flatMap) {
         return flatMap(ls, (i, t) -> flatMap.apply(t));
+    }
+
+    /**
+     * Filters a list based on the given predicate. If no elements are removed, the original list is returned.
+     *
+     * @param ls        The list to filter.
+     * @param predicate The predicate to test each element.
+     * @param <T>       The type of elements in the list.
+     * @return A new list with filtered elements, or the original list if unchanged.
+     */
+    @Contract("null, _ -> null; !null, _ -> !null")
+    public static <T> @Nullable List<T> filter(@Nullable List<T> ls, Predicate<T> predicate) {
+        if (ls == null || ls.isEmpty()) {
+            //noinspection ConstantConditions
+            return ls;
+        }
+
+        List<T> newLs = ls;
+        int j = 0;
+        for (int i = 0; i < ls.size(); i++, j++) {
+            T elem = ls.get(i);
+            if (!predicate.test(elem)) {
+                if (newLs == ls) {
+                    newLs = new ArrayList<>(ls);
+                }
+                newLs.remove(j);
+                j--;
+            }
+        }
+
+        return newLs;
     }
 
     /**

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -268,7 +268,7 @@ public class ChangePropertyKey extends Recipe {
                     } else {
                         m = (Yaml.Mapping) new DeletePropertyVisitor<>(entryToReplace).visitNonNull(m, p);
                         Yaml.Mapping newMapping = m.withEntries(Collections.singletonList(newEntry));
-                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, newMapping, true, null, false).visitMapping(m, p);
+                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, newMapping, true, null, false, null).visitMapping(m, p);
                         m = maybeAutoFormat(m, mergedMapping, p, getCursor().getParentOrThrow());
                     }
                 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -268,7 +268,7 @@ public class ChangePropertyKey extends Recipe {
                     } else {
                         m = (Yaml.Mapping) new DeletePropertyVisitor<>(entryToReplace).visitNonNull(m, p);
                         Yaml.Mapping newMapping = m.withEntries(Collections.singletonList(newEntry));
-                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, newMapping, true, null, false, null).visitMapping(m, p);
+                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, newMapping, true, null, false, null, null).visitMapping(m, p);
                         m = maybeAutoFormat(m, mergedMapping, p, getCursor().getParentOrThrow());
                     }
                 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CopyValue.java
@@ -125,7 +125,7 @@ public class CopyValue extends ScanningRecipe<CopyValue.Accumulator> {
         if(acc.snippet == null) {
             return TreeVisitor.noop();
         }
-        TreeVisitor<?, ExecutionContext> visitor = new MergeYaml(newKey, acc.snippet, false, null, null, null).getVisitor();
+        TreeVisitor<?, ExecutionContext> visitor = new MergeYaml(newKey, acc.snippet, false, null, null, null, null).getVisitor();
         if(newFilePath == null) {
             visitor = Preconditions.check(new FindSourceFiles(acc.path.toString()).getVisitor(), visitor);
         } else {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
@@ -28,6 +29,7 @@ import static org.openrewrite.yaml.MergeYaml.InsertMode.*;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
 public class MergeYaml extends Recipe {
     @Option(displayName = "Key path",
             description = "A [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expression used to find matching keys.",
@@ -75,6 +77,14 @@ public class MergeYaml extends Recipe {
             example = "some-key")
     @Nullable
     String insertProperty;
+
+    /**
+     * @deprecated Use {@link #MergeYaml(String, String, Boolean, String, String, InsertMode, String)} instead.
+     */
+    @Deprecated
+    public MergeYaml(String key, @Language("yml") String yaml, @Nullable Boolean acceptTheirs, @Nullable String objectIdentifyingProperty, @Nullable String filePattern, @Nullable String insertProperty) {
+        this(key, yaml, acceptTheirs, objectIdentifyingProperty, filePattern, null, insertProperty);
+    }
 
     public enum InsertMode { Before, After, Last }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -23,6 +23,8 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.yaml.tree.Yaml;
 
+import static org.openrewrite.internal.StringUtils.isBlank;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class MergeYaml extends Recipe {
@@ -91,7 +93,6 @@ public class MergeYaml extends Recipe {
     }
 
     final static String FOUND_MATCHING_ELEMENT = "FOUND_MATCHING_ELEMENT";
-    final static String REMOVE_DOCUMENT_PREFIX = "REMOVE_DOCUMENT_PREFIX";
     final static String REMOVE_PREFIX = "REMOVE_PREFIX";
 
     @Override
@@ -123,11 +124,8 @@ public class MergeYaml extends Recipe {
                             new MergeYamlVisitor<>(document.getBlock(), yaml, Boolean.TRUE.equals(acceptTheirs), objectIdentifyingProperty, insertBefore)
                                     .visitNonNull(document.getBlock(), ctx, getCursor())
                     );
-                    if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
-                        d = d.withPrefix("");
-                    }
                     if (getCursor().getMessage(REMOVE_PREFIX, false)) {
-                        d = d.withEnd(d.getEnd().withPrefix(""));
+                        d = isBlank(insertBefore) ? d.withEnd(d.getEnd().withPrefix("")) : d.withPrefix("");
                     }
                     return d;
                 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -68,8 +68,7 @@ public class MergeYaml extends Recipe {
     @Option(displayName = "Insert mode",
             description = "Choose an insertion point when multiple mappings exist. Default is `Last`.",
             valid = {"Before", "After", "Last"},
-            required = false,
-            example = "Last")
+            required = false)
     @Nullable
     InsertMode insertMode;
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -91,6 +91,7 @@ public class MergeYaml extends Recipe {
     }
 
     final static String FOUND_MATCHING_ELEMENT = "FOUND_MATCHING_ELEMENT";
+    final static String REMOVE_DOCUMENT_PREFIX = "REMOVE_DOCUMENT_PREFIX";
     final static String REMOVE_PREFIX = "REMOVE_PREFIX";
 
     @Override
@@ -122,7 +123,13 @@ public class MergeYaml extends Recipe {
                             new MergeYamlVisitor<>(document.getBlock(), yaml, Boolean.TRUE.equals(acceptTheirs), objectIdentifyingProperty, insertBefore)
                                     .visitNonNull(document.getBlock(), ctx, getCursor())
                     );
-                    return getCursor().getMessage(REMOVE_PREFIX, false) ? d.withEnd(d.getEnd().withPrefix("")) : d;
+                    if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
+                        d = d.withPrefix("");
+                    }
+                    if (getCursor().getMessage(REMOVE_PREFIX, false)) {
+                        d = d.withEnd(d.getEnd().withPrefix(""));
+                    }
+                    return d;
                 }
                 Yaml.Document d = super.visitDocument(document, ctx);
                 if (d == document && !getCursor().getMessage(FOUND_MATCHING_ELEMENT, false)) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -17,6 +17,7 @@ package org.openrewrite.yaml;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.Value;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
@@ -29,7 +30,8 @@ import static org.openrewrite.yaml.MergeYaml.InsertMode.*;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-@AllArgsConstructor
+@NoArgsConstructor(force = true) // TODO: remove with @deprecated constructor
+@AllArgsConstructor // TODO: remove with @deprecated constructor
 public class MergeYaml extends Recipe {
     @Option(displayName = "Key path",
             description = "A [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expression used to find matching keys.",

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -356,7 +356,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
      * Specialized concatAll function which takes the `insertPlace` property into account.
      */
     private <T> ListConcat<T> concatAll(List<T> ls, List<T> t, Function<T, String> getValue) {
-        if (insertMode == null || insertMode == Last || t.isEmpty()) {
+        if (insertMode == null || insertMode == Last || insertProperty == null || t.isEmpty()) {
             return new ListConcat<>(ListUtils.concatAll(ls, t), -1,-1);
         }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -209,7 +209,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
 
         // copy comment to previous element if needed
         if (m1.getEntries().size() < mutatedEntries.ls.size() && !getCursor().isRoot()) {
-            // If newly entries are inserted somewhere, but not the last entry nor at the document root, we can be sure no changes to the rest of the tree are needed
+            // If newly entries are inserted somewhere, but not the last entry nor at the document root, we can be sure no changes to the rest of the tree is needed
             if (mutatedEntries.lastNewlyAddedItemIndex != -1 && mutatedEntries.lastNewlyAddedItemIndex < mutatedEntries.ls.size() - 1) {
                 Yaml.Mapping.Entry afterInsertEntry = mutatedEntries.ls.get(mutatedEntries.lastNewlyAddedItemIndex + 1);
 
@@ -295,14 +295,14 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         boolean isSequenceOfScalars = s2.getEntries().stream().allMatch(entry -> entry.getBlock() instanceof Yaml.Scalar);
         if (isSequenceOfScalars) {
             List<Yaml.Sequence.Entry> incomingEntries = new ArrayList<>(s2.getEntries());
-            NEXT_ENTRY:
+            nextEntry:
             for (Yaml.Sequence.Entry entry : s1.getEntries()) {
                 if (entry.getBlock() instanceof Yaml.Scalar) {
                     String existingScalar = ((Yaml.Scalar) entry.getBlock()).getValue();
                     for (Yaml.Sequence.Entry incomingEntry : incomingEntries) {
                         if (((Yaml.Scalar) incomingEntry.getBlock()).getValue().equals(existingScalar)) {
                             incomingEntries.remove(incomingEntry);
-                            continue NEXT_ENTRY;
+                            continue nextEntry;
                         }
                     }
                 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -2122,6 +2122,7 @@ class MergeYamlTest implements RewriteTest {
             //language=yaml
             """
               A: a
+              B: b
               """,
             null,
             null,
@@ -2137,6 +2138,7 @@ class MergeYamlTest implements RewriteTest {
               """,
             """
               A: a
+              B: b
               # Comment moved from root prefix to first
               first: value
               second: value
@@ -2146,14 +2148,14 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
-    void insertBeforeElementWithCommentOnFirstLineWithNesting() {
+    void insertBeforeElementWithCommentsWithNesting() {
         rewriteRun(
           spec -> spec.recipe(new MergeYaml(
             "$.level",
             //language=yaml
             """
-              A: a # New comment 1
-              B: b # New comment 2
+              A: a
+              B: b
               """,
             null,
             null,
@@ -2174,8 +2176,8 @@ class MergeYamlTest implements RewriteTest {
               # Comment 1
               level:
                   before: value # Comment 2
-                  A: a # New comment 1
-                  B: b # New comment 2
+                  A: a
+                  B: b
                   # Comment 3
                   first: value
                   second: value
@@ -2541,6 +2543,7 @@ class MergeYamlTest implements RewriteTest {
             //language=yaml
             """
               A: a
+              B: a
               """,
             null,
             null,
@@ -2569,6 +2572,7 @@ class MergeYamlTest implements RewriteTest {
                 # Comment 3
                 second: value # Comment 4
                 A: a
+                B: a
                 third: value # Comment 5
                 fourth: value # Comment 6
               # Comment 7
@@ -2676,7 +2680,7 @@ class MergeYamlTest implements RewriteTest {
               widget:
                 list:
                   - item 1
-                  # Comment untouched
+                  # Comment 2
                   - item 3
               """,
             """
@@ -2684,7 +2688,7 @@ class MergeYamlTest implements RewriteTest {
                 list:
                   - item 1
                   - item 2
-                  # Comment untouched
+                  # Comment 2
                   - item 3
                 another:
                   prop: value

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -21,6 +21,8 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
+import static org.openrewrite.yaml.MergeYaml.InsertMode.After;
+import static org.openrewrite.yaml.MergeYaml.InsertMode.Before;
 
 @SuppressWarnings({"KubernetesUnknownResourcesInspection", "KubernetesNonEditableResources"})
 class MergeYamlTest implements RewriteTest {
@@ -37,6 +39,7 @@ class MergeYamlTest implements RewriteTest {
                   - cron: "0 18 * * *"
               """,
             true,
+            null,
             null,
             null,
             null
@@ -66,7 +69,8 @@ class MergeYamlTest implements RewriteTest {
             false,
             null,
             null,
-          null
+          null,
+            null
           )),
           yaml(
             "",
@@ -96,7 +100,8 @@ class MergeYamlTest implements RewriteTest {
             false,
             null,
             null,
-          null
+          null,
+            null
           )),
           yaml(
             """
@@ -129,6 +134,7 @@ class MergeYamlTest implements RewriteTest {
                         age: 7
               """,
             false,
+            null,
             null,
             null,
             null
@@ -170,6 +176,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               null,
               null,
+              null,
               null
             )),
           yaml(
@@ -204,7 +211,8 @@ class MergeYamlTest implements RewriteTest {
               true,
               null,
               null,
-              null
+              null,
+            null
             )
           ),
           yaml(
@@ -227,6 +235,7 @@ class MergeYamlTest implements RewriteTest {
               bucketPolicyOnly: true
               """,
             false,
+            null,
             null,
             null,
             null
@@ -267,6 +276,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               null,
               null,
+              null,
               null
             )),
           yaml(
@@ -301,6 +311,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -324,6 +335,7 @@ class MergeYamlTest implements RewriteTest {
             "$.spec.containers",
             "imagePullPolicy: Always",
             true,
+            null,
             null,
             null,
             null
@@ -355,6 +367,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -384,6 +397,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -404,6 +418,7 @@ class MergeYamlTest implements RewriteTest {
             "$..containers",
             "imagePullPolicy: Always",
             true,
+            null,
             null,
             null,
             null
@@ -435,6 +450,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -456,6 +472,7 @@ class MergeYamlTest implements RewriteTest {
             //language=yaml
             "imagePullPolicy: Always",
             true,
+            null,
             null,
             null,
             null
@@ -490,6 +507,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -515,6 +533,7 @@ class MergeYamlTest implements RewriteTest {
                 privileged: false
               """,
             true,
+            null,
             null,
             null,
             null
@@ -554,6 +573,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -586,6 +606,7 @@ class MergeYamlTest implements RewriteTest {
                 cache: 'gradle'
               """,
             false,
+            null,
             null,
             null,
             null
@@ -629,6 +650,7 @@ class MergeYamlTest implements RewriteTest {
                       - Mangrove
               """,
             true,
+            null,
             null,
             null,
             null
@@ -675,6 +697,7 @@ class MergeYamlTest implements RewriteTest {
             true,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -711,6 +734,7 @@ class MergeYamlTest implements RewriteTest {
                     nnmap2: v222
               """,
             true,
+            null,
             null,
             null,
             null
@@ -757,6 +781,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -793,6 +818,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "name2",
+              null,
               null,
               null
             )),
@@ -831,6 +857,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -865,6 +892,7 @@ class MergeYamlTest implements RewriteTest {
             false,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -897,6 +925,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "name",
+              null,
               null,
               null
             )),
@@ -935,6 +964,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -968,6 +998,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "name",
+              null,
               null,
               null
             )),
@@ -1004,6 +1035,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "name",
+              null,
               null,
               null
             )),
@@ -1054,6 +1086,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -1100,6 +1133,7 @@ class MergeYamlTest implements RewriteTest {
                   E: description
               """,
             false,
+            null,
             null,
             null,
             null
@@ -1155,6 +1189,7 @@ class MergeYamlTest implements RewriteTest {
             false,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -1194,6 +1229,7 @@ class MergeYamlTest implements RewriteTest {
                       2: new text
               """,
             false,
+            null,
             null,
             null,
             null
@@ -1262,6 +1298,7 @@ class MergeYamlTest implements RewriteTest {
             false,
             null,
             null,
+            null,
             null
           )),
           yaml(
@@ -1292,6 +1329,7 @@ class MergeYamlTest implements RewriteTest {
               first:
                 new: value
               """,
+            null,
             null,
             null,
             null,
@@ -1328,6 +1366,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               null,
               null,
+              null,
               null
             )),
           yaml(
@@ -1354,6 +1393,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               null,
               null,
+              null,
               null
             )),
           yaml(
@@ -1378,6 +1418,7 @@ class MergeYamlTest implements RewriteTest {
                     - newJob
                 """,
               false, "name",
+              null,
               null,
               null
             )),
@@ -1421,6 +1462,7 @@ class MergeYamlTest implements RewriteTest {
                 false,
                 null,
                 null,
+                null,
                 null
               ),
               new CopyValue("$.spec.level1.level2", null, "$.spec.empty.initially", null))
@@ -1461,6 +1503,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               null,
               null,
+              null,
               null
             )),
           yaml(
@@ -1497,6 +1540,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "id",
+              null,
               null,
               null
             )),
@@ -1537,6 +1581,7 @@ class MergeYamlTest implements RewriteTest {
               true,
               null,
               null,
+              null,
               null
             )),
           yaml(
@@ -1571,6 +1616,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -1604,6 +1650,7 @@ class MergeYamlTest implements RewriteTest {
                 something: else
                 """,
               false,
+              null,
               null,
               null,
               null
@@ -1648,6 +1695,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -1691,6 +1739,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "name",
+              null,
               null,
               null
             )),
@@ -1744,6 +1793,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -1776,6 +1826,7 @@ class MergeYamlTest implements RewriteTest {
                 """,
               false,
               "name",
+              null,
               null,
               null
             )),
@@ -1810,6 +1861,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              null,
               null
             )),
           yaml(
@@ -1839,6 +1891,7 @@ class MergeYamlTest implements RewriteTest {
               // language=yaml
               "vars: { version: 10.3 }",
               false,
+              null,
               null,
               null,
               null
@@ -1872,6 +1925,7 @@ class MergeYamlTest implements RewriteTest {
               // language=yaml
               "vars: { mapping: { version: 10.3 } }",
               false,
+              null,
               null,
               null,
               null
@@ -1908,6 +1962,7 @@ class MergeYamlTest implements RewriteTest {
                   version: 10.3 }
                 """,
               false,
+              null,
               null,
               null,
               null
@@ -1947,6 +2002,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "second"
           )),
           yaml(
@@ -1982,6 +2038,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "level"
           )),
           yaml(
@@ -2015,6 +2072,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "no-key"
           )),
           yaml(
@@ -2041,6 +2099,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "first"
           )),
           yaml(
@@ -2067,6 +2126,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "first"
           )),
           yaml(
@@ -2097,6 +2157,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "first"
           )),
           yaml(
@@ -2131,6 +2192,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "second"
           )),
           yaml(
@@ -2154,40 +2216,6 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
-    void insertBeforeEmpty() {
-        rewriteRun(
-          spec -> spec.recipe(new MergeYaml(
-            "$",
-            //language=yaml
-            """
-              A: a
-              B:
-                A: b
-              """,
-            null,
-            null,
-            null,
-            ""
-          )),
-          yaml(
-            """
-              first:
-              second: 2
-              third: 3
-              """,
-            """
-              first:
-              second: 2
-              third: 3
-              A: a
-              B:
-                A: b
-              """
-          )
-        );
-    }
-
-    @Test
     void insertBeforeWithKey() {
         rewriteRun(
           spec -> spec.recipe(new MergeYaml(
@@ -2199,6 +2227,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "some"
           )),
           yaml(
@@ -2241,6 +2270,7 @@ class MergeYamlTest implements RewriteTest {
             null,
             null,
             null,
+            Before,
             "item 3"
           )),
           yaml(
@@ -2279,6 +2309,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               "name",
               null,
+              Before,
               "name: x"
             )),
           yaml(
@@ -2294,6 +2325,365 @@ class MergeYamlTest implements RewriteTest {
                   value: 1
                 # Comment untouched
                 - name: x
+                  value: 1
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfter() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              B:
+                A: b
+              """,
+            null,
+            null,
+            null,
+            After,
+            "first"
+          )),
+          yaml(
+            """
+              first:
+              second: 2
+              third: 3
+              """,
+            """
+              first:
+              A: a
+              B:
+                A: b
+              second: 2
+              third: 3
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterMultiple() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              first:
+                key: one
+              second:
+                key: two
+              """,
+            null,
+            null,
+            null,
+            After,
+            "level-x"
+          )),
+          yaml(
+            """
+              first:
+                level-x: one
+                level-y: one
+              second:
+                level-x: two
+                level-y: two
+              """,
+            """
+              first:
+                level-x: one
+                key: one
+                level-y: one
+              second:
+                level-x: two
+                key: two
+                level-y: two
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterWithNoMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            After,
+            "no-key"
+          )),
+          yaml(
+            """
+              first:
+              """,
+            """
+              first:
+              A: a
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterElementLastLine() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            After,
+            "first"
+          )),
+          yaml(
+            """
+              first: value
+              """,
+            """
+              first: value
+              A: a
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterElementWithCommentOnFirstLine() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            After,
+            "first"
+          )),
+          yaml(
+            """
+              # Comment untouched
+              first: value
+              second: value
+              """,
+            """
+              # Comment untouched
+              first: value
+              A: a
+              second: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterElementWithCommentsWithNesting() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.level",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            After,
+            "second"
+          )),
+          yaml(
+            """
+              # Comment untouched 1
+              level:
+                # Comment untouched 2
+                first: value
+                # Comment untouched 3
+                second: value
+              # Comment untouched 3
+              another: value
+              """,
+            """
+              # Comment untouched 1
+              level:
+                # Comment untouched 2
+                first: value
+                # Comment untouched 3
+                second: value
+                A: a
+              # Comment untouched 3
+              another: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterElementWithComments() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            After,
+            "second"
+          )),
+          yaml(
+            """
+              # Some comment
+              first: value
+              # Some comment
+              # with multilines
+              second: value # Comment should be moved from root to previous element
+              """,
+            """
+              # Some comment
+              first: value
+              # Some comment
+              # with multilines
+              second: value # Comment should be moved from root to previous element
+              A: a
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterWithKey() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.some.very.deep.object",
+            //language=yaml
+            """
+              and: B
+              """,
+            null,
+            null,
+            null,
+            After,
+            "with"
+          )),
+          yaml(
+            """
+              some:
+                very:
+                  deep:
+                    object:
+                      with: A
+                      some: C
+              yet: another
+              """,
+            """
+             some:
+               very:
+                 deep:
+                   object:
+                     with: A
+                     and: B
+                     some: C
+             yet: another
+             """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterMergeList() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              widget:
+                list:
+                  - item 2
+                another:
+                  prop: value
+              """,
+            null,
+            null,
+            null,
+            After,
+            "item 1"
+          )),
+          yaml(
+            """
+              widget:
+                list:
+                  - item 1
+                  # Comment untouched
+                  - item 3
+              """,
+            """
+              widget:
+                list:
+                  - item 1
+                  - item 2
+                  # Comment untouched
+                  - item 3
+                another:
+                  prop: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertAfterMergeSequenceMapAddAdditionalObject() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new MergeYaml(
+              "$.testing",
+              //language=yaml
+              """
+                - name: y
+                  value: 1
+                """,
+              false,
+              "name",
+              null,
+              After,
+              "name: x"
+            )),
+          yaml(
+            """
+              testing:
+                # Comment untouched
+                - name: x
+                  value: 1
+                # Comment untouched
+                - name: z
+                  value: 1
+              """,
+            """
+              testing:
+                # Comment untouched
+                - name: x
+                  value: 1
+                - name: y
+                  value: 1
+                # Comment untouched
+                - name: z
                   value: 1
               """
           )

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1246,6 +1246,39 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
+    void existingEntryBlockWithCommentOnNextBlock() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              first:
+                new: value
+              """,
+            null,
+            null,
+            null,
+            null
+          )),
+          yaml(
+            """
+              first:
+                existing: value
+              # Some comment
+              second: value
+              """,
+            """
+              first:
+                existing: value
+                new: value
+              # Some comment
+              second: value
+              """
+          )
+        );
+    }
+
+    @Test
     void mergeScalar() {
         rewriteRun(
           spec -> spec
@@ -1892,6 +1925,130 @@ class MergeYamlTest implements RewriteTest {
                 A: b
               second: 2
               third: 3
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertBeforeElementFirstLine() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            "first"
+          )),
+          yaml(
+            """
+              first: value
+              """,
+            """
+              A: a
+              first: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertBeforeElementWithCommentOnFirstLine() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            "first"
+          )),
+          yaml(
+            """
+              # Comment moved from root prefix to first
+              first: value
+              second: value
+              """,
+            """
+              A: a
+              # Comment moved from root prefix to first
+              first: value
+              second: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertBeforeElementWithCommentOnFirstLineWithNesting() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.level",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            "first"
+          )),
+          yaml(
+            """
+              # Comment untouched 1
+              level:
+                  # Comment untouched 2
+                  first: value
+                  second: value
+              """,
+            """
+              # Comment untouched 1
+              level:
+                  A: a
+                  # Comment untouched 2
+                  first: value
+                  second: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertBeforeElementWithComments() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$",
+            //language=yaml
+            """
+              A: a
+              """,
+            null,
+            null,
+            null,
+            "second"
+          )),
+          yaml(
+            """
+              # Some comment
+              first: value
+              # Some comment
+              # with multilines
+              second: value # Comment should not be moved from root to previous element
+              """,
+            """
+              # Some comment
+              first: value
+              A: a
+              # Some comment
+              # with multilines
+              second: value # Comment should not be moved from root to previous element
               """
           )
         );

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -2152,7 +2152,8 @@ class MergeYamlTest implements RewriteTest {
             "$.level",
             //language=yaml
             """
-              A: a
+              A: a # New comment 1
+              B: b # New comment 2
               """,
             null,
             null,
@@ -2162,19 +2163,57 @@ class MergeYamlTest implements RewriteTest {
           )),
           yaml(
             """
-              # Comment untouched 1
+              # Comment 1
               level:
-                  # Comment untouched 2
+                  before: value # Comment 2
+                  # Comment 3
                   first: value
                   second: value
               """,
             """
-              # Comment untouched 1
+              # Comment 1
               level:
-                  A: a
-                  # Comment untouched 2
+                  before: value # Comment 2
+                  A: a # New comment 1
+                  B: b # New comment 2
+                  # Comment 3
                   first: value
                   second: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void insertBeforeElementWithCommentOnFirstLineWithNesting2() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.level",
+            //language=yaml
+            """
+              A: a
+              B: b
+              """,
+            null,
+            null,
+            null,
+            Before,
+            "first"
+          )),
+          yaml(
+            """
+              # Comment 1
+              level: # Comment 2
+                # Comment 3
+                first: value
+              """,
+            """
+              # Comment 1
+              level: # Comment 2
+                A: a
+                B: b
+                # Comment 3
+                first: value
               """
           )
         );
@@ -2353,6 +2392,7 @@ class MergeYamlTest implements RewriteTest {
               first:
               second: 2
               third: 3
+              fourth: 4
               """,
             """
               first:
@@ -2361,6 +2401,7 @@ class MergeYamlTest implements RewriteTest {
                 A: b
               second: 2
               third: 3
+              fourth: 4
               """
           )
         );
@@ -2509,24 +2550,28 @@ class MergeYamlTest implements RewriteTest {
           )),
           yaml(
             """
-              # Comment untouched 1
+              # Comment 1
               level:
-                # Comment untouched 2
+                # Comment 2
                 first: value
-                # Comment untouched 3
-                second: value
-              # Comment untouched 3
+                # Comment 3
+                second: value # Comment 4
+                third: value # Comment 5
+                fourth: value # Comment 6
+              # Comment 7
               another: value
               """,
             """
-              # Comment untouched 1
+              # Comment 1
               level:
-                # Comment untouched 2
+                # Comment 2
                 first: value
-                # Comment untouched 3
-                second: value
+                # Comment 3
+                second: value # Comment 4
                 A: a
-              # Comment untouched 3
+                third: value # Comment 5
+                fourth: value # Comment 6
+              # Comment 7
               another: value
               """
           )

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -778,8 +778,6 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
-
-
     @Issue("https://github.com/openrewrite/rewrite/issues/2157")
     @Test
     void mergeSequenceMapAddAdditionalDifferentObject() {


### PR DESCRIPTION
## What's changed?
- Support comments for the `insert before` option
- Support `insert before` for sequences
- Add support to `insert after`.

## What's your motivation?
- https://github.com/openrewrite/rewrite/pull/4992

was written a little to fast. Lot's of edge cases were missing.

## Any additional context
There are still bugs left:
- Adding comments in the `YAML snippet` option does not really work; all cases where it does work are just by luck.
- Comments in [sequences](https://docs.openrewrite.org/concepts-and-explanations/yaml-lst-examples#sequence) do not work very well either. To fix this with current LST model, the same kind of code written inside the `mergeMapping` function should be written inside the `mergeSequence` too.
