### PR TITLE
MergeYaml: prevent keys to be appended to the last commit tests

### DIFF
--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -2738,4 +2738,86 @@ class MergeYamlTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5031")
+    void preventKeysToBeAppendedToPreviousComment() {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$",
+              // language=yaml
+              """
+                foo:
+                  new-key: new-value
+                """,
+              false,
+              null,
+              null,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              #
+              foo:
+                existing-key: existing-value
+              # A simple comment
+              bar: bar-value
+              """,
+            // language=yaml
+            """
+              #
+              foo:
+                existing-key: existing-value
+                new-key: new-value
+              # A simple comment
+              bar: bar-value
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5031")
+    void preventKeysToBeAppendedToPreviousCommentIfManyLineBreaks() {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$",
+              // language=yaml
+              """
+                foo:
+                  new-key: new-value
+                """,
+              false,
+              null,
+              null,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              #
+              foo:
+                existing-key: existing-value
+              # A simple comment with trailing line breaks
+              
+              
+              
+              bar: bar-value
+              """,
+            // language=yaml
+            """
+              #
+              foo:
+                existing-key: existing-value
+                new-key: new-value
+              # A simple comment with trailing line breaks
+              
+              
+              
+              bar: bar-value
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This is an attempt to fix this issue #5031

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
resolves #5031

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
In the tests, I didn't have the chance to cover the windows line break `CRLF`, though it is implemented in the code.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
### What causes the problem : 
The prefix of the YML entry is split with respect to the line breaks, this way, the last line breaks are lost, then the next entry is appended directly to the comment above, which is considered its prefix.

<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
