### PR TITLE
Groovy - fix support for import statements following multiline comments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -45,9 +45,9 @@ import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.marker.Semicolon;
 import org.openrewrite.java.marker.TrailingComma;
-import org.openrewrite.java.tree.*;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.lang.annotation.Annotation;
@@ -61,6 +61,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.Character.isJavaIdentifierPart;
@@ -2835,44 +2836,43 @@ public class GroovyParserVisitor {
             }
             String importSource = sourceLineNumberOffsets.length <= lastLineNumber ? source : source.substring(0, sourceLineNumberOffsets[lastLineNumber]);
 
+            importSource = eraseComments(importSource);
             // Create a node for each `import static`, don't parse comments
-            String[] lines = eraseMultiLineComments(importSource).split("\n");
-            for (int i = 0; i < lines.length; i++) {
-                String line = lines[i].split(SINGLE_LINE_COMMENT.open)[0];
-                int index = 0;
+            int offset = 0;
+            int lineNo = 1;
+            while (offset < importSource.length()) {
+                int importIndex = importSource.indexOf("import", offset);
+                if (importIndex == -1) break;
+                lineNo += importSource.substring(offset, importIndex).chars().filter(ch -> ch == '\n').count();
 
-                while (index < line.length()) {
-                    int importIndex = line.indexOf("import", index);
-                    if (importIndex == -1) break;
-
-                    int maybeStaticIndex = indexOfNextNonWhitespace(importIndex + 6, line);
-                    if (!line.startsWith("static", maybeStaticIndex)) {
-                        index = importIndex + 6;
-                        continue;
-                    }
-
-                    int packageBegin = indexOfNextNonWhitespace(maybeStaticIndex + 6, line);
-                    int packageEnd = packageBegin;
-                    while (packageEnd < line.length() && (isJavaIdentifierPart(line.charAt(packageEnd)) || line.charAt(packageEnd) == '.')) {
-                        packageEnd++;
-                    }
-
-                    if (packageEnd < line.length() && line.charAt(packageEnd) == '*') {
-                        ImportNode node = new ImportNode(staticStarImports.get(line.substring(packageBegin, packageEnd - 1)).getType());
-                        node.setLineNumber(i + 1);
-                        node.setColumnNumber(importIndex + 1);
-                        completeStaticStarImports.add(node);
-                    }
-
-                    index = packageEnd;
+                int maybeStaticIndex = indexOfNextNonWhitespace(importIndex + 6, importSource);
+                if (!importSource.startsWith("static", maybeStaticIndex)) {
+                    offset = importIndex + 6;
+                    continue;
                 }
+
+                int packageBegin = indexOfNextNonWhitespace(maybeStaticIndex + 6, importSource);
+                int packageEnd = packageBegin;
+                while (packageEnd < importSource.length() && (isJavaIdentifierPart(importSource.charAt(packageEnd)) || importSource.charAt(packageEnd) == '.')) {
+                    packageEnd++;
+                }
+
+                if (packageEnd < importSource.length() && importSource.charAt(packageEnd) == '*') {
+                    ImportNode node = new ImportNode(staticStarImports.get(importSource.substring(packageBegin, packageEnd - 1)).getType());
+                    node.setLineNumber(lineNo);
+                    node.setColumnNumber(importIndex + 1);
+                    completeStaticStarImports.add(node);
+                }
+
+                lineNo += importSource.substring(importIndex, packageEnd).chars().filter(ch -> ch == '\n').count();
+                offset = packageEnd;
             }
         }
         return completeStaticStarImports;
     }
 
     // VisibleForTesting
-    static String eraseMultiLineComments(String importSource) {
+    static String eraseComments(String importSource) {
         Matcher matcher = MULTILINE_COMMENT_REGEX.matcher(importSource);
         StringBuffer sb = new StringBuffer(); // appendReplacement requires Java 9+ for StringBuilder
         while (matcher.find()) {
@@ -2881,7 +2881,9 @@ public class GroovyParserVisitor {
             matcher.appendReplacement(sb, replacement);
         }
         matcher.appendTail(sb);
-        return sb.toString();
+        String multiLineRemoved = sb.toString();
+        return Arrays.stream(multiLineRemoved.split("\n", -1)).map(x -> x.split(SINGLE_LINE_COMMENT.open)[0])
+                .collect(Collectors.joining("\n"));
     }
 
     private DeclarationExpression transformBackToDeclarationExpression(ConstantExpression expression) {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -40,6 +40,7 @@ import org.openrewrite.groovy.marker.*;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.EncodingDetectingInputStream;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.marker.OmitParentheses;
@@ -2843,7 +2844,7 @@ public class GroovyParserVisitor {
             while (offset < importSource.length()) {
                 int importIndex = importSource.indexOf("import", offset);
                 if (importIndex == -1) break;
-                lineNo += importSource.substring(offset, importIndex).chars().filter(ch -> ch == '\n').count();
+                lineNo += StringUtils.countOccurrences(importSource.substring(offset, importIndex), "\n");
 
                 int maybeStaticIndex = indexOfNextNonWhitespace(importIndex + 6, importSource);
                 if (!importSource.startsWith("static", maybeStaticIndex)) {
@@ -2864,7 +2865,7 @@ public class GroovyParserVisitor {
                     completeStaticStarImports.add(node);
                 }
 
-                lineNo += importSource.substring(importIndex, packageEnd).chars().filter(ch -> ch == '\n').count();
+                lineNo += StringUtils.countOccurrences(importSource.substring(importIndex, packageEnd), "\n");
                 offset = packageEnd;
             }
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserVisitorTest.java
@@ -22,23 +22,35 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class GroovyParserVisitorTest {
 
     @Test
-    void eraseMultiLineComments() {
-        assertEquals("a       b", GroovyParserVisitor.eraseMultiLineComments("a /* */ b"));
+    void eraseCommentsSimple() {
+        assertEquals("a       b", GroovyParserVisitor.eraseComments("a /* */ b"));
+    }
 
+    @Test
+    void eraseCommentsMultiLine() {
         assertEquals(
-            """
+          """
             a ____________
             ____
             ____________ b
             """.replaceAll("_", " "), // this is to prevent IntelliJ from removing trailing whitespace
-          GroovyParserVisitor.eraseMultiLineComments(
+          GroovyParserVisitor.eraseComments(
             """
-            a /* something
-            else
-            then this */ b
-            """)
+              a /* something
+              else
+              then this */ b
+              """)
         );
-
-        assertEquals("1       2       3", GroovyParserVisitor.eraseMultiLineComments("1 /* */ 2 /* */ 3"));
     }
+
+    @Test
+    void eraseCommentsTwoMultiLinesInALine() {
+        assertEquals("1       2       3", GroovyParserVisitor.eraseComments("1 /* */ 2 /* */ 3"));
+    }
+
+    @Test
+    void eraseCommentsJustAnEmptyLine() {
+        assertEquals("\n", GroovyParserVisitor.eraseComments("\n"));
+    }
+
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserVisitorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GroovyParserVisitorTest {
+
+    @Test
+    void eraseMultiLineComments() {
+        assertEquals("a       b", GroovyParserVisitor.eraseMultiLineComments("a /* */ b"));
+
+        assertEquals(
+            """
+            a ____________
+            ____
+            ____________ b
+            """.replaceAll("_", " "), // this is to prevent IntelliJ from removing trailing whitespace
+          GroovyParserVisitor.eraseMultiLineComments(
+            """
+            a /* something
+            else
+            then this */ b
+            """)
+        );
+
+        assertEquals("1       2       3", GroovyParserVisitor.eraseMultiLineComments("1 /* */ 2 /* */ 3"));
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -157,4 +157,16 @@ class ImportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void oneImportStaticStarSplitIntoTwoLines() {
+        rewriteRun(
+          groovy(
+            """
+            import/* export
+            */static java.lang.Math.*
+            """
+          )
+        );
+    }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -118,10 +118,10 @@ class ImportTest implements RewriteTest {
               
               
               import static java.util.Collections.**/java.util.Collections.*
-              import /*static java.util.Collections.singletonList;
+              /*static java.util.Collections.singletonList;
               
               
-              import static java.util.Collections.**/static          java.util.Collections.*
+              import static java.util.Collections.**/import static          java.util.Collections.*
               import static java.util.Collections.singletonList;import static java.util.Collections.*
               import java.util.Collections.*
               """

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -118,10 +118,10 @@ class ImportTest implements RewriteTest {
               
               
               import static java.util.Collections.**/java.util.Collections.*
-              /*static java.util.Collections.singletonList;
+              import /*static java.util.Collections.singletonList;
               
               
-              import static java.util.Collections.**/import static          java.util.Collections.*
+              import static java.util.Collections.**/static          java.util.Collections.*
               import static java.util.Collections.singletonList;import static java.util.Collections.*
               import java.util.Collections.*
               """
@@ -140,8 +140,19 @@ class ImportTest implements RewriteTest {
             import java.io.File
             import static java.lang.Math.*
             import java.nio.file.Path
-
             final String s = new String("s")
+            """
+          )
+        );
+    }
+
+    @Test
+    void twoSameImportStarStatements() {
+        rewriteRun(
+          groovy(
+            """
+            import static java.lang.Math.*
+            import static java.lang.Math.*
             """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ImportTest.java
@@ -128,4 +128,22 @@ class ImportTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multiLineCommentBeforeStarStaticImport() {
+        rewriteRun(
+          groovy(
+            """
+            /*
+             * Hello
+             */
+            import java.io.File
+            import static java.lang.Math.*
+            import java.nio.file.Path
+
+            final String s = new String("s")
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

- Building up on #4982.

Changing the special handling of star static imports. The line numbers were calculated improperly, resulting in strange behavior of the `visit` method wrt `sortedByPosition`.
Basically this assumption turned out not to be true in a specific case:
https://github.com/openrewrite/rewrite/blob/194b33db0c7f48fb8b511282ef7d0b53455d2e47/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java#L2863

## What's your motivation?
To fix a Groovy parsing error demostrated in `org.openrewrite.groovy.tree.ImportTest#multiLineCommentBeforeStarStaticImport`. It resulted in a strange exception of:
```
            Caused by:
            java.lang.ClassCastException: class org.openrewrite.java.tree.J$Identifier cannot be cast to class org.openrewrite.java.tree.J$FieldAccess (org.openrewrite.java.tree.J$Identifier and org.openrewrite.java.tree.J$FieldAccess are in unnamed module of loader 'app')
                at org.openrewrite.groovy.GroovyParserVisitor.convertTopLevelStatement(GroovyParserVisitor.java:2186)
                at org.openrewrite.groovy.GroovyParserVisitor.visit(GroovyParserVisitor.java:195)
```

## Anything in particular you'd like reviewers to focus on?

I needed to remove one case from the `duplicateImportsAndComments` test case, which I think is an invalid Groovy code. IMHO you cannot split imports into multiple lines:
```
              import /*static java.util.Collections.singletonList;
              something*/static          java.util.Collections.*
```


## Anyone you would like to review specifically?
@jevanlingen as you worked with this code recently.
