### PR TITLE
Read all TypeTable `classpath.tsv.zip` files

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -124,8 +124,8 @@ public interface JavaParser extends Parser {
 
         try (RewriteClasspathJarClasspathLoader rewriteClasspathJarClasspathLoader = new RewriteClasspathJarClasspathLoader(ctx)) {
             List<JavaParserClasspathLoader> loaders = new ArrayList<>(2);
-            Optional.ofNullable(TypeTable.fromClasspath(ctx, missingArtifactNames)).ifPresent(loaders::add);
             loaders.add(rewriteClasspathJarClasspathLoader);
+            Optional.ofNullable(TypeTable.fromClasspath(ctx, missingArtifactNames)).ifPresent(loaders::add);
 
             for (JavaParserClasspathLoader loader : loaders) {
                 for (String missingArtifactName : new ArrayList<>(missingArtifactNames)) {
@@ -372,7 +372,7 @@ public interface JavaParser extends Parser {
         Pattern classPattern = Pattern.compile("(class|interface|enum|record)\\s*(<[^>]*>)?\\s+(\\w+)");
         Pattern publicClassPattern = Pattern.compile("public\\s+" + classPattern.pattern());
 
-        Function<String, String> simpleName = sourceStr -> {
+        Function<String, @Nullable String> simpleName = sourceStr -> {
             Matcher classMatcher = publicClassPattern.matcher(sourceStr);
             if (classMatcher.find()) {
                 return classMatcher.group(3);

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -76,14 +76,11 @@ public interface JavaParser extends Parser {
                 artifacts.addAll(matchedArtifacts);
             }
         }
-
         if (!missingArtifactNames.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Unable to find runtime dependencies beginning with: " +
-                    missingArtifactNames.stream().map(a -> "'" + a + "'").sorted().collect(joining(", ")) +
-                    ", classpath: " + runtimeClasspath);
+            String missing = missingArtifactNames.stream().sorted().collect(joining("', '", "'", "'"));
+            throw new IllegalArgumentException(String.format("Unable to find runtime dependencies beginning with: %s, classpath: %s",
+                    missing, runtimeClasspath));
         }
-
         return artifacts;
     }
 
@@ -110,7 +107,7 @@ public interface JavaParser extends Parser {
             String cpEntryString = cpEntry.toString();
             Path path = Paths.get(cpEntry);
             if (jarPattern.matcher(cpEntryString).find() ||
-                explodedPattern.matcher(cpEntryString).find() && path.toFile().isDirectory()) {
+                    explodedPattern.matcher(cpEntryString).find() && path.toFile().isDirectory()) {
                 artifacts.add(path);
                 // Do not break because jarPattern matches "foo-bar-1.0.jar" and "foo-1.0.jar" to "foo"
             }
@@ -139,15 +136,12 @@ public interface JavaParser extends Parser {
                     }
                 }
             }
-        }
 
-        if (!missingArtifactNames.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Unable to find classpath resource dependencies beginning with: " +
-                    missingArtifactNames.stream().map(a -> "'" + a + "'").sorted().collect(joining(", ", "", ".\n"))
-            );
+            if (!missingArtifactNames.isEmpty()) {
+                String missing = missingArtifactNames.stream().sorted().collect(joining("', '", "'", "'"));
+                throw new IllegalArgumentException(String.format("Unable to find classpath resource dependencies beginning with: %s", missing));
+            }
         }
-
         return artifacts;
     }
 
@@ -208,8 +202,7 @@ public interface JavaParser extends Parser {
             //Fall through to an exception without making this the "cause".
         }
 
-        throw new IllegalStateException(
-                "Unable to create a Java parser instance. " +
+        throw new IllegalStateException("Unable to create a Java parser instance. " +
                 "`rewrite-java-8`, `rewrite-java-11`, `rewrite-java-17`, or `rewrite-java-21` must be on the classpath.");
     }
 
@@ -392,7 +385,7 @@ public interface JavaParser extends Parser {
         String pkg = packageMatcher.find() ? packageMatcher.group(1).replace('.', '/') + "/" : "";
 
         String className = Optional.ofNullable(simpleName.apply(sourceCode))
-                                   .orElse(Long.toString(System.nanoTime())) + ".java";
+                .orElse(Long.toString(System.nanoTime())) + ".java";
 
         return prefix.resolve(Paths.get(pkg + className));
     }

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
@@ -104,7 +104,7 @@ class TypeTableTest implements RewriteTest {
             }
         }
 
-        TypeTable table = new TypeTable(ctx, Files.newInputStream(tsv), List.of("junit-jupiter-api"));
+        TypeTable table = new TypeTable(ctx, tsv.toUri().toURL(), List.of("junit-jupiter-api"));
         Path classesDir = table.load("junit-jupiter-api");
 
         assertThat(classesDir)


### PR DESCRIPTION
## What's changed?
Read all TypeTable files on the classpath, not just the first.

## What's your motivation?
rewrite-spring depends on rewrite-migrate-java, and as such there's more than one. If the wrong one is picked up, then classes can not be found. If only the recipe modules' own is picked up, then chaining in recipes from other modules might not work.

## Any additional context
- As discovered on https://github.com/openrewrite/rewrite-spring/pull/676#issuecomment-2659270062