### PR TITLE
Groovy Parser - Improve retrieval of modifiers

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -235,7 +235,7 @@ public class GroovyParserVisitor {
         public void visitClass(ClassNode clazz) {
             Space fmt = whitespace();
             List<J.Annotation> leadingAnnotations = visitAndGetAnnotations(clazz, this);
-            List<J.Modifier> modifiers = getModifiers(clazz.getName());
+            List<J.Modifier> modifiers = getModifiers();
 
             Space kindPrefix = whitespace();
             J.ClassDeclaration.Kind.Type kindType = null;
@@ -418,8 +418,8 @@ public class GroovyParserVisitor {
             RewriteGroovyVisitor visitor = new RewriteGroovyVisitor(field, this);
 
             List<J.Annotation> annotations = visitAndGetAnnotations(field, this);
-            List<J.Modifier> modifiers = getModifiers(field.getName(), new HashSet<>(Arrays.asList("def", "var")));
-            TypeTree typeExpr = visitTypeTree(field.getOriginType());
+            List<J.Modifier> modifiers = getModifiers();
+            TypeTree typeExpr = field.isDynamicTyped() ? null : visitTypeTree(field.getOriginType());
 
             J.Identifier name = new J.Identifier(randomId(), sourceBefore(field.getName()), Markers.EMPTY,
                     emptyList(), field.getName(), typeMapping.type(field.getOriginType()), typeMapping.variableType(field));
@@ -465,9 +465,8 @@ public class GroovyParserVisitor {
             Space fmt = whitespace();
 
             List<J.Annotation> annotations = visitAndGetAnnotations(method, this);
-            List<J.Modifier> modifiers = getModifiers(method.getName(), singleton("def"));
+            List<J.Modifier> modifiers = getModifiers();
             boolean isConstructorOfInnerNonStaticClass = false;
-            RedundantDef redundantDef = getRedundantDefMarker(method);
             J.TypeParameters typeParameters = null;
             if (method.getGenericsTypes() != null) {
                 Space prefix = sourceBefore("<");
@@ -479,7 +478,7 @@ public class GroovyParserVisitor {
                 }
                 typeParameters = new J.TypeParameters(randomId(), prefix, Markers.EMPTY, emptyList(), typeParametersList);
             }
-            TypeTree returnType = method instanceof ConstructorNode ? null : visitTypeTree(method.getReturnType());
+            TypeTree returnType = method instanceof ConstructorNode || method.isDynamicReturnType() ? null : visitTypeTree(method.getReturnType());
 
             Space namePrefix = whitespace();
             String methodName;
@@ -525,7 +524,7 @@ public class GroovyParserVisitor {
                 Parameter param = unparsedParams[i];
 
                 List<J.Annotation> paramAnnotations = visitAndGetAnnotations(param, this);
-                List<J.Modifier> paramModifiers = getModifiers(param.getName());
+                List<J.Modifier> paramModifiers = getModifiers();
                 TypeTree paramType = param.isDynamicTyped() ?
                         new J.Identifier(randomId(), EMPTY, Markers.EMPTY, emptyList(), "", JavaType.ShallowClass.build("java.lang.Object"), null) :
                         visitTypeTree(param.getOriginType());
@@ -583,7 +582,7 @@ public class GroovyParserVisitor {
 
             queue.add(new J.MethodDeclaration(
                     randomId(), fmt,
-                    redundantDef == null ? Markers.EMPTY : Markers.EMPTY.add(redundantDef),
+                    Markers.EMPTY,
                     annotations,
                     modifiers,
                     typeParameters,
@@ -595,24 +594,6 @@ public class GroovyParserVisitor {
                     null,
                     typeMapping.methodType(method)
             ));
-        }
-
-        /**
-         * Methods can be declared with "def" AND a return type (or constructors with "def").
-         * In these cases the "def" is semantically meaningless but needs to be preserved for source code accuracy.
-         * If there is both a def and a return type, this method returns a RedundantDef object and advances the cursor
-         * position past the "def" keyword, leaving the return type to be parsed as normal.
-         */
-        private @Nullable RedundantDef getRedundantDefMarker(MethodNode method) {
-            int saveCursor = cursor;
-            Space defPrefix = whitespace();
-            if (source.startsWith("def", cursor) && (method.getReturnType().isRedirectNode() || !Object.class.getName().equals(method.getReturnType().getName()))) {
-                skip("def");
-                return new RedundantDef(randomId(), defPrefix);
-            }
-
-            cursor = saveCursor;
-            return null;
         }
 
         @SuppressWarnings({"ConstantConditions", "unchecked"})
@@ -1371,7 +1352,7 @@ public class GroovyParserVisitor {
             Space prefix = whitespace();
             List<J.Annotation> leadingAnnotations = visitAndGetAnnotations(expression, classVisitor);
             Optional<MultiVariable> multiVariable = maybeMultiVariable();
-            List<J.Modifier> modifiers = getModifiers(expression.getVariableExpression().getName());
+            List<J.Modifier> modifiers = getModifiers();
             TypeTree typeExpr = visitVariableExpressionType(expression.getVariableExpression());
 
             J.VariableDeclarations.NamedVariable namedVariable;
@@ -1477,7 +1458,7 @@ public class GroovyParserVisitor {
                 } else {
                     Parameter param = forLoop.getVariable();
                     Space paramFmt = whitespace();
-                    List<J.Modifier> modifiers = getModifiers(param.getName());
+                    List<J.Modifier> modifiers = getModifiers();
                     TypeTree paramType = param.getOriginType().getColumnNumber() >= 0 ? visitTypeTree(param.getOriginType()) : null;
                     JRightPadded<J.VariableDeclarations.NamedVariable> paramName = JRightPadded.build(
                             new J.VariableDeclarations.NamedVariable(randomId(), whitespace(), Markers.EMPTY,
@@ -2440,6 +2421,20 @@ public class GroovyParserVisitor {
         return source.startsWith(delimiter, indexOfNextNonWhitespace(cursor, source));
     }
 
+    private boolean sourceStartsWith(String delimiter, String... optionalSuffixes) {
+        int whitespaceIndex = indexOfNextNonWhitespace(cursor, source);
+        boolean startsWith = source.startsWith(delimiter, whitespaceIndex);
+        if (startsWith) {
+            for (String suffix : optionalSuffixes) {
+                if (source.startsWith(suffix, whitespaceIndex + delimiter.length())) {
+                    return true;
+                }
+            }
+            return optionalSuffixes.length == 0;
+        }
+        return false;
+    }
+
     /**
      * Returns a string that is a part of this source. The substring begins at the specified beginIndex and extends until delimiter.
      * The cursor will not be moved.
@@ -2575,27 +2570,17 @@ public class GroovyParserVisitor {
         return typeTree(classNode, inferredType);
     }
 
-    private List<J.Modifier> getModifiers(String varName) {
-        return getModifiers(varName, emptySet());
-    }
-
-    private List<J.Modifier> getModifiers(String varName, Set<String> excludeModifiers) {
+    private List<J.Modifier> getModifiers() {
         List<J.Modifier> modifiers = new ArrayList<>();
-        Set<String> possibleModifiers = new LinkedHashSet<>(modifierNameToType.size());
-        for (String modifier : modifierNameToType.keySet()) {
-            if (!excludeModifiers.contains(modifier)) {
-                possibleModifiers.add(modifier);
-            }
-        }
+        Set<String> possibleModifiers = new LinkedHashSet<>(modifierNameToType.keySet());
         String currentModifier = possibleModifiers.stream().filter(this::sourceStartsWith).findFirst().orElse(null);
         while (currentModifier != null) {
             possibleModifiers.remove(currentModifier);
             modifiers.add(new J.Modifier(randomId(), whitespace(), Markers.EMPTY, currentModifier, modifierNameToType.get(currentModifier), emptyList()));
             skip(currentModifier);
             currentModifier = possibleModifiers.stream()
-                    .filter(modifierName ->
-                            // Try to avoid confusing a variable name with an incidentally similar modifier keyword like `def defaultPublicStaticFinal = 0`
-                            (varName.length() < modifierName.length() || !sourceStartsWith(varName)) && sourceStartsWith(modifierName))
+                    // Try to avoid confusing a variable name with an incidentally similar modifier keyword like `def defaultPublicStaticFinal = 0`
+                    .filter(modifierName -> sourceStartsWith(modifierName, "\n", " ", ")"))
                     .findFirst()
                     .orElse(null);
         }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/RedundantDef.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/RedundantDef.java
@@ -17,6 +17,7 @@ package org.openrewrite.groovy.marker;
 
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
@@ -25,9 +26,11 @@ import java.util.UUID;
 /**
  * In Groovy methods can be declared with a return type and also a redundant 'def' keyword.
  * This captures the extra def keyword.
+ * @deprecated The `def` keyword is now parsed as a {@link J.Modifier.Type.LanguageExtension} type.
  */
 @Value
 @With
+@Deprecated
 public class RedundantDef implements Marker {
     UUID id;
     Space prefix;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -281,4 +281,3 @@ class MethodDeclarationTest implements RewriteTest {
         );
     }
 }
-

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -71,7 +71,7 @@ class MethodDeclarationTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              def accept(final def Map m) {
+              public final accept(final def Map m) {
               }
               """
           )
@@ -232,4 +232,41 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void parameterWithConflictingTypeName() {
+        rewriteRun(
+          groovy(
+            """
+              class variable {}
+              def accept(final def variable m) {}
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.MethodDeclaration accept = (J.MethodDeclaration) cu.getStatements().get(1);
+                J.VariableDeclarations m = (J.VariableDeclarations) accept.getParameters().get(0);
+                assertThat(m.getModifiers()).satisfiesExactly(
+                  mod -> assertThat(mod.getType()).isEqualTo(J.Modifier.Type.Final),
+                  mod -> assertThat(mod.getKeyword()).isEqualTo("def")
+                );
+            })
+          )
+        );
+    }
+
+    @Test
+    void defIsNotReturnType() {
+        rewriteRun(
+          groovy(
+            """
+              final def accept(final def Object m) {
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.MethodDeclaration accept = (J.MethodDeclaration) cu.getStatements().get(0);
+                assertThat(accept.getReturnTypeExpression()).isNull();
+            })
+          )
+        );
+    }
 }
+

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -67,18 +67,6 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void methodDeclarationWithModifiers() {
-        rewriteRun(
-          groovy(
-            """
-              public final accept(final def Map m) {
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void primitiveReturn() {
         rewriteRun(
           groovy(
@@ -92,7 +80,7 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void genericTypeParameter() {
+    void genericTypeParameterReturn() {
         rewriteRun(
           groovy(
             """
@@ -105,21 +93,21 @@ class MethodDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void emptyArguments() {
+    void modifiersReturn() {
         rewriteRun(
-          groovy("def foo( ) {}")
+          groovy(
+            """
+              public final accept(Map m) {
+              }
+              """
+          )
         );
     }
 
     @Test
-    void methodThrows() {
+    void emptyArguments() {
         rewriteRun(
-          groovy(
-            """
-              def foo(int a) throws Exception , RuntimeException {
-              }
-              """
-          )
+          groovy("def foo( ) {}")
         );
     }
 
@@ -154,6 +142,30 @@ class MethodDeclarationTest implements RewriteTest {
           groovy(
             """
               def confirmNextStepWithCredentials(String message /* = prefix */ = /* hello prefix */ "Hello" ) {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void modifiersArguments() {
+        rewriteRun(
+          groovy(
+            """
+              def accept(final def Map m) {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodThrows() {
+        rewriteRun(
+          groovy(
+            """
+              def foo(int a) throws Exception , RuntimeException {
               }
               """
           )


### PR DESCRIPTION
## What's changed?
- Removed use of `RedundantDef` marker in parser
- Improved use of `getModifiers` method

## What's your motivation?
Improvement to:
- https://github.com/openrewrite/rewrite/pull/5045
