### PR TITLE
Add a RemoveAfter annotation to mark elements to be deleted

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.internal;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * An annotation that indicates that the element should be removed after a certain point.
+ * Intended to be used with a matching recipe to clear out elements on a schedule.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RemoveAfter {
+    /**
+     * Expects a date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.
+     * @return The date after which this element should be removed.
+     */
+    String date();
+}

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
@@ -20,6 +20,7 @@ import java.lang.annotation.RetentionPolicy;
 
 /**
  * An annotation that indicates that the element should be removed after a certain point.
+ * Ideally applied with a matching `@Deprecated` annotation listing the reason & replacement.
  * Intended to be used with a matching recipe to clear out elements on a schedule.
  */
 @Retention(RetentionPolicy.SOURCE)

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
@@ -15,10 +15,8 @@
  */
 package org.openrewrite.internal;
 
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 /**
  * An annotation that indicates that the element should be removed after a certain point.

--- a/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/RemoveAfter.java
@@ -15,14 +15,16 @@
  */
 package org.openrewrite.internal;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * An annotation that indicates that the element should be removed after a certain point.
  * Intended to be used with a matching recipe to clear out elements on a schedule.
  */
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface RemoveAfter {
     /**
      * Expects a date without a time-zone in the ISO-8601 calendar system, such as 2007-12-03.


### PR DESCRIPTION
## What's changed?
Add a new annotation.
Possibly add recipe was well.

## What's your motivation?
Mark elements we want removed in the future, and automate their removal.

## Anything in particular you'd like reviewers to focus on?
I went for a `date` field as opposed to `value`, to keep the door open to a future `version` field too (not planned).

## Anyone you would like to review specifically?
@knutwannheden has suggested something like this in the past I believe; figured open a draft to discuss adding this, and a matching a recipe.

## Have you considered any alternatives or workarounds?
- Log issues for removal: that would clutter the backlog quite a bit, and not lead to a guaranteed removal.
- Add `@Deprecated` annotations: again not guaranteed to lead to removal; and on Java 8 we can not use `forRemoval = true`.

## Any additional context
- Prompted by discussion here: https://github.com/openrewrite/rewrite/pull/5036#discussion_r1958049146