### PR TITLE
Rewrite RPC

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("io.github.classgraph:classgraph:latest.release")
     implementation("org.yaml:snakeyaml:latest.release")
+    implementation("io.moderne:jsonrpc:latest.release")
 
     testImplementation("org.assertj:assertj-core:latest.release")
     testImplementation(project(":rewrite-test"))

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/ParserInput.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/ParserInput.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import lombok.Value;
+import org.openrewrite.FileAttributes;
+
+import java.nio.file.Path;
+
+@Value
+public class ParserInput {
+    Path sourcePath;
+    String text;
+    FileAttributes fileAttributes;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RecipeRpcException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RecipeRpcException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+public class RecipeRpcException extends RuntimeException {
+    public RecipeRpcException(String message) {
+        super(message);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/Reference.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/Reference.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An instance that is passed to the remote by reference (i.e. for instances
+ * that are referentially deduplicated in the LST).
+ */
+@Getter
+public class Reference {
+    @SuppressWarnings("AccessStaticViaInstance")
+    private static final ThreadLocal<Reference> flyweight = new ThreadLocal<>()
+            .withInitial(Reference::new);
+
+    @Nullable
+    private Object value;
+
+    /**
+     * @param t Any instance.
+     * @return A reference wrapper, which assists the sender to know when to pass by reference
+     * rather than by value.
+     */
+    public static Reference asRef(@Nullable Object t) {
+        Reference ref = flyweight.get();
+        ref.value = t;
+        return ref;
+    }
+
+    /**
+     * @param maybeRef A reference (or not).
+     * @param <T>      The type of the value.
+     * @return The value of the reference, or the value itself if it is not a reference.
+     */
+    public static <T> @Nullable T getValue(@Nullable Object maybeRef) {
+        // noinspection unchecked
+        return (T) (maybeRef instanceof Reference ? ((Reference) maybeRef).getValue() : maybeRef);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import io.moderne.jsonrpc.JsonRpc;
+import io.moderne.jsonrpc.JsonRpcRequest;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.rpc.request.GetTreeDataRequest;
+import org.openrewrite.rpc.request.RecipeRpcRequest;
+import org.openrewrite.rpc.request.VisitRequest;
+import org.openrewrite.rpc.request.VisitResponse;
+
+import java.lang.reflect.Constructor;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static io.moderne.jsonrpc.JsonRpcMethod.typed;
+import static org.openrewrite.rpc.TreeDatum.State.END_OF_TREE;
+
+public class RewriteRpc {
+    private final JsonRpc jsonRpc;
+    private final Duration timeout;
+
+    /**
+     * Keeps track of the local and remote state of trees that are used in
+     * visits.
+     */
+    private final Map<UUID, SourceFile> remoteTrees = new HashMap<>();
+    private final Map<UUID, SourceFile> localTrees = new HashMap<>();
+
+    /**
+     * Keeps track of objects that need to be referentially deduplicated, and
+     * the ref IDs to look them up by on the remote.
+     */
+    private final Map<Object, Integer> localRefs = new IdentityHashMap<>();
+    private final Map<Integer, Object> remoteRefs = new IdentityHashMap<>();
+
+    // TODO This should be keyed on both the visit (transaction) ID in addition to the tree ID
+    private final Map<UUID, BlockingQueue<TreeData>> inProgressGetTreeDatas = new ConcurrentHashMap<>();
+
+    private static final ExecutorService forkJoin = ForkJoinPool.commonPool();
+
+    public RewriteRpc(JsonRpc jsonRpc, Duration timeout) {
+        this.jsonRpc = jsonRpc;
+        this.timeout = timeout;
+
+        jsonRpc.method("visit", typed(VisitRequest.class, request -> {
+            Constructor<?> ctor = Class.forName(request.getVisitor()).getDeclaredConstructor();
+            ctor.setAccessible(true);
+
+            //noinspection unchecked
+            TreeVisitor<Tree, Object> visitor = (TreeVisitor<Tree, Object>) ctor.newInstance();
+            SourceFile before = getTree(request.getTreeId());
+
+            localTrees.put(before.getId(), before);
+
+            SourceFile after = (SourceFile) visitor.visit(before, request.getP());
+            if (after == null) {
+                localTrees.remove(before.getId());
+            } else {
+                localTrees.put(after.getId(), after);
+            }
+            return new VisitResponse(before != after);
+        }));
+
+        jsonRpc.method("getTree", typed(GetTreeDataRequest.class, request -> {
+            BlockingQueue<TreeData> q = inProgressGetTreeDatas.computeIfAbsent(request.getTreeId(), id -> {
+                BlockingQueue<TreeData> batch = new ArrayBlockingQueue<>(1);
+                SourceFile before = remoteTrees.get(id);
+                RpcSendQueue sendQueue = new RpcSendQueue(10, batch::put, localRefs);
+                forkJoin.submit(() -> {
+                    try {
+                        SourceFile after = localTrees.get(id);
+                        sendQueue.send(after, before, () -> {
+                            if (after instanceof RpcCodec) {
+                                //noinspection unchecked
+                                ((RpcCodec<SourceFile>) after).rpcSend(after, sendQueue);
+                            }
+                            throw new IllegalArgumentException(after.getClass().getName() + " is not an RpcCodec");
+                        });
+
+                        // All the data has been sent, and the remote should have received
+                        // the full tree, so update our understanding of the remote state
+                        // of this tree.
+                        remoteTrees.put(id, after);
+                    } catch (Throwable ignored) {
+                        // TODO do something with this exception
+                    } finally {
+                        sendQueue.put(new TreeDatum(END_OF_TREE, null, null, null));
+                        sendQueue.flush();
+                    }
+                    return 0;
+                });
+                return batch;
+            });
+
+            TreeData batch = q.take();
+            List<TreeDatum> data = batch.getData();
+            if (data.get(data.size() - 1).getState() == END_OF_TREE) {
+                inProgressGetTreeDatas.remove(request.getTreeId());
+            }
+            return batch;
+        }));
+        jsonRpc.bind();
+    }
+
+    public void shutdown() {
+        jsonRpc.shutdown();
+    }
+
+    public <P> Tree visit(SourceFile sourceFile, String visitorName, P p) {
+        VisitResponse response = scan(sourceFile, visitorName, p);
+        return response.isModified() ?
+                getTree(sourceFile.getId()) :
+                sourceFile;
+    }
+
+    public <P> VisitResponse scan(SourceFile sourceFile, String visitorName, P p) {
+        // Set the local state of this tree, so that when the remote
+        // asks for it, we know what to send.
+        localTrees.put(sourceFile.getId(), sourceFile);
+        return send("visit", new VisitRequest(visitorName, sourceFile.getId(), p),
+                VisitResponse.class);
+    }
+
+    private SourceFile getTree(UUID treeId) {
+        RpcReceiveQueue q = new RpcReceiveQueue(remoteRefs, () -> send("getTree",
+                new GetTreeDataRequest(treeId), TreeData.class));
+        SourceFile remoteTree = q.receive(localTrees.get(treeId), before -> {
+            if (before instanceof RpcCodec) {
+                //noinspection unchecked
+                return ((RpcCodec<SourceFile>) before).rpcReceive(before, q);
+            }
+            throw new IllegalArgumentException(before.getClass().getName() + " is not an RpcCodec");
+        });
+//                (SourceFile) language
+//                .getReceiver().visit(before, q));
+        if (!q.take().getState().equals(END_OF_TREE)) {
+            throw new IllegalStateException("Expected END_OF_TREE");
+        }
+        // We are now in sync with the remote state of the tree.
+        remoteTrees.put(treeId, remoteTree);
+        return remoteTree;
+    }
+
+    private <P> P send(String method, RecipeRpcRequest body, Class<P> responseType) {
+        try {
+            // TODO handle error
+            return jsonRpc
+                    .send(JsonRpcRequest.newRequest(method)
+                            .namedParameters(body)
+                            .build())
+                    .get(timeout.getSeconds(), TimeUnit.SECONDS)
+                    .getResult(responseType);
+        } catch (ExecutionException | TimeoutException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcCodec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+/**
+ * A codec decomposes a value into multiple RPC {@link TreeDatum} events, and
+ * on the receiving side reconstitutes the value from those events.
+ *
+ * @param <T> The type of the value being sent and received.
+ */
+public interface RpcCodec<T> {
+
+    /**
+     * When the value has been determined to have been changed, this method is called
+     * to send the values that comprise it.
+     *
+     * @param after The value that has been either added or changed.
+     * @param q     The send queue that is collecting {@link TreeDatum} to send.
+     */
+    void rpcSend(T after, RpcSendQueue q);
+
+    /**
+     * When the value has been determined to have been changed, this method is called
+     * to receive the values that comprise it.
+     *
+     * @param before The value that has been either added or changed. In the case where it is added,
+     *               the before state will be non-null, but will be an initialized object with
+     *               all null fields that are expecting to be populated by this method.
+     * @param q      The queue that is receiving {@link TreeDatum} from a remote.
+     */
+    T rpcReceive(T before, RpcReceiveQueue q);
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import static java.util.Objects.requireNonNull;
+
+public class RpcReceiveQueue {
+    private final List<TreeDatum> batch;
+    private final Map<Integer, Object> refs;
+    private final Supplier<TreeData> pull;
+
+    public RpcReceiveQueue(Map<Integer, Object> refs, Supplier<TreeData> pull) {
+        this.refs = refs;
+        this.batch = new ArrayList<>();
+        this.pull = pull;
+    }
+
+    public TreeDatum take() {
+        if (batch.isEmpty()) {
+            TreeData data = pull.get();
+            batch.addAll(data.getData());
+        }
+        return batch.remove(0);
+    }
+
+    /**
+     * Receive a value from the queue and apply a function to it, usually to
+     * convert it to a string or fetch some nested object off of it.
+     *
+     * @param before The value to apply the function to, which may be null.
+     * @param apply  A function that is called only when before is non-null.
+     * @param <T>    A before value ahead of the function call.
+     * @param <U>    The return type of the function. This will match the type that is
+     *               being received from the remote.
+     * @return The received value. To set the correct before state when the received state
+     * is NO_CHANGE or CHANGE, the function is applied to the before parameter, unless before
+     * is null in which case the before state is assumed to be null.
+     */
+    public <T, U> U receiveAndGet(@Nullable T before, Function<T, U> apply) {
+        return receive(before == null ? null : apply.apply(before), null);
+    }
+
+    /**
+     * Receive a simple value from the remote.
+     *
+     * @param before The before state.
+     * @param <T>    The type of the value being received.
+     * @return The received value.
+     */
+    public <T> T receive(@Nullable T before) {
+        return receive(before, null);
+    }
+
+    /**
+     * Receive a value from the remote and, when it is an ADD or CHANGE, invoke a callback
+     * to receive its constituent parts.
+     *
+     * @param before   The before state.
+     * @param onChange When the state is ADD or CHANGE, this function is called to receive the
+     *                 pieces of this value. If the callback is null, the value is assumed to
+     *                 be in the value part of the message and is deserialized directly.
+     * @param <T>      The type of the value being received.
+     * @return The received value.
+     */
+    @SuppressWarnings("DataFlowIssue")
+    public <T> T receive(@Nullable T before, @Nullable UnaryOperator<T> onChange) {
+        TreeDatum message = take();
+        switch (message.getState()) {
+            case NO_CHANGE:
+                return before;
+            case DELETE:
+                return null;
+            case ADD:
+                Integer ref = message.getRef();
+                if (ref != null) {
+                    if (refs.containsKey(ref)) {
+                        //noinspection unchecked
+                        return (T) refs.get(ref);
+                    } else {
+                        before = onChange == null ?
+                                message.getValue() :
+                                newObj(message.getValueType());
+                        refs.put(ref, before);
+                    }
+                } else {
+                    before = onChange == null ?
+                            message.getValue() :
+                            newObj(message.getValueType());
+                }
+                // Intentional fall-through...
+            case CHANGE:
+                return onChange == null ? message.getValue() : onChange.apply(before);
+            default:
+                throw new UnsupportedOperationException("Unknown state type " + message.getState());
+        }
+    }
+
+    public <T> List<T> receiveList(@Nullable List<T> before, UnaryOperator<@Nullable T> onChange) {
+        TreeDatum msg = take();
+        switch (msg.getState()) {
+            case NO_CHANGE:
+                //noinspection DataFlowIssue
+                return before;
+            case DELETE:
+                //noinspection DataFlowIssue
+                return null;
+            case ADD:
+                before = new ArrayList<>();
+                // Intentional fall-through...
+            case CHANGE:
+                msg = take(); // the next message should be a CHANGE with a list of positions
+                assert msg.getState() == TreeDatum.State.CHANGE;
+                List<Integer> positions = msg.getValue();
+
+                List<T> after = new ArrayList<>(positions.size());
+                for (int beforeIdx : positions) {
+                    msg = take();
+                    switch (msg.getState()) {
+                        case NO_CHANGE:
+                            after.add(requireNonNull(before).get(beforeIdx));
+                            break;
+                        case ADD:
+                            // Intentional fall-through...
+                        case CHANGE:
+                            after.add(onChange.apply(beforeIdx == -1 ?
+                                    newObj(requireNonNull(msg.getValueType())) :
+                                    requireNonNull(before).get(beforeIdx)));
+                            break;
+                        default:
+                            throw new UnsupportedOperationException("Unknown state type " + msg.getState());
+                    }
+                }
+                return after;
+            default:
+                throw new UnsupportedOperationException(msg.getState() + " is not supported for lists.");
+        }
+    }
+
+    private static <T> T newObj(String type) {
+        try {
+            Class<?> clazz = Class.forName(type);
+            for (Constructor<?> ctor : clazz.getDeclaredConstructors()) {
+                Object[] args = new Object[ctor.getParameterCount()];
+                for (int i = 0; i < args.length; i++) {
+                    Class<?> paramType = ctor.getParameters()[i].getType();
+                    if (paramType == boolean.class) {
+                        args[i] = false;
+                    } else if (paramType == int.class) {
+                        args[i] = 0;
+                    } else if (paramType == short.class) {
+                        args[i] = (short) 0;
+                    } else if (paramType == long.class) {
+                        args[i] = 0L;
+                    } else if (paramType == byte.class) {
+                        args[i] = (byte) 0;
+                    } else if (paramType == float.class) {
+                        args[i] = 0.0f;
+                    } else if (paramType == double.class) {
+                        args[i] = 0.0d;
+                    } else if (paramType == char.class) {
+                        args[i] = '\u0000';
+                    }
+                }
+                ctor.setAccessible(true);
+                //noinspection unchecked
+                return (T) ctor.newInstance(args);
+            }
+            throw new IllegalStateException("Unable to find a constructor for " + clazz);
+        } catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException |
+                 InstantiationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.internal.ThrowingConsumer;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.openrewrite.rpc.TreeDatum.ADDED_LIST_ITEM;
+import static org.openrewrite.rpc.TreeDatum.State.*;
+
+public class RpcSendQueue {
+    private final int batchSize;
+    private final List<TreeDatum> batch;
+    private final Consumer<TreeData> drain;
+    private final Map<Object, Integer> refs;
+
+    private @Nullable Object before;
+
+    public RpcSendQueue(int batchSize, ThrowingConsumer<TreeData> drain, Map<Object, Integer> refs) {
+        this.batchSize = batchSize;
+        this.batch = new ArrayList<>(batchSize);
+        this.drain = drain;
+        this.refs = refs;
+    }
+
+    public void put(TreeDatum treeDatum) {
+        batch.add(treeDatum);
+        if (batch.size() == batchSize) {
+            flush();
+        }
+    }
+
+    /**
+     * Called whenever the batch size is reached or at the end of the tree.
+     */
+    public void flush() {
+        if (batch.isEmpty()) {
+            return;
+        }
+        drain.accept(new TreeData(new ArrayList<>(batch)));
+        batch.clear();
+    }
+
+    public <T, U> void getAndSend(@Nullable T parent, Function<T, @Nullable U> value) {
+        getAndSend(parent, value, null);
+    }
+
+    public <T, U> void getAndSend(@Nullable T parent, Function<T, @Nullable U> value, @Nullable Consumer<U> onChange) {
+        U after = value.apply(parent);
+        //noinspection unchecked
+        U before = this.before == null ? null : value.apply((T) this.before);
+        send(after, before, onChange == null ? null : () -> onChange.accept(after));
+    }
+
+    public <T, U> void getAndSendList(@Nullable T parent,
+                                      Function<T, @Nullable List<U>> values,
+                                      Function<U, ?> id,
+                                      Consumer<U> onChange) {
+        List<U> after = values.apply(parent);
+        //noinspection unchecked
+        List<U> before = this.before == null ? null : values.apply((T) this.before);
+        sendList(after, before, id, onChange);
+    }
+
+    public <T> void send(@Nullable T after, @Nullable T before, @Nullable Runnable onChange) {
+        Object afterVal = Reference.getValue(after);
+        Object beforeVal = Reference.getValue(before);
+
+        if (beforeVal == afterVal) {
+            put(new TreeDatum(NO_CHANGE, null, null, null));
+        } else if (beforeVal == null) {
+            add(after, onChange);
+        } else if (afterVal == null) {
+            put(new TreeDatum(DELETE, null, null, null));
+        } else {
+            put(new TreeDatum(CHANGE, null, onChange == null ? afterVal : null, null));
+            doChange(after, before, onChange);
+        }
+    }
+
+    public <T> void sendList(@Nullable List<T> after,
+                             @Nullable List<T> before,
+                             Function<T, ?> id,
+                             Consumer<T> onChange) {
+        send(after, before, () -> {
+            assert after != null : "A DELETE event should have been sent.";
+
+            Map<Object, Integer> beforeIdx = putListPositions(after, before, id);
+
+            for (T anAfter : after) {
+                Integer beforePos = beforeIdx.get(id.apply(anAfter));
+                Runnable onChangeRun = () -> onChange.accept(anAfter);
+                if (beforePos == null) {
+                    put(new TreeDatum(ADD, getValueType(anAfter), null, null));
+                    doChange(anAfter, null, onChangeRun);
+                } else {
+                    T aBefore = before == null ? null : before.get(beforePos);
+                    if (aBefore == anAfter) {
+                        put(new TreeDatum(NO_CHANGE, null, null, null));
+                    } else {
+                        put(new TreeDatum(CHANGE, null, null, null));
+                        doChange(anAfter, aBefore, onChangeRun);
+                    }
+                }
+            }
+        });
+    }
+
+    private <T> Map<Object, Integer> putListPositions(List<T> after, @Nullable List<T> before, Function<T, ?> id) {
+        Map<Object, Integer> beforeIdx = new IdentityHashMap<>();
+        if (before != null) {
+            for (int i = 0; i < before.size(); i++) {
+                beforeIdx.put(id.apply(before.get(i)), i);
+            }
+        }
+        List<Integer> positions = new ArrayList<>();
+        for (T t : after) {
+            Integer beforePos = beforeIdx.get(id.apply(t));
+            positions.add(beforePos == null ? ADDED_LIST_ITEM : beforePos);
+        }
+        put(new TreeDatum(CHANGE, null, positions, null));
+        return beforeIdx;
+    }
+
+    private void add(@Nullable Object after, @Nullable Runnable onChange) {
+        Object afterVal = Reference.getValue(after);
+        if (afterVal != null && after != afterVal /* Is a reference */) {
+            if (refs.containsKey(afterVal)) {
+                put(new TreeDatum(ADD, getValueType(afterVal), null, refs.get(afterVal)));
+                // No onChange call because the remote will be using an instance from its ref cache
+            } else {
+                int ref = refs.size() + 1;
+                refs.put(afterVal, ref);
+                put(new TreeDatum(ADD, getValueType(afterVal),
+                        onChange == null ? afterVal : null, ref));
+                doChange(afterVal, null, onChange);
+            }
+        } else {
+            put(new TreeDatum(ADD, getValueType(afterVal),
+                    onChange == null ? afterVal : null, null));
+            doChange(afterVal, null, onChange);
+        }
+    }
+
+    private void doChange(@Nullable Object after, @Nullable Object before, @Nullable Runnable onChange) {
+        if (onChange != null) {
+            Object lastBefore = this.before;
+            this.before = before;
+            if (after != null) {
+                onChange.run();
+            }
+            this.before = lastBefore;
+        }
+    }
+
+    private static @Nullable String getValueType(@Nullable Object after) {
+        if (after == null) {
+            return null;
+        }
+        Class<?> type = after.getClass();
+        if (type.isPrimitive() || type.getPackage().getName().startsWith("java.lang") ||
+            type.equals(UUID.class)) {
+            return null;
+        }
+        return type.getName();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/TreeData.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/TreeData.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class TreeData {
+    List<TreeDatum> data;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/TreeDatum.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/TreeDatum.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+
+import java.util.Map;
+
+/**
+ * A single piece of data in a tree, which can be a marker, leaf value, tree element, etc.
+ */
+@Value
+public class TreeDatum {
+    private static final ObjectMapper mapper = JsonMapper.builder()
+            // to be able to construct classes that have @Data and a single field
+            // see https://cowtowncoder.medium.com/jackson-2-12-most-wanted-3-5-246624e2d3d0
+            .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
+            .build()
+            .registerModules(new ParameterNamesModule(), new JavaTimeModule())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    public static final int ADDED_LIST_ITEM = -1;
+
+    State state;
+
+    /**
+     * Used to construct a new instance of the class with
+     * initially only the ID populated. Subsequent {@link TreeDatum}
+     * messages will fill in the object fully.
+     */
+    @Nullable
+    String valueType;
+
+    /**
+     * Not always a {@link Tree}. This can be a marker or leaf element
+     * value element of a tree as well. At any rate, it's a part of
+     * the data modeled by a {@link Tree}.
+     * <p>
+     * In the case of a {@link Tree} ADD, this is the tree ID.
+     */
+    @Nullable
+    Object value;
+
+    /**
+     * Used for instances that should be referentially equal in multiple parts
+     * of the tree (e.g. Space, some Marker types, JavaType). The first time the
+     * object is seen, it is transmitted with a ref ID. Subsequent references
+     * to the same object are transmitted with the ref ID and no value.
+     */
+    @Nullable
+    Integer ref;
+
+    public TreeDatum(State state, @Nullable String valueType, @Nullable Object value, @Nullable Integer ref) {
+        this.state = state;
+        this.valueType = valueType;
+        this.value = value;
+        this.ref = ref;
+    }
+
+    public <V> V getValue() {
+        if (value instanceof Map) {
+            try {
+                //noinspection unchecked
+                return (V) mapper.convertValue(value, Class.forName(valueType));
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        //noinspection DataFlowIssue,unchecked
+        return (V) value;
+    }
+
+    public enum State {
+        NO_CHANGE,
+        ADD,
+        DELETE,
+        CHANGE,
+        END_OF_TREE
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/package-info.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.openrewrite.rpc;
+
+import org.jspecify.annotations.NullMarked;

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetTreeDataRequest.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetTreeDataRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import lombok.Value;
+
+import java.util.UUID;
+
+@Value
+public class GetTreeDataRequest implements RecipeRpcRequest {
+    UUID treeId;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/RecipeRpcRequest.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/RecipeRpcRequest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+public interface RecipeRpcRequest {
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/VisitRequest.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/VisitRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import lombok.Value;
+
+import java.util.UUID;
+
+@Value
+public class VisitRequest implements RecipeRpcRequest {
+    String visitor;
+    UUID treeId;
+    Object p;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/VisitResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/VisitResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import lombok.Value;
+
+@Value
+public class VisitResponse {
+    boolean modified;
+}

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/TreeDataSendQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/TreeDataSendQueueTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.internal.ListUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TreeDataSendQueueTest {
+
+    @Test
+    void sendDifference() throws InterruptedException {
+        List<String> before = List.of("A", "B", "C", "D");
+        List<String> after = List.of("A", "E", "F", "C");
+        Map<String, UUID> ids = ListUtils.concatAll(before, after).stream()
+          .distinct()
+          .collect(Collectors.toMap(s -> s, s -> UUID.randomUUID()));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        RpcSendQueue q = new RpcSendQueue(10, t -> {
+            assertThat(t.getData()).containsExactly(
+              new TreeDatum(TreeDatum.State.CHANGE, null, List.of(0, -1, -1, 2), null),
+              new TreeDatum(TreeDatum.State.NO_CHANGE, null, null, null) /* A */,
+              new TreeDatum(TreeDatum.State.ADD, "string", ids.get("E"), null),
+              new TreeDatum(TreeDatum.State.ADD, "string", ids.get("F"), null),
+              new TreeDatum(TreeDatum.State.NO_CHANGE, null, null, null) /* C */
+            );
+            latch.countDown();
+        }, new HashMap<>());
+
+        q.send(after, before, () -> {
+        });
+        q.flush();
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    }
+}

--- a/rewrite-json/build.gradle.kts
+++ b/rewrite-json/build.gradle.kts
@@ -6,9 +6,9 @@ tasks.register<JavaExec>("generateAntlrSources") {
     mainClass.set("org.antlr.v4.Tool")
 
     args = listOf(
-            "-o", "src/main/java/org/openrewrite/json/internal/grammar",
-            "-package", "org.openrewrite.json.internal.grammar",
-            "-visitor"
+        "-o", "src/main/java/org/openrewrite/json/internal/grammar",
+        "-package", "org.openrewrite.json.internal.grammar",
+        "-visitor"
     ) + fileTree("src/main/antlr").matching { include("**/*.g4") }.map { it.path }
 
     classpath = sourceSets["main"].runtimeClasspath
@@ -26,4 +26,5 @@ dependencies {
 
     testImplementation(project(":rewrite-test"))
     testImplementation(project(":rewrite-yaml"))
+    testImplementation("io.moderne:jsonrpc:latest.release")
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonReceiver.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonReceiver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.json.internal.rpc;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.json.JsonVisitor;
+import org.openrewrite.json.tree.Json;
+import org.openrewrite.json.tree.JsonRightPadded;
+import org.openrewrite.json.tree.JsonValue;
+import org.openrewrite.rpc.RpcReceiveQueue;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonReceiver extends JsonVisitor<RpcReceiveQueue> {
+
+    @Override
+    public Json preVisit(@NonNull Json j, RpcReceiveQueue q) {
+        j = j.withId(UUID.fromString(q.receiveAndGet(j.getId(), UUID::toString)));
+        j = j.withPrefix(q.receive(j.getPrefix()));
+        j = j.withMarkers(q.receive(j.getMarkers()));
+        return j;
+    }
+
+    public Json visitDocument(Json.Document document, RpcReceiveQueue q) {
+        String sourcePath = q.receiveAndGet(document.getSourcePath(), Path::toString);
+        return document.withSourcePath(Paths.get(sourcePath))
+                .withCharset(Charset.forName(q.receiveAndGet(document.getCharset(), Charset::name)))
+                .withCharsetBomMarked(q.receive(document.isCharsetBomMarked()))
+                .withChecksum(q.receive(document.getChecksum()))
+                .withFileAttributes(q.receive(document.getFileAttributes()))
+                .withValue(q.receive(document.getValue(), j -> (JsonValue) visitNonNull(j, q)))
+                .withEof(q.receive(document.getEof()));
+    }
+
+    public Json visitArray(Json.Array array, RpcReceiveQueue q) {
+        return array.getPadding().withValues(
+                q.receiveList(array.getPadding().getValues(), j -> visitRightPadded(j, q)));
+    }
+
+    public Json visitEmpty(Json.Empty empty, RpcReceiveQueue q) {
+        return empty;
+    }
+
+    public Json visitIdentifier(Json.Identifier identifier, RpcReceiveQueue q) {
+        return identifier.withName(q.receive(identifier.getName()));
+    }
+
+    public Json visitLiteral(Json.Literal literal, RpcReceiveQueue q) {
+        return literal.withSource(q.receive(literal.getSource()))
+                .withValue(q.receive(literal.getValue()));
+    }
+
+    public Json visitMember(Json.Member member, RpcReceiveQueue q) {
+        return member
+                .getPadding().withKey(q.receive(member.getPadding().getKey(),
+                        j -> requireNonNull(visitRightPadded(j, q))))
+                .withValue(q.receive(member.getValue(), j -> (JsonValue) visitNonNull(j, q)));
+    }
+
+    public Json visitObject(Json.JsonObject object, RpcReceiveQueue q) {
+        return object.getPadding().withMembers(
+                q.receiveList(object.getPadding().getMembers(), j -> visitRightPadded(j, q)));
+    }
+
+    @Override
+    public @Nullable <T extends Json> JsonRightPadded<T> visitRightPadded(@Nullable JsonRightPadded<T> right, RpcReceiveQueue q) {
+        assert right != null : "TreeDataReceiveQueue should have instantiated an empty padding";
+
+        //noinspection unchecked
+        return right.withElement(q.receive(right.getElement(), j -> (T) visitNonNull(j, q)))
+                .withAfter(q.receive(right.getAfter()))
+                .withMarkers(q.receive(right.getMarkers()));
+    }
+}

--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonSender.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/JsonSender.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.json.internal.rpc;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.json.JsonVisitor;
+import org.openrewrite.json.tree.Json;
+import org.openrewrite.json.tree.JsonRightPadded;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import static org.openrewrite.rpc.Reference.asRef;
+
+public class JsonSender extends JsonVisitor<RpcSendQueue> {
+
+    @Override
+    public Json preVisit(@NonNull Json j, RpcSendQueue q) {
+        q.getAndSend(j, Tree::getId);
+        q.getAndSend(j, j2 -> asRef(j2.getPrefix()));
+        q.getAndSend(j, j2 -> asRef(j2.getMarkers()));
+        return j;
+    }
+
+    @Override
+    public Json visitDocument(Json.Document document, RpcSendQueue q) {
+        q.getAndSend(document, (Json.Document d) -> d.getSourcePath().toString());
+        q.getAndSend(document, (Json.Document d) -> d.getCharset().name());
+        q.getAndSend(document, Json.Document::isCharsetBomMarked);
+        q.getAndSend(document, Json.Document::getChecksum);
+        q.getAndSend(document, Json.Document::getFileAttributes);
+        q.getAndSend(document, Json.Document::getValue, j -> visit(j, q));
+        q.getAndSend(document, d -> asRef(d.getEof()));
+        return document;
+    }
+
+    @Override
+    public Json visitArray(Json.Array array, RpcSendQueue q) {
+        q.getAndSendList(array, a -> a.getPadding().getValues(),
+                j -> j.getElement().getId(),
+                j -> visitRightPadded(j, q));
+        return array;
+    }
+
+    @Override
+    public Json visitEmpty(Json.Empty empty, RpcSendQueue q) {
+        return empty;
+    }
+
+    @Override
+    public Json visitIdentifier(Json.Identifier identifier, RpcSendQueue q) {
+        q.getAndSend(identifier, Json.Identifier::getName);
+        return identifier;
+    }
+
+    @Override
+    public Json visitLiteral(Json.Literal literal, RpcSendQueue q) {
+        q.getAndSend(literal, Json.Literal::getSource);
+        q.getAndSend(literal, Json.Literal::getValue);
+        return literal;
+    }
+
+    @Override
+    public Json visitMember(Json.Member member, RpcSendQueue q) {
+        q.getAndSend(member, m -> m.getPadding().getKey(), j -> visitRightPadded(j, q));
+        q.getAndSend(member, Json.Member::getValue, j -> visit(j, q));
+        return member;
+    }
+
+    @Override
+    public Json visitObject(Json.JsonObject obj, RpcSendQueue q) {
+        q.getAndSendList(obj, o -> o.getPadding().getMembers(),
+                j -> j.getElement().getId(),
+                j -> visitRightPadded(j, q));
+        return obj;
+    }
+
+    @Override
+    public @Nullable <T extends Json> JsonRightPadded<T> visitRightPadded(@Nullable JsonRightPadded<T> right, RpcSendQueue q) {
+        q.getAndSend(right, JsonRightPadded::getElement, j -> visit(j, q));
+        q.getAndSend(right, j -> asRef(j.getAfter()));
+        q.getAndSend(right, j -> asRef(j.getMarkers()));
+        return right;
+    }
+}

--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/package-info.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/rpc/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+@NonNullFields
+package org.openrewrite.json.internal.rpc;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/rewrite-json/src/test/java/org/openrewrite/json/internal/rpc/JsonSendReceiveTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/internal/rpc/JsonSendReceiveTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.json.internal.rpc;
+
+import io.moderne.jsonrpc.JsonRpc;
+import io.moderne.jsonrpc.handler.HeaderDelimitedMessageHandler;
+import io.moderne.jsonrpc.handler.TraceMessageHandler;
+import lombok.SneakyThrows;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.json.JsonVisitor;
+import org.openrewrite.json.tree.Json;
+import org.openrewrite.rpc.RewriteRpc;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.time.Duration;
+
+import static org.openrewrite.json.Assertions.json;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class JsonSendReceiveTest implements RewriteTest {
+    RewriteRpc server;
+    RewriteRpc client;
+
+    @BeforeEach
+    void before() throws IOException {
+        PipedOutputStream serverOut = new PipedOutputStream();
+        PipedOutputStream clientOut = new PipedOutputStream();
+        PipedInputStream serverIn = new PipedInputStream(clientOut);
+        PipedInputStream clientIn = new PipedInputStream(serverOut);
+
+        JsonRpc serverJsonRpc = new JsonRpc(new TraceMessageHandler("server",
+          new HeaderDelimitedMessageHandler(serverIn, serverOut)));
+        server = new RewriteRpc(serverJsonRpc, Duration.ofSeconds(10));
+
+        JsonRpc clientJsonRpc = new JsonRpc(new TraceMessageHandler("client",
+          new HeaderDelimitedMessageHandler(clientIn, clientOut)));
+        client = new RewriteRpc(clientJsonRpc, Duration.ofSeconds(10));
+    }
+
+    @AfterEach
+    void after() {
+        server.shutdown();
+        client.shutdown();
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new TreeVisitor<>() {
+            @SneakyThrows
+            @Override
+            public Tree preVisit(@NonNull Tree tree, ExecutionContext ctx) {
+                Tree t = server.visit((SourceFile) tree, ChangeValue.class.getName(), 0);
+                stopAfterPreVisit();
+                return t;
+            }
+        }));
+    }
+
+    @Test
+    void sendReceiveIdempotence() {
+        rewriteRun(
+          //language=json
+          json(
+            """
+              {
+                "key": "value",
+                "array": [1, 2, 3]
+              }
+              """,
+            """
+              {
+                "key": "changed",
+                "array": [1, 2, 3]
+              }
+              """
+          )
+        );
+    }
+
+    static class ChangeValue extends JsonVisitor<Integer> {
+        @Override
+        public Json visitLiteral(Json.Literal literal, Integer p) {
+            if (literal.getValue().equals("value")) {
+                return literal.withValue("changed").withSource("\"changed\"");
+            }
+            return literal;
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?

Rewrite RPC is used to support non-JVM languages for both parsing and recipe writing/running, allowing LSTs to be passed between process boundaries.

We had an initial implementation that we've worked on over the last year and which was called `rewrite-remote`. We're now incorporating the lessons we learned from that initial work to perfect(ish) the design as we bring it into openrewrite/rewrite.

We'll also be bringing rewrite-javascript/python/csharp into this repository as a part of this work, though maybe not all in this single PR.

## Anyone you would like to review specifically?
@knutwannheden 