### PR TITLE
JavaTemplate don't use type params on matching method invocations

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -976,8 +976,7 @@ public class SemanticallyEqual {
                       !nullMissMatch(method.getSelect(), compareTo.getSelect())) ||
                     method.getMethodType() == null ||
                     compareTo.getMethodType() == null ||
-                    !TypeUtils.isAssignableTo(method.getMethodType().getReturnType(), compareTo.getMethodType().getReturnType()) ||
-                    nullListSizeMissMatch(method.getTypeParameters(), compareTo.getTypeParameters())) {
+                    !TypeUtils.isAssignableTo(method.getMethodType().getReturnType(), compareTo.getMethodType().getReturnType())) {
                     isEqual.set(false);
                     return method;
                 }
@@ -1019,7 +1018,6 @@ public class SemanticallyEqual {
                 if (compareMethodArguments || containsLiteral) {
                     this.visitList(method.getArguments(), compareTo.getArguments());
                 }
-                this.visitList(method.getTypeParameters(), compareTo.getTypeParameters());
             }
             return method;
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
