### PR TITLE
Re-enable disabled test case

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/RemoveTrailingWhitespaceTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/RemoveTrailingWhitespaceTest.java
@@ -57,7 +57,6 @@ class RemoveTrailingWhitespaceTest implements RewriteTest {
         );
     }
 
-    @Disabled // TODO: This exposes bug around trailing commas in the parser
     @Issue("https://github.com/openrewrite/rewrite/issues/1053")
     @Test
     void doNotRemoveTrailingComma() {


### PR DESCRIPTION
## What's changed?
Removing `@Disabled` annotation from one of the test cases.

## What's your motivation?

I just found it by accident.
And just figured out the test passes, so I thought we should re-enable.
