### PR TITLE
Record a SourcesFileResults.Row for generated sources

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -133,8 +133,9 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                 }
                 List<SourceFile> generated = new ArrayList<>(scanningRecipe.generate(scanningRecipe.getAccumulator(rootCursor, ctx), unmodifiableList(acc), ctx));
                 generated.replaceAll(source -> addRecipesThatMadeChanges(recipeStack, source));
-                acc.addAll(generated);
                 if (!generated.isEmpty()) {
+                    acc.addAll(generated);
+                    generated.forEach(source -> recordSourceFileResult(null, source, recipeStack, ctx));
                     madeChangesInThisCycle.add(recipe);
                 }
             }


### PR DESCRIPTION
## What's your motivation?
- Partial(?) fix for https://github.com/openrewrite/rewrite/issues/4909

## Anything in particular you'd like reviewers to focus on?
Do we want to see additional effort logged for #4909 ? This seemed like an omission, but I'm not sure about further changes.

## Anyone you would like to review specifically?
@bmuschko @sambsnyd 

## Have you considered any alternatives or workarounds?
We could also assign some effort for the scanning phase of a recipe, or when creating a data table row. That seems a bit further removed from how we've traditionally estimated and measured effort though, so not (yet) included here.