### PR TITLE
Add `io.moderne` as root category, same as `org.openrewrite`

### DIFF
--- a/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
+++ b/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
@@ -20,6 +20,11 @@ packageName: org.openrewrite
 root: true
 ---
 type: specs.openrewrite.org/v1beta/category
+name: Moderne
+packageName: io.moderne
+root: true
+---
+type: specs.openrewrite.org/v1beta/category
 packageName: io
 root: true
 ---


### PR DESCRIPTION
## Anything in particular you'd like reviewers to focus on?
We already had `io` there, but then we also have both `org` and `org.openrewrite`. Would this then similarly help group recipes? as needed for 
- https://github.com/openrewrite/rewrite-recipe-markdown-generator/issues/167


## Any additional context
- https://github.com/moderneinc/rewrite-ai-search/commit/76df9fb37d57791f0e86e9d5eb1f0b46878045f1
