### PR TITLE
Restore Yaml.* constructors without Tag for gradual adoption

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/tree/Yaml.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
@@ -243,6 +244,22 @@ public interface Yaml extends Tree {
             PLAIN
         }
 
+        @Deprecated
+        public Scalar(UUID id, String prefix, Markers markers, Style style, @Nullable Anchor anchor, String value) {
+            this(id, prefix, markers, style, anchor, null, value);
+        }
+
+        @JsonCreator
+        public Scalar(UUID id, String prefix, Markers markers, Style style, @Nullable Anchor anchor, @Nullable Tag tag, String value) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.style = style;
+            this.anchor = anchor;
+            this.tag = tag;
+            this.value = value;
+        }
+
         @Override
         public <P> Yaml acceptYaml(YamlVisitor<P> v, P p) {
             return v.visitScalar(this, p);
@@ -282,6 +299,22 @@ public interface Yaml extends Tree {
 
         @Nullable
         Tag tag;
+
+        @Deprecated
+        public Mapping(UUID id, Markers markers, @Nullable String openingBracePrefix, List<Entry> entries, @Nullable String closingBracePrefix, @Nullable Anchor anchor) {
+            this(id, markers, openingBracePrefix, entries, closingBracePrefix, anchor, null);
+        }
+
+        @JsonCreator
+        public Mapping(UUID id, Markers markers, @Nullable String openingBracePrefix, List<Entry> entries, @Nullable String closingBracePrefix, @Nullable Anchor anchor, @Nullable Tag tag) {
+            this.id = id;
+            this.markers = markers;
+            this.openingBracePrefix = openingBracePrefix;
+            this.entries = entries;
+            this.closingBracePrefix = closingBracePrefix;
+            this.anchor = anchor;
+            this.tag = tag;
+        }
 
         @Override
         public <P> Yaml acceptYaml(YamlVisitor<P> v, P p) {
@@ -370,6 +403,22 @@ public interface Yaml extends Tree {
 
         @Nullable
         Tag tag;
+
+        @Deprecated
+        public Sequence(UUID id, Markers markers, @Nullable String openingBracketPrefix, List<Entry> entries, @Nullable String closingBracketPrefix, @Nullable Anchor anchor) {
+            this(id, markers, openingBracketPrefix, entries, closingBracketPrefix, anchor, null);
+        }
+
+        @JsonCreator
+        public Sequence(UUID id, Markers markers, @Nullable String openingBracketPrefix, List<Entry> entries, @Nullable String closingBracketPrefix, @Nullable Anchor anchor, @Nullable Tag tag) {
+            this.id = id;
+            this.markers = markers;
+            this.openingBracketPrefix = openingBracketPrefix;
+            this.entries = entries;
+            this.closingBracketPrefix = closingBracketPrefix;
+            this.anchor = anchor;
+            this.tag = tag;
+        }
 
         @Override
         public <P> Yaml acceptYaml(YamlVisitor<P> v, P p) {


### PR DESCRIPTION
## What's changed?
Add constructors to Yaml.Scalar, Yaml.Sequence and Yaml.Mapping as they existed before
- https://github.com/openrewrite/rewrite/pull/4934

## What's your motivation?
We're getting reports about folks that are attempting to run older compiled recipes with newer versions of the CLI.
```
java.lang.NoSuchMethodError: 'void org.openrewrite.yaml.tree.Yaml$Scalar.<init>(java.util.UUID, java.lang.String, org.openrewrite.marker.Markers, org.openrewrite.yaml.tree.Yaml$Scalar$Style, org.openrewrite.yaml.tree.Yaml$Anchor, java.lang.String)'
```
By restoring these constructors we allow for a gradual adoption, as opposed to a hard required cut over.

## Anything in particular you'd like reviewers to focus on?
I'd added the JsonCreator to avoid ambiguity with deserialization; anything else we'd need to think of?

## Have you considered any alternatives or workarounds?
Not possible to force everyone to switch over at once.
Not desirable to roll back the change that added tags.