### PR TITLE
Make doAfterVisit() public

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -102,7 +102,7 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
      *
      * @param visitor The visitor to run.
      */
-    protected void doAfterVisit(TreeVisitor<?, P> visitor) {
+    public void doAfterVisit(TreeVisitor<?, P> visitor) {
         if (afterVisit == null) {
             afterVisit = new ArrayList<>(2);
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The `TreeVisitor.doAfterVisit()` method was changed from `protected` to `public`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
This will allow `doAfterVisit()` to be called from outside of the `TreeVisitor` class. This enables you to create reuseable helper methods which can be used across multiple recipes. Here is an example of such a use case:

```
public class MyRecipe extends Recipe {
    @Override
    public TreeVisitor<?, ExecutionContext> getVisitor() {
        return new JavaVisitor<ExecutionContext>() {
            @Override
            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration cd, ExecutionContext ctx) {
                    Utilities.changeTypeHelper(this);
                    return super.visitClassDeclaration(cd, ctx);
            }
        }
    }
}
```
```
public class Utilities {
    public static void changeTypeHelper(JavaVisitor<ExecutionContext> javaVisitor) {
        if (someCondition) {
            javaVisitor.doAfterVisit(new ChangeType(class1, class2, true).getVisitor());
        }
    }
}
```
 
## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
You can reimplement the helper method within each `TreeVisitor` class. However, this results in duplicated code.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
