### PR TITLE
Java parsing fix for empty comment as last line

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
@@ -65,4 +65,17 @@ class CommentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void commentAsLastLine() {
+        rewriteRun(
+          java(
+            """
+            class A {
+            }
+            //
+            """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Space.java
@@ -211,7 +211,7 @@ public class Space {
             last = c;
         }
         // If a file ends with a single-line comment there may be no terminating newline
-        if (comment.length() > 0) {
+        if (comment.length() > 0 || inSingleLineComment) {
             comments.add(new TextComment(false, comment.toString(), prefix.toString(), Markers.EMPTY));
             prefix.setLength(0);
         }


### PR DESCRIPTION
## What's changed?

Fixing an edge case of Java parsing. Namely when a single-line empty comment is at the end of the file and there's no newline after that.
```
class A {
}
//
```

## What's your motivation?

Feedback from one of the OpenRewrite users.
