### PR TITLE
Fixing handling of trailing empty single-line comment

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Space.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/tree/Space.java
@@ -225,7 +225,7 @@ public class Space {
             last = c;
         }
 
-        if ((comment.length() > 0)) {
+        if ((comment.length() > 0) || inSingleLineComment) {
             comments.add(new Comment(inLineSlashOrHashComment, comment.toString(), prefix.toString(), Markers.EMPTY));
             prefix = new StringBuilder();
         }

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -223,4 +223,18 @@ class HclCommentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptySingleLineCommentAtTheEndOfTheFile() {
+        rewriteRun(
+          hcl(
+            """
+              module "something" {
+                source = "../else/"
+              }
+              //
+              """
+          )
+        );
+    }
 }

--- a/rewrite-json/src/main/java/org/openrewrite/json/tree/Space.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/tree/Space.java
@@ -221,7 +221,7 @@ public class Space {
             last = c;
         }
         // If a file ends with a single-line comment there may be no terminating newline
-        if (comment.length() > 0) {
+        if (comment.length() > 0 || inSingleLineComment) {
             comments.add(new Comment(false, comment.toString(), prefix.toString(), Markers.EMPTY));
             prefix.setLength(0);
         }

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -39,7 +39,7 @@ class JsonParserTest implements RewriteTest {
     void parseJsonDocument() {
         rewriteRun(
           json(
-      """
+            """
             {
               // comments
               unquoted: 'and you can quote me on that',
@@ -50,6 +50,7 @@ class JsonParserTest implements RewriteTest {
               trailingComma: 'in objects', andIn: ['arrays',],
               "backwardsCompatible": "with JSON",
             }
+            //
             """
           )
         );

--- a/rewrite-toml/src/main/java/org/openrewrite/toml/tree/Space.java
+++ b/rewrite-toml/src/main/java/org/openrewrite/toml/tree/Space.java
@@ -189,7 +189,7 @@ public class Space {
             }
         }
         // If a file ends with a single-line comment there may be no terminating newline
-        if (comment.length() > 0) {
+        if (comment.length() > 0 || inSingleLineComment) {
             comments.add(new Comment(comment.toString(), prefix.toString(), Markers.EMPTY));
             prefix.setLength(0);
         }

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
@@ -337,6 +337,18 @@ class TomlParserTest implements RewriteTest {
     }
 
     @Test
+    void trailingEmptyComment() {
+        rewriteRun(
+          toml(
+              """
+              str = "I'm a string. \\"You can quote me\\". Name\\tJos\\u00E9\\nLocation\\tSF."
+              #
+              """
+          )
+        );
+    }
+
+    @Test
     void multiBytesUnicode() {
         rewriteRun(
           toml(


### PR DESCRIPTION
## What's changed?

A follow-up on #5076. I.e. fixing handling of trailing empty single-line comments in:
- HCL
- JSON
- TOML

## What's your motivation?

Addressing this comment: https://github.com/openrewrite/rewrite/pull/5076#issuecomment-2673756937
