### PR TITLE
Reformat the method pattern description to be more readable

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -60,10 +60,12 @@ import static org.openrewrite.java.tree.TypeUtils.fullyQualifiedNamesAreEqual;
 @SuppressWarnings("NotNullFieldNotInitialized")
 public class MethodMatcher {
     //language=markdown
-    public static final String METHOD_PATTERN_DESCRIPTION = "To find all method invocations in the Guava library, use the pattern " +
-                                                             "`com.google.common..*#*(..)`. The pattern format is `<PACKAGE>#<METHOD_NAME>(<ARGS>)`. " +
-                                                             "`..*` includes all subpackages of `com.google.common`. " +
-                                                             "`*(..)` matches any method name with any number of arguments. " +
+    public static final String METHOD_PATTERN_DESCRIPTION = "A [method pattern](https://docs.openrewrite.org/reference/method-patterns) is used to find matching method invocations. " +
+                                                             "For example, to find all method invocations in the Guava library, use the pattern: " +
+                                                             "`com.google.common..*#*(..)`.<br/><br/>" +
+                                                             "The pattern format is `<PACKAGE>#<METHOD_NAME>(<ARGS>)`. <br/><br/>" +
+                                                             "`..*` includes all subpackages of `com.google.common`. <br/>" +
+                                                             "`*(..)` matches any method name with any number of arguments. <br/><br/>" +
                                                              "For more specific queries, like Guava's `ImmutableMap`, use " +
                                                              "`com.google.common.collect.ImmutableMap#*(..)` to narrow down the results.";
 


### PR DESCRIPTION
As many of us found it difficult to read/parse. I think just adding newlines and bringing back the link to docs will be helpful.
