### PR TITLE
Add failing test `FindLiterals` on Groovy code

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/FindLiteralsInGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/FindLiteralsInGroovyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/FindLiteralsInGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/FindLiteralsInGroovyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.search.FindLiterals;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+class FindLiteralsInGroovyTest implements RewriteTest {
+
+    @Test
+    void findLiterals() {
+        rewriteRun(
+          spec -> spec.recipe(new FindLiterals("org.openrewrite.*")),
+          groovy("""
+            String httpBaseUrl = "http://${host}:${httpPort}${contextPath}"
+            """)
+        );
+    }
+}


### PR DESCRIPTION
# Recipe name: Find literals

## Recipe id: org.openrewrite.java.search.FindLiterals
# Error:
```
:
```

# Message:
```
begin 1, end 0, length 1
```

# Detail:
```
java.lang.StringIndexOutOfBoundsException: begin 1, end 0, length 1
java.base/java.lang.String.checkBoundsBeginEnd(String.java:4606)
java.base/java.lang.String.substring(String.java:2709)
org.openrewrite.java.search.FindLiterals$1.visitLiteral(FindLiterals.java:70)
org.openrewrite.java.search.FindLiterals$1.visitLiteral(FindLiterals.java:65)
org.openrewrite.java.search.FindLiterals_1_GroovyVisitor.visitLiteral(FindLiterals_1_GroovyVisitor.zig:81)
org.openrewrite.java.tree.J$Literal.acceptJava(J.java:3466)
org.openrewrite.java.tree.J.accept(J.java:58)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
org.openrewrite.groovy.GroovyVisitor.lambda$visitGString$1(GroovyVisitor.java:64)
org.openrewrite.internal.ListUtils.map(ListUtils.java:244)
org.openrewrite.internal.ListUtils.map(ListUtils.java:267)
org.openrewrite.groovy.GroovyVisitor.visitGString(GroovyVisitor.java:64)
org.openrewrite.groovy.tree.G$GString.acceptGroovy(G.java:694)
org.openrewrite.groovy.tree.G.accept(G.java:47)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:320)
...
```