### PR TITLE
Fix parsing of multi-line comments "containing" single-line comments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2255,7 +2255,7 @@ public class GroovyParserVisitor {
                 if (source.length() - untilDelim.length() > delimIndex + 1) {
                     switch (source.substring(delimIndex, delimIndex + 2)) {
                         case "//":
-                            inSingleLineComment = true;
+                            inSingleLineComment = !inMultiLineComment;
                             delimIndex++;
                             break;
                         case "/*":

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CompilationUnitTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/CompilationUnitTest.java
@@ -89,6 +89,19 @@ class CompilationUnitTest implements RewriteTest {
     }
 
     @Test
+    void multilineCommentWithUrl() {
+        rewriteRun(
+          groovy(
+            """
+              class Foo {
+              /* https://foo.bar */
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void scriptImportsCanBeAnywhere() {
         rewriteRun(
           spec -> spec.parser(GroovyParser.builder().compilerCustomizers(config -> {

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/HclParserVisitor.java
@@ -771,7 +771,7 @@ public class HclParserVisitor extends HCLParserBaseVisitor<Hcl> {
                         inSingleLineComment = true;
                     } else switch (source.substring(delimIndex, delimIndex + 2)) {
                         case "//":
-                            inSingleLineComment = true;
+                            inSingleLineComment = !inMultiLineComment;
                             delimIndex += 1;
                             break;
                         case "/*":

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclCommentTest.java
@@ -237,4 +237,17 @@ class HclCommentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multiLineCommentWithUrl() {
+        rewriteRun(
+          hcl(
+            """
+              module "something" {
+                /* https://www.example.com */
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1994,7 +1994,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                         case '/':
                             switch (c2) {
                                 case '/':
-                                    inSingleLineComment = true;
+                                    inSingleLineComment = !inMultiLineComment;
                                     delimIndex++;
                                     break;
                                 case '*':

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -64,7 +64,6 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.internal.StringUtils.indexOf;
 import static org.openrewrite.internal.StringUtils.indexOfNextNonWhitespace;
 import static org.openrewrite.java.tree.Space.EMPTY;
 import static org.openrewrite.java.tree.Space.format;
@@ -2081,7 +2080,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                         case '/':
                             switch (c2) {
                                 case '/':
-                                    inSingleLineComment = true;
+                                    inSingleLineComment = !inMultiLineComment;
                                     delimIndex++;
                                     break;
                                 case '*':

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -2106,7 +2106,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                         case '/':
                             switch (c2) {
                                 case '/':
-                                    inSingleLineComment = true;
+                                    inSingleLineComment = !inMultiLineComment;
                                     delimIndex++;
                                     break;
                                 case '*':

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1990,7 +1990,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                         case '/':
                             switch (c2) {
                                 case '/':
-                                    inSingleLineComment = true;
+                                    inSingleLineComment = !inMultiLineComment;
                                     delimIndex++;
                                     break;
                                 case '*':

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
@@ -78,4 +78,21 @@ class CommentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/pull/5090")
+    void multiLineCommentWithUrl() {
+        rewriteRun(
+          java(
+            """
+              package hello;
+              public class Test {
+                public static void test() {
+                  /*addItem("Site A", "https://hello.com/A");*/
+                }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -374,4 +374,22 @@ class JavaParserTest implements RewriteTest {
           .containsOnly(Paths.get("/.m2/repository/org/openrewrite/rewrite-java/8.41.1/rewrite-java-8.41.1.jar"));
     }
 
+    @Test
+    void multiLineComment() {
+        rewriteRun(
+          java(
+            """
+              package hello;
+              public class Test {
+                public static void test() {
+                  /*addItem("Site A", "http://hello.com/A");
+                  addItem("Site B", "http://hello.com/B");
+                  addItem("Site C", "http://hello.com/C");*/
+                }
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -373,23 +373,4 @@ class JavaParserTest implements RewriteTest {
         assertThat(JavaParser.filterArtifacts("rewrite-java", classpath))
           .containsOnly(Paths.get("/.m2/repository/org/openrewrite/rewrite-java/8.41.1/rewrite-java-8.41.1.jar"));
     }
-
-    @Test
-    void multiLineComment() {
-        rewriteRun(
-          java(
-            """
-              package hello;
-              public class Test {
-                public static void test() {
-                  /*addItem("Site A", "http://hello.com/A");
-                  addItem("Site B", "http://hello.com/B");
-                  addItem("Site C", "http://hello.com/C");*/
-                }
-              }
-              """
-          )
-        );
-    }
-
 }

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -129,6 +129,19 @@ class JsonParserTest implements RewriteTest {
         );
     }
 
+    @Test
+    void multilineCommentWithUrl() {
+        rewriteRun(
+          json(
+            """
+            {
+              /* https://foo.bar */
+            }
+            """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1145")
     @Test
     void longValue() {

--- a/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/internal/ProtoParserVisitor.java
+++ b/rewrite-protobuf/src/main/java/org/openrewrite/protobuf/internal/ProtoParserVisitor.java
@@ -487,7 +487,7 @@ public class ProtoParserVisitor extends Protobuf2ParserBaseVisitor<Proto> {
                 if (source.length() - untilDelim.length() > delimIndex + 1) {
                     switch (source.substring(delimIndex, delimIndex + 2)) {
                         case "//":
-                            inSingleLineComment = true;
+                            inSingleLineComment = !inMultiLineComment;
                             delimIndex++;
                             break;
                         case "/*":

--- a/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/tree/EmptyTest.java
+++ b/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/tree/EmptyTest.java
@@ -33,4 +33,16 @@ class EmptyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void multilineCommentWithUrl() {
+        rewriteRun(
+          proto(
+            """
+              /* https://foo.bar */
+              syntax = 'proto2';
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR adds a test case to demonstrate an error that occurs when parsing multi-line comments in Java.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Source file to parse:
```
package hello;
public class Test {
  public static void test() {
    /*addItem("Site A", "http://hello.com/A");
    addItem("Site B", "http://hello.com/B");
    addItem("Site C", "http://hello.com/C");*/
  }
}
```

Resulting error from the parser:
```
[When parsing and printing the source code back to text without modifications, the printed source didn't match the original source code. This means there is a bug in the parser implementation itself. Please open an issue to report this, providing a sample of the code that generated this error for "hello/Test.java":

diff --git a/hello/Test.java b/hello/Test.java
index a16afb8..629000e 100644
--- a/hello/Test.java
+++ b/hello/Test.java
@@ -1,8 +1,4 @@ 
 package hello;
 public class Test {
-  public static void test() {
-    /*addItem("Site A", "http://hello.com/A");
-    addItem("Site B", "http://hello.com/B");
-    addItem("Site C", "http://hello.com/C");*/
-  }
+  public static void test() {}
 }
\ No newline at end of file
] 
expected: 
  "package hello;
  public class Test {
    public static void test() {
      /*addItem("Site A", "http://hello.com/A");
      addItem("Site B", "http://hello.com/B");
      addItem("Site C", "http://hello.com/C");*/
    }
  }"
 but was: 
  "package hello;
  public class Test {
    public static void test() {}
  }"
```

It seems like the parser removes the comment unexpectedly.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@MBoegers

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
