### PR TITLE
Performance improvement for `TypeTable.Reader`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
@@ -135,7 +136,6 @@ public class TypeTable implements JavaParserClasspathLoader {
     @RequiredArgsConstructor
     static class Reader {
         private final ExecutionContext ctx;
-        private @Nullable GroupArtifactVersion gav;
         private final Map<ClassDefinition, List<Member>> membersByClassName = new HashMap<>();
 
         public void read(InputStream is, Collection<String> artifactNames) throws IOException {
@@ -148,24 +148,29 @@ public class TypeTable implements JavaParserClasspathLoader {
                     .map(name -> Pattern.compile(name + ".*"))
                     .collect(Collectors.toSet());
 
+            AtomicReference<@Nullable GroupArtifactVersion> matchedGav = new AtomicReference<>();
             try (BufferedReader in = new BufferedReader(new InputStreamReader(is))) {
+                AtomicReference<@Nullable GroupArtifactVersion> lastGav = new AtomicReference<>();
                 in.lines().skip(1).forEach(line -> {
                     String[] fields = line.split("\t", -1);
                     GroupArtifactVersion rowGav = new GroupArtifactVersion(fields[0], fields[1], fields[2]);
-                    if (!rowGav.equals(gav)) {
-                        writeClassesDir();
-                    }
 
-                    String artifactVersion = fields[1] + "-" + fields[2];
+                    if (!Objects.equals(rowGav, lastGav.get())) {
+                        writeClassesDir(matchedGav.get());
+                        matchedGav.set(null);
 
-                    for (Pattern artifactNamePattern : artifactNamePatterns) {
-                        if (artifactNamePattern.matcher(artifactVersion).matches()) {
-                            gav = rowGav;
-                            break;
+                        String artifactVersion = fields[1] + "-" + fields[2];
+
+                        for (Pattern artifactNamePattern : artifactNamePatterns) {
+                            if (artifactNamePattern.matcher(artifactVersion).matches()) {
+                                matchedGav.set(rowGav);
+                                break;
+                            }
                         }
                     }
+                    lastGav.set(rowGav);
 
-                    if (gav != null) {
+                    if (matchedGav.get() != null) {
                         ClassDefinition classDefinition = new ClassDefinition(
                                 Integer.parseInt(fields[3]),
                                 fields[4],
@@ -188,10 +193,11 @@ public class TypeTable implements JavaParserClasspathLoader {
                     }
                 });
             }
-            writeClassesDir();
+
+            writeClassesDir(matchedGav.get());
         }
 
-        private void writeClassesDir() {
+        private void writeClassesDir(@Nullable GroupArtifactVersion gav) {
             if (gav == null) {
                 return;
             }
@@ -265,8 +271,6 @@ public class TypeTable implements JavaParserClasspathLoader {
                     throw new UncheckedIOException(e);
                 }
             });
-
-            gav = null;
         }
     }
 


### PR DESCRIPTION
Only match row GAV against artifact name patterns when different from previous row's GAV.

Also, don't accumulate classes over artifact boundaries.