### PR TITLE
Fix caching issues in rewrite build

### DIFF
--- a/rewrite-java-tck/build.gradle.kts
+++ b/rewrite-java-tck/build.gradle.kts
@@ -16,6 +16,14 @@ dependencies {
     }
 }
 
+infoBroker {
+    // Prevent cache misses due to unstable attributes, e.g. "Build-Date"
+    includedManifestProperties = listOf(
+        "Module-Owner",
+        "Module-Email",
+    )
+}
+
 tasks.withType<Javadoc> {
     isFailOnError = false
     exclude("org/openrewrite/java/**")

--- a/rewrite-java-tck/build.gradle.kts
+++ b/rewrite-java-tck/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("org.openrewrite.build.language-library")
     id("org.openrewrite.build.java8-text-blocks")
+    // Prevent cache misses due to metadata differences inside the JAR
+    id("org.gradlex.reproducible-builds") version "1.0"
 }
 
 dependencies {


### PR DESCRIPTION
Optimize rewrite build time by fixing caching issues, potentially saving **4m48s** on each `compatibilityTest`, `check` and `build` build.

These were discovered running [develocity-build-validation-scripts](https://github.com/gradle/develocity-build-validation-scripts) against the rewrite project. The scripts run 2 subsequent builds to validate that the 2nd was able to re-use work done by the 1st. 4 tasks in `rewrite` couldn't be re-used:

<img width="1051" alt="Screenshot 2025-02-25 at 19 23 02" src="https://github.com/user-attachments/assets/27875984-4f21-4bb0-9263-b9d7adc2e1db" />

([Workflow run](https://github.com/jprinet/gradle-enterprise-oss-projects/actions/runs/13389683413/job/37394343957#step:6:1479))

In practice, these 4 tasks always re-run and are never `UP-TO-DATE` or `FROM-CACHE`. In Develocity, we can see that re-running these tasks amounts to **4m48s** wall-clock time.

<img width="1505" alt="Screenshot 2025-02-25 at 19 24 41" src="https://github.com/user-attachments/assets/df962293-7203-46c2-8a14-177cdbe68dd9" />

([Build Scan®](https://ge.solutions-team.gradle.com/s/ox7an6roqeoje/timeline?cacheability=cacheable&hide-timeline&kind=task&outcome=success,failed&sort=longest))

Using Develocity Build Scan comparison, we can compare the 2 builds and see what caused the cache misses:

<img width="1496" alt="Screenshot 2025-02-25 at 19 28 39" src="https://github.com/user-attachments/assets/0dae0c85-4fea-4c78-8a1e-8882d41da650" />

([Build Scan comparison](https://ge.solutions-team.gradle.com/c/5cf5bram6dxlw/ox7an6roqeoje/task-inputs?cacheability=cacheable&expanded=WyJlam15cWdub213eG1nLWNhbmRpZGF0ZWNsYXNzZmlsZXMiXQ))

By diffing this JAR across the 2 builds, we find that the _cache misses_ are caused by always-changing (timestamp) attributes in the `rewrite-java-tck` JAR manifest. 

<img width="1257" alt="Screenshot 2025-02-19 at 19 08 05" src="https://github.com/user-attachments/assets/e19eef28-f3fe-4ba9-8087-d2dce0e046de" />

These properties are added by the [`com.netflix.nebula.info` plugin](https://github.com/nebula-plugins/gradle-info-plugin).

## What's changed?

Configure the `com.netflix.nebula.info` plugin to no longer write the "Build-Date*" attributes to the manifest. By re-running the develocity-build-validation-scripts, we could confirm this fixes the build caching issue, allowing for 100% cache hit:

<img width="1508" alt="Screenshot 2025-02-25 at 19 42 25" src="https://github.com/user-attachments/assets/39d6d2a8-005f-474b-9474-1d3e055092f5" />

([Build Scan®](https://ge.solutions-team.gradle.com/s/alkeqnorpf4c6/performance/build-cache#summary-hit))

### Before/after

- [Failed run of develocity-build-validation-scripts against the `rewrite` project](https://github.com/jprinet/gradle-enterprise-oss-projects/actions/runs/13389683413/job/37394343957#step:6:1479)
- [Successful run of develocity-build-validation-scripts after this fix](https://ge.solutions-team.gradle.com/c/u3qe3boufs4zm/alkeqnorpf4c6/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)
