### PR TITLE
MergeYaml recipe: Handle ParseError LSTs

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -123,22 +123,13 @@ public class MergeYaml extends Recipe {
         return Preconditions.check(new FindSourceFiles(filePattern), new YamlIsoVisitor<ExecutionContext>() {
             final JsonPathMatcher matcher = new JsonPathMatcher(key);
 
-            final Yaml incoming = new YamlParser().parse(yaml)
-                    .findFirst()
-                    .map(Yaml.Documents.class::cast)
-                    .map(docs -> {
-                        // Any comments will have been put on the parent Document node, preserve by copying to the mapping
-                        Yaml.Document doc = docs.getDocuments().get(0);
-                        if (doc.getBlock() instanceof Yaml.Mapping) {
-                            Yaml.Mapping m = (Yaml.Mapping) doc.getBlock();
-                            return m.withEntries(ListUtils.mapFirst(m.getEntries(), entry -> entry.withPrefix(doc.getPrefix())));
-                        } else if (doc.getBlock() instanceof Yaml.Sequence) {
-                            Yaml.Sequence s = (Yaml.Sequence) doc.getBlock();
-                            return s.withEntries(ListUtils.mapFirst(s.getEntries(), entry -> entry.withPrefix(doc.getPrefix())));
-                        }
-                        return doc.getBlock().withPrefix(doc.getPrefix());
-                    })
-                    .orElseThrow(() -> new IllegalArgumentException("Could not parse as YAML"));
+            @Nullable Yaml incoming;
+            private Yaml incoming() {
+                if (incoming == null) {
+                    incoming = parse(yaml);
+                }
+                return incoming;
+            }
 
             @Override
             public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
@@ -161,7 +152,7 @@ public class MergeYaml extends Recipe {
                     }
                     // If there is no space between the colon and the value it will not be interpreted as a mapping
                     String snippet;
-                    if (incoming instanceof Yaml.Mapping) {
+                    if (incoming() instanceof Yaml.Mapping) {
                         snippet = valueKey + ":\n" + indent(yaml);
                     } else {
                         snippet = valueKey + ":" + (yaml.startsWith(" ") ? yaml : " " + yaml);
@@ -213,7 +204,7 @@ public class MergeYaml extends Recipe {
                 Yaml.Mapping m = super.visitMapping(mapping, ctx);
                 if (matcher.matches(getCursor())) {
                     getCursor().putMessageOnFirstEnclosing(Yaml.Document.class, FOUND_MATCHING_ELEMENT, true);
-                    m = (Yaml.Mapping) new MergeYamlVisitor<>(mapping, incoming, Boolean.TRUE.equals(acceptTheirs),
+                    m = (Yaml.Mapping) new MergeYamlVisitor<>(mapping, incoming(), Boolean.TRUE.equals(acceptTheirs),
                             objectIdentifyingProperty, insertMode, insertProperty).visitNonNull(mapping, ctx, getCursor().getParentOrThrow());
                 }
                 return m;
@@ -223,7 +214,7 @@ public class MergeYaml extends Recipe {
             public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
                 if (matcher.matches(getCursor())) {
                     getCursor().putMessageOnFirstEnclosing(Yaml.Document.class, FOUND_MATCHING_ELEMENT, true);
-                    Yaml.Block value = (Yaml.Block) new MergeYamlVisitor<>(entry.getValue(), incoming,
+                    Yaml.Block value = (Yaml.Block) new MergeYamlVisitor<>(entry.getValue(), incoming(),
                             Boolean.TRUE.equals(acceptTheirs), objectIdentifyingProperty, insertMode, insertProperty).visitNonNull(entry.getValue(),
                             ctx, getCursor());
                     if (value instanceof Yaml.Scalar && value.getPrefix().isEmpty()) {
@@ -239,12 +230,31 @@ public class MergeYaml extends Recipe {
                 if (matcher.matches(getCursor().getParentOrThrow())) {
                     getCursor().putMessageOnFirstEnclosing(Yaml.Document.class, FOUND_MATCHING_ELEMENT, true);
                     return sequence.withEntries(ListUtils.map(sequence.getEntries(),
-                            entry -> entry.withBlock((Yaml.Block) new MergeYamlVisitor<>(entry.getBlock(), incoming,
+                            entry -> entry.withBlock((Yaml.Block) new MergeYamlVisitor<>(entry.getBlock(), incoming(),
                                     Boolean.TRUE.equals(acceptTheirs), objectIdentifyingProperty, insertMode, insertProperty)
                                     .visitNonNull(entry.getBlock(), ctx, new Cursor(getCursor(), entry)))));
                 }
                 return super.visitSequence(sequence, ctx);
             }
         });
+    }
+
+    static Yaml parse(@Language("yml") String yaml) {
+        return new YamlParser().parse(yaml)
+                .findFirst()
+                .map(Yaml.Documents.class::cast)
+                .map(docs -> {
+                    // Any comments will have been put on the parent Document node, preserve by copying to the mapping
+                    Yaml.Document doc = docs.getDocuments().get(0);
+                    if (doc.getBlock() instanceof Yaml.Mapping) {
+                        Yaml.Mapping m = (Yaml.Mapping) doc.getBlock();
+                        return m.withEntries(ListUtils.mapFirst(m.getEntries(), entry -> entry.withPrefix(doc.getPrefix())));
+                    } else if (doc.getBlock() instanceof Yaml.Sequence) {
+                        Yaml.Sequence s = (Yaml.Sequence) doc.getBlock();
+                        return s.withEntries(ListUtils.mapFirst(s.getEntries(), entry -> entry.withPrefix(doc.getPrefix())));
+                    }
+                    return doc.getBlock().withPrefix(doc.getPrefix());
+                })
+                .orElseThrow(() -> new IllegalArgumentException("Could not parse as YAML"));
     }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -94,6 +94,7 @@ public class MergeYaml extends Recipe {
         return super.validate()
                 .and(Validated.test("yaml", "Must be valid YAML",
                         yaml, y -> new YamlParser().parse(yaml)
+                                .filter(it -> it instanceof Yaml.Documents) // Could also be a ParserError
                                 .findFirst()
                                 .map(doc -> !((Yaml.Documents) doc).getDocuments().isEmpty())
                                 .orElse(false)))

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -109,9 +109,8 @@ public class MergeYaml extends Recipe {
         return super.validate()
                 .and(Validated.test("yaml", "Must be valid YAML",
                         yaml, y -> {
-                            Optional<Yaml.Block> firstDocument = MergeYaml.maybeParse(yaml);
-                            firstDocument.ifPresent(it -> incoming = it);
-                            return firstDocument.isPresent();
+                            MergeYaml.maybeParse(yaml).ifPresent(it -> incoming = it);
+                            return incoming != null;
                         }))
                 .and(Validated.test("insertProperty", "Insert property must be filed when `insert mode` is either `BeforeProperty` or `AfterProperty`.", insertProperty,
                         s -> insertMode == null || insertMode == Last || !isBlank(s)));

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -90,27 +90,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     }
 
     public MergeYamlVisitor(Yaml scope, @Language("yml") String yamlString, boolean acceptTheirs, @Nullable String objectIdentifyingProperty, @Nullable InsertMode insertMode, @Nullable String insertProperty) {
-        this(scope,
-                new YamlParser().parse(yamlString)
-                        .findFirst()
-                        .map(Yaml.Documents.class::cast)
-                        .map(docs -> {
-                            // Any comments will have been put on the parent Yaml.Document node, preserve by copying to the mapping
-                            Yaml.Document doc = docs.getDocuments().get(0);
-                            if (doc.getBlock() instanceof Yaml.Mapping) {
-                                Yaml.Mapping m = (Yaml.Mapping) doc.getBlock();
-                                return m.withEntries(mapFirst(m.getEntries(), entry -> entry.withPrefix(doc.getPrefix())));
-                            } else if (doc.getBlock() instanceof Yaml.Sequence) {
-                                Yaml.Sequence s = (Yaml.Sequence) doc.getBlock();
-                                return s.withEntries(mapFirst(s.getEntries(), entry -> entry.withPrefix(doc.getPrefix())));
-                            }
-                            return doc.getBlock().withPrefix(doc.getPrefix());
-                        })
-                        .orElseThrow(() -> new IllegalArgumentException("Could not parse as YAML")),
-                acceptTheirs,
-                objectIdentifyingProperty,
-                insertMode,
-                insertProperty);
+        this(scope, MergeYaml.parse(yamlString), acceptTheirs, objectIdentifyingProperty, insertMode, insertProperty);
     }
 
     @Override

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -89,6 +89,10 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         this.shouldAutoFormat = shouldAutoFormat;
     }
 
+    /**
+     * @deprecated Use {@link #MergeYamlVisitor(Yaml.Block, Yaml, boolean, String, boolean, InsertMode, String)} instead.
+     */
+    @Deprecated
     public MergeYamlVisitor(Yaml scope, @Language("yml") String yamlString, boolean acceptTheirs, @Nullable String objectIdentifyingProperty, @Nullable InsertMode insertMode, @Nullable String insertProperty) {
         this(scope, MergeYaml.parse(yamlString), acceptTheirs, objectIdentifyingProperty, insertMode, insertProperty);
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openrewrite.yaml.Assertions.yaml;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.After;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.Before;
@@ -2819,5 +2820,24 @@ class MergeYamlTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void invalidYaml() {
+        assertThrows(AssertionError.class, () -> rewriteRun(
+          spec -> spec
+            .recipe(new MergeYaml(
+              "$.some.object",
+              // language=yaml
+              """
+                script: |-ParseError
+                """,
+              false,
+              "name",
+              null,
+              null,
+              null
+            ))
+        ));
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -2754,6 +2754,7 @@ class MergeYamlTest implements RewriteTest {
               false,
               null,
               null,
+              null,
               null
             )),
 
@@ -2790,6 +2791,7 @@ class MergeYamlTest implements RewriteTest {
                   new-key: new-value
                 """,
               false,
+              null,
               null,
               null,
               null


### PR DESCRIPTION
## What's changed?
- The `validate` function can now handle wrong input yaml (it fails gracefully, as it is supposed to be)
- The `incoming` field is parsed once it is needed in the MergeYaml recipe.   

## What's your motivation?
The MergeYaml recipe throws a ClassCastException if invalid Yaml is provided (for instance a [ParseError ](https://github.com/openrewrite/rewrite/blob/main/rewrite-core/src/main/java/org/openrewrite/tree/ParseError.java) LST). Normally the YamlIsoVisitor does only run for yaml sources:

```java
@Override
public boolean isAcceptable(SourceFile sourceFile, P p) {
    return sourceFile instanceof Yaml.Documents;
}
```

But the MergeYaml recipe does already do some parsing work for the `incoming` field, which is executed by the JVM before the `isAcceptable` has been called. This PR changes this behaviour to start parsing it once it is used.

In addition, this change improves performance for all use of the MergeYaml recipe with a `$` key. In that case, the `incoming` field is not used at all, allowing an unnecessary parse step to be skipped.
