### PR TITLE
`DependencyVersionSelector`: Upgrade from milestone to `latest.patch`

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyVersionSelector.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyVersionSelector.java
@@ -30,7 +30,6 @@ import org.openrewrite.maven.tree.*;
 import org.openrewrite.semver.*;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
@@ -141,8 +140,7 @@ public class DependencyVersionSelector {
 
             if (versionComparator instanceof ExactVersion) {
                 return versionComparator.upgrade(gav.getVersion(), singletonList(version)).orElse(null);
-            } else if (versionComparator instanceof LatestPatch &&
-                    !versionComparator.isValid(gav.getVersion(), gav.getVersion())) {
+            } else if (versionComparator instanceof LatestPatch && !Semver.isVersion(gav.getVersion())) {
                 // in the case of "latest.patch", a new version can only be derived if the
                 // current version is a semantic version
                 return null;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -100,6 +100,33 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void fromMilestoneToLatestPatch() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "latest.patch", null)),
+          //language=groovy
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1'
+              }
+              """,
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.27'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void mockitoTestImplementation() {
         rewriteRun(recipeSpec -> {
               recipeSpec.beforeRecipe(withToolingApi())


### PR DESCRIPTION
Upgrading from a milestone version like 1.0.0-M1 to `latest.patch` should be allowed.
