### PR TITLE
Make sure `YamlParser#unwrapPrefixedMappings()` visits entire tree

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -673,7 +673,7 @@ public class YamlParser implements org.openrewrite.Parser {
                     SequenceWithPrefix sequenceWithPrefix = (SequenceWithPrefix) sequence;
                     if (sequenceWithPrefix.getOpeningBracketPrefix() != null) {
                         // For inline sequence, the prefix got already transferred to the left-hand neighbor
-                        return sequenceWithPrefix.toSequence();
+                        return super.visitSequence(sequenceWithPrefix.toSequence(), p);
                     } else {
                         // For normal sequence with dashes, the prefix of the sequence gets transferred to the first entry
                         return super.visitSequence(


### PR DESCRIPTION
The `visitSequence()` method pruned the subtree in some cases leading to that subtree maybe still containing `SequenceWithPrefix` or `MappingWithPrefix` objects, which should be "unwrapped".
