### PR TITLE
Guard against null repos in `MavenPomDownloader#distinctNormalizedRepositories`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -759,7 +759,15 @@ public class MavenPomDownloader {
             List<MavenRepository> repositories,
             @Nullable ResolvedPom containingPom,
             @Nullable String acceptsVersion) {
+        // Temporary guard for the introduction of pluginRepositories to ResolvedPom,
+        //  which on older LSTs will be null.
+        //noinspection ConstantValue
+        if (repositories == null) {
+            repositories = emptyList();
+        }
+
         LinkedHashMap<String, MavenRepository> normalizedRepositories = new LinkedHashMap<>();
+
         if (addLocalRepository) {
             normalizedRepositories.put(ctx.getLocalRepository().getId(), ctx.getLocalRepository());
         }
@@ -838,7 +846,7 @@ public class MavenPomDownloader {
 
                 mavenCache.putNormalizedRepository(repository, normalized);
                 result = Optional.ofNullable(normalized);
-            } else if(!result.isPresent()) {
+            } else if (!result.isPresent()) {
                 ctx.getResolutionListener().repositoryAccessFailedPreviously(repository.getUri());
             }
         } catch (Exception e) {


### PR DESCRIPTION
Simple NPE fix for old LSTs that don't have `ResolvedPom#pluginRepositories`.