### PR TITLE
Detect shell command timeouts and throw an appropriate exception

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/shell/exec/ShellExecutor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/shell/exec/ShellExecutor.java
@@ -56,8 +56,9 @@ public interface ShellExecutor {
             builder.redirectError(ProcessBuilder.Redirect.to(stdErr.toFile()));
             Process process = builder.start();
 
-            process.waitFor(timeout.getSeconds(), TimeUnit.SECONDS);
-            if (process.exitValue() != 0) {
+            if (!process.waitFor(timeout.getSeconds(), TimeUnit.SECONDS)) {
+                throw new RuntimeException(String.format("Command '%s' timed out after %d seconds", String.join(" ", command), timeout.getSeconds()));
+            } else if (process.exitValue() != 0) {
                 String error = "Command failed:" + String.join(" ", command);
                 if (Files.exists(stdErr)) {
                     error += "\n" + new String(Files.readAllBytes(stdErr));


### PR DESCRIPTION
## What's changed?
Update `ShellExecutor#exec` to throw an appropriate exception when a shell command's execution fails to complete within the given timeout.

## What's your motivation?
This change will assist in troubleshooting recipes relying on execution of external shell commands. Prior to these changes the following exception was thrown on the call to `Process#waitForm`: `java.lang.IllegalThreadStateException: process hasn't exited` 

## Anything in particular you'd like reviewers to focus on?
No.

## Anyone you would like to review specifically?
@timtebeek @sambsnyd 

## Have you considered any alternatives or workarounds?
No.

## Any additional context
No.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
