### PR TITLE
fix: ResolvedPom with type=zip

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -890,7 +890,7 @@ public class ResolvedPom {
                         throw new MavenDownloadingException("No version provided", null, dd.getDependency().getGav());
                     }
 
-                    if (d.getType() != null && (!"jar".equals(d.getType()) && !"pom".equals(d.getType()))) {
+                    if (d.getType() != null && (!"jar".equals(d.getType()) && !"pom".equals(d.getType()) && !"zip".equals(d.getType()))) {
                         continue;
                     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDependencyTest.java
@@ -262,4 +262,54 @@ class RemoveDependencyTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/5117")
+    @Test
+    void removeDependencyWithTypeZip() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveDependency("org.elasticsearch.distribution.integ-test-zip", "elasticsearch", null)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.elasticsearch.distribution.integ-test-zip</groupId>
+                    <artifactId>elasticsearch</artifactId>
+                    <version>7.17.15</version>
+                    <type>zip</type>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
- Fix https://github.com/openrewrite/rewrite/issues/5117

The reason for this bug should be we ignore parse pom when `type=zip`.
https://github.com/openrewrite/rewrite/blob/main/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java#L893

I think currently the check is too restrict and for `type=zip` its ok to do after pom parse. For example for the dependency in my test case:
```xml
<dependency>
    <groupId>org.elasticsearch.distribution.integ-test-zip</groupId>
    <artifactId>elasticsearch</artifactId>
    <version>7.17.15</version>
    <type>zip</type>
</dependency>
```

Its `pom.xml` is:
https://repo1.maven.org/maven2/org/elasticsearch/distribution/integ-test-zip/elasticsearch/7.17.15/elasticsearch-7.17.15.pom

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Fix https://github.com/openrewrite/rewrite/issues/5117

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
