### PR TITLE
MergeYaml recipe should not do anything when key does not match

### DIFF
--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -986,7 +986,7 @@ class MergeYamlTest implements RewriteTest {
     }
 
     @Test
-    void mergeMappingIntoNewMapping() {
+    void dontMergeMappingIntoNewMapping() {
         rewriteRun(
           spec -> spec
             .recipe(new MergeYaml(
@@ -1006,13 +1006,6 @@ class MergeYamlTest implements RewriteTest {
           yaml(
             """
               foo: bar
-              """,
-            """
-              foo: bar
-              testing:
-                table:
-                  - name: jdk_version
-                    value: 17
               """
           )
         );
@@ -1399,6 +1392,7 @@ class MergeYamlTest implements RewriteTest {
             )),
           yaml(
             """
+              name:
               """,
             """
               name: sam


### PR DESCRIPTION
## What's changed?
The MergeYaml recipe added new keys when there was no matching key:

```java
@Test
void keyHasNoMatch() {
    rewriteRun(spec -> spec
        .recipe(new MergeYaml("$.foo",
          """
            new-key: new-value
            """, false, null, null, null)),
      yaml("some: thing")
    );
}
``` 

## What's your motivation?
Although this add-new-key-when-key-does-not-match behavior is intentionally programmed this way, after more thought, we do not want it. The user of the recipe can achieve the very same result by using the root key (which is `$`).  Conversely, if another key is specified, the user might or might not mean to add the specified yaml. Therefore, we decided to remove this behavior.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
