### PR TITLE
find-dependency-with-versions

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
@@ -92,7 +92,7 @@ public class FindDependency extends Recipe {
                 String gav = (String) gavValue.getValue();
                 assert gav != null;
                 String[] parts = gav.split(":");
-                if (gav.length() >= 2) {
+                if (parts.length >= 2) {
                     return StringUtils.matchesGlob(parts[0], groupId) && StringUtils.matchesGlob(parts[1], artifactId);
                 }
                 return false;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.groovy.GroovyVisitor;
+import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
@@ -75,21 +76,29 @@ public class FindDependency extends Recipe {
                 if (dependency.matches(method)) {
                     if (StringUtils.isBlank(configuration) || method.getSimpleName().equals(configuration)) {
                         List<Expression> depArgs = method.getArguments();
-                        if (depArgs.get(0) instanceof J.Literal) {
-                            String gav = (String) ((J.Literal) depArgs.get(0)).getValue();
-                            assert gav != null;
-                            String[] parts = gav.split(":");
-                            if(gav.length() >= 2) {
-                                if (StringUtils.matchesGlob(parts[0], groupId) &&
-                                    StringUtils.matchesGlob(parts[1], artifactId)) {
-                                    return SearchResult.found(method);
-                                }
-                            }
+                        if (depArgs.get(0) instanceof J.Literal &&
+                                groupArtifactMatches((J.Literal) depArgs.get(0))) {
+                            return SearchResult.found(method);
+                        } else if (depArgs.get(0) instanceof G.GString &&
+                                groupArtifactMatches((J.Literal) ((G.GString) depArgs.get(0)).getStrings().get(0))) {
+                            return SearchResult.found(method);
                         }
                     }
                 }
                 return super.visitMethodInvocation(method, ctx);
             }
+
+            boolean groupArtifactMatches(J.Literal gavValue) {
+                String gav = (String) gavValue.getValue();
+                assert gav != null;
+                String[] parts = gav.split(":");
+                if (gav.length() >= 2) {
+                    return StringUtils.matchesGlob(parts[0], groupId) && StringUtils.matchesGlob(parts[1], artifactId);
+                }
+                return false;
+            }
         });
     }
+
+
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -17,9 +17,11 @@ package org.openrewrite.gradle.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class FindDependencyTest implements RewriteTest {
 
@@ -39,7 +41,7 @@ class FindDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  api 'org.openrewrite:rewrite-core:latest.release'
+                  api "org.openrewrite:rewrite-core:latest.release"
               }
               """,
             """
@@ -52,7 +54,7 @@ class FindDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  /*~~>*/api 'org.openrewrite:rewrite-core:latest.release'
+                  /*~~>*/api "org.openrewrite:rewrite-core:latest.release"
               }
               """
           )
@@ -90,6 +92,61 @@ class FindDependencyTest implements RewriteTest {
                   /*~~>*/api 'org.openrewrite:rewrite-core:latest.release'
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void findWithExternalVersion () {
+        rewriteRun(
+          spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")),
+          buildGradle(
+            //language=gradle
+            """
+          plugins {
+              id 'java-library'
+          }
+          
+          repositories {
+              mavenCentral()
+          }
+          
+          ext {
+              someVersion = 'latest.release'
+              otherVersion = 'latest.integration'
+          }
+          
+          dependencies {
+              api 'org.openrewrite:rewrite-core:${someVersion}'
+              api 'org.openrewrite.internal:rewrite-core:${otherVersion}'
+              api 'org.openrewrite:rewrite-java:${someVersion}'
+              implementation 'org.openrewrite:rewrite-core:${someVersion}'
+              api 'de.openrewrite:rewrite-core:${someVersion}'
+              implementation 'de.openrewrite:rewrite-core:${someVersion}'
+          }
+          ""","""
+          plugins {
+              id 'java-library'
+          }
+          
+          repositories {
+              mavenCentral()
+          }
+          
+          ext {
+              someVersion = 'latest.release'
+              otherVersion = 'latest.integration'
+          }
+          
+          dependencies {
+              /*~~>*/api 'org.openrewrite:rewrite-core:${someVersion}'
+              /*~~>*/api 'org.openrewrite.internal:rewrite-core:${otherVersion}'
+              api 'org.openrewrite:rewrite-java:${someVersion}'
+              implementation 'org.openrewrite:rewrite-core:${someVersion}'
+              api 'de.openrewrite:rewrite-core:${someVersion}'
+              implementation 'de.openrewrite:rewrite-core:${someVersion}'
+          }
+          """
           )
         );
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -28,7 +28,9 @@ class FindDependencyTest implements RewriteTest {
     @DocumentExample
     @Test
     void findDependency() {
-        rewriteRun(spec -> spec.recipe(new FindDependency("org.openrewrite", "rewrite-core", "api")), buildGradle("""
+        rewriteRun(spec -> spec.recipe(new FindDependency("org.openrewrite", "rewrite-core", "api")), buildGradle(
+          //language=gradle
+          """
           plugins {
               id 'java-library'
           }
@@ -57,7 +59,9 @@ class FindDependencyTest implements RewriteTest {
 
     @Test
     void findDependencyByGlob() {
-        rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "*", "")), buildGradle("""
+        rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "*", "")), buildGradle(
+            //language=gradle
+          """
           plugins {
               id 'java-library'
           }
@@ -108,6 +112,8 @@ class FindDependencyTest implements RewriteTest {
                 dependencies {
                     api "org.openrewrite:rewrite-core:${someVersion}"
                     api "org.openrewrite.internal:rewrite-core:${otherVersion}"
+                    api "org.openrewrite.internal:rewrite-core:latest.${release}"
+                    api "org.openrewrite:rewrite-core:${someVersion}${otherVersion}"
                     api "org.openrewrite:rewrite-java:${someVersion}"
                     implementation "org.openrewrite:rewrite-core:${someVersion}"
                     api "de.openrewrite:rewrite-core:${someVersion}"
@@ -130,6 +136,8 @@ class FindDependencyTest implements RewriteTest {
                 dependencies {
                     /*~~>*/api "org.openrewrite:rewrite-core:${someVersion}"
                     /*~~>*/api "org.openrewrite.internal:rewrite-core:${otherVersion}"
+                    /*~~>*/api "org.openrewrite.internal:rewrite-core:latest.${release}"
+                    /*~~>*/api "org.openrewrite:rewrite-core:${someVersion}${otherVersion}"
                     api "org.openrewrite:rewrite-java:${someVersion}"
                     implementation "org.openrewrite:rewrite-core:${someVersion}"
                     api "de.openrewrite:rewrite-core:${someVersion}"
@@ -139,7 +147,7 @@ class FindDependencyTest implements RewriteTest {
         }
 
         @Test
-        void noCurly() {
+        void dontMigrate() {
             rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")), buildGradle(
               //language=gradle
               """
@@ -153,40 +161,14 @@ class FindDependencyTest implements RewriteTest {
                 
                 ext {
                     someVersion = 'latest.release'
-                    otherVersion = 'latest.integration'
+                    otherVersion = 'integration'
                 }
                 
                 dependencies {
-                    api "org.openrewrite:rewrite-core:$someVersion"
-                    api "org.openrewrite.internal:rewrite-core:$otherVersion"
-                    api "org.openrewrite:rewrite-java:$someVersion"
-                    implementation "org.openrewrite:rewrite-core:$someVersion"
-                    api "de.openrewrite:rewrite-core:$someVersion"
-                    implementation "de.openrewrite:rewrite-core:$someVersion"
-                }
-                """, """
-                plugins {
-                    id 'java-library'
-                }
-                
-                repositories {
-                    mavenCentral()
-                }
-                
-                ext {
-                    someVersion = 'latest.release'
-                    otherVersion = 'latest.integration'
-                }
-                
-                dependencies {
-                    /*~~>*/api "org.openrewrite:rewrite-core:$someVersion"
-                    /*~~>*/api "org.openrewrite.internal:rewrite-core:$otherVersion"
-                    api "org.openrewrite:rewrite-java:$someVersion"
-                    implementation "org.openrewrite:rewrite-core:$someVersion"
-                    api "de.openrewrite:rewrite-core:$someVersion"
-                    implementation "de.openrewrite:rewrite-core:$someVersion"
+                    api "org.openrewrite:${otherVersion}:${someVersion}"
                 }
                 """));
         }
+
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.gradle.search;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -83,55 +84,109 @@ class FindDependencyTest implements RewriteTest {
           """));
     }
 
+    @Nested
     @Issue("https://github.com/moderneinc/customer-requests/issues/895")
-    @Test
-    void findWithInterpolatedVersion() {
-        rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")), buildGradle(
-          //language=gradle
-          """
-            plugins {
-                id 'java-library'
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-            
-            ext {
-                someVersion = "latest.release"
-                otherVersion = "latest.integration"
-            }
-            
-            dependencies {
-                api "org.openrewrite:rewrite-core:${someVersion}"
-                api "org.openrewrite.internal:rewrite-core:${otherVersion}"
-                api "org.openrewrite:rewrite-java:${someVersion}"
-                implementation "org.openrewrite:rewrite-core:${someVersion}"
-                api "de.openrewrite:rewrite-core:${someVersion}"
-                implementation "de.openrewrite:rewrite-core:${someVersion}"
-            }
-            """, """
-            plugins {
-                id 'java-library'
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-            
-            ext {
-                someVersion = 'latest.release'
-                otherVersion = 'latest.integration'
-            }
-            
-            dependencies {
-                /*~~>*/api "org.openrewrite:rewrite-core:${someVersion}"
-                /*~~>*/api "org.openrewrite.internal:rewrite-core:${otherVersion}"
-                api "org.openrewrite:rewrite-java:$someVersion"
-                implementation "org.openrewrite:rewrite-core:$someVersion"
-                api "de.openrewrite:rewrite-core:$someVersion"
-                implementation "de.openrewrite:rewrite-core:$someVersion"
-            }
-            """));
+    class WithInterpolatedVersion {
+        @Test
+        void withCurly() {
+            rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")), buildGradle(
+              //language=gradle
+              """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                ext {
+                    someVersion = 'latest.release'
+                    otherVersion = 'latest.integration'
+                }
+                
+                dependencies {
+                    api "org.openrewrite:rewrite-core:${someVersion}"
+                    api "org.openrewrite.internal:rewrite-core:${otherVersion}"
+                    api "org.openrewrite:rewrite-java:${someVersion}"
+                    implementation "org.openrewrite:rewrite-core:${someVersion}"
+                    api "de.openrewrite:rewrite-core:${someVersion}"
+                    implementation "de.openrewrite:rewrite-core:${someVersion}"
+                }
+                """, """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                ext {
+                    someVersion = 'latest.release'
+                    otherVersion = 'latest.integration'
+                }
+                
+                dependencies {
+                    /*~~>*/api "org.openrewrite:rewrite-core:${someVersion}"
+                    /*~~>*/api "org.openrewrite.internal:rewrite-core:${otherVersion}"
+                    api "org.openrewrite:rewrite-java:${someVersion}"
+                    implementation "org.openrewrite:rewrite-core:${someVersion}"
+                    api "de.openrewrite:rewrite-core:${someVersion}"
+                    implementation "de.openrewrite:rewrite-core:${someVersion}"
+                }
+                """));
+        }
+
+        @Test
+        void noCurly() {
+            rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")), buildGradle(
+              //language=gradle
+              """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                ext {
+                    someVersion = 'latest.release'
+                    otherVersion = 'latest.integration'
+                }
+                
+                dependencies {
+                    api "org.openrewrite:rewrite-core:$someVersion"
+                    api "org.openrewrite.internal:rewrite-core:$otherVersion"
+                    api "org.openrewrite:rewrite-java:$someVersion"
+                    implementation "org.openrewrite:rewrite-core:$someVersion"
+                    api "de.openrewrite:rewrite-core:$someVersion"
+                    implementation "de.openrewrite:rewrite-core:$someVersion"
+                }
+                """, """
+                plugins {
+                    id 'java-library'
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                ext {
+                    someVersion = 'latest.release'
+                    otherVersion = 'latest.integration'
+                }
+                
+                dependencies {
+                    /*~~>*/api "org.openrewrite:rewrite-core:$someVersion"
+                    /*~~>*/api "org.openrewrite.internal:rewrite-core:$otherVersion"
+                    api "org.openrewrite:rewrite-java:$someVersion"
+                    implementation "org.openrewrite:rewrite-core:$someVersion"
+                    api "de.openrewrite:rewrite-core:$someVersion"
+                    implementation "de.openrewrite:rewrite-core:$someVersion"
+                }
+                """));
+        }
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -17,137 +17,121 @@ package org.openrewrite.gradle.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class FindDependencyTest implements RewriteTest {
 
     @DocumentExample
     @Test
     void findDependency() {
-        rewriteRun(
-          spec -> spec.recipe(new FindDependency("org.openrewrite", "rewrite-core", "api")),
-          buildGradle(
-            """
-              plugins {
-                  id 'java-library'
-              }
-              
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  api "org.openrewrite:rewrite-core:latest.release"
-              }
-              """,
-            """
-              plugins {
-                  id 'java-library'
-              }
-              
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  /*~~>*/api "org.openrewrite:rewrite-core:latest.release"
-              }
-              """
-          )
-        );
+        rewriteRun(spec -> spec.recipe(new FindDependency("org.openrewrite", "rewrite-core", "api")), buildGradle("""
+          plugins {
+              id 'java-library'
+          }
+          
+          repositories {
+              mavenCentral()
+          }
+          
+          dependencies {
+              api "org.openrewrite:rewrite-core:latest.release"
+          }
+          """, """
+          plugins {
+              id 'java-library'
+          }
+          
+          repositories {
+              mavenCentral()
+          }
+          
+          dependencies {
+              /*~~>*/api "org.openrewrite:rewrite-core:latest.release"
+          }
+          """));
     }
 
     @Test
     void findDependencyByGlob() {
-        rewriteRun(
-          spec -> spec.recipe(new FindDependency("org.*", "*", "")),
-          buildGradle(
-            """
-              plugins {
-                  id 'java-library'
-              }
-              
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  api 'org.openrewrite:rewrite-core:latest.release'
-              }
-              """,
-            """
-              plugins {
-                  id 'java-library'
-              }
-              
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  /*~~>*/api 'org.openrewrite:rewrite-core:latest.release'
-              }
-              """
-          )
-        );
+        rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "*", "")), buildGradle("""
+          plugins {
+              id 'java-library'
+          }
+          
+          repositories {
+              mavenCentral()
+          }
+          
+          dependencies {
+              api 'org.openrewrite:rewrite-core:latest.release'
+          }
+          """, """
+          plugins {
+              id 'java-library'
+          }
+          
+          repositories {
+              mavenCentral()
+          }
+          
+          dependencies {
+              /*~~>*/api 'org.openrewrite:rewrite-core:latest.release'
+          }
+          """));
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/895")
     @Test
-    void findWithExternalVersion () {
-        rewriteRun(
-          spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")),
-          buildGradle(
-            //language=gradle
-            """
-          plugins {
-              id 'java-library'
-          }
-          
-          repositories {
-              mavenCentral()
-          }
-          
-          ext {
-              someVersion = 'latest.release'
-              otherVersion = 'latest.integration'
-          }
-          
-          dependencies {
-              api 'org.openrewrite:rewrite-core:${someVersion}'
-              api 'org.openrewrite.internal:rewrite-core:${otherVersion}'
-              api 'org.openrewrite:rewrite-java:${someVersion}'
-              implementation 'org.openrewrite:rewrite-core:${someVersion}'
-              api 'de.openrewrite:rewrite-core:${someVersion}'
-              implementation 'de.openrewrite:rewrite-core:${someVersion}'
-          }
-          ""","""
-          plugins {
-              id 'java-library'
-          }
-          
-          repositories {
-              mavenCentral()
-          }
-          
-          ext {
-              someVersion = 'latest.release'
-              otherVersion = 'latest.integration'
-          }
-          
-          dependencies {
-              /*~~>*/api 'org.openrewrite:rewrite-core:${someVersion}'
-              /*~~>*/api 'org.openrewrite.internal:rewrite-core:${otherVersion}'
-              api 'org.openrewrite:rewrite-java:${someVersion}'
-              implementation 'org.openrewrite:rewrite-core:${someVersion}'
-              api 'de.openrewrite:rewrite-core:${someVersion}'
-              implementation 'de.openrewrite:rewrite-core:${someVersion}'
-          }
+    void findWithInterpolatedVersion() {
+        rewriteRun(spec -> spec.recipe(new FindDependency("org.*", "rewrite-core", "api")), buildGradle(
+          //language=gradle
           """
-          )
-        );
+            plugins {
+                id 'java-library'
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            ext {
+                someVersion = "latest.release"
+                otherVersion = "latest.integration"
+            }
+            
+            dependencies {
+                api "org.openrewrite:rewrite-core:${someVersion}"
+                api "org.openrewrite.internal:rewrite-core:${otherVersion}"
+                api "org.openrewrite:rewrite-java:${someVersion}"
+                implementation "org.openrewrite:rewrite-core:${someVersion}"
+                api "de.openrewrite:rewrite-core:${someVersion}"
+                implementation "de.openrewrite:rewrite-core:${someVersion}"
+            }
+            """, """
+            plugins {
+                id 'java-library'
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            ext {
+                someVersion = 'latest.release'
+                otherVersion = 'latest.integration'
+            }
+            
+            dependencies {
+                /*~~>*/api "org.openrewrite:rewrite-core:${someVersion}"
+                /*~~>*/api "org.openrewrite.internal:rewrite-core:${otherVersion}"
+                api "org.openrewrite:rewrite-java:$someVersion"
+                implementation "org.openrewrite:rewrite-core:$someVersion"
+                api "de.openrewrite:rewrite-core:$someVersion"
+                implementation "de.openrewrite:rewrite-core:$someVersion"
+            }
+            """));
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
GAVs in gradle are represented as `G.GString` if they utilize String interpolation.

## What's your motivation?
able to match `api "org.openrewrite:rewrite-core:${someVersion}"`

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
