### PR TITLE
Fully qualified reference gets shortened

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2257,4 +2257,16 @@ class ChangeTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("java.util.List", "java.util.Set", null)),
+          java(
+            "import java.util.*;\nclass Test { java.util.List<?> l; }",
+            "import java.util.*;\nclass Test { java.util.Set<?> l; }",
+            spec -> spec.path("Test.java")
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Add reproducer

## Anyone you would like to review specifically?
<!-- @mention them here -->
@MBoegers 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
