### PR TITLE
Validation for recipe options that `MethodMatcher`s are constructed from.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/MethodMatcherTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/MethodMatcherTest.java
@@ -35,16 +35,25 @@ import static org.openrewrite.java.tree.JavaType.ShallowClass.build;
 
 @SuppressWarnings("ConstantConditions")
 class MethodMatcherTest implements RewriteTest {
+    @SuppressWarnings("deprecation")
     private Pattern typeRegex(String signature) {
         return new MethodMatcher(signature).getTargetTypePattern();
     }
 
+    @SuppressWarnings("deprecation")
     private Pattern nameRegex(String signature) {
         return new MethodMatcher(signature).getMethodNamePattern();
     }
 
+    @SuppressWarnings("deprecation")
     private Pattern argRegex(String signature) {
         return new MethodMatcher(signature).getArgumentPattern();
+    }
+
+    @Test
+    void invalidMethodMatcher() {
+        assertThat(MethodMatcher.validate("com.google.common.collect.*")
+          .isValid()).isFalse();
     }
 
     @Test
@@ -192,7 +201,7 @@ class MethodMatcherTest implements RewriteTest {
             """
               package a;
               import java.util.function.Supplier;
-                            
+              
               class A {
                   Supplier<A> a = A::new;
               }
@@ -208,7 +217,7 @@ class MethodMatcherTest implements RewriteTest {
           java(
             """
               package a;
-
+              
               class A {
                   void setInt(int value) {}
                   int getInt() {}
@@ -226,6 +235,7 @@ class MethodMatcherTest implements RewriteTest {
         );
     }
 
+    @SuppressWarnings("RedundantMethodOverride")
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1215")
     void strictMatchMethodOverride() {
@@ -233,12 +243,12 @@ class MethodMatcherTest implements RewriteTest {
           java(
             """
               package com.abc;
-
+              
               class Parent {
                   public void method(String s) {
                   }
               }
-                          
+              
               class Test extends Parent {
                   @Override
                   public void method(String s) {
@@ -261,7 +271,7 @@ class MethodMatcherTest implements RewriteTest {
           java(
             """
               package a;
-
+              
               class A {
                   void foo() {}
               }
@@ -305,7 +315,7 @@ class MethodMatcherTest implements RewriteTest {
           java(
             """
               package com.yourorg;
-
+              
               class Foo {
                   void bar(int i, String s) {}
                   void other() {
@@ -420,7 +430,7 @@ class MethodMatcherTest implements RewriteTest {
           java(
             """
               package com.yourorg;
-
+              
               class Foo {
                   void bar(String[] s) {}
                   void test() {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindDeprecatedMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindDeprecatedMethodsTest.java
@@ -63,7 +63,7 @@ class FindDeprecatedMethodsTest implements RewriteTest {
                   @Deprecated
                   void test(int n) {
                   }
-                  
+              
                   Test() {
                       int n = 1;
                       if(n == 1) {
@@ -234,7 +234,6 @@ class FindDeprecatedMethodsTest implements RewriteTest {
           java(
             """
               package com.yourorg;
-                            
               public class Foo {
                   @Deprecated
                   public void foo() {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
@@ -29,6 +29,7 @@ import org.openrewrite.test.TypeValidation;
 
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings("RedundantOperationOnEmptyContainer")
@@ -36,6 +37,12 @@ class FindMethodsTest implements RewriteTest {
 
     static Stream<JavaType.FullyQualified> missingTypes() {
         return Stream.of(null, JavaType.Unknown.getInstance());
+    }
+
+    @Test
+    void incorrectMethodPattern() {
+        assertThat(new FindMethods("com.google.common.collect.*", false)
+          .validate().isValid()).isFalse();
     }
 
     @ParameterizedTest
@@ -303,7 +310,7 @@ class FindMethodsTest implements RewriteTest {
             """
               public @interface Example {
                   String name() default "";
-                            
+              
                   String description() default "";
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToMethod.java
@@ -71,6 +71,11 @@ public class AddCommentToMethod extends Recipe {
     private static final Pattern NEWLINE = Pattern.compile("\\R");
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher methodMatcher = new MethodMatcher(methodPattern);
         return Preconditions.check(new DeclaresMethod<>(methodMatcher), new JavaIsoVisitor<ExecutionContext>() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddLiteralMethodArgument.java
@@ -26,7 +26,6 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.openrewrite.Tree.randomId;
@@ -83,6 +82,11 @@ public class AddLiteralMethodArgument extends Recipe {
     @Override
     public String getDescription() {
         return "Add a literal `String` or `int` argument to method invocations.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddNullMethodArgument.java
@@ -88,6 +88,11 @@ public class AddNullMethodArgument extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesMethod<>(methodPattern), new AddNullMethodArgumentVisitor(new MethodMatcher(methodPattern)));
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevel.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodAccessLevel.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.search.DeclaresMethod;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 
 @Value
@@ -60,8 +61,10 @@ public class ChangeMethodAccessLevel extends Recipe {
 
     @Override
     public Validated<Object> validate() {
-        return super.validate().and(Validated.test("newAccessLevel", "Must be one of 'private', 'protected', 'package', 'public'",
-                newAccessLevel, level -> "private".equals(level) || "protected".equals(level) || "package".equals(level) || "public".equals(level)));
+        return super.validate()
+                .and(Validated.test("newAccessLevel", "Must be one of 'private', 'protected', 'package', 'public'",
+                        newAccessLevel, level -> "private".equals(level) || "protected".equals(level) || "package".equals(level) || "public".equals(level)))
+                .and(MethodMatcher.validate(methodPattern));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
@@ -17,10 +17,7 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -51,6 +48,11 @@ public class ChangeMethodInvocationReturnType extends Recipe {
     @Override
     public String getDescription() {
         return "Changes the return type of a method invocation.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java
@@ -66,6 +66,11 @@ public class ChangeMethodName extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaIsoVisitor<ExecutionContext> condition = new JavaIsoVisitor<ExecutionContext>() {
             @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -93,6 +93,11 @@ public class ChangeMethodTargetToStatic extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         boolean matchUnknown = Boolean.TRUE.equals(matchUnknownTypes);
         ChangeMethodTargetToStaticVisitor visitor = new ChangeMethodTargetToStaticVisitor(new MethodMatcher(methodPattern, matchOverrides), matchUnknown);

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToVariable.java
@@ -72,6 +72,11 @@ public class ChangeMethodTargetToVariable extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 new UsesMethod<>(methodPattern, matchOverrides),

--- a/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/DeleteMethodArgument.java
@@ -69,6 +69,11 @@ public class DeleteMethodArgument extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesMethod<>(methodPattern), new DeleteMethodArgumentVisitor(new MethodMatcher(methodPattern)));
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -22,6 +22,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Validated;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.internal.grammar.MethodSignatureLexer;
 import org.openrewrite.java.internal.grammar.MethodSignatureParser;
@@ -61,13 +62,13 @@ import static org.openrewrite.java.tree.TypeUtils.fullyQualifiedNamesAreEqual;
 public class MethodMatcher {
     //language=markdown
     public static final String METHOD_PATTERN_DESCRIPTION = "A [method pattern](https://docs.openrewrite.org/reference/method-patterns) is used to find matching method invocations. " +
-                                                             "For example, to find all method invocations in the Guava library, use the pattern: " +
-                                                             "`com.google.common..*#*(..)`.<br/><br/>" +
-                                                             "The pattern format is `<PACKAGE>#<METHOD_NAME>(<ARGS>)`. <br/><br/>" +
-                                                             "`..*` includes all subpackages of `com.google.common`. <br/>" +
-                                                             "`*(..)` matches any method name with any number of arguments. <br/><br/>" +
-                                                             "For more specific queries, like Guava's `ImmutableMap`, use " +
-                                                             "`com.google.common.collect.ImmutableMap#*(..)` to narrow down the results.";
+                                                            "For example, to find all method invocations in the Guava library, use the pattern: " +
+                                                            "`com.google.common..*#*(..)`.<br/><br/>" +
+                                                            "The pattern format is `<PACKAGE>#<METHOD_NAME>(<ARGS>)`. <br/><br/>" +
+                                                            "`..*` includes all subpackages of `com.google.common`. <br/>" +
+                                                            "`*(..)` matches any method name with any number of arguments. <br/><br/>" +
+                                                            "For more specific queries, like Guava's `ImmutableMap`, use " +
+                                                            "`com.google.common.collect.ImmutableMap#*(..)` to narrow down the results.";
 
     private static final String ASPECTJ_DOT_PATTERN = StringUtils.aspectjNameToPattern(".");
     private static final String ASPECTJ_DOTDOT_PATTERN = StringUtils.aspectjNameToPattern("..");
@@ -97,15 +98,15 @@ public class MethodMatcher {
     @Getter
     private final boolean matchOverrides;
 
-    public MethodMatcher(String signature, @Nullable Boolean matchOverrides) {
-        this(signature, Boolean.TRUE.equals(matchOverrides));
+    public MethodMatcher(String methodPattern, @Nullable Boolean matchOverrides) {
+        this(methodPattern, Boolean.TRUE.equals(matchOverrides));
     }
 
-    public MethodMatcher(String signature, boolean matchOverrides) {
+    public MethodMatcher(String methodPattern, boolean matchOverrides) {
         this.matchOverrides = matchOverrides;
 
         MethodSignatureParser parser = new MethodSignatureParser(new CommonTokenStream(new MethodSignatureLexer(
-                CharStreams.fromString(signature))));
+                CharStreams.fromString(methodPattern))));
 
         new MethodSignatureParserBaseVisitor<Void>() {
 
@@ -147,6 +148,25 @@ public class MethodMatcher {
         }.visit(parser.methodPattern());
     }
 
+    public static Validated<String> validate(@Nullable String signature) {
+        return Validated.test(
+                "methodPattern",
+                "Tried to construct a method matcher with an invalid method pattern. " +
+                "An example of a good method pattern is `java.util.List add(..)`.",
+                signature,
+                s -> {
+                    if (signature == null) {
+                        return true;
+                    }
+                    try {
+                        new MethodMatcher(s, null);
+                        return true;
+                    } catch (Throwable t) {
+                        return false;
+                    }
+                });
+    }
+
     private static boolean matchAllArguments(MethodSignatureParser.FormalsPatternContext context) {
         return context.dotDot() != null && context.formalsPatternAfterDotDot().isEmpty();
     }
@@ -167,8 +187,8 @@ public class MethodMatcher {
         this(methodPattern(method), matchOverrides);
     }
 
-    public MethodMatcher(String signature) {
-        this(signature, false);
+    public MethodMatcher(String methodPattern) {
+        this(methodPattern, false);
     }
 
     public MethodMatcher(J.MethodDeclaration method) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/NoStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/NoStaticImport.java
@@ -53,6 +53,11 @@ public class NoStaticImport extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesMethod<>(methodPattern), new JavaIsoVisitor<ExecutionContext>() {
             @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocations.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodInvocations.java
@@ -17,11 +17,7 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.java.search.UsesMethod;
 
 import static java.util.Collections.singletonList;
@@ -42,6 +38,11 @@ public class RemoveMethodInvocations extends Recipe {
     @Override
     public String getDescription() {
         return "Remove method invocations if syntactically safe.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReorderMethodArguments.java
@@ -93,6 +93,11 @@ public class ReorderMethodArguments extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new JavaVisitor<ExecutionContext>() {
             @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -54,6 +54,11 @@ public class UseStaticImport extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TreeVisitor<?, ExecutionContext> preconditions = new UsesMethod<>(methodPattern);
         if (!methodPattern.contains(" *(")) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -71,6 +71,11 @@ public class FindDeprecatedMethods extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher methodMatcher = methodPattern == null || methodPattern.isEmpty() ? null : new MethodMatcher(methodPattern, true);
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
@@ -72,6 +73,9 @@ public class FindDeprecatedMethods extends Recipe {
 
     @Override
     public Validated<Object> validate() {
+        if (StringUtils.isBlank(methodPattern)) {
+            return super.validate();
+        }
         return super.validate().and(MethodMatcher.validate(methodPattern));
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethodDeclaration.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethodDeclaration.java
@@ -50,6 +50,11 @@ public class FindMethodDeclaration extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new DeclaresMethod<>(methodPattern, matchOverrides), new JavaIsoVisitor<ExecutionContext>() {
             final MethodMatcher m = new MethodMatcher(methodPattern, matchOverrides);

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -66,6 +66,22 @@ public class FindMethods extends Recipe {
     }
 
     @Override
+    public String getInstanceName() {
+        //noinspection ConstantValue
+        if (methodPattern == null) {
+            // Temporary while the defensive coding in Recipe is percolating to all
+            // deployed environments.
+            return getDisplayName();
+        }
+        return super.getInstanceName();
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
+    }
+
+    @Override
     @SuppressWarnings("ConstantConditions")
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesMethod<>(methodPattern, matchOverrides), new JavaIsoVisitor<ExecutionContext>() {
@@ -75,11 +91,11 @@ public class FindMethods extends Recipe {
             public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
                 // In an annotation @Example(value = "") the identifier "value" may have a method type
                 J.Identifier i = super.visitIdentifier(identifier, ctx);
-                if(i.getType() instanceof JavaType.Method && methodMatcher.matches((JavaType.Method) i.getType()) &&
-                   !(getCursor().getParentTreeCursor().getValue() instanceof J.MethodInvocation)) {
+                if (i.getType() instanceof JavaType.Method && methodMatcher.matches((JavaType.Method) i.getType()) &&
+                    !(getCursor().getParentTreeCursor().getValue() instanceof J.MethodInvocation)) {
                     JavaType.Method m = (JavaType.Method) i.getType();
                     JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                    if(javaSourceFile != null) {
+                    if (javaSourceFile != null) {
                         methodCalls.insertRow(ctx, new MethodCalls.Row(
                                 javaSourceFile.getSourcePath().toString(),
                                 m.getName(),

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/ResultOfMethodCallIgnored.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/ResultOfMethodCallIgnored.java
@@ -18,10 +18,7 @@ package org.openrewrite.java.search;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
@@ -53,6 +50,11 @@ public class ResultOfMethodCallIgnored extends Recipe {
     @Override
     public String getDescription() {
         return "Find locations where the result of the method call is being ignored.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        return super.validate().and(MethodMatcher.validate(methodPattern));
     }
 
     @Override


### PR DESCRIPTION
## What's changed?

Added validation to recipe options (usually called `methodPattern`) that will be turned into a `MethodMatcher`, as misconfiguring the method pattern is a common source of both human and AI error.

## What's your motivation?

Help teach how to use these method patterns correctly, as misconfiguring will simply lead to no results.