### PR TITLE
Groovy Parser supports unassigned closure with GString as return value

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -974,11 +974,12 @@ public class GroovyParserVisitor {
             Space staticInitPadding = EMPTY;
             boolean isStaticInit = sourceStartsWith("static");
             Object parent = nodeCursor.getParentOrThrow().getValue();
+            boolean withinClosure = parent instanceof ClosureExpression || (parent instanceof ExpressionStatement && ((ExpressionStatement) parent).getExpression() instanceof ClosureExpression);
             if (isStaticInit) {
                 fmt = sourceBefore("static");
                 staticInitPadding = whitespace();
                 skip("{");
-            } else if (!(parent instanceof ClosureExpression)) {
+            } else if (!withinClosure) {
                 fmt = sourceBefore("{");
             }
             List<JRightPadded<Statement>> statements = new ArrayList<>(block.getStatements().size());
@@ -1010,7 +1011,7 @@ public class GroovyParserVisitor {
                 statements.add(stat);
             }
             queue.add(new J.Block(randomId(), fmt, Markers.EMPTY, new JRightPadded<>(isStaticInit, staticInitPadding, Markers.EMPTY), statements, whitespace()));
-            if (!(parent instanceof ClosureExpression)) {
+            if (!withinClosure) {
                 skip("}");
             }
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -229,6 +229,18 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/4116")
+    @Test
+    void closureWithGString() {
+        rewriteRun(
+          groovy(
+            """
+            { x -> "${x.y}" }
+            """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4766")
     @Test
     void gradleFileWithMultipleClosuresWithoutParentheses() {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/RealWorldGroovyTest.java
@@ -27,6 +27,31 @@ import static org.openrewrite.groovy.Assertions.groovy;
 class RealWorldGroovyTest implements RewriteTest {
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4116")
+    void jenkinsFile() {
+        rewriteRun(
+          groovy(
+            """
+              #!groovy
+              def getEndBuild() {
+                  { steps , config , domain ->
+                      new net.one.gtu.jenkins.helper.ConsoleLogger(steps)
+                          .logInfo("Intentionally exiting the build early. Please disregard subsequent errors; they do not represent real concerns/issues");
+                      throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.SUCCESS);
+                  }
+              }
+              def buildPipeline1() {
+                  pipelineRunner {
+                      yml = 'jenkins_old.yml'
+                      endBuild = getEndBuild();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/spring-projects/spring-boot/blob/v3.4.1/settings.gradle")
     void springBootSettingsGradle() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Bugfix, the groovy parser did not support unassigned closure with GString as return value.

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4116

## Any additional context
Actually the groovy parser did support it already, it just broke because a `sourceBefore("{")` was called falsy (the `{` char is also part of a GString, which made the parser go wacky). 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
