### PR TITLE
Fixes parsing of switch expression with combined null and default

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -339,6 +339,11 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     }
 
     @Override
+    public J visitDefaultCaseLabel(DefaultCaseLabelTree node, Space space) {
+        return new J.Identifier(randomId(), space, Markers.EMPTY, emptyList(), skip("default"), null, null);
+    }
+
+    @Override
     public J visitCase(CaseTree node, Space fmt) {
         J.Case.Type type = node.getCaseKind() == CaseTree.CaseKind.RULE ? J.Case.Type.Rule : J.Case.Type.Statement;
         return new J.Case(
@@ -351,9 +356,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 JContainer.build(
                         node.getLabels().isEmpty() || node.getLabels().getFirst() instanceof DefaultCaseLabelTree ?
                                 EMPTY : sourceBefore("case"),
-                        node.getLabels().isEmpty() || node.getLabels().getFirst() instanceof DefaultCaseLabelTree ?
-                                List.of(JRightPadded.build(new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), skip("default"), null, null))) :
-                                convertAll(node.getLabels(), commaDelim, ignored -> node.getGuard() != null ? sourceBefore("when", '-') : EMPTY),
+                        convertAll(node.getLabels(), commaDelim, ignored -> node.getGuard() != null ? sourceBefore("when", '-') : EMPTY),
                         Markers.EMPTY
                 ),
                 convert(node.getGuard()),

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/SwitchPatternMatchingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/SwitchPatternMatchingTest.java
@@ -65,6 +65,24 @@ class SwitchPatternMatchingTest implements RewriteTest {
     }
 
     @Test
+    void shouldSupportParsingNullSwitchCombined() {
+        rewriteRun(
+          java(
+            //language=java
+            """
+              class Test {
+                void fooBarWithNull(String s) {
+                    switch (s) {
+                        case "Foo", "Bar" -> System.out.println("Great");
+                        case null, default -> System.out.println("Ok");
+                    }
+                }
+              }
+              """
+          ));
+    }
+
+    @Test
     void shouldParseJava21EnumSupportInSwitch() {
         rewriteRun(
           java(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Adds unit test and fix for parsing of switch expression.


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

- provide a fix for #5139 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

Changing the Java code, splitting the combined case. 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
