### PR TITLE
Use GZIP rather than raw zlib

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -67,9 +67,8 @@ import static org.openrewrite.java.internal.parser.JavaParserCaller.findCaller;
  * There is of course a lot of duplication in the class and GAV columns, but compression cuts down on
  * the disk impact of that and the value is an overall single table representation.
  * <p>
- * To read a compressed type table file (which is compressed with zlib), the following command can be used:
- * <code>printf "\x1f\x8b\x08\x00\x00\x00\x00\x00" |cat - types.tsv.zip |gzip -dc</code>
- * It prepends the gzip magic header onto the zlib data and used gzip to decompress.
+ * To read a compressed type table file (which is compressed with gzip), the following command can be used:
+ * <code>gzcat types.tsv.zip</code>.
  */
 @Incubating(since = "8.44.0")
 @Value


### PR DESCRIPTION
Using GZIP adds a small header and a checksum at the end and is a bit "friendlier" as it allows a developer to use `gzcat` to inspect the file contents.
