### PR TITLE
Fix groovy parser parsing package definition

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -62,7 +62,7 @@ public class GroovyParser implements Parser {
 
     @Override
     public Stream<SourceFile> parse(@Language("groovy") String... sources) {
-        Pattern packagePattern = Pattern.compile("^package\\s+([^;]+);");
+        Pattern packagePattern = Pattern.compile("\\bpackage\\s+([`.\\w]+)");
         Pattern classPattern = Pattern.compile("(class|interface|enum)\\s*(<[^>]*>)?\\s+(\\w+)");
 
         Function<String, @Nullable String> simpleName = sourceStr -> {

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -62,7 +62,7 @@ public class GroovyParser implements Parser {
 
     @Override
     public Stream<SourceFile> parse(@Language("groovy") String... sources) {
-        Pattern packagePattern = Pattern.compile("\\bpackage\\s+([`.\\w]+)");
+        Pattern packagePattern = Pattern.compile("\\bpackage\\s+([.\\w]+)");
         Pattern classPattern = Pattern.compile("(class|interface|enum)\\s*(<[^>]*>)?\\s+(\\w+)");
 
         Function<String, @Nullable String> simpleName = sourceStr -> {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -1,0 +1,39 @@
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class GroovyParserTest {
+
+    @Test
+    void groovyPackageDefinition() {
+        assertThatCode(() -> {
+            GroovyParser.builder().build()
+              .parse(
+                """
+                  package org.openrewrite.groovy
+                  
+                  class A {
+                      static void main(String[] args) {
+                         String name = "John"
+                         println(name)
+                      }
+                   }
+                  """,
+                """
+                  package org.openrewrite.groovy;
+                  
+                  class B {
+                      static void main(String[] args) {
+                         String name = "Doe"
+                         println(name)
+                      }
+                   }
+                  """
+              );
+        }).doesNotThrowAnyException();
+
+    }
+
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Test;
@@ -33,7 +48,6 @@ class GroovyParserTest {
                   """
               );
         }).doesNotThrowAnyException();
-
     }
 
 }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Regex for parsing package definition in Groovy now correctly handles the optional semicolon

## Anyone you would like to review specifically?
<!-- @mention them here -->
@knutwannheden @shanman190 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
