### PR TITLE
There're no references to classes of `com.gradle:gradle-enterprise-gradle-plugin` in the Gradle module

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -32,7 +32,6 @@ recipeDependencies {
     parserClasspath("org.gradle:gradle-resources:latest.release")
     parserClasspath("org.gradle:gradle-testing-base:latest.release")
     parserClasspath("org.gradle:gradle-testing-jvm:latest.release")
-    parserClasspath("com.gradle:gradle-enterprise-gradle-plugin:latest.release")
 }
 
 //val rewriteVersion = rewriteRecipe.rewriteVersion.get()


### PR DESCRIPTION
## What's changed?

The dependency on `com.gradle:gradle-enterprise-gradle-plugin` has been removed from the Gradle module.

## What's your motivation?

The Gradle module doesn't use any of the classes brought in by the dependency AFAIKT. We are using type tables here now so the dependency wouldn't be added as a transitive anymore though there's not point in having it's classes aren't used.

For reference, the two recipes that would potentially use the dependency:

- https://docs.openrewrite.org/recipes/gradle/plugins/adddevelocitygradleplugin
- https://docs.openrewrite.org/recipes/gradle/plugins/migrategradleenterprisetodevelocity

## Anything in particular you'd like reviewers to focus on?

No

## Anyone you would like to review specifically?

No
