### PR TITLE
Handling enums with no values as J.EnumValueSet

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -458,6 +458,11 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                     ),
                     EMPTY
             );
+        } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
+            if (positionOfNext(";", null) >= 0) {
+                Space prefix = sourceBefore(";");
+                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+            }
         }
 
         List<Tree> membersMultiVariablesSeparated = new ArrayList<>(node.getMembers().size());

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -460,8 +460,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
             if (positionOfNext(";", null) >= 0) {
-                Space prefix = sourceBefore(";");
-                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+                enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -516,8 +516,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
             if (positionOfNext(";", null) >= 0) {
-                Space prefix = sourceBefore(";");
-                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+                enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -514,6 +514,11 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                     ),
                     EMPTY
             );
+        } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
+            if (positionOfNext(";", null) >= 0) {
+                Space prefix = sourceBefore(";");
+                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+            }
         }
 
         List<Tree> membersMultiVariablesSeparated = new ArrayList<>(node.getMembers().size());

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -515,6 +515,11 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                     ),
                     EMPTY
             );
+        } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
+            if (positionOfNext(";", null) >= 0) {
+                Space prefix = sourceBefore(";");
+                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+            }
         }
 
         List<Tree> membersMultiVariablesSeparated = new ArrayList<>(node.getMembers().size());

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -517,8 +517,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
             if (positionOfNext(";", null) >= 0) {
-                Space prefix = sourceBefore(";");
-                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+                enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }
 

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -456,6 +456,11 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                     ),
                     EMPTY
             );
+        } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
+            if (positionOfNext(";", null) >= 0) {
+                Space prefix = sourceBefore(";");
+                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+            }
         }
 
         List<Tree> membersMultiVariablesSeparated = new ArrayList<>(node.getMembers().size());

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -458,8 +458,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
             if (positionOfNext(";", null) >= 0) {
-                Space prefix = sourceBefore(";");
-                enumSet = padRight(new J.EnumValueSet(randomId(), prefix, Markers.EMPTY, emptyList(), true), EMPTY);
+                enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/EnumTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/EnumTest.java
@@ -178,4 +178,24 @@ class EnumTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5146")
+    void noValuesJustSemicolon() {
+        rewriteRun(
+          java(
+            """
+             public enum A {
+                 ;
+                 public static final String X = "receipt-id";
+             }
+             """,
+            spec -> spec.afterRecipe( cu -> {
+                J.EnumValueSet enumValueStatement = (J.EnumValueSet) cu.getClasses().get(0).getBody().getStatements().get(0);
+                assert enumValueStatement.getEnums().isEmpty();
+                assert enumValueStatement.isTerminatedWithSemicolon();
+            })
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing how Java enums with no values are parsed. Now they get the `J.EnumValueSet` element with no values. Previously they were parsed as `J.Empty`.

## What's your motivation?

- addressing #5146
