### PR TITLE
Pin AssertJ for `rewrite-java-8` to 3.x

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
     implementation("org.ow2.asm:asm:latest.release")
 
     testImplementation(project(":rewrite-test"))
-    testImplementation("org.assertj:assertj-core:latest.release")
     "javaTck"(project(":rewrite-java-tck"))
 }
 

--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -18,7 +18,18 @@ dependencies {
     implementation("org.ow2.asm:asm:latest.release")
 
     testImplementation(project(":rewrite-test"))
+    testImplementation("org.assertj:assertj-core:latest.release")
     "javaTck"(project(":rewrite-java-tck"))
+}
+
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            if (requested.group == "org.assertj" && requested.name == "assertj-core") {
+                useVersion("3.+") // Pin to latest 3.+ version as AssertJ 4 requires Java 17
+            }
+        }
+    }
 }
 
 java {
@@ -66,7 +77,7 @@ testing {
                 implementation(project(":rewrite-test"))
                 implementation(project(":rewrite-java-tck"))
                 implementation(project(":rewrite-java-test"))
-                implementation("org.assertj:assertj-core:3.+")
+                implementation("org.assertj:assertj-core:latest.release")
             }
 
             targets {

--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -66,7 +66,7 @@ testing {
                 implementation(project(":rewrite-test"))
                 implementation(project(":rewrite-java-tck"))
                 implementation(project(":rewrite-java-test"))
-                implementation("org.assertj:assertj-core:latest.release")
+                implementation("org.assertj:assertj-core:3.+")
             }
 
             targets {

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -26,7 +26,18 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     testImplementation(project(":rewrite-test"))
+    testImplementation("org.assertj:assertj-core:latest.release")
     "javaTck"(project(":rewrite-java-tck"))
+}
+
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            if (requested.group == "org.assertj" && requested.name == "assertj-core") {
+                useVersion("3.+") // Pin to latest 3.+ version as AssertJ 4 requires Java 17
+            }
+        }
+    }
 }
 
 java {
@@ -63,7 +74,7 @@ testing {
                 implementation(project(":rewrite-test"))
                 implementation(project(":rewrite-java-tck"))
                 implementation(project(":rewrite-java-test"))
-                implementation("org.assertj:assertj-core:3.+")
+                implementation("org.assertj:assertj-core:latest.release")
             }
 
             targets {

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -63,7 +63,7 @@ testing {
                 implementation(project(":rewrite-test"))
                 implementation(project(":rewrite-java-tck"))
                 implementation(project(":rewrite-java-test"))
-                implementation("org.assertj:assertj-core:latest.release")
+                implementation("org.assertj:assertj-core:3.+")
             }
 
             targets {

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     testImplementation(project(":rewrite-test"))
-    testImplementation("org.assertj:assertj-core:latest.release")
     "javaTck"(project(":rewrite-java-tck"))
 }
 

--- a/rewrite-java-tck/build.gradle.kts
+++ b/rewrite-java-tck/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.assertj:assertj-core:latest.release")
+    implementation("org.assertj:assertj-core:3.+")
     implementation(project(":rewrite-java"))
     implementation(project(":rewrite-java-test"))
     implementation(project(":rewrite-test"))

--- a/rewrite-java-tck/build.gradle.kts
+++ b/rewrite-java-tck/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.assertj:assertj-core:3.+")
+    implementation("org.assertj:assertj-core:latest.release")
     implementation(project(":rewrite-java"))
     implementation(project(":rewrite-java-test"))
     implementation(project(":rewrite-test"))
@@ -15,6 +15,16 @@ dependencies {
             System.getProperty("idea.sync.active") != null) {
         // so we can run tests in the IDE with the IntelliJ IDEA runner
         runtimeOnly(project(":rewrite-java-17"))
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            if (requested.group == "org.assertj" && requested.name == "assertj-core") {
+                useVersion("3.+") // Pin to latest 3.+ version as AssertJ 4 requires Java 17
+            }
+        }
     }
 }
 


### PR DESCRIPTION
For `rewrite-java-8`, `rewrite-java-11`, and `rewrite-java-tck` we need to use AssertJ 3.x, as AssertJ 4.x now requires Java 17.
