### PR TITLE
Handling null source in MergeYaml

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -121,6 +121,9 @@ public class MergeYaml extends Recipe {
         return super.validate()
                 .and(Validated.test("yaml", "Must be valid YAML",
                         yaml, y -> {
+                            if (yaml == null) {
+                                return false;
+                            }
                             MergeYaml.maybeParse(yaml).ifPresent(it -> incoming = it);
                             return incoming != null;
                         }))

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -2984,4 +2984,22 @@ class MergeYamlTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void sourceNull() {
+        assertThrows(AssertionError.class, () ->
+            rewriteRun(
+              spec -> spec
+                .recipe(new MergeYaml(
+                  "$.some.object",
+                  null,
+                  false,
+                  "name",
+                  null,
+                  null,
+                  null,
+                  null
+                ))
+            ));
+    }
 }


### PR DESCRIPTION
## What's changed?

Slight change in how invalid input (null source) is handled by `MergeYaml`.
Now returning a proper validation error instead of `NullPointerException`.

## What's your motivation?
- fixes #4955
