### PR TITLE
Fixing MergeYaml not to duplicate a comment

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -190,6 +190,9 @@ public class MergeYaml extends Recipe {
                             new MergeYamlVisitor<>(d.getBlock(), MergeYaml.parse(snippet), accptTheirs, objectIdentifyingProperty, insertMode, insertProperty)
                                     .visitNonNull(d.getBlock(), ctx, getCursor()));
                 }
+                if (getCursor().getMessage(REMOVE_PREFIX, false)) {
+                    d = d.withEnd(d.getEnd().withPrefix(""));
+                }
                 return d;
             }
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -3002,4 +3002,29 @@ class MergeYamlTest implements RewriteTest {
                 ))
             ));
     }
+
+    @Test
+    void lastEntryShouldKeepItsComment() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.",
+            "imagePullPolicy: Always",
+            true,
+            null,
+            null,
+            null,
+            null,
+            true
+          )),
+          yaml(
+            """
+            containers: ALEF # comment
+            """,
+            """
+            containers: ALEF # comment
+            imagePullPolicy: Always
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing `MergeYaml` wrt not duplicating a comment in the specific case of the comment being the last thing:
```diff
             containers: ALEF # comment
-            imagePullPolicy: Always # comment
+            imagePullPolicy: Always
```

## What's your motivation?

I started looking at #5135, but this case showed up as related and even simpler, so I figured I could fix this one too.
#5135 is not fixed yet. Let's keep it open, hopefully another fix will address it.