### PR TITLE
Using current sequence indent, instead of autoformat() in MergeYaml

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -292,7 +292,9 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                 }
             }
 
-            List<Yaml.Sequence.Entry> newEntries = map(incomingEntries, it -> autoFormat(it, p, cursor));
+            String existingEntryPrefix = s1.getEntries().get(0).getPrefix();
+            String currentIndent = existingEntryPrefix.substring(existingEntryPrefix.lastIndexOf('\n'));
+            List<Yaml.Sequence.Entry> newEntries = ListUtils.map(incomingEntries, it -> it.withPrefix(currentIndent));
             List<Yaml.Sequence.Entry> mutatedEntries = concatAll(s1.getEntries(), newEntries, it -> ((Yaml.Scalar) it.getBlock()).getValue()).ls;
 
             return s1.withEntries(mutatedEntries);

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -3027,4 +3027,38 @@ class MergeYamlTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void mergeListRespectIndentation() {
+        rewriteRun(spec ->
+            spec.recipe(new MergeYaml(
+              "$",
+              //language=yaml
+              """
+                widget:
+                  list:
+                  - item 2
+                """,
+              false,
+              null,
+              null,
+              null,
+              null,
+              true
+            )),
+          yaml(
+            """
+              widget:
+                list:
+                - item 1
+              """,
+            """
+              widget:
+                list:
+                - item 1
+                - item 2
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
