### PR TITLE
Class files from type tables should not include all nested types

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -253,11 +253,10 @@ public class TypeTable implements JavaParserClasspathLoader {
                 );
 
                 for (ClassDefinition innerClassDef : nestedTypesByOwner.getOrDefault(classDef.getName(), emptyList())) {
-                    int lastIndexOf$ = innerClassDef.getName().lastIndexOf('$');
                     classWriter.visitInnerClass(
                             innerClassDef.getName(),
                             classDef.getName(),
-                            innerClassDef.getName().substring(lastIndexOf$ + 1),
+                            innerClassDef.getName().substring(classDef.getName().length() + 1),
                             innerClassDef.getAccess() & NESTED_TYPE_ACCESS_MASK
                     );
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -201,9 +201,9 @@ public class TypeTable implements JavaParserClasspathLoader {
                                         fields[6].isEmpty() ? null : fields[6],
                                         fields[7].isEmpty() ? null : fields[7].split("\\|")
                                 ));
-                        int lastIndexOf$ = classDefinition.getName().lastIndexOf('$');
+                        int lastIndexOf$ = className.lastIndexOf('$');
                         if (lastIndexOf$ != -1) {
-                            String ownerName = classDefinition.getName().substring(0, lastIndexOf$);
+                            String ownerName = className.substring(0, lastIndexOf$);
                             nestedTypesByOwner.computeIfAbsent(ownerName, k -> new ArrayList<>(4))
                                     .add(classDefinition);
                         }


### PR DESCRIPTION
When we write the `.class` files for a `TypeTable`, the file should only contain information about the nested types which also belong to that type.

Before this change all `.class` files would contain information about all nested types, which could result in very large `.class` files.

For the `develocity-gradle-plugin` dependency the `TypeTable.Reader` would end up writing 2.7G worth of class files. With this change this drops down to 32M. At the same time this operation now also takes a lot less time to complete.
