### PR TITLE
Handle double quotes in addition of simple quote in XPathMatcher 

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -42,7 +42,7 @@ public class XPathMatcher {
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
     private static final Pattern ELEMENT_WITH_CONDITION_PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)(\\[.+])");
     private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[.*?])+?");
-    private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))='(.*?)'(\\h?(or|and)\\h?)?)+?");
+    private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))=[\"'](.*?)[\"'](\\h?(or|and)\\h?)?)+?");
 
     private final String expression;
     private final boolean startsWithSlash;


### PR DESCRIPTION
XPath expression like 
`"//build/plugins/plugin[artifactId=\"openapi-generator-maven-plugin\"]/executions/execution/configuration/configOptions"` should work like
`"//build/plugins/plugin[artifactId='openapi-generator-maven-plugin']/executions/execution/configuration/configOptions"`