### PR TITLE
`TypeTable`: Add method bodies

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/JavaParserCaller.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/JavaParserCaller.java
@@ -59,7 +59,10 @@ class JavaParserCaller {
                         @Override
                         public boolean test(Class<?> c1) {
                             if (c1.getName().equals(JavaParser.class.getName()) ||
-                                c1.getName().equals(JavaParser.Builder.class.getName())) {
+                                c1.getName().equals(JavaParser.Builder.class.getName()) ||
+                                // FIXME this is a hack
+                                c1.getName().equals("org.openrewrite.gradle.GradleParser") ||
+                                c1.getName().equals("org.openrewrite.gradle.GradleParser$Builder")) {
                                 parserOrBuilderFound = true;
                                 return false;
                             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/parser/TypeTable.java
@@ -428,6 +428,7 @@ public class TypeTable implements JavaParserClasspathLoader {
                                 new ClassReader(inputStream).accept(new ClassVisitor(Opcodes.ASM9) {
                                     @Nullable
                                     ClassDefinition classDefinition;
+
                                     boolean wroteFieldOrMethod;
 
                                     @Override

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/parser/TypeTableTest.java
@@ -46,7 +46,7 @@ class TypeTableTest implements RewriteTest {
 
     @BeforeEach
     void before() {
-        //TODO ctx.putMessage(TypeTable.VERIFY_CLASS_WRITING, true);
+        ctx.putMessage(TypeTable.VERIFY_CLASS_WRITING, true);
         JavaParserExecutionContextView.view(ctx).setParserClasspathDownloadTarget(temp.toFile());
         tsv = temp.resolve("types.tsv.zip");
         System.out.println(tsv);


### PR DESCRIPTION
For non-abstract methods the byte code should contain a `return` statement bytecode.
