### PR TITLE
Fix nullability warnings around ExecutionContext.getMessages()

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/DelegatingExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/DelegatingExecutionContext.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+@Getter
 public class DelegatingExecutionContext implements ExecutionContext {
-    @Getter
     private final ExecutionContext delegate;
 
     public DelegatingExecutionContext(ExecutionContext delegate) {
@@ -31,7 +31,7 @@ public class DelegatingExecutionContext implements ExecutionContext {
     }
 
     @Override
-    public @Nullable Map<String, Object> getMessages() {
+    public Map<String, @Nullable Object> getMessages() {
         return delegate.getMessages();
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -54,7 +54,7 @@ public interface ExecutionContext extends RpcCodec<ExecutionContext> {
         return getMessage("org.openrewrite.internal.treeObservers", Collections.emptySet());
     }
 
-    Map<String, Object> getMessages();
+    Map<String, @Nullable Object> getMessages();
 
     void putMessage(String key, @Nullable Object value);
 

--- a/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite;
 
-import lombok.Getter;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
@@ -25,7 +24,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class InMemoryExecutionContext implements ExecutionContext, Cloneable {
-    @Getter
     @Nullable
     private Map<String, Object> messages;
 
@@ -53,32 +51,32 @@ public class InMemoryExecutionContext implements ExecutionContext, Cloneable {
     }
 
     @Override
+    public Map<String, @Nullable Object> getMessages() {
+        if (messages == null) {
+            messages = new ConcurrentHashMap<>();
+        }
+        return messages;
+    }
+
+    @Override
     public void putMessage(String key, @Nullable Object value) {
-        if (value == null && messages != null) {
-            messages.remove(key);
+        if (value == null) {
+            getMessages().remove(key);
         } else {
-            if (messages == null) {
-                messages = new ConcurrentHashMap<>();
-            }
-            if (value != null) {
-                messages.put(key, value);
-            }
+            getMessages().put(key, value);
         }
     }
 
     @Override
     public <T> @Nullable T getMessage(String key) {
-        if (messages == null) {
-            messages = new ConcurrentHashMap<>();
-        }
         //noinspection unchecked
-        return (T) messages.get(key);
+        return (T) getMessages().get(key);
     }
 
     @Override
     public <T> @Nullable T pollMessage(String key) {
         //noinspection unchecked
-        return (T) (messages == null ? null : messages.remove(key));
+        return (T) getMessages().remove(key);
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
@@ -61,7 +61,9 @@ public class InMemoryExecutionContext implements ExecutionContext, Cloneable {
     @Override
     public void putMessage(String key, @Nullable Object value) {
         if (value == null) {
-            getMessages().remove(key);
+            if (messages != null) {
+                getMessages().remove(key);
+            }
         } else {
             getMessages().put(key, value);
         }


### PR DESCRIPTION
I got a test failure locally which didn't seem like it should be the result of this change so I wanted to check if it reproduced on CI