### PR TITLE
Adding a missing return, without which a supposed optimization does nothing

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -417,7 +417,7 @@ public class ChangeType extends Recipe {
 
                 if (type.getOwningClass() == null) {
                     // just a performance shortcut when this isn't an inner class
-                    typeTree.withType(updateType(targetType));
+                    return typeTree.withType(updateType(targetType));
                 }
 
                 Stack<Expression> typeStack = new Stack<>();


### PR DESCRIPTION
## What's changed?
Added a missing return statement in `ChangeType.updateOuterClassTypes()`.

## What's your motivation?
The comment in line 419 says "just a performance shortcut when this isn't an inner class", but without a return statement, the line only creates a modified object which is then discarded.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases (nope, since this is just a minor performance improvement)
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
