### PR TITLE
Origins information in `RecipeDescriptor`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -219,16 +219,10 @@ public abstract class Recipe implements Cloneable {
             recipeList1.add(next.getDescriptor());
         }
         recipeList1.trimToSize();
-        URI recipeSource;
-        try {
-            recipeSource = getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
 
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription(), getTags(),
                 getEstimatedEffortPerOccurrence(), options, recipeList1, getDataTableDescriptors(),
-                getMaintainers(), getContributors(), getExamples(), recipeSource, getLicense());
+                getMaintainers(), getContributors(), getExamples(), getOrigin());
     }
 
     private List<OptionDescriptor> getOptionDescriptors() {
@@ -305,13 +299,21 @@ public abstract class Recipe implements Cloneable {
 
     @Setter
     @Nullable
-    protected transient License license;
+    protected transient RecipeOrigin origin;
 
-    public License getLicense() {
-        if (license == null) {
-            return License.Proprietary;
+    public RecipeOrigin getOrigin() {
+        if (origin == null) {
+            origin = new RecipeOrigin(getLocalSource(), License.Proprietary);
         }
-        return license;
+        return origin;
+    }
+
+    protected URI getLocalSource() {
+        try {
+            return getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -24,10 +24,7 @@ import lombok.Setter;
 import lombok.experimental.FieldDefaults;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.config.DataTableDescriptor;
-import org.openrewrite.config.OptionDescriptor;
-import org.openrewrite.config.RecipeDescriptor;
-import org.openrewrite.config.RecipeExample;
+import org.openrewrite.config.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NullUtils;
@@ -231,7 +228,7 @@ public abstract class Recipe implements Cloneable {
 
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription(), getTags(),
                 getEstimatedEffortPerOccurrence(), options, recipeList1, getDataTableDescriptors(),
-                getMaintainers(), getContributors(), getExamples(), recipeSource);
+                getMaintainers(), getContributors(), getExamples(), recipeSource, getLicense());
     }
 
     private List<OptionDescriptor> getOptionDescriptors() {
@@ -304,6 +301,17 @@ public abstract class Recipe implements Cloneable {
             return new ArrayList<>();
         }
         return examples;
+    }
+
+    @Setter
+    @Nullable
+    protected transient License license;
+
+    public License getLicense() {
+        if (license == null) {
+            return License.Proprietary;
+        }
+        return license;
     }
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/config/CategoryTree.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/CategoryTree.java
@@ -328,7 +328,7 @@ public class CategoryTree<G> {
 
     void addRecipe(G group, RecipeDescriptor recipe) {
         if (recipe.getName() == null) {
-            throw new IllegalArgumentException("Expected recipe to have a name " + recipe.getSource());
+            throw new IllegalArgumentException("Expected recipe to have a name " + recipe.getOrigin().getSourceLocation());
         }
         if (!recipe.getName().contains(".")) {
             throw new IllegalArgumentException("Expected recipe with name '" + recipe.getName() + "' to have " +

--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -46,7 +46,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
 
     private final Map<String, List<Contributor>> recipeAttributions = new HashMap<>();
     private final Map<String, List<RecipeExample>> recipeExamples = new HashMap<>();
-    private final Map<String, License> recipeLicense = new HashMap<>();
+    private final Map<String, RecipeOrigin> recipeOrigins = new HashMap<>();
 
     /**
      * Construct a ClasspathScanningLoader scans the runtime classpath of the current java process for recipes
@@ -127,10 +127,10 @@ public class ClasspathScanningLoader implements ResourceLoader {
                 styles.addAll(resourceLoader.listStyles());
                 recipeAttributions.putAll(resourceLoader.listContributors());
                 recipeExamples.putAll(resourceLoader.listRecipeExamples());
-                recipeLicense.putAll(resourceLoader.listLicenses());
+                recipeOrigins.putAll(resourceLoader.listRecipeOrigins());
             }
             for (YamlResourceLoader resourceLoader : yamlResourceLoaders) {
-                recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes, recipeAttributions, recipeExamples, recipeLicense));
+                recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes, recipeAttributions, recipeExamples, recipeOrigins));
             }
         }
     }
@@ -210,8 +210,8 @@ public class ClasspathScanningLoader implements ResourceLoader {
     }
 
     @Override
-    public Map<String, License> listLicenses() {
-        return recipeLicense;
+    public Map<String, RecipeOrigin> listRecipeOrigins() {
+        return recipeOrigins;
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ClasspathScanningLoader.java
@@ -46,6 +46,7 @@ public class ClasspathScanningLoader implements ResourceLoader {
 
     private final Map<String, List<Contributor>> recipeAttributions = new HashMap<>();
     private final Map<String, List<RecipeExample>> recipeExamples = new HashMap<>();
+    private final Map<String, License> recipeLicense = new HashMap<>();
 
     /**
      * Construct a ClasspathScanningLoader scans the runtime classpath of the current java process for recipes
@@ -126,9 +127,10 @@ public class ClasspathScanningLoader implements ResourceLoader {
                 styles.addAll(resourceLoader.listStyles());
                 recipeAttributions.putAll(resourceLoader.listContributors());
                 recipeExamples.putAll(resourceLoader.listRecipeExamples());
+                recipeLicense.putAll(resourceLoader.listLicenses());
             }
             for (YamlResourceLoader resourceLoader : yamlResourceLoaders) {
-                recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes, recipeAttributions, recipeExamples));
+                recipeDescriptors.addAll(resourceLoader.listRecipeDescriptors(recipes, recipeAttributions, recipeExamples, recipeLicense));
             }
         }
     }
@@ -205,6 +207,11 @@ public class ClasspathScanningLoader implements ResourceLoader {
     @Override
     public Map<String, List<RecipeExample>> listRecipeExamples() {
         return recipeExamples;
+    }
+
+    @Override
+    public Map<String, License> listLicenses() {
+        return recipeLicense;
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.*;
 import java.util.function.Supplier;
@@ -111,7 +112,7 @@ public class DeclarativeRecipe extends Recipe {
                 } else {
                     initValidation = initValidation.and(
                             invalid(name + ".recipeList" +
-                                    "[" + i + "] (in " + source + ")",
+                                    "[" + i + "] (in " + getLocalSource() + ")",
                                     recipeFqn,
                                     "recipe '" + recipeFqn + "' does not exist.",
                                     null));
@@ -372,7 +373,7 @@ public class DeclarativeRecipe extends Recipe {
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription() != null ? getDescription() : "",
                 getTags(), getEstimatedEffortPerOccurrence(),
                 emptyList(), recipeList, getDataTableDescriptors(), getMaintainers(), getContributors(),
-                getExamples(), source, getLicense());
+                getExamples(), getOrigin());
     }
 
     @Value

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -372,7 +372,7 @@ public class DeclarativeRecipe extends Recipe {
         return new RecipeDescriptor(getName(), getDisplayName(), getInstanceName(), getDescription() != null ? getDescription() : "",
                 getTags(), getEstimatedEffortPerOccurrence(),
                 emptyList(), recipeList, getDataTableDescriptors(), getMaintainers(), getContributors(),
-                getExamples(), source);
+                getExamples(), source, getLicense());
     }
 
     @Value

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -16,7 +16,6 @@
 package org.openrewrite.config;
 
 import org.apache.commons.lang3.StringUtils;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.Contributor;
 import org.openrewrite.Recipe;
 import org.openrewrite.RecipeException;
@@ -26,7 +25,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -47,12 +45,12 @@ public class Environment {
         }
         Map<String, List<Contributor>> recipeToContributors = new HashMap<>();
         Map<String, List<RecipeExample>> recipeExamples = new HashMap<>();
-        Map<String, License> recipeLicenses = new HashMap<>();
+        Map<String, RecipeOrigin> recipeOrigins = new HashMap<>();
         for (ResourceLoader r : resourceLoaders) {
             if (r instanceof YamlResourceLoader) {
                 recipeExamples.putAll(r.listRecipeExamples());
                 recipeToContributors.putAll(r.listContributors());
-                recipeLicenses.putAll(r.listLicenses());
+                recipeOrigins.putAll(r.listRecipeOrigins());
             }
         }
 
@@ -67,7 +65,7 @@ public class Environment {
         }
         for (Recipe recipe : recipes) {
             recipe.setContributors(recipeToContributors.get(recipe.getName()));
-            recipe.setLicense(recipeLicenses.get(recipe.getName()));
+            recipe.setOrigin(recipeOrigins.get(recipe.getName()));
 
             if (recipeExamples.containsKey(recipe.getName())) {
                 recipe.setExamples(recipeExamples.get(recipe.getName()));
@@ -92,12 +90,12 @@ public class Environment {
     public Collection<RecipeDescriptor> listRecipeDescriptors() {
         Map<String, List<Contributor>> recipeToContributors = new HashMap<>();
         Map<String, List<RecipeExample>> recipeToExamples = new HashMap<>();
-        Map<String, License> recipeToLicense = new HashMap<>();
+        Map<String, RecipeOrigin> recipeToLicense = new HashMap<>();
         for (ResourceLoader r : resourceLoaders) {
             if (r instanceof YamlResourceLoader) {
                 recipeToContributors.putAll(r.listContributors());
                 recipeToExamples.putAll(r.listRecipeExamples());
-                recipeToLicense.putAll(r.listLicenses());
+                recipeToLicense.putAll(r.listRecipeOrigins());
             } else if (r instanceof ClasspathScanningLoader) {
                 ClasspathScanningLoader classpathScanningLoader = (ClasspathScanningLoader) r;
 
@@ -121,7 +119,7 @@ public class Environment {
 
                 // because we have a 1-1 relation between recipe name and license, we can just put all
                 // we could add a check here to verify that the licenses are the same
-                recipeToLicense.putAll(classpathScanningLoader.listLicenses());
+                recipeToLicense.putAll(classpathScanningLoader.listRecipeOrigins());
             }
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/License.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/License.java
@@ -2,7 +2,6 @@ package org.openrewrite.config;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum License {

--- a/rewrite-core/src/main/java/org/openrewrite/config/License.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/License.java
@@ -2,6 +2,7 @@ package org.openrewrite.config;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum License {

--- a/rewrite-core/src/main/java/org/openrewrite/config/License.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/License.java
@@ -1,0 +1,31 @@
+package org.openrewrite.config;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum License {
+    Apache2("Apache License Version 2.0","https://www.apache.org/licenses/LICENSE-2.0"),
+    MSAL("Moderne Source Available", "https://docs.moderne.io/licensing/moderne-source-available-license"),
+    Proprietary("Moderne Proprietary","https://docs.moderne.io/licensing/overview");
+    private final String fullName;
+    private final String url;
+
+    public static License fromFullName(String name) {
+        for (License license : values()) {
+            if (license.fullName.equalsIgnoreCase(name)) {
+                return license;
+            }
+        }
+        throw new IllegalArgumentException("Invalid license name: " + name);
+    }
+
+    public static License fromUrl(String url) {
+        for (License license : values()) {
+            if (license.url.equalsIgnoreCase(url)) {
+                return license;
+            }
+        }
+        throw new IllegalArgumentException("Invalid license url: " + url);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
@@ -63,7 +63,5 @@ public class RecipeDescriptor {
 
     List<RecipeExample> examples;
 
-    URI source;
-
-    License license;
+    RecipeOrigin origin;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeDescriptor.java
@@ -64,4 +64,6 @@ public class RecipeDescriptor {
     List<RecipeExample> examples;
 
     URI source;
+
+    License license;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/RecipeOrigin.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/RecipeOrigin.java
@@ -1,0 +1,11 @@
+package org.openrewrite.config;
+
+import lombok.Value;
+
+import java.net.URI;
+
+@Value
+public class RecipeOrigin {
+    URI sourceLocation;
+    License license;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
@@ -36,5 +36,5 @@ public interface ResourceLoader {
 
     Map<String, List<RecipeExample>> listRecipeExamples();
 
-    Map<String, License> listLicenses();
+    Map<String, RecipeOrigin> listRecipeOrigins();
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
@@ -35,4 +35,6 @@ public interface ResourceLoader {
     Map<String, List<Contributor>> listContributors();
 
     Map<String, List<RecipeExample>> listRecipeExamples();
+
+    Map<String, License> listLicenses();
 }

--- a/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
@@ -112,7 +112,7 @@ class CategoryTreeTest {
     private static RecipeDescriptor recipeDescriptor(String packageName) {
         return new RecipeDescriptor(packageName + ".MyRecipe",
           "My recipe", "", "", emptySet(), null, emptyList(),
-          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"), License.MSAL);
+          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), new RecipeOrigin(URI.create("https://openrewrite.org"), License.Apache2));
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/CategoryTreeTest.java
@@ -112,7 +112,7 @@ class CategoryTreeTest {
     private static RecipeDescriptor recipeDescriptor(String packageName) {
         return new RecipeDescriptor(packageName + ".MyRecipe",
           "My recipe", "", "", emptySet(), null, emptyList(),
-          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"));
+          emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://openrewrite.org"), License.MSAL);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -298,6 +298,44 @@ class YamlResourceLoaderTest implements RewriteTest {
     }
 
     @Test
+    void recipeOrigin() {
+        Environment env = Environment.builder()
+          .load(new YamlResourceLoader(new ByteArrayInputStream(
+            //language=yml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: test.ChangeTextToHello
+              displayName: Change text to hello
+              recipeList:
+                  - org.openrewrite.text.ChangeText:
+                      toText: Hello!
+              """.getBytes()
+          ), URI.create("rewrite.yml"), new Properties()))
+          .load(new YamlResourceLoader(new ByteArrayInputStream(
+            //language=yml
+            """
+              type: specs.openrewrite.org/v1beta/origin
+              recipeName: test.ChangeTextToHello
+              recipeUrl: "https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"
+              recipeLicenseUrl: "https://www.apache.org/licenses/LICENSE-2.0"
+              """.getBytes()
+          ), URI.create("origin/test.ChangeTextToHello.yml"), new Properties()))
+          .build();
+
+        Collection<Recipe> recipes = env.listRecipes();
+        assertThat(recipes).singleElement().satisfies(r ->
+            assertThat(r.getOrigin()).isEqualTo(new RecipeOrigin(
+              URI.create("https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"),
+              License.Apache2)));
+
+        Collection<RecipeDescriptor> recipeDescriptors = env.listRecipeDescriptors();
+        assertThat(recipeDescriptors).singleElement().satisfies(d ->
+            assertThat(d.getOrigin()).isEqualTo(new RecipeOrigin(
+              URI.create("https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"),
+              License.Apache2)));
+    }
+
+    @Test
     void caseInsensitiveEnums() {
         rewriteRun(
           spec -> spec.recipeFromYaml(

--- a/rewrite-test/src/test/java/org/openrewrite/config/EnvironmentTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/config/EnvironmentTest.java
@@ -351,6 +351,12 @@ class EnvironmentTest implements RewriteTest {
                 - name: "Jonathan Schneider"
                   email: "jon@moderne.io"
                   lineCount: 5
+              
+              ---
+              type: specs.openrewrite.org/v1beta/origin
+              recipeName: org.openrewrite.text.ChangeTextToJon
+              recipeUrl: "https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"
+              recipeLicenseUrl: "https://www.apache.org/licenses/LICENSE-2.0"
               """.getBytes()
           ), URI.create("attribution/test.ChangeTextToHello.yml"), new Properties()))
           .build();
@@ -370,8 +376,11 @@ class EnvironmentTest implements RewriteTest {
           .findAny()
           .get();
 
-        assertThat(cttj.getContributors())
-          .isNotEmpty();
+        assertThat(cttj)
+          .satisfies(
+            r -> assertThat(r.getContributors()).containsExactly(new Contributor("Jonathan Schneider", "jon@moderne.io", 5)),
+            r -> assertThat(r.getOrigin()).isEqualTo(new RecipeOrigin(URI.create("https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"), License.Apache2))
+          );
     }
 
     @Test

--- a/rewrite-test/src/test/java/org/openrewrite/config/EnvironmentTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/config/EnvironmentTest.java
@@ -351,14 +351,17 @@ class EnvironmentTest implements RewriteTest {
                 - name: "Jonathan Schneider"
                   email: "jon@moderne.io"
                   lineCount: 5
-              
-              ---
+              """.getBytes()
+          ), URI.create("attribution/test.ChangeTextToHello.yml"), new Properties()))
+          .load(new YamlResourceLoader(new ByteArrayInputStream(
+            //language=yml
+            """
               type: specs.openrewrite.org/v1beta/origin
               recipeName: org.openrewrite.text.ChangeTextToJon
               recipeUrl: "https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"
               recipeLicenseUrl: "https://www.apache.org/licenses/LICENSE-2.0"
               """.getBytes()
-          ), URI.create("attribution/test.ChangeTextToHello.yml"), new Properties()))
+          ), URI.create("origin/test.ChangeTextToHello.yml"), new Properties()))
           .build();
 
         Collection<Recipe> recipes = env.listRecipes();
@@ -377,10 +380,10 @@ class EnvironmentTest implements RewriteTest {
           .get();
 
         assertThat(cttj)
-          .satisfies(
-            r -> assertThat(r.getContributors()).containsExactly(new Contributor("Jonathan Schneider", "jon@moderne.io", 5)),
-            r -> assertThat(r.getOrigin()).isEqualTo(new RecipeOrigin(URI.create("https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"), License.Apache2))
-          );
+          .hasFieldOrPropertyWithValue("contributors", List.of(new Contributor("Jonathan Schneider", "jon@moderne.io", 5)))
+          .hasFieldOrPropertyWithValue("origin", new RecipeOrigin(
+            URI.create("https://github.com/openrewrite/rewrite/blob/main/rewrite-gradle/src/main/java/org/openrewrite/gradle/AddDependencyVisitor.java"),
+            License.Apache2));
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The Enviroment loads the GitHub URL and LIcense information per Recipe from provided resources. The resouces are generated here https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/83. 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

The Documentation uses a heuristic approach to determine which the GitHub URL and correct license information. 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
