### PR TITLE
Find type field references in JavaDoc in interfaces and superclasses

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -748,8 +748,15 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
 
-        // a member reference, but not matching anything on type attribution
-        return null;
+        for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+            for (JavaType.Variable member : interface_.getMembers()) {
+                if (member.getName().equals(ref.memberName.toString())) {
+                    return member;
+                }
+            }
+        }
+
+        return fieldReferenceType(ref, classType.getSupertype());
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -751,8 +751,15 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
 
-        // a member reference, but not matching anything on type attribution
-        return null;
+        for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+            for (JavaType.Variable member : interface_.getMembers()) {
+                if (member.getName().equals(ref.memberName.toString())) {
+                    return member;
+                }
+            }
+        }
+
+        return fieldReferenceType(ref, classType.getSupertype());
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -751,8 +751,15 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
 
-        // a member reference, but not matching anything on type attribution
-        return null;
+        for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+            for (JavaType.Variable member : interface_.getMembers()) {
+                if (member.getName().equals(ref.memberName.toString())) {
+                    return member;
+                }
+            }
+        }
+
+        return fieldReferenceType(ref, classType.getSupertype());
     }
 
     @Override

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -702,8 +702,15 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
             }
         }
 
-        // a member reference, but not matching anything on type attribution
-        return null;
+        for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+            for (JavaType.Variable member : interface_.getMembers()) {
+                if (member.getName().equals(ref.memberName.toString())) {
+                    return member;
+                }
+            }
+        }
+
+        return fieldReferenceType(ref, classType.getSupertype());
     }
 
     @Override

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -1049,6 +1049,60 @@ class JavadocTest implements RewriteTest {
     }
 
     @Test
+    void seeWithRefInInterface() {
+        rewriteRun(
+          java(
+            """
+                import javax.swing.text.html.HTML.Tag;
+                
+                public interface HtmlMarkup {
+                    Tag H1 = Tag.H1;
+                }
+                """
+          ),
+          java(
+            """
+              interface Test extends HtmlMarkup {
+                  /**
+                    * Starts a section title.
+                    *
+                    * @see #H1
+                    */
+                    void onSectionTitle();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void seeWithRefInSuperclass() {
+        rewriteRun(
+          java(
+            """
+                import javax.swing.text.html.HTML.Tag;
+                
+                public abstract class HtmlMarkup {
+                    Tag H1 = Tag.H1;
+                }
+                """
+          ),
+          java(
+            """
+              class Test extends HtmlMarkup {
+                  /**
+                    * Starts a section title.
+                    *
+                    * @see #H1
+                    */
+                    void onSectionTitle();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void methodFound() {
         rewriteRun(
           java(


### PR DESCRIPTION
## What's changed?
Field type references in superclasses and interfaces are now discovered as well.

## What's your motivation?
Having a setup like 
[Xhtml5BaseSink](https://github.com/apache/maven-doxia/blob/ede159d464cebf5fb17131794cac0b48d7f21f5a/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSink.java#L372):

```java
import javax.swing.text.html.HTML.Tag;
                
public interface HtmlMarkup {
  Tag H1 = Tag.H1;
}

interface Test extends HtmlMarkup {
    /**
     * @see #H1
     */
    void onSectionTitle();
}
```

would not find the `H1` type.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
