### PR TITLE
Find method type references in JavaDoc in interfaces and superclasses

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -681,27 +681,20 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         if (type instanceof JavaType.Class) {
             JavaType.Class classType = (JavaType.Class) type;
 
-            nextMethod:
-            for (JavaType.Method method : classType.getMethods()) {
-                if (method.getName().equals(ref.memberName.toString())) {
-                    if (ref.paramTypes != null) {
-                        List<JavaType> parameterTypes = method.getParameterTypes();
-                        if (ref.paramTypes.size() != parameterTypes.size()) {
-                            continue;
-                        }
-                        for (int i = 0; i < ref.paramTypes.size(); i++) {
-                            JCTree param = ref.paramTypes.get(i);
-                            JavaType testParamType = parameterTypes.get(i);
-                            Type paramType = attr.attribType(param, symbol);
-                            if (!paramTypeMatches(testParamType, paramType)) {
-                                continue nextMethod;
-                            }
-                        }
-                    }
+            JavaType.@Nullable Method method = methodReferenceType(ref, classType.getMethods());
+            if (method != null) return method;
 
-                    return method;
+            // Superclass fields takes presence over interface fields
+            method = methodReferenceType(ref, classType.getSupertype());
+
+            if (method == null) {
+                for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+                    method = methodReferenceType(ref, interface_.getMethods());
+                    if (method != null) return method;
                 }
             }
+
+            return method;
         } else if (type instanceof JavaType.GenericTypeVariable) {
             JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;
             for (JavaType bound : generic.getBounds()) {
@@ -712,6 +705,30 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
         // a member reference, but not matching anything on type attribution
+        return null;
+    }
+
+    private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
+        nextMethod:
+        for (JavaType.Method method : methods) {
+            if (method.getName().equals(ref.memberName.toString())) {
+                if (ref.paramTypes != null) {
+                    List<JavaType> parameterTypes = method.getParameterTypes();
+                    if (ref.paramTypes.size() != parameterTypes.size()) {
+                        continue;
+                    }
+                    for (int i = 0; i < ref.paramTypes.size(); i++) {
+                        JCTree param = ref.paramTypes.get(i);
+                        JavaType testParamType = parameterTypes.get(i);
+                        Type paramType = attr.attribType(param, symbol);
+                        if (!paramTypeMatches(testParamType, paramType)) {
+                            continue nextMethod;
+                        }
+                    }
+                }
+                return method;
+            }
+        }
         return null;
     }
 

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -684,27 +684,20 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         if (type instanceof JavaType.Class) {
             JavaType.Class classType = (JavaType.Class) type;
 
-            nextMethod:
-            for (JavaType.Method method : classType.getMethods()) {
-                if (method.getName().equals(ref.memberName.toString())) {
-                    if (ref.paramTypes != null) {
-                        List<JavaType> parameterTypes = method.getParameterTypes();
-                        if (ref.paramTypes.size() != parameterTypes.size()) {
-                            continue;
-                        }
-                        for (int i = 0; i < ref.paramTypes.size(); i++) {
-                            JCTree param = ref.paramTypes.get(i);
-                            JavaType testParamType = parameterTypes.get(i);
-                            Type paramType = attr.attribType(param, symbol);
-                            if (!paramTypeMatches(testParamType, paramType)) {
-                                continue nextMethod;
-                            }
-                        }
-                    }
+            JavaType.@Nullable Method method = methodReferenceType(ref, classType.getMethods());
+            if (method != null) return method;
 
-                    return method;
+            // Superclass fields takes presence over interface fields
+            method = methodReferenceType(ref, classType.getSupertype());
+
+            if (method == null) {
+                for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+                    method = methodReferenceType(ref, interface_.getMethods());
+                    if (method != null) return method;
                 }
             }
+
+            return method;
         } else if (type instanceof JavaType.GenericTypeVariable) {
             JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;
             for (JavaType bound : generic.getBounds()) {
@@ -715,6 +708,30 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
         }
         // a member reference, but not matching anything on type attribution
+        return null;
+    }
+
+    private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
+        nextMethod:
+        for (JavaType.Method method : methods) {
+            if (method.getName().equals(ref.memberName.toString())) {
+                if (ref.paramTypes != null) {
+                    List<JavaType> parameterTypes = method.getParameterTypes();
+                    if (ref.paramTypes.size() != parameterTypes.size()) {
+                        continue;
+                    }
+                    for (int i = 0; i < ref.paramTypes.size(); i++) {
+                        JCTree param = ref.paramTypes.get(i);
+                        JavaType testParamType = parameterTypes.get(i);
+                        Type paramType = attr.attribType(param, symbol);
+                        if (!paramTypeMatches(testParamType, paramType)) {
+                            continue nextMethod;
+                        }
+                    }
+                }
+                return method;
+            }
+        }
         return null;
     }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -735,34 +735,6 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         return null;
     }
 
-    private JavaType.@Nullable Variable xx(DCTree.DCReference ref, @Nullable JavaType type) {
-        JavaType.Class classType = TypeUtils.asClass(type);
-        if (classType == null) {
-            return null;
-        }
-
-        for (JavaType.Variable member : classType.getMembers()) {
-            if (member.getName().equals(ref.memberName.toString())) {
-                return member;
-            }
-        }
-
-        // Superclass fields takes presence over interface fields
-        JavaType.@Nullable Variable refType = xx(ref, classType.getSupertype());
-
-        if (refType == null) {
-            for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
-                for (JavaType.Variable member : interface_.getMembers()) {
-                    if (member.getName().equals(ref.memberName.toString())) {
-                        return member;
-                    }
-                }
-            }
-        }
-
-        return refType;
-    }
-
     private boolean paramTypeMatches(JavaType parameterType, Type javadocType) {
         return paramTypeMatches(parameterType, typeMapping.type(javadocType));
     }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -684,27 +684,20 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         if (type instanceof JavaType.Class) {
             JavaType.Class classType = (JavaType.Class) type;
 
-            nextMethod:
-            for (JavaType.Method method : classType.getMethods()) {
-                if (method.getName().equals(ref.memberName.toString())) {
-                    if (ref.paramTypes != null) {
-                        List<JavaType> parameterTypes = method.getParameterTypes();
-                        if (ref.paramTypes.size() != parameterTypes.size()) {
-                            continue;
-                        }
-                        for (int i = 0; i < ref.paramTypes.size(); i++) {
-                            JCTree param = ref.paramTypes.get(i);
-                            JavaType testParamType = parameterTypes.get(i);
-                            Type paramType = attr.attribType(param, symbol);
-                            if (!paramTypeMatches(testParamType, paramType)) {
-                                continue nextMethod;
-                            }
-                        }
-                    }
+            JavaType.@Nullable Method method = methodReferenceType(ref, classType.getMethods());
+            if (method != null) return method;
 
-                    return method;
+            // Superclass fields takes presence over interface fields
+            method = methodReferenceType(ref, classType.getSupertype());
+
+            if (method == null) {
+                for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+                    method = methodReferenceType(ref, interface_.getMethods());
+                    if (method != null) return method;
                 }
             }
+
+            return method;
         } else if (type instanceof JavaType.GenericTypeVariable) {
             JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;
             for (JavaType bound : generic.getBounds()) {
@@ -716,6 +709,58 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
         }
         // a member reference, but not matching anything on type attribution
         return null;
+    }
+
+    private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
+        nextMethod:
+        for (JavaType.Method method : methods) {
+            if (method.getName().equals(ref.memberName.toString())) {
+                if (ref.paramTypes != null) {
+                    List<JavaType> parameterTypes = method.getParameterTypes();
+                    if (ref.paramTypes.size() != parameterTypes.size()) {
+                        continue;
+                    }
+                    for (int i = 0; i < ref.paramTypes.size(); i++) {
+                        JCTree param = ref.paramTypes.get(i);
+                        JavaType testParamType = parameterTypes.get(i);
+                        Type paramType = attr.attribType(param, symbol);
+                        if (!paramTypeMatches(testParamType, paramType)) {
+                            continue nextMethod;
+                        }
+                    }
+                }
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private JavaType.@Nullable Variable xx(DCTree.DCReference ref, @Nullable JavaType type) {
+        JavaType.Class classType = TypeUtils.asClass(type);
+        if (classType == null) {
+            return null;
+        }
+
+        for (JavaType.Variable member : classType.getMembers()) {
+            if (member.getName().equals(ref.memberName.toString())) {
+                return member;
+            }
+        }
+
+        // Superclass fields takes presence over interface fields
+        JavaType.@Nullable Variable refType = xx(ref, classType.getSupertype());
+
+        if (refType == null) {
+            for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+                for (JavaType.Variable member : interface_.getMembers()) {
+                    if (member.getName().equals(ref.memberName.toString())) {
+                        return member;
+                    }
+                }
+            }
+        }
+
+        return refType;
     }
 
     private boolean paramTypeMatches(JavaType parameterType, Type javadocType) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -638,13 +638,39 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
     }
 
     private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, @Nullable JavaType type) {
-        JavaType.Class classType = TypeUtils.asClass(type);
-        if (classType == null) {
-            return null;
-        }
+        if (type instanceof JavaType.Class) {
+            JavaType.Class classType = (JavaType.Class) type;
 
+            JavaType.@Nullable Method method = methodReferenceType(ref, classType.getMethods());
+            if (method != null) return method;
+
+            // Superclass fields takes presence over interface fields
+            method = methodReferenceType(ref, classType.getSupertype());
+
+            if (method == null) {
+                for (JavaType.FullyQualified interface_ : classType.getInterfaces()) {
+                    method = methodReferenceType(ref, interface_.getMethods());
+                    if (method != null) return method;
+                }
+            }
+
+            return method;
+        } else if (type instanceof JavaType.GenericTypeVariable) {
+            JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) type;
+            for (JavaType bound : generic.getBounds()) {
+                JavaType.Method method = methodReferenceType(ref, bound);
+                if (method != null) {
+                    return method;
+                }
+            }
+        }
+        // a member reference, but not matching anything on type attribution
+        return null;
+    }
+
+    private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
         nextMethod:
-        for (JavaType.Method method : classType.getMethods()) {
+        for (JavaType.Method method : methods) {
             if (method.getName().equals(ref.memberName.toString())) {
                 if (ref.paramTypes != null) {
                     List<JavaType> parameterTypes = method.getParameterTypes();
@@ -660,12 +686,9 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
                         }
                     }
                 }
-
                 return method;
             }
         }
-
-        // a member reference, but not matching anything on type attribution
         return null;
     }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -15,13 +15,13 @@
  */
 package org.openrewrite.java.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.java.MinimumJava11;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.java.Assertions.java;
 
@@ -1056,7 +1056,7 @@ class JavadocTest implements RewriteTest {
             """
                 import javax.swing.text.html.HTML.Tag;
                 
-                public interface HtmlMarkup {
+                interface HtmlMarkup {
                     Tag H1 = Tag.H1;
                 }
                 """
@@ -1081,7 +1081,7 @@ class JavadocTest implements RewriteTest {
             """
                 import javax.swing.text.html.HTML.Tag;
                 
-                public abstract class HtmlMarkup {
+                abstract class HtmlMarkup {
                     Tag H1 = Tag.H1;
                 }
                 """
@@ -1106,15 +1106,15 @@ class JavadocTest implements RewriteTest {
             """
                 import javax.swing.text.html.HTML.Tag;
                 
-                public interface HtmlMarkupI {
+                interface HtmlMarkupI {
                     Tag H1 = Tag.H1;
                 }
                 
-                public abstract class HtmlMarkup2 implements HtmlMarkupI {
+                abstract class HtmlMarkup2 implements HtmlMarkupI {
                     String H1 = "aa";
                 }
                 
-                public abstract class HtmlMarkup extends HtmlMarkup2 implements HtmlMarkupI {
+                abstract class HtmlMarkup extends HtmlMarkup2 implements HtmlMarkupI {
                 }
                 """
           ),
@@ -1144,6 +1144,88 @@ class JavadocTest implements RewriteTest {
                   boolean test();
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void methodFoundInInterface() {
+        rewriteRun(
+          java(
+            """
+                interface SomeInterface {
+                  boolean test();
+                }
+                """
+          ),
+          java(
+            """
+              interface Test extends SomeInterface {
+                  /**
+                   * @see #test()
+                   */
+                 void method();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodFoundInSuperclass() {
+        rewriteRun(
+          java(
+            """
+                class SomeParent {
+                    boolean test() {}
+                }
+                """
+          ),
+          java(
+            """
+              class Test extends SomeParent {
+                  /**
+                   * @see #test()
+                   */
+                  void method() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodFoundInSuperclassBecauseSuperclassFieldsTakesPresenceOverInterfaceFields() {
+        rewriteRun(
+          java(
+            """
+                import javax.swing.text.html.HTML.Tag;
+                
+                interface SomeInterface {
+                    int test();
+                }
+                
+                abstract class SomeParent2 implements SomeInterface {
+                    abstract boolean test();
+                }
+                
+                abstract class SomeParent extends SomeParent2 implements SomeInterface {
+                }
+                """
+          ),
+          java(
+            """
+              class Test extends SomeParent implements SomeInterface {
+                  /**
+                    * @see #test()
+                    */
+                    void method() {}
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                assertEquals("test", cu.getTypesInUse().getUsedMethods().iterator().next().getName());
+                assertEquals("SomeParent2", cu.getTypesInUse().getUsedMethods().iterator().next().getDeclaringType().getFullyQualifiedName());
+            })
           )
         );
     }


### PR DESCRIPTION
## What's changed?
Method field type references in superclasses and interfaces are now discovered as well.

## What's your motivation?
Having a setup like [AbstractSinkTest](https://github.com/apache/maven-doxia/blob/ede159d464cebf5fb17131794cac0b48d7f21f5a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java#L101):

```java    
public interface SomeInterface {
    boolean test();
}

interface Test extends SomeInterface {
    /**
     * @see #test()
     */
    void onSectionTitle();
}
```

would not find the `test` method reference.

### Any additional context
Conceptually equal to:
- https://github.com/openrewrite/rewrite/pull/5163

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
