### PR TITLE
Retry searching for proper parent

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -75,6 +75,16 @@ public class AnnotationTemplateGenerator {
 
                     J j = cursor.getValue();
                     J annotationParent = j instanceof J.Annotation && cursor.getParent() != null ? cursor.getParent().firstEnclosing(J.class) : null;
+
+                    int level = 1;
+                    while (annotationParent instanceof J.NewArray || annotationParent instanceof J.Annotation) {
+                        level += 1;
+                        if (cursor.getParent(level) == null) {
+                            break;
+                        }
+                        annotationParent = cursor.getParent(level).firstEnclosing(J.class);
+                    }
+
                     if (j instanceof J.MethodDeclaration || annotationParent instanceof J.MethodDeclaration) {
                         after.insert(0, " void $method() {}");
                     } else if (j instanceof J.VariableDeclarations || annotationParent instanceof J.VariableDeclarations) {


### PR DESCRIPTION
## What's changed?
Find an valid `annotationParent` to avoid exception.

## What's your motivation?
I have no idea how to program a UT in `rewrite-java`.

Here's how I reproduce the exception:
Run `MigrateApiImplicitParam` on below code, and it throws exception. After debugging, It seems that `AnnotationTemplateGenerator` didn't generate a proper template due to an invalid `annotationParent`. 
This PR tries to find an valid parent.

Code:
```java
import io.swagger.annotations.*;
import jakarta.ws.rs.Consumes;
import jakarta.ws.rs.POST;
import jakarta.ws.rs.Path;
import jakarta.ws.rs.Produces;
import jakarta.ws.rs.core.MediaType;
import jakarta.ws.rs.core.Response;
import org.apache.hc.core5.http.HttpStatus;

public class Example {
    @ApiImplicitParams({
        @ApiImplicitParam(name = "version", defaultValue="X", required = true, dataType = "string", paramType = "path")
    })
    public Response add() {
        return null;
    }
}
```

Exception:
```
Caused by: org.openrewrite.internal.RecipeRunException: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:290)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:157)
	at org.openrewrite.java.JavaTemplate.apply(JavaTemplate.java:115)
	at org.openrewrite.openapi.swagger.MigrateApiImplicitParam$1.visitAnnotation(MigrateApiImplicitParam.java:96)
	at org.openrewrite.openapi.swagger.MigrateApiImplicitParam$1.visitAnnotation(MigrateApiImplicitParam.java:54)
```

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
