### PR TITLE
Support this-constructor-links in JavaDoc

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -711,7 +711,7 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
         nextMethod:
         for (JavaType.Method method : methods) {
-            if (method.getName().equals(ref.memberName.toString())) {
+            if (ref.memberName.toString().equals(method.getName()) || ref.memberName.toString().equals(method.getConstructorName())) {
                 if (ref.paramTypes != null) {
                     List<JavaType> parameterTypes = method.getParameterTypes();
                     if (ref.paramTypes.size() != parameterTypes.size()) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -714,7 +714,7 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
         nextMethod:
         for (JavaType.Method method : methods) {
-            if (method.getName().equals(ref.memberName.toString())) {
+            if (ref.memberName.toString().equals(method.getName()) || ref.memberName.toString().equals(method.getConstructorName())) {
                 if (ref.paramTypes != null) {
                     List<JavaType> parameterTypes = method.getParameterTypes();
                     if (ref.paramTypes.size() != parameterTypes.size()) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -714,7 +714,7 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
         nextMethod:
         for (JavaType.Method method : methods) {
-            if (method.getName().equals(ref.memberName.toString())) {
+            if (ref.memberName.toString().equals(method.getName()) || ref.memberName.toString().equals(method.getConstructorName())) {
                 if (ref.paramTypes != null) {
                     List<JavaType> parameterTypes = method.getParameterTypes();
                     if (ref.paramTypes.size() != parameterTypes.size()) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -671,7 +671,7 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
     private JavaType.@Nullable Method methodReferenceType(DCTree.DCReference ref, List<JavaType.Method> methods) {
         nextMethod:
         for (JavaType.Method method : methods) {
-            if (method.getName().equals(ref.memberName.toString())) {
+            if (ref.memberName.toString().equals(method.getName()) || ref.memberName.toString().equals(method.getConstructorName())) {
                 if (ref.paramTypes != null) {
                     List<JavaType> parameterTypes = method.getParameterTypes();
                     if (ref.paramTypes.size() != parameterTypes.size()) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -656,10 +656,45 @@ class JavadocTest implements RewriteTest {
           java(
             """
               /**
-               *   {@link #test() }
+               *   {@link #test(Integer) }
                */
               class Test {
-                  void test() {}
+                  void test(Integer a) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void thisConstructorLink() {
+        rewriteRun(
+          java(
+            """
+              /**
+               * {@link #Test(Integer) }
+               */
+              class Test {
+                  Test(Integer a) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void thisConstructorLinkInnerClass() {
+        rewriteRun(
+          java(
+            """
+              class Outer {
+                  class Test {
+                      Test(Integer a) {}
+                      /**
+                       * Use: {@link #Test(Integer) }
+                       */
+                      Test of(Integer a) {}
+                  }
               }
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1390,8 +1390,8 @@ public interface JavaType {
                 return null;
             }
             String className = ((JavaType.Class) getReturnType()).getClassName();
-            String[] parts = className.split("\\.");
-            return parts[parts.length - 1];
+            int beginIndex = className.lastIndexOf(".");
+            return beginIndex == -1 ? className : className.substring(beginIndex);
         }
 
         public FullyQualified getDeclaringType() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1385,6 +1385,15 @@ public interface JavaType {
             return "<constructor>".equals(name);
         }
 
+        public @Nullable String getConstructorName() {
+            if (!isConstructor()) {
+                return null;
+            }
+            String className = ((JavaType.Class) getReturnType()).getClassName();
+            String[] parts = className.split("\\.");
+            return parts[parts.length - 1];
+        }
+
         public FullyQualified getDeclaringType() {
             return declaringType;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1391,7 +1391,7 @@ public interface JavaType {
             }
             String className = ((JavaType.Class) getReturnType()).getClassName();
             int beginIndex = className.lastIndexOf(".");
-            return beginIndex == -1 ? className : className.substring(beginIndex);
+            return beginIndex == -1 ? className : className.substring(beginIndex + 1);
         }
 
         public FullyQualified getDeclaringType() {


### PR DESCRIPTION
## What's changed?
Direct links to constructors are now supported.

## What's your motivation?
Code like [Maven Doxia's](https://github.com/apache/maven-doxia/blob/ede159d464cebf5fb17131794cac0b48d7f21f5a/doxia-core/src/main/java/org/apache/maven/doxia/index/IndexingSink.java#L41) IndexingSink class gave missing type reference errors:

```java
public class IndexingSink {
    /**
     * @deprecated legacy constructor, use {@link #IndexingSink(Sink)}.
     */
    @Deprecated
    public IndexingSink(IndexEntry rootEntry) {
        this(rootEntry, new SinkAdapter());
    }

    public IndexingSink(Sink delegate) {
        this(new IndexEntry("index"), delegate);
    }
}
```

The parser could not find the types for the constructor arguments.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
