### PR TITLE
Fix handling of maven compiler plugin configuration for java version upgrade

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddProperty.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddProperty.java
@@ -75,18 +75,14 @@ public class AddProperty extends Recipe {
         return new MavenIsoVisitor<ExecutionContext>() {
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                String parentValue = getResolutionResult().getPom().getRequested().getProperties().get(key);
-                if ((Boolean.TRUE.equals(trustParent) && (parentValue == null || value.equals(parentValue))) ||
+                String parentValue = getResolutionResult().getParent() != null ? getResolutionResult().getParent().getPom().getRequested().getProperties().get(key) : null;
+                if ((Boolean.TRUE.equals(trustParent) && parentValue != null) ||
                         value.equals(getResolutionResult().getPom().getProperties().get(key))) {
                     return document;
                 }
 
                 // If there is a parent pom in the same project, update the property there instead
-                if (document.getRoot().getChild("parent")
-                        .flatMap(tag -> tag.getChild("relativePath"))
-                        .flatMap(Xml.Tag::getValue)
-                        .flatMap(v -> v.trim().isEmpty() ? Optional.empty() : Optional.of(v))
-                        .isPresent()) {
+                if (getResolutionResult().parentPomIsProjectPom() && parentValue != null) {
                     if (Boolean.TRUE.equals(preserveExistingValue)) {
                         return document;
                     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -89,6 +89,7 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                 // Return early if the parent appears to be within the current repository, as properties defined there will be updated
                 outer:
                 if (getResolutionResult().parentPomIsProjectPom()) {
+                    // Unless the plugin config in the parent defines source/target/release with a property
                     if (getResolutionResult().getParent() != null) {
                         for (Plugin plugin : getResolutionResult().getParent().getPom().getPlugins()) {
                             if (plugin.getGroupId().equals("org.apache.maven.plugins") && plugin.getArtifactId().equals("maven-compiler-plugin") && plugin.getConfiguration() != null) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -89,7 +89,6 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                 // Return early if the parent appears to be within the current repository, as properties defined there will be updated
                 if (getResolutionResult().getParent() != null && getResolutionResult().parentPomIsProjectPom()) {
                     // Unless the plugin config in the parent defines source/target/release with a property
-                    outerFor:
                     for (Plugin plugin : getResolutionResult().getParent().getPom().getPlugins()) {
                         if (plugin.getGroupId().equals("org.apache.maven.plugins") && plugin.getArtifactId().equals("maven-compiler-plugin") && plugin.getConfiguration() != null) {
                             for (String property : JAVA_VERSION_PROPERTIES) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -89,16 +89,18 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                 // Return early if the parent appears to be within the current repository, as properties defined there will be updated
                 outer:
                 if (getResolutionResult().parentPomIsProjectPom()) {
-                    for (Plugin plugin : getResolutionResult().getParent().getPom().getPlugins()) {
-                        if (plugin.getGroupId().equals("org.apache.maven.plugins") && plugin.getArtifactId().equals("maven-compiler-plugin")) {
-                            for (String property : JAVA_VERSION_PROPERTIES) {
-                                if ((plugin.getConfiguration().get("source") != null && plugin.getConfiguration().get("source").textValue().contains(property)) ||
-                                    (plugin.getConfiguration().get("target") != null && plugin.getConfiguration().get("target").textValue().contains(property)) ||
-                                    (plugin.getConfiguration().get("release") != null && plugin.getConfiguration().get("release").textValue().contains(property))) {
-                                    break outer;
+                    if (getResolutionResult().getParent() != null) {
+                        for (Plugin plugin : getResolutionResult().getParent().getPom().getPlugins()) {
+                            if (plugin.getGroupId().equals("org.apache.maven.plugins") && plugin.getArtifactId().equals("maven-compiler-plugin") && plugin.getConfiguration() != null) {
+                                for (String property : JAVA_VERSION_PROPERTIES) {
+                                    if ((plugin.getConfiguration().get("source") != null && plugin.getConfiguration().get("source").textValue().contains(property)) ||
+                                        (plugin.getConfiguration().get("target") != null && plugin.getConfiguration().get("target").textValue().contains(property)) ||
+                                        (plugin.getConfiguration().get("release") != null && plugin.getConfiguration().get("release").textValue().contains(property))) {
+                                        break outer;
+                                    }
                                 }
-                            }
 
+                            }
                         }
                     }
                     return d;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -24,7 +24,6 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-@Deprecated(forRemoval = true)
 class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
 
     @Override
@@ -181,6 +180,72 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                       """
                 )
             )
+        );
+    }
+
+
+    @Test
+    void UpdateChildProperty() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <groupId>com.example</groupId>
+                  <artifactId>example-parent</artifactId>
+                  <version>1.0.0</version>
+                  <modelVersion>4.0</modelVersion>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.8.0</version>
+                              <configuration>
+                                  <source>${java.version}</source>
+                              </configuration>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """),
+          mavenProject("example-child",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>example-parent</artifactId>
+                        <version>1.0.0</version>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>example-child</artifactId>
+                    <version>1.0.0</version>
+                    <modelVersion>4.0</modelVersion>
+                    <properties>
+                        <java.version>11</java.version>
+                    </properties>
+                </project>
+                """,
+              """
+                <project>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>example-parent</artifactId>
+                        <version>1.0.0</version>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>example-child</artifactId>
+                    <version>1.0.0</version>
+                    <modelVersion>4.0</modelVersion>
+                    <properties>
+                        <java.version>17</java.version>
+                    </properties>
+                </project>
+                """
+            )
+          )
         );
     }
 


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
When the maven compiler plugin is configured with a property in the parent pom which is overridden by child poms the child pom is now correctly updated instead of adding the property to the parent

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
