### PR TITLE
Add new test validation that ScanningRecipe.getScanner() does not attempt edits.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -41,6 +41,7 @@ public interface ExecutionContext extends RpcCodec<ExecutionContext> {
     String DATA_TABLES = "org.openrewrite.dataTables";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
     String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
+    String SCANNING_MUTATION_VALIDATION = "org.openrewrite.test.scanningMutationValidation";
 
     @Incubating(since = "7.20.0")
     default ExecutionContext addObserver(TreeObserver.Subscription observer) {

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -93,11 +93,11 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                                 TreeVisitor<?, ExecutionContext> scanner = scanningRecipe.getScanner(acc);
                                 if (scanner.isAcceptable(source, ctx)) {
                                     Tree maybeMutated = scanner.visit(source, ctx, rootCursor);
-                                    if (maybeMutated != source && ctx.getMessage(SCANNING_MUTATION_VALIDATION, false)) {
-                                        throw new AssertionError("ScanningRecipe.getScanner() may not edit source files. " +
-                                                                 "The purpose of a scanner is to aggregate information for use in subsequent phases. " +
-                                                                 "Use ScanningRecipe.getVisitor() for making edits.");
-                                    }
+                                    assert maybeMutated == source || !ctx.getMessage(SCANNING_MUTATION_VALIDATION, false) :
+                                            "Edits made from within ScanningRecipe.getScanner() are discarded. " +
+                                            "The purpose of a scanner is to aggregate information for use in subsequent phases. " +
+                                            "Use ScanningRecipe.getVisitor() for making edits. " +
+                                            "To disable this warning set TypeValidation.immutableScanning to false in your tests.";
                                 }
                                 return source;
                             });

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -20,7 +20,6 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.StringUtils;
-import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.trait.MavenDependency;
 import org.openrewrite.maven.tree.*;
@@ -162,7 +161,7 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                     }
                 });
                 if (acc.usingType) {
-                    return SearchResult.found(document);
+                    return document;
                 }
                 super.visitDocument(document, ctx);
                 return document;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -24,7 +24,6 @@ import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.trait.MavenDependency;
 import org.openrewrite.maven.tree.*;
-import org.openrewrite.semver.LatestRelease;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.xml.tree.Xml;
@@ -165,8 +164,8 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                 if (acc.usingType) {
                     return SearchResult.found(document);
                 }
-
-                return super.visitDocument(document, ctx);
+                super.visitDocument(document, ctx);
+                return document;
             }
 
             @Override

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.openrewrite.ExecutionContext.SCANNING_MUTATION_VALIDATION;
 import static org.openrewrite.internal.StringUtils.trimIndentPreserveCRLF;
 
 @SuppressWarnings("unused")
@@ -298,7 +299,9 @@ public interface RewriteTest extends SourceSpecs {
                 sourceFile = sourceFile.withMarkers(markers);
 
                 // Validate before source
-                nextSpec.validateSource.accept(sourceFile, TypeValidation.before(testMethodSpec, testClassSpec));
+                TypeValidation beforeValidations = TypeValidation.before(testMethodSpec, testClassSpec);
+                nextSpec.validateSource.accept(sourceFile, beforeValidations);
+                ctx.putMessage(SCANNING_MUTATION_VALIDATION, beforeValidations.immutableScanning());
 
                 // Validate that printing the LST yields the same source text
                 // Validate that the LST whitespace do not contain any non-whitespace characters

--- a/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
@@ -118,6 +118,16 @@ public class TypeValidation {
     private boolean immutableExecutionContext = true;
 
     /**
+     * If ScanningRecipe.getScanner() attempts an edit during normal recipe execution it will be silently ignored.
+     * This can be a source of confusion for new recipe authors that don't understand the difference between the
+     * scanning and editing phases of the recipe lifecycle.
+     * This validation raises an error if a scanner attempts an edit. You can disable this validation if your recipe
+     * deliberately attempts an edit during scanning, and you don't care that this edit is ultimately ignored.
+     */
+    @Builder.Default
+    private boolean immutableScanning = true;
+
+    /**
      * Enable all invariant validation checks.
      */
     public static TypeValidation all() {
@@ -128,7 +138,7 @@ public class TypeValidation {
      * Skip all invariant validation checks.
      */
     public static TypeValidation none() {
-        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false, false, false);
+        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false, false, false, false);
     }
 
     static TypeValidation before(RecipeSpec testMethodSpec, RecipeSpec testClassSpec) {

--- a/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.*;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -120,6 +121,55 @@ class RewriteTestTest implements RewriteTest {
             spec -> spec.recipe(new MutateExecutionContext()),
             text("irrelevant")
           ));
+    }
+
+    @Test
+    void rejectScannerEdit() {
+        assertThrows(AssertionError.class, () -> rewriteRun(
+          spec -> spec.recipe(new ScannerEdit()),
+          text("foo")
+        ));
+    }
+
+    @Test
+    void allowScannerEdit() {
+        rewriteRun(
+          spec -> spec
+            .typeValidationOptions(TypeValidation.builder().immutableScanning(false).build())
+            .recipe(new ScannerEdit()),
+          text("foo")
+        );
+    }
+}
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@NullMarked
+class ScannerEdit extends ScanningRecipe<AtomicBoolean> {
+
+    @Override
+    public String getDisplayName() {
+        return "Attempts mutation during getScanner()";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Any changes attempted by a visitor returned from getScanner() should be an error during test execution.";
+    }
+
+    @Override
+    public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+        return new AtomicBoolean();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean acc) {
+        return new PlainTextVisitor<>() {
+            @Override
+            public PlainText visitText(PlainText text, ExecutionContext executionContext) {
+                return text.withText("mutated");
+            }
+        };
     }
 }
 


### PR DESCRIPTION
By design edits during the scanning phase are ignored. This can be a source of confusion for new recipe authors who don't yet fully understand the difference between the scanning and editing phases of the recipe lifecycle.
