### PR TITLE
Assign response from `withTypeParameters` in `SpacesVisitor`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/SpacesVisitor.java
@@ -869,7 +869,7 @@ public class SpacesVisitor<P> extends JavaIsoVisitor<P> {
                 spaceAfter(m.getPadding().getContaining(), style.getAroundOperators().getMethodReferenceDoubleColon())
         );
         if (m.getPadding().getTypeParameters() != null) {
-            m.getPadding().withTypeParameters(spaceBefore(m.getPadding().getTypeParameters(), style.getAroundOperators().getMethodReferenceDoubleColon()));
+            m = m.getPadding().withTypeParameters(spaceBefore(m.getPadding().getTypeParameters(), style.getAroundOperators().getMethodReferenceDoubleColon()));
         } else {
             m = m.getPadding().withReference(
                     spaceBefore(m.getPadding().getReference(), style.getAroundOperators().getMethodReferenceDoubleColon())

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -1046,7 +1046,7 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
 
         // aroundOperatorsBeforeMethodReferenceDoubleColon is defaulted to `false` in IntelliJ's Kotlin formatting.
         if (m.getPadding().getTypeParameters() != null) {
-            m.getPadding().withTypeParameters(spaceBefore(m.getPadding().getTypeParameters(), false, true));
+            m = m.getPadding().withTypeParameters(spaceBefore(m.getPadding().getTypeParameters(), false, true));
         } else {
             m = m.getPadding().withReference(
                     spaceBefore(m.getPadding().getReference(), false)


### PR DESCRIPTION
I have a local recipe that still has some false positives, but already was able to find these two cases where the response to an `@With` annotated method call went unchecked.

- Inspired by https://github.com/openrewrite/rewrite/pull/5160