### PR TITLE
fix: ReplaceConstantWithAnotherConstant not work when use static constant within method

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceConstantWithAnotherConstant.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceConstantWithAnotherConstant.java
@@ -79,7 +79,7 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
         @Override
         public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
             JavaType.Variable fieldType = ident.getFieldType();
-            if (isConstant(fieldType) && !isVariableDeclaration()) {
+            if (isConstant(fieldType)) {
                 return replaceFieldAccess(ident, fieldType);
             }
             return super.visitIdentifier(ident, ctx);
@@ -124,25 +124,6 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
         private boolean isConstant(JavaType.@Nullable Variable varType) {
             return varType != null && TypeUtils.isOfClassType(varType.getOwner(), existingOwningType) &&
                     varType.getName().equals(constantName);
-        }
-
-        private boolean isVariableDeclaration() {
-            Cursor maybeVariable = getCursor().dropParentUntil(is -> is instanceof J.VariableDeclarations || is instanceof J.CompilationUnit);
-            if (!(maybeVariable.getValue() instanceof J.VariableDeclarations)) {
-                return false;
-            }
-            JavaType.Variable variableType = ((J.VariableDeclarations) maybeVariable.getValue()).getVariables().get(0).getVariableType();
-            if (variableType == null) {
-                return true;
-            }
-
-            JavaType.FullyQualified ownerFqn = TypeUtils.asFullyQualified(variableType.getOwner());
-            if (ownerFqn == null) {
-                return true;
-            }
-
-            return constantName.equals(((J.VariableDeclarations) maybeVariable.getValue()).getVariables().get(0).getSimpleName()) &&
-                    existingOwningType.equals(ownerFqn.getFullyQualifiedName());
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
- Fix https://github.com/openrewrite/rewrite/issues/5174

## What's changed?
<!-- A brief description of the changes in this pull request -->
Remove redundant `isVariableDeclaration`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix https://github.com/openrewrite/rewrite/issues/5174

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
