### PR TITLE
Fixing parsing of empty enums with no semicolon

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -459,7 +459,9 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                     EMPTY
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
-            if (positionOfNext(";", null) >= 0) {
+            int nextSemicolonPosition = positionOfNext(";", null);
+            int nextClosingBracePosition = positionOfNext("}", null);
+            if (nextSemicolonPosition >= 0 && nextSemicolonPosition < nextClosingBracePosition) {
                 enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -515,7 +515,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                     EMPTY
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
-            if (positionOfNext(";", null) >= 0) {
+            int nextSemicolonPosition = positionOfNext(";", null);
+            int nextClosingBracePosition = positionOfNext("}", null);
+            if (nextSemicolonPosition >= 0 && nextSemicolonPosition < nextClosingBracePosition) {
                 enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -519,7 +519,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                     EMPTY
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
-            if (positionOfNext(";", null) >= 0) {
+            int nextSemicolonPosition = positionOfNext(";", null);
+            int nextClosingBracePosition = positionOfNext("}", null);
+            if (nextSemicolonPosition >= 0 && nextSemicolonPosition < nextClosingBracePosition) {
                 enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -457,7 +457,9 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                     EMPTY
             );
         } else if (kind.getType() == J.ClassDeclaration.Kind.Type.Enum) {
-            if (positionOfNext(";", null) >= 0) {
+            int nextSemicolonPosition = positionOfNext(";", null);
+            int nextClosingBracePosition = positionOfNext("}", null);
+            if (nextSemicolonPosition >= 0 && nextSemicolonPosition < nextClosingBracePosition) {
                 enumSet = padRight(new J.EnumValueSet(randomId(), sourceBefore(";"), Markers.EMPTY, emptyList(), true), EMPTY);
             }
         }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -373,4 +373,22 @@ class JavaParserTest implements RewriteTest {
         assertThat(JavaParser.filterArtifacts("rewrite-java", classpath))
           .containsOnly(Paths.get("/.m2/repository/org/openrewrite/rewrite-java/8.41.1/rewrite-java-8.41.1.jar"));
     }
+
+    @Test
+    void emptyEnum() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+            package com.helloworld;
+            import java.time.Instant;
+            public class InstallationStatus {
+              public enum InstallationFeatures {}
+              public InstallationStatus create(Instant updateTime) {
+                return null;
+              }
+            }
+            """));
+    }
+
 }


### PR DESCRIPTION
## What's changed?

Fixing parsing of Java enums with no values (and no closing semicolon - as opposed to #5147).

## What's your motivation?

- closes #5186.
