### PR TITLE
`LatestPatch#isValid()` should allow pre-releases

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestIntegration.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestIntegration.java
@@ -29,7 +29,7 @@ public class LatestIntegration extends LatestRelease {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        return VersionComparator.checkVersion(version, getMetadataPattern(), true);
+        return VersionComparator.checkVersion(version, getMetadataPattern(), false);
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestIntegration.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestIntegration.java
@@ -17,9 +17,6 @@ package org.openrewrite.semver;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
-import org.openrewrite.internal.StringUtils;
-
-import java.util.regex.Matcher;
 
 public class LatestIntegration extends LatestRelease {
 
@@ -32,24 +29,7 @@ public class LatestIntegration extends LatestRelease {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        Matcher matcher = VersionComparator.RELEASE_PATTERN.matcher(version);
-        if (!matcher.matches()) {
-            return false;
-        }
-        boolean requireMeta = !StringUtils.isNullOrEmpty(metadataPattern);
-        String versionMeta = matcher.group(6);
-        if (requireMeta) {
-            return versionMeta != null && versionMeta.matches(metadataPattern);
-        } else if (versionMeta == null) {
-            return true;
-        }
-        String lowercaseVersionMeta = versionMeta.toLowerCase();
-        for (String suffix : RELEASE_SUFFIXES) {
-            if (suffix.equals(lowercaseVersionMeta)) {
-                return true;
-            }
-        }
-        return PRE_RELEASE_ENDING.matcher(lowercaseVersionMeta).matches();
+        return VersionComparator.checkVersion(version, getMetadataPattern(), true);
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -34,7 +34,7 @@ public class LatestRelease implements VersionComparator {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        return VersionComparator.checkVersion(version, metadataPattern, false);
+        return VersionComparator.checkVersion(version, metadataPattern, true);
     }
 
     static String normalizeVersion(String version) {
@@ -119,8 +119,8 @@ public class LatestRelease implements VersionComparator {
         Matcher v1Gav = VersionComparator.RELEASE_PATTERN.matcher(nv1);
         Matcher v2Gav = VersionComparator.RELEASE_PATTERN.matcher(nv2);
 
-        v1Gav.matches();
-        v2Gav.matches();
+        v1Gav.find();
+        v2Gav.find();
 
         // Remove the metadata pattern from the normalized versions, this only impacts the comparison when all version
         // parts are the same:

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -17,7 +17,6 @@ package org.openrewrite.semver;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
-import org.openrewrite.internal.StringUtils;
 
 import java.util.regex.Matcher;
 
@@ -29,26 +28,13 @@ public class LatestRelease implements VersionComparator {
         this.metadataPattern = metadataPattern;
     }
 
+    protected @Nullable String getMetadataPattern() {
+        return metadataPattern;
+    }
+
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        Matcher matcher = VersionComparator.RELEASE_PATTERN.matcher(version);
-        if (!matcher.matches() || PRE_RELEASE_ENDING.matcher(version).find()) {
-            return false;
-        }
-        boolean requireMeta = !StringUtils.isNullOrEmpty(metadataPattern);
-        String versionMeta = matcher.group(6);
-        if (requireMeta) {
-            return versionMeta != null && versionMeta.matches(metadataPattern);
-        } else if (versionMeta == null) {
-            return true;
-        }
-        String lowercaseVersionMeta = versionMeta.toLowerCase();
-        for (String suffix : RELEASE_SUFFIXES) {
-            if (suffix.equals(lowercaseVersionMeta)) {
-                return true;
-            }
-        }
-        return false;
+        return VersionComparator.isValid(version, metadataPattern, false);
     }
 
     static String normalizeVersion(String version) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -34,7 +34,7 @@ public class LatestRelease implements VersionComparator {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        return VersionComparator.isValid(version, metadataPattern, false);
+        return VersionComparator.checkVersion(version, metadataPattern, false);
     }
 
     static String normalizeVersion(String version) {

--- a/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
@@ -41,7 +41,7 @@ public class TildeRange extends LatestRelease {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        return super.isValid(currentVersion, version) &&
+        return VersionComparator.isValid(version, getMetadataPattern(), true) &&
                 super.compare(currentVersion, version, upperExclusive) < 0 &&
                 super.compare(currentVersion, version, lower) >= 0;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
@@ -41,7 +41,7 @@ public class TildeRange extends LatestRelease {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        return VersionComparator.isValid(version, getMetadataPattern(), true) &&
+        return VersionComparator.checkVersion(version, getMetadataPattern(), true) &&
                 super.compare(currentVersion, version, upperExclusive) < 0 &&
                 super.compare(currentVersion, version, lower) >= 0;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/TildeRange.java
@@ -41,7 +41,7 @@ public class TildeRange extends LatestRelease {
 
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        return VersionComparator.checkVersion(version, getMetadataPattern(), true) &&
+        return VersionComparator.checkVersion(version, getMetadataPattern(), false) &&
                 super.compare(currentVersion, version, upperExclusive) < 0 &&
                 super.compare(currentVersion, version, lower) >= 0;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -56,7 +56,7 @@ public interface VersionComparator extends Comparator<String> {
                 .filter(v -> !v.equals(currentVersion));
     }
 
-    static boolean isValid(String version, @Nullable String metadataPattern, boolean allowPreRelease) {
+    static boolean checkVersion(String version, @Nullable String metadataPattern, boolean allowPreRelease) {
         Matcher matcher = VersionComparator.RELEASE_PATTERN.matcher(version);
         if (!matcher.matches()) {
             return false;

--- a/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/VersionComparator.java
@@ -56,13 +56,12 @@ public interface VersionComparator extends Comparator<String> {
                 .filter(v -> !v.equals(currentVersion));
     }
 
-    static boolean checkVersion(String version, @Nullable String metadataPattern, boolean allowPreRelease) {
+    static boolean checkVersion(String version, @Nullable String metadataPattern, boolean requireRelease) {
         Matcher matcher = VersionComparator.RELEASE_PATTERN.matcher(version);
         if (!matcher.matches()) {
             return false;
         }
-        boolean matchesPreRelease = PRE_RELEASE_ENDING.matcher(version).find();
-        if (!allowPreRelease && matchesPreRelease) {
+        if (requireRelease && PRE_RELEASE_ENDING.matcher(version).find()) {
             return false;
         }
 
@@ -72,14 +71,16 @@ public interface VersionComparator extends Comparator<String> {
             return versionMeta != null && versionMeta.matches(metadataPattern);
         } else if (versionMeta == null) {
             return true;
-        }
-        String lowercaseVersionMeta = versionMeta.toLowerCase();
-        for (String suffix : RELEASE_SUFFIXES) {
-            if (suffix.equals(lowercaseVersionMeta)) {
-                return true;
+        } else if (requireRelease) {
+            String lowercaseVersionMeta = versionMeta.toLowerCase();
+            for (String suffix : RELEASE_SUFFIXES) {
+                if (suffix.equals(lowercaseVersionMeta)) {
+                    return true;
+                }
             }
+            return false;
         }
-        return matchesPreRelease;
+        return true;
     }
 
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestPatchTest.java
@@ -38,6 +38,7 @@ class LatestPatchTest {
         assertThat(latestPatch.isValid("1.0", "1.0.1")).isTrue();
         assertThat(latestPatch.isValid("1.0.0", "1.1.0")).isFalse();
         assertThat(latestPatch.isValid("1.0.0", "2.0.0")).isFalse();
+        assertThat(latestPatch.isValid("2.0.0.Alpha1", "2.0.0.Beta1")).isTrue();
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/semver/TildeRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/TildeRangeTest.java
@@ -52,6 +52,7 @@ class TildeRangeTest {
         assertThat(tildeRange.isValid("1.0", "1.2.3.RELEASE")).isTrue();
         assertThat(tildeRange.isValid("1.0", "1.2.4")).isTrue();
         assertThat(tildeRange.isValid("1.0", "1.3.0")).isFalse();
+        assertThat(tildeRange.isValid("1.0", "1.2.3.v20130506")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
A pre-release like `2.0.0.Alpha1` should be allowed by the `LatestPatch#isValid()` check. This is only not allowed by `LatestRelease`.

Also, `TildeRange` should accept a version like `1.2.3.v20130506`.