### PR TITLE
Speed-up of `MavenDependencyFailuresTest#unresolvableParent` by declaring central maven repo first

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -88,7 +88,10 @@ class MavenDependencyFailuresTest implements RewriteTest {
           spec -> spec
             .recipe(new UpgradeParentVersion("*", "*", "latest.patch", null, null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
-              .setRepositories(List.of(MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public").knownToExist(true).build())))
+              .setRepositories(List.of(
+                MavenRepository.builder().id("central").uri("https://repo1.maven.org/maven2").knownToExist(true).build(),
+                MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public").knownToExist(true).build()
+              )))
             .recipeExecutionContext(new InMemoryExecutionContext())
             .cycles(1)
             .expectedCyclesThatMakeChanges(1),


### PR DESCRIPTION
## What's changed?

Speeding up the execution of a single unit test case: `MavenDependencyFailuresTest#unresolvableParent` by adding the Maven central repo explicitly as the first one which effectively changes the order of repositories used:

- Before the change the POM resolution first went to the Jenkins repo and then to Maven Central.
- Now it queries Maven Central first, and only then Jenkins.

## What's your motivation?

Speeding up the whole CI suite for this repo.

Specifically:

- This test case has been observed to be one of the slowest in the whole CI suite.
- Not sure if this is in my location and how it works exactly in Github Actions running CI, but the Jenkins CI Maven repo is fairly slow to me. And most of the artefacts queried don't exist there (and thus they result in 404).

## Measurements

Non-scientific on my laptop; running `./gradlew rewrite-maven:test --scan --tests MavenDependencyFailuresTest`:

- before: [2m20s](https://ge.openrewrite.org/s/fite4cplruyxw)
- after: [1m19s](https://ge.openrewrite.org/s/u2h7a5kculolw)