### PR TITLE
Adding migratesTernaryOperator() unit test case to ChangeStaticFieldToMethodTest

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeStaticFieldToMethodTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeStaticFieldToMethodTest.java
@@ -337,4 +337,32 @@ class ChangeStaticFieldToMethodTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4390")
+    void migratesTernaryOperator() {
+        rewriteRun(
+          java(acmeLists),
+          java(
+            """
+              import java.util.Collections;
+
+              class A {
+                  static Object empty() {
+                      return (1 == 1) ? Collections.EMPTY_LIST : new RuntimeException("what universe is this?");
+                  }
+              }
+              """,
+            """
+              import com.acme.Lists;
+
+              class A {
+                  static Object empty() {
+                      return (1 == 1) ? Lists.of() : new RuntimeException("what universe is this?");
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding a unit test case of `migratesTernaryOperator` to `ChangeStaticFieldToMethodTest`.

## What's your motivation?

Incorporate input from #4390.
And since the test passes now, conclude #4390 should be closed.
