### PR TITLE
Ensure a divison is not interpreted as a `SLASHY_STRING` delimiter

### DIFF
--- a/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -27,9 +27,9 @@ class GroovyParserTest implements RewriteTest {
         rewriteRun(
                 groovy(
                         """
-                                def x = (1 / 1) * 2
-                                System.out.println("test")
-                                """
+                        def x = (1 / 1) * 2
+                        System.out.println("test")
+                        """
                 )
         );
     }
@@ -39,9 +39,9 @@ class GroovyParserTest implements RewriteTest {
         rewriteRun(
                 groovy(
                         """
-                                def x = (Integer.parseInt(/3/) / Integer.parseInt(/2/)) * Integer.parseInt(/5/)
-                                System.out.println("test")
-                                """
+                        def x = (Integer.parseInt(/3/) / Integer.parseInt(/2/)) * Integer.parseInt(/5/)
+                        System.out.println("test")
+                        """
                 )
         );
     }

--- a/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -16,19 +16,33 @@
 package org.openrewrite.groovy;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.tree.ParseError;
+import org.openrewrite.test.RewriteTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.groovy.Assertions.groovy;
 
-class GroovyParserTest {
+class GroovyParserTest implements RewriteTest {
 
     @Test
-    void souldNotTreatDivisionAsDelimiter() {
-        assertThat(GroovyParser.builder().build()
-                    .parse(
+    void shouldNotTreatDivisionAsDelimiter() {
+        rewriteRun(
+                groovy(
+                        """
+                                def x = (1 / 1) * 2
+                                System.out.println("test")
+                                """
+                )
+        );
+    }
 
-                            "def x = (1 / 1) * 2 \n" +
-                                    "System.out.println(\"test\")"
-                    ).findFirst().get()).isNotInstanceOf(ParseError.class);
+    @Test
+    void shouldHandleUsingSlashyStringsWithDivision() {
+        rewriteRun(
+                groovy(
+                        """
+                                def x = (Integer.parseInt(/3/) / Integer.parseInt(/2/)) * Integer.parseInt(/5/)
+                                System.out.println("test")
+                                """
+                )
+        );
     }
 }

--- a/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.tree.ParseError;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GroovyParserTest {
+
+    @Test
+    void souldNotTreatDivisionAsDelimiter() {
+        assertThat(GroovyParser.builder().build()
+                    .parse(
+
+                            "def x = (1 / 1) * 2 \n" +
+                                    "System.out.println(\"test\")"
+                    ).findFirst().get()).isNotInstanceOf(ParseError.class);
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/FindBinaryOperationVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/FindBinaryOperationVisitor.java
@@ -18,10 +18,8 @@ package org.openrewrite.groovy;
 import lombok.Getter;
 import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
-import org.codehaus.groovy.ast.stmt.BlockStatement;
-import org.codehaus.groovy.ast.stmt.Statement;
 
-public class FindTokenVisitor extends CodeVisitorSupport {
+public class FindBinaryOperationVisitor extends CodeVisitorSupport {
 
     private final int[] sourceLineNumberOffsets;
     private final int index;
@@ -30,7 +28,7 @@ public class FindTokenVisitor extends CodeVisitorSupport {
     @Getter
     private boolean found = false;
 
-    public FindTokenVisitor(String tokenToFind, int index, int[] sourceLineNumberOffsets) {
+    public FindBinaryOperationVisitor(String tokenToFind, int index, int[] sourceLineNumberOffsets) {
         this.index = index;
         this.tokenToFind = tokenToFind;
         this.sourceLineNumberOffsets = sourceLineNumberOffsets;
@@ -40,22 +38,10 @@ public class FindTokenVisitor extends CodeVisitorSupport {
     public void visitBinaryExpression(BinaryExpression be) {
         if (toSourceIndex(be.getRightExpression().getLineNumber(), be.getRightExpression().getColumnNumber()) <= index) {
             be.getRightExpression().visit(this);
-        }
-        else if (toSourceIndex(be.getLeftExpression().getLastLineNumber(), be.getLeftExpression().getLastColumnNumber()) > index) {
+        } else if (toSourceIndex(be.getLeftExpression().getLastLineNumber(), be.getLeftExpression().getLastColumnNumber()) > index) {
             be.getLeftExpression().visit(this);
-        } else if (tokenToFind.equals(be.getOperation().getText())){
+        } else if (tokenToFind.equals(be.getOperation().getText())) {
             found = true;
-        }
-    }
-
-    @Override
-    public void visitBlockStatement(BlockStatement block) {
-        for (Statement statement : block.getStatements()) {
-            int start = toSourceIndex(statement.getLineNumber(), statement.getColumnNumber());
-            int end = toSourceIndex(statement.getLastLineNumber(), statement.getLastColumnNumber());
-            if (start >= index && end < index) {
-                statement.visit(this);
-            }
         }
     }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/FindTokenVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/FindTokenVisitor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import lombok.Getter;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+
+public class FindTokenVisitor extends CodeVisitorSupport {
+
+    private final int[] sourceLineNumberOffsets;
+    private final int index;
+    private final String tokenToFind;
+
+    @Getter
+    private boolean found = false;
+
+    public FindTokenVisitor(String tokenToFind, int index, int[] sourceLineNumberOffsets) {
+        this.index = index;
+        this.tokenToFind = tokenToFind;
+        this.sourceLineNumberOffsets = sourceLineNumberOffsets;
+    }
+
+    @Override
+    public void visitBinaryExpression(BinaryExpression be) {
+        if (toSourceIndex(be.getRightExpression().getLineNumber(), be.getRightExpression().getColumnNumber()) <= index) {
+            be.getRightExpression().visit(this);
+        }
+        else if (toSourceIndex(be.getLeftExpression().getLastLineNumber(), be.getLeftExpression().getLastColumnNumber()) > index) {
+            be.getLeftExpression().visit(this);
+        } else if (tokenToFind.equals(be.getOperation().getText())){
+            found = true;
+        }
+    }
+
+    @Override
+    public void visitBlockStatement(BlockStatement block) {
+        for (Statement statement : block.getStatements()) {
+            int start = toSourceIndex(statement.getLineNumber(), statement.getColumnNumber());
+            int end = toSourceIndex(statement.getLastLineNumber(), statement.getLastColumnNumber());
+            if (start >= index && end < index) {
+                statement.visit(this);
+            }
+        }
+    }
+
+    private int toSourceIndex(int lineNumber, int columnNumber) {
+        return sourceLineNumberOffsets[lineNumber - 1] + columnNumber - 1;
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1683,7 +1683,7 @@ public class GroovyParserVisitor {
                 MethodNode methodNode = (MethodNode) call.getNodeMetaData().get(StaticTypesMarker.DIRECT_METHOD_CALL_TARGET);
                 JavaType.Method methodType = null;
                 if (methodNode == null && call.getObjectExpression() instanceof VariableExpression &&
-                    ((VariableExpression) call.getObjectExpression()).getAccessedVariable() != null) {
+                        ((VariableExpression) call.getObjectExpression()).getAccessedVariable() != null) {
                     // Groovy doesn't know what kind of object this method is being invoked on
                     // But if this invocation is inside a Closure we may have already enriched its parameters with types from the static type checker
                     // Use any such type information to attempt to find a matching method
@@ -2563,7 +2563,7 @@ public class GroovyParserVisitor {
     }
 
     private boolean validateIsDelimiter(ASTNode node, int c) {
-        FindTokenVisitor visitor = new FindTokenVisitor(source.substring(c, c+1), c, sourceLineNumberOffsets);
+        FindBinaryOperationVisitor visitor = new FindBinaryOperationVisitor(source.substring(c, c + 1), c, sourceLineNumberOffsets);
         node.visit(visitor);
         return !visitor.isFound();
     }
@@ -2837,7 +2837,7 @@ public class GroovyParserVisitor {
             start--;
         }
 
-        int startX = indexOfNextNonWhitespace( equalsIndex + 1, str);
+        int startX = indexOfNextNonWhitespace(equalsIndex + 1, str);
         int endX = startX;
         Delimiter delim = getDelimiter(expression, endX);
         if (delim != null) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added validation which, if a slash is found when determining parenthesis level, will traverse the node to find whether it is actually a division operator.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- #5072 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Whether this is a valid solution, and if so, is narrowing down the traversal based on source offsets of each expression (like in `FindTokenVisitor.visitBinaryExpression`) necessary.

Also added some Groovy 2 tests to replicate for now, although maybe this would not be preferred as the "JVM Test Suite plugin is an [incubating](https://docs.gradle.org/current/userguide/feature_lifecycle.html#sec:incubating_state) API".

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
I considered whether we should skip the string parsing altogether and only find delimiters via traversing the node tree somehow, but validating the `SLASHY_STRING` seemed to require less change.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
