### PR TITLE
Add recipe MoveLambdaArgumentParentheses

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/cleanup/MoveLambdaArgumentParentheses.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/cleanup/MoveLambdaArgumentParentheses.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.KotlinTemplate;
+import org.openrewrite.kotlin.KotlinVisitor;
+import org.openrewrite.kotlin.tree.K;
+
+import java.time.Duration;
+import java.util.List;
+
+public class MoveLambdaArgumentParentheses extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Move lambda argument outside of method invocation parentheses";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Move lambda argument outside of method invocation parentheses when they are the only argument. " +
+               "For example, converts `1.let({ it + 1 })` to `1.let { it + 1 }`.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new KotlinVisitor<ExecutionContext>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                // Check if this is a method call has a single lambda argument
+                List<Expression> arguments = method.getArguments();
+                if (method.getArguments().size() == 1 && arguments.get(0) instanceof J.Lambda) {
+                    K.Lambda arg = ((K.Lambda) arguments.get(0));
+
+                    String select = method.getSelect() == null ? "" : method.getSelect().print(getCursor()) + ".";
+                    String methodName = method.getSimpleName() + " ";
+                    String lambda = arg.print(getCursor());
+
+                    return KotlinTemplate.builder(select + methodName + lambda)
+                            .build()
+                            .apply(getCursor(), method.getCoordinates().replace())
+                            .withPrefix(method.getPrefix());
+
+                }
+
+                return method;
+
+            }
+        };
+    }
+
+}

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/cleanup/RemoveLambdaArgumentParenthesesTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/cleanup/RemoveLambdaArgumentParenthesesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class RemoveLambdaArgumentParenthesesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MoveLambdaArgumentParentheses())
+                .typeValidationOptions(TypeValidation.none())
+                .expectedCyclesThatMakeChanges(1)
+                .cycles(1);
+    }
+
+    @DocumentExample
+    @Test
+    void removeParenthesesFromLet() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  val foo = 1.let({ it + 1 })
+              }
+              """,
+            """
+              fun method() {
+                  val foo = 1.let { it + 1 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeParenthesesFromFilter() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  val list = listOf(1, 2, 3)
+                  list.filter({ it > 1 })
+              }
+              """,
+            """
+              fun method() {
+                  val list = listOf(1, 2, 3)
+                  list.filter { it > 1 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeParenthesesFromRun() {
+        rewriteRun(
+            kotlin(
+            """
+              fun method() {
+                  run({ print("Hello world") })
+              }
+              """,
+            """
+              fun method() {
+                  run { print("Hello world") }
+              }
+              """
+            )
+        );
+    }
+
+    @Test
+    void removeParentheses() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  val list = listOf(1, 2, 3)
+                  list.filterIndexed({ index, value -> index > 1 && value > 1 })
+              }
+              """,
+                """
+              fun method() {
+                  val list = listOf(1, 2, 3)
+                  list.filterIndexed { index, value -> index > 1 && value > 1 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWhenNotLambda() {
+        rewriteRun(
+                spec -> spec.recipe(new MoveLambdaArgumentParentheses())
+                        .expectedCyclesThatMakeChanges(0),
+            kotlin(
+            """
+              fun method() {
+                  val list = listOf(1, 2, 3)
+                  list.filter(::isEven)
+              }
+              """
+            ),
+            kotlin(
+            """
+              fun method() {
+                  run(::print)
+              }
+              """
+            )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
- Add kotlin recipe in rewrite-kotlin module.
- The new recipe to Move lambda argument outside of method invocation parenthesis when they are the only argument

### Example 
#### Before 
```kotlin
val foo = 1.let({ it + 1 })
```
#### After
```kotlin
val foo = 1.let { it + 1 }
```

## What's your motivation?
- The original idea coming from [#544](https://github.com/openrewrite/rewrite-kotlin/issues/544). 

## Anyone you would like to review specifically?
@shauvik and anyone.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
