### PR TITLE
`FindMissingTypes`: New option to check references in Javadoc

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateInstanceOfTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateInstanceOfTest.java
@@ -531,7 +531,7 @@ class JavaTemplateInstanceOfTest implements RewriteTest {
 
     @SuppressWarnings("SuspiciousMethodCalls")
     static void assertTypeAttribution(J sf) {
-        List<FindMissingTypes.MissingTypeResult> missingTypes = FindMissingTypes.findMissingTypes(sf);
+        List<FindMissingTypes.MissingTypeResult> missingTypes = FindMissingTypes.findMissingTypes(sf, false);
         Map<J, Cursor> expectedMissing = new LinkedHashMap<>();
         Map<J, Cursor> actualMissing = new LinkedHashMap<>();
         new JavaIsoVisitor<Integer>() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -96,7 +96,7 @@ public class Assertions {
     private static void assertValidTypes(TypeValidation typeValidation, J sf) {
         if (typeValidation.identifiers() || typeValidation.methodInvocations() || typeValidation.methodDeclarations() || typeValidation.classDeclarations() ||
             typeValidation.constructorInvocations()) {
-            List<FindMissingTypes.MissingTypeResult> missingTypeResults = FindMissingTypes.findMissingTypes(sf);
+            List<FindMissingTypes.MissingTypeResult> missingTypeResults = FindMissingTypes.findMissingTypes(sf, true);
             missingTypeResults = missingTypeResults.stream()
                     .filter(missingType -> {
                         if (missingType.getJ() instanceof J.Identifier) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/NoMissingTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/NoMissingTypes.java
@@ -33,7 +33,7 @@ public class NoMissingTypes extends JavaVisitor<ExecutionContext> {
     @Override
     public J visit(@Nullable Tree tree, ExecutionContext ctx) {
         if (tree instanceof JavaSourceFile) {
-            JavaSourceFile cu = (JavaSourceFile) new FindMissingTypes().getVisitor().visitNonNull(tree, ctx);
+            JavaSourceFile cu = (JavaSourceFile) new FindMissingTypes(false).getVisitor().visitNonNull(tree, ctx);
             if (tree == cu) {
                 return SearchResult.found(cu, "All AST elements have type information");
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
@@ -60,8 +60,8 @@ public class FindMissingTypes extends Recipe {
         return new FindMissingTypesVisitor(checkDocumentation);
     }
 
-    public static List<MissingTypeResult> findMissingTypes(J j) {
-        J j1 = new FindMissingTypesVisitor(false).visit(j, new InMemoryExecutionContext());
+    public static List<MissingTypeResult> findMissingTypes(J j, boolean checkDocumentation) {
+        J j1 = new FindMissingTypesVisitor(checkDocumentation).visit(j, new InMemoryExecutionContext());
         List<MissingTypeResult> results = new ArrayList<>();
         if (j1 != j) {
             new JavaIsoVisitor<List<MissingTypeResult>>() {


### PR DESCRIPTION
Up until now references in Javadoc have always been checked and reported by this recipe. Now this check is optional.