### PR TITLE
rewrite-xml not to depend on rewrite-maven

### DIFF
--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation("org.apache.commons:commons-text:1.11.+")
 
     testImplementation(project(":rewrite-test"))
-    testImplementation(project(":rewrite-maven"))
 }
 
 //Javadoc compiler will complain about the use of the internal types.

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/AddCommentToXmlTagTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/AddCommentToXmlTagTest.java
@@ -19,7 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.xml.Assertions.xml;
+
 
 class AddCommentToXmlTagTest implements RewriteTest {
 
@@ -33,7 +34,7 @@ class AddCommentToXmlTagTest implements RewriteTest {
               " Comment text "
             )
           ),
-          pomXml(
+          xml(
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## What's changed?

Removing the dependency of `rewrite-xml` on `rewrite-maven`.

## What's your motivation?

To speed up the CI builds in this project.
`rewrite-xml` happened to be one of the modules I saw being built in what seemed an unrelated PR:
<img width="1517" alt="image" src="https://github.com/user-attachments/assets/1af58586-5250-4c31-bb04-689a7ad22bcb" />
It turned out `rewrite-xml` depends on `rewrite-maven` for no strong reason, so I thought we could remove the dependency. And for the context `rewrite-maven` depends on `rewrite-core`, `rewrite-java` and more. Thus it's likely to be built in most of the PRs.
