### PR TITLE
AddDependency recipe: Support only non-dependencies in Gradle's dependency block

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/InsertDependencyComparator.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/InsertDependencyComparator.java
@@ -16,56 +16,66 @@
 package org.openrewrite.gradle.internal;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class InsertDependencyComparator implements Comparator<Statement> {
     private final Map<Statement, Float> positions = new LinkedHashMap<>();
 
     @Getter
+    @Nullable
     private Statement afterDependency;
 
     @Getter
+    @Nullable
     private Statement beforeDependency;
 
-    public InsertDependencyComparator(List<Statement> existingStatements, J.MethodInvocation dependencyToAdd) {
-        for (int i = 0, len = existingStatements.size(); i < len; i++) {
-            positions.put(existingStatements.get(i), (float) i);
+    public InsertDependencyComparator(List<Statement> statements, J.MethodInvocation dependencyToAdd) {
+        for (int i = 0, len = statements.size(); i < len; i++) {
+            positions.put(statements.get(i), (float) i);
         }
 
-        List<Statement> ideallySortedDependencies = existingStatements.stream()
-                .filter(s -> s instanceof J.MethodInvocation || (s instanceof J.Return && ((J.Return) s).getExpression() instanceof J.MethodInvocation))
-                .collect(Collectors.toList());
+        // Make a copy of statements with only dependencies
+        List<Statement> dependencies = new ArrayList<>(statements.size() + 1);
+        for (Statement s : statements) {
+            if (s instanceof J.MethodInvocation || (s instanceof J.Return && ((J.Return) s).getExpression() instanceof J.MethodInvocation)) {
+                dependencies.add(s);
+            }
+        }
 
-        ideallySortedDependencies.add(dependencyToAdd);
-        ideallySortedDependencies.sort(dependenciesComparator);
+        if (dependencies.isEmpty()) {
+            positions.put(dependencyToAdd, statements.size() + 0.5f);
+            return;
+        }
 
-        for (int i = 0, len = ideallySortedDependencies.size(); i < len; i++) {
-            Statement d = ideallySortedDependencies.get(i);
-            if (dependencyToAdd == d) {
+        // Fill `afterDependency` and `beforeDependency`
+        dependencies.add(dependencyToAdd);
+        dependencies.sort(dependenciesComparator);
+        for (int i = 0, len = dependencies.size(); i < len; i++) {
+            if (dependencyToAdd == dependencies.get(i)) {
                 if (i > 0) {
-                    afterDependency = ideallySortedDependencies.get(i - 1);
+                    afterDependency = dependencies.get(i - 1);
                 }
-                if (i + 1 < ideallySortedDependencies.size()) {
-                    beforeDependency = ideallySortedDependencies.get(i + 1);
+                if (i + 1 < dependencies.size()) {
+                    beforeDependency = dependencies.get(i + 1);
                 }
                 break;
             }
         }
 
-        float insertPos = afterDependency == null ? -0.5f : 0.5f;
-        List<Statement> statements = new ArrayList<>(positions.keySet());
-        for (float f = afterDependency == null ? 0 : positions.get(afterDependency); f < statements.size(); f++) {
+        // Put `dependencyToAdd` at the proper place in the positions map
+        boolean isFirst = afterDependency == null;
+        for (float f = isFirst ? 0 : positions.get(afterDependency); f < statements.size(); f++) {
             Statement s = statements.get((int) f);
             if (!(s instanceof J.MethodInvocation || (s instanceof J.Return && ((J.Return) s).getExpression() instanceof J.MethodInvocation))) {
                 continue;
             }
-            positions.put(dependencyToAdd, positions.get(statements.get((int) f)) + insertPos);
+            positions.put(dependencyToAdd, positions.get(s) + (isFirst ? -0.5f : 0.5f));
             break;
         }
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -1578,6 +1578,51 @@ class AddDependencyTest implements RewriteTest {
                     """.formatted(gradleConfiguration)
                 )));
         }
+
+        @Test
+        void onlyNonDependenciesInDirectDependencyBlock() {
+            rewriteRun(
+              spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre")),
+              mavenProject("project",
+                srcMainJava(
+                  java(usingGuavaIntMath)
+                ),
+                buildGradle(
+                  """
+                    plugins {
+                        id "java-library"
+                    }
+                    
+                    repositories {
+                        mavenCentral()
+                    }
+                    
+                    dependencies {
+                        if (project.hasProperty('x')) {
+                            implementation "commons-lang:commons-lang:1.0"
+                        }
+                    }
+                    """,
+                  """
+                    plugins {
+                        id "java-library"
+                    }
+                    
+                    repositories {
+                        mavenCentral()
+                    }
+                    
+                    dependencies {
+                        if (project.hasProperty('x')) {
+                            implementation "commons-lang:commons-lang:1.0"
+                        }
+                        implementation "com.google.guava:guava:29.0-jre"
+                    }
+                    """
+                )
+              )
+            );
+        }
     }
 
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/InsertDependencyComparator.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/InsertDependencyComparator.java
@@ -20,7 +20,6 @@ import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class InsertDependencyComparator implements Comparator<Content> {
     private final Map<Content, Float> positions = new LinkedHashMap<>();
@@ -30,42 +29,48 @@ public class InsertDependencyComparator implements Comparator<Content> {
             positions.put(existingDependencies.get(i), (float) i);
         }
 
-        // if everything were ideally sorted, which dependency would the addable dependency
-        // come after?
-        List<Xml.Tag> ideallySortedDependencies = existingDependencies.stream()
-                .filter(c -> c instanceof Xml.Tag)
-                .map(c -> (Xml.Tag) c)
-                .collect(Collectors.toList());
+        // Make a copy of statements with only dependencies
+        List<Xml.Tag> dependencies = new ArrayList<>();
+        for (Content c : existingDependencies) {
+            if (c instanceof Xml.Tag) {
+                dependencies.add((Xml.Tag) c);
+            }
+        }
 
-        ideallySortedDependencies.add(dependencyTag);
-        ideallySortedDependencies.sort(dependencyComparator);
+        if (dependencies.isEmpty()) {
+            positions.put(dependencyTag, existingDependencies.size() + 0.5f);
+            return;
+        }
+
+        dependencies.add(dependencyTag);
+        dependencies.sort(dependencyComparator);
 
         Content afterDependency = null;
-        for (int i = 0; i < ideallySortedDependencies.size(); i++) {
-            Content d = ideallySortedDependencies.get(i);
+        for (int i = 0; i < dependencies.size(); i++) {
+            Content d = dependencies.get(i);
             if (dependencyTag == d) {
                 if (i > 0) {
-                    afterDependency = ideallySortedDependencies.get(i - 1);
+                    afterDependency = dependencies.get(i - 1);
                 }
                 break;
             }
         }
 
-        float insertPos = afterDependency == null ? -0.5f : 0.5f;
-        List<? extends Content> contents = new ArrayList<>(positions.keySet());
-        for (float f = afterDependency == null ? 0 : positions.get(afterDependency); f < contents.size(); f++) {
-            if (!(contents.get((int) f) instanceof Xml.Tag)) {
+        // Put `dependencyTag` at the proper place in the positions map
+        boolean isFirst = afterDependency == null;
+        for (float f = isFirst ? 0 : positions.get(afterDependency); f < existingDependencies.size(); f++) {
+            Content content = existingDependencies.get((int) f);
+            if (!(content instanceof Xml.Tag)) {
                 continue;
             }
-            positions.put(dependencyTag, positions.get(contents.get((int) f)) + insertPos);
+            positions.put(dependencyTag, positions.get(content) + (isFirst ? -0.5f : 0.5f));
             break;
         }
     }
 
     @Override
     public int compare(Content o1, Content o2) {
-        Float anotherFloat = positions.get(o2);
-        return anotherFloat == null ? 0 : positions.get(o1).compareTo(anotherFloat);
+        return positions.get(o1).compareTo(positions.get(o2));
     }
 
     private static final Comparator<Xml.Tag> dependencyComparator = (d1, d2) -> {


### PR DESCRIPTION
## What's changed?
The AddDependency recipe does support gradle files with only non-dependencies in its dependency block.

## What's your motivation?
If you have a gradle file that looks for example like this:

```groovy
dependencies {
  if (project.hasProperty('x')) {
    implementation "commons-lang:commons-lang:1.0"
  }
}
```

The recipe would throw an error:

```bash
Caused by: java.lang.NullPointerException: Cannot read field "value" because "anotherFloat" is null
	at java.base/java.lang.Float.compareTo(Float.java:923)
	at org.openrewrite.gradle.internal.InsertDependencyComparator.compare(InsertDependencyComparator.java:85)
	at org.openrewrite.gradle.AddDependencyVisitor$InsertDependencyInOrder.visitMethodInvocation(AddDependencyVisitor.java:282)
```

## Any additional context
For the maven counterpart, this actually has already been addressed in https://github.com/openrewrite/rewrite/pull/3460. As I found this out after I created this PR, I had already written my code. To be honest, I find my code a little bit cleaner (as it fixes the problem instead of working around it with a null-check), I also updated the maven counterpart :innocent:.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
