### PR TITLE
Assume timeSavings=0 when no changes are made

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -23,6 +23,7 @@ import org.openrewrite.jgit.lib.FileMode;
 import org.openrewrite.marker.DeserializationError;
 import org.openrewrite.marker.RecipesThatMadeChanges;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.remote.Remote;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -63,7 +64,7 @@ public class Result {
         this.recipes = recipes;
 
         Duration timeSavings = null;
-        if ((before == after) || (before != null && after != null && before.printAllTrimmed().equals(after.printAllTrimmed()))) {
+        if (isLocalAndHasNoChanges(before, after)) {
             timeSavings = Duration.ZERO;
         } else {
             for (List<Recipe> recipesStack : recipes) {
@@ -258,5 +259,14 @@ public class Result {
     @Override
     public String toString() {
         return diff();
+    }
+
+    public static boolean isLocalAndHasNoChanges(@Nullable SourceFile before, @Nullable SourceFile after) {
+        return (before == after) ||
+                (before != null && after != null &&
+                        // Remote source files are fetched on `printAll`, let's avoid that cost.
+                        !(before instanceof Remote) &&
+                        !(after instanceof Remote) &&
+                        before.printAll().equals(after.printAll()));
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -265,8 +265,7 @@ public class Result {
         return (before == after) ||
                 (before != null && after != null &&
                         // Remote source files are fetched on `printAll`, let's avoid that cost.
-                        !(before instanceof Remote) &&
-                        !(after instanceof Remote) &&
+                        !(before instanceof Remote) && !(after instanceof Remote) &&
                         before.printAll().equals(after.printAll()));
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -63,12 +63,16 @@ public class Result {
         this.recipes = recipes;
 
         Duration timeSavings = null;
-        for (List<Recipe> recipesStack : recipes) {
-            if (recipesStack != null && !recipesStack.isEmpty()) {
-                Duration perOccurrence = recipesStack.get(recipesStack.size() - 1).getEstimatedEffortPerOccurrence();
-                if (perOccurrence != null) {
-                    timeSavings = perOccurrence;
-                    break;
+        if ((before == after) || (before != null && after != null && before.printAllTrimmed().equals(after.printAllTrimmed()))) {
+            timeSavings = Duration.ZERO;
+        } else {
+            for (List<Recipe> recipesStack : recipes) {
+                if (recipesStack != null && !recipesStack.isEmpty()) {
+                    Duration perOccurrence = recipesStack.get(recipesStack.size() - 1).getEstimatedEffortPerOccurrence();
+                    if (perOccurrence != null) {
+                        timeSavings = perOccurrence;
+                        break;
+                    }
                 }
             }
         }

--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -63,10 +63,8 @@ public class Result {
         this.after = after;
         this.recipes = recipes;
 
-        Duration timeSavings = null;
-        if (isLocalAndHasNoChanges(before, after)) {
-            timeSavings = Duration.ZERO;
-        } else {
+        Duration timeSavings = Duration.ZERO;
+        if (!isLocalAndHasNoChanges(before, after)) {
             for (List<Recipe> recipesStack : recipes) {
                 if (recipesStack != null && !recipesStack.isEmpty()) {
                     Duration perOccurrence = recipesStack.get(recipesStack.size() - 1).getEstimatedEffortPerOccurrence();
@@ -77,7 +75,6 @@ public class Result {
                 }
             }
         }
-
         this.timeSavings = timeSavings;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -225,7 +225,13 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         String beforePath = (before == null) ? "" : before.getSourcePath().toString();
         String afterPath = (after == null) ? "" : after.getSourcePath().toString();
         Recipe recipe = recipeStack.peek();
-        Long effortSeconds = (recipe.getEstimatedEffortPerOccurrence() == null) ? 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
+        Long effortSeconds;
+        if ((before == after) || (before != null && after != null && before.printAllTrimmed().equals(after.printAllTrimmed()))) {
+            effortSeconds = 0L;
+        } else {
+            effortSeconds = recipe.getEstimatedEffortPerOccurrence() == null ? 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
+        }
+
         String parentName = "";
         boolean hierarchical = recipeStack.size() > 1;
         if (hierarchical) {

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -225,12 +225,8 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         String beforePath = (before == null) ? "" : before.getSourcePath().toString();
         String afterPath = (after == null) ? "" : after.getSourcePath().toString();
         Recipe recipe = recipeStack.peek();
-        Long effortSeconds;
-        if ((before == after) || (before != null && after != null && before.printAllTrimmed().equals(after.printAllTrimmed()))) {
-            effortSeconds = 0L;
-        } else {
-            effortSeconds = recipe.getEstimatedEffortPerOccurrence() == null ? 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
-        }
+        Long effortSeconds = (recipe.getEstimatedEffortPerOccurrence() == null || Result.isLocalAndHasNoChanges(before, after))
+                ? 0L : recipe.getEstimatedEffortPerOccurrence().getSeconds();
 
         String parentName = "";
         boolean hierarchical = recipeStack.size() > 1;


### PR DESCRIPTION
## What's changed?

Making Estimated Time Savings count as 0 for source files which didn't have any change to their text.

## What's your motivation?

To fix the cases of overestimation of the time spent in some cases. E.g. this claims 23 hours saved on a purely mechanical change of 8 files:
<img src='https://github.com/user-attachments/assets/e6f1823a-bdef-4f7b-8881-a8b6397a50bf' width='250px'/>
## Anything in particular you'd like reviewers to focus on?

I couldn't find a better way to exclude the remote source files than this ugly `instanceof Remote`.
