### PR TITLE
fix ReplaceConstantWithAnotherConstant not work when contains import conflict

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceConstantWithAnotherConstant.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceConstantWithAnotherConstant.java
@@ -20,10 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.java.tree.*;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -57,13 +54,17 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
 
         private final String existingOwningType;
         private final String constantName;
+        private final JavaType.FullyQualified existingOwningTypeFqn;
         private final JavaType.FullyQualified newOwningType;
+        private final JavaType.FullyQualified newTargetType;
         private final String newConstantName;
 
         public ReplaceConstantWithAnotherConstantVisitor(String existingFullyQualifiedConstantName, String fullyQualifiedConstantName) {
             this.existingOwningType = existingFullyQualifiedConstantName.substring(0, existingFullyQualifiedConstantName.lastIndexOf('.'));
             this.constantName = existingFullyQualifiedConstantName.substring(existingFullyQualifiedConstantName.lastIndexOf('.') + 1);
+            this.existingOwningTypeFqn = JavaType.ShallowClass.build(existingOwningType);
             this.newOwningType = JavaType.ShallowClass.build(fullyQualifiedConstantName.substring(0, fullyQualifiedConstantName.lastIndexOf('.')));
+            this.newTargetType = JavaType.ShallowClass.build(fullyQualifiedConstantName);
             this.newConstantName = fullyQualifiedConstantName.substring(fullyQualifiedConstantName.lastIndexOf('.') + 1);
         }
 
@@ -71,7 +72,8 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
         public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
             JavaType.Variable fieldType = fieldAccess.getName().getFieldType();
             if (isConstant(fieldType)) {
-                return replaceFieldAccess(fieldAccess, fieldType);
+                JavaSourceFile sf = getCursor().firstEnclosing(JavaSourceFile.class);
+                return replaceFieldAccess(fieldAccess, fieldType, hasNoConflictingImport(sf));
             }
             return super.visitFieldAccess(fieldAccess, ctx);
         }
@@ -80,12 +82,13 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
         public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
             JavaType.Variable fieldType = ident.getFieldType();
             if (isConstant(fieldType)) {
-                return replaceFieldAccess(ident, fieldType);
+                JavaSourceFile sf = getCursor().firstEnclosing(JavaSourceFile.class);
+                return replaceFieldAccess(ident, fieldType, hasNoConflictingImport(sf));
             }
             return super.visitIdentifier(ident, ctx);
         }
 
-        private J replaceFieldAccess(Expression expression, JavaType.Variable fieldType) {
+        private J replaceFieldAccess(Expression expression, JavaType.Variable fieldType, boolean hasNoConflictingImport) {
             JavaType owner = fieldType.getOwner();
             while (owner instanceof JavaType.FullyQualified) {
                 maybeRemoveImport(((JavaType.FullyQualified) owner).getFullyQualifiedName());
@@ -93,23 +96,29 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
             }
 
             if (expression instanceof J.Identifier) {
-                maybeAddImport(newOwningType.getFullyQualifiedName(), newConstantName, false);
+                String realName = hasNoConflictingImport ? newConstantName : newTargetType.getFullyQualifiedName();
+                if (hasNoConflictingImport) {
+                    maybeAddImport(newOwningType.getFullyQualifiedName(), newConstantName, false);
+                }
                 J.Identifier identifier = (J.Identifier) expression;
                 return identifier
-                        .withSimpleName(newConstantName)
-                        .withFieldType(fieldType.withOwner(newOwningType).withName(newConstantName));
+                        .withSimpleName(realName)
+                        .withFieldType(fieldType.withOwner(newOwningType).withName(realName));
             } else if (expression instanceof J.FieldAccess) {
-                maybeAddImport(newOwningType.getFullyQualifiedName(), false);
+                if (hasNoConflictingImport) {
+                    maybeAddImport(newOwningType.getFullyQualifiedName(), false);
+                }
                 J.FieldAccess fieldAccess = (J.FieldAccess) expression;
                 Expression target = fieldAccess.getTarget();
                 J.Identifier name = fieldAccess.getName();
+                String realName = hasNoConflictingImport ? newOwningType.getClassName() : newOwningType.getFullyQualifiedName();
                 if (target instanceof J.Identifier) {
-                    target = ((J.Identifier) target).withType(newOwningType).withSimpleName(newOwningType.getClassName());
+                    target = ((J.Identifier) target).withType(newOwningType).withSimpleName(realName);
                     name = name
                             .withFieldType(fieldType.withOwner(newOwningType).withName(newConstantName))
                             .withSimpleName(newConstantName);
                 } else {
-                    target = (((J.FieldAccess) target).getName()).withType(newOwningType).withSimpleName(newOwningType.getClassName());
+                    target = (((J.FieldAccess) target).getName()).withType(newOwningType).withSimpleName(realName);
                     name = name
                             .withFieldType(fieldType.withOwner(newOwningType).withName(newConstantName))
                             .withSimpleName(newConstantName);
@@ -124,6 +133,36 @@ public class ReplaceConstantWithAnotherConstant extends Recipe {
         private boolean isConstant(JavaType.@Nullable Variable varType) {
             return varType != null && TypeUtils.isOfClassType(varType.getOwner(), existingOwningType) &&
                     varType.getName().equals(constantName);
+        }
+
+        private boolean hasNoConflictingImport(@Nullable JavaSourceFile sf) {
+            return hasNoConflictingImport(sf, newOwningType) && hasNoConflictingImport(sf, newTargetType);
+        }
+
+        private boolean hasNoConflictingImport(@Nullable JavaSourceFile sf, JavaType.FullyQualified targetType) {
+            if (sf == null || targetType == null) {
+                return true;
+            }
+
+            for (J.Import anImport : sf.getImports()) {
+                if (anImport.isStatic()) {
+                    JavaType.FullyQualified fqn = TypeUtils.asFullyQualified(anImport.getQualid().getTarget().getType());
+                    if (anImport.getQualid().getSimpleName().equals(newConstantName) && !TypeUtils.isOfClassType(fqn, newOwningType.getFullyQualifiedName())) {
+                        if (!anImport.getQualid().getSimpleName().equals(constantName) || !TypeUtils.isOfClassType(fqn, existingOwningTypeFqn.getFullyQualifiedName())) {
+                            return false;
+                        }
+                    }
+                } else {
+                    JavaType.FullyQualified currType = TypeUtils.asFullyQualified(anImport.getQualid().getType());
+                    if (currType != null &&
+                            !TypeUtils.isOfType(currType, targetType) &&
+                            currType.getClassName().equals(targetType.getClassName())) {
+                        return false;
+                    }
+                }
+
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->
Fix https://github.com/openrewrite/rewrite/issues/5224

## What's changed?
<!-- A brief description of the changes in this pull request -->
Update `ReplaceConstantWithAnotherConstant` recipe to handle more cases with import conflict.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- Fix https://github.com/openrewrite/rewrite/issues/5224

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
