### PR TITLE
Support properties for RemoveExclusion recipe

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
@@ -94,8 +94,8 @@ public class RemoveExclusion extends Recipe {
                                     e = e.withContent(ListUtils.map(e.getContent(), child2 -> {
                                         if (child2 instanceof Xml.Tag && "exclusion".equals(((Xml.Tag) child2).getName())) {
                                             GroupArtifact exclusion = getResolutionResult().getPom().getValues(groupArtifact((Xml.Tag) child2));
-                                            if (Optional.of(exclusion.getGroupId()).map(g -> matchesGlob(g, exclusionGroupId)).orElse(false) &&
-                                                Optional.of(exclusion.getArtifactId()).map(g -> matchesGlob(g, exclusionArtifactId)).orElse(false) &&
+                                            if (matchesGlob(exclusion.getGroupId(), exclusionGroupId) &&
+                                                matchesGlob(exclusion.getArtifactId(), exclusionArtifactId) &&
                                                 !(isEffectiveExclusion(tag, exclusion) && Boolean.TRUE.equals(onlyIneffective))) {
                                                 return null;
                                             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveExclusion.java
@@ -93,10 +93,10 @@ public class RemoveExclusion extends Recipe {
                                 if (e.getContent() != null) {
                                     e = e.withContent(ListUtils.map(e.getContent(), child2 -> {
                                         if (child2 instanceof Xml.Tag && "exclusion".equals(((Xml.Tag) child2).getName())) {
-                                            Xml.Tag exclusion = (Xml.Tag) child2;
-                                            if (exclusion.getChildValue("groupId").map(g -> matchesGlob(g, exclusionGroupId)).orElse(false) &&
-                                                exclusion.getChildValue("artifactId").map(g -> matchesGlob(g, exclusionArtifactId)).orElse(false) &&
-                                                !(isEffectiveExclusion(tag, groupArtifact(exclusion)) && Boolean.TRUE.equals(onlyIneffective))) {
+                                            GroupArtifact exclusion = getResolutionResult().getPom().getValues(groupArtifact((Xml.Tag) child2));
+                                            if (Optional.of(exclusion.getGroupId()).map(g -> matchesGlob(g, exclusionGroupId)).orElse(false) &&
+                                                Optional.of(exclusion.getArtifactId()).map(g -> matchesGlob(g, exclusionArtifactId)).orElse(false) &&
+                                                !(isEffectiveExclusion(tag, exclusion) && Boolean.TRUE.equals(onlyIneffective))) {
                                                 return null;
                                             }
                                         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindDependency.java
@@ -110,7 +110,7 @@ public class FindDependency extends Recipe {
     }
 
     private static boolean versionIsValid(@Nullable String desiredVersion, @Nullable String versionPattern,
-                                          Supplier<ResolvedDependency> resolvedDependencySupplier) {
+                                          Supplier<@Nullable ResolvedDependency> resolvedDependencySupplier) {
         if (desiredVersion == null) {
             return true;
         }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveExclusionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveExclusionTest.java
@@ -589,4 +589,60 @@ class RemoveExclusionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void removeUnusedExclusionsWithProperties() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava</artifactId>
+                  <version>29.0-jre</version>
+                  <exclusionGroupId>commons-lang</exclusionGroupId>
+                  <exclusionArtifactId>commons-lang</exclusionArtifactId>
+                </properties>
+                <dependencies>
+                  <dependency>
+                    <groupId>${groupId}</groupId>
+                    <artifactId>${artifactId}</artifactId>
+                    <version>${version}</version>
+                    <exclusions>
+                      <exclusion>
+                        <groupId>${exclusionGroupId}</groupId>
+                        <artifactId>${exclusionArtifactId}</artifactId>
+                      </exclusion>
+                    </exclusions>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <properties>
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava</artifactId>
+                  <version>29.0-jre</version>
+                  <exclusionGroupId>commons-lang</exclusionGroupId>
+                  <exclusionArtifactId>commons-lang</exclusionArtifactId>
+                </properties>
+                <dependencies>
+                  <dependency>
+                    <groupId>${groupId}</groupId>
+                    <artifactId>${artifactId}</artifactId>
+                    <version>${version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindDependencyTest.java
@@ -251,4 +251,54 @@ class FindDependencyTest implements RewriteTest {
           ,sourceSpecs -> sourceSpecs.path("sample-module/pom.xml"))
         );
     }
+
+    @Test
+    void withProperties() {
+        rewriteRun(spec -> spec.recipe(new FindDependency("jakarta.activation", "jakarta.activation-api", "2.1.2", null)),
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                <properties>
+                  <groupId>jakarta.activation</groupId>
+                  <artifactId>jakarta.activation-api</artifactId>
+                  <version>2.1.2</version>
+                </properties>
+                <dependencies>
+                  <dependency>
+                    <groupId>${groupId}</groupId>
+                    <artifactId>${artifactId}</artifactId>
+                    <version>${version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+                <properties>
+                  <groupId>jakarta.activation</groupId>
+                  <artifactId>jakarta.activation-api</artifactId>
+                  <version>2.1.2</version>
+                </properties>
+                <dependencies>
+                  <!--~~>--><dependency>
+                    <groupId>${groupId}</groupId>
+                    <artifactId>${artifactId}</artifactId>
+                    <version>${version}</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
If there are properties in the exclusion block, the recipe can still remove the exclusion block if needed.  

## What's your motivation?
Currently pom files with exclusions with properties were ignored by the recipe.

## Any additional context
Also added a properties test for FindDependency recipe to check if the same case applies. The test succeeds without any problems :D.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
