### PR TITLE
Do not accept statuc 408 as server is reached

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -1078,8 +1078,9 @@ public class MavenPomDownloader {
         }
 
         // Any response code below 100 implies that no connection was made. Sometimes 0 or -1 is used for connection failures.
+        // 408 is sometimes used for connection timeouts as well. So we cannot assume that a 408 means the server is reached
         public boolean isServerReached() {
-            return responseCode != null && responseCode >= 100;
+            return responseCode != null && responseCode >= 100 && responseCode != 408;
         }
     }
 


### PR DESCRIPTION
There are systems in play that return 408 in case of a connection timeout. While this is probably wrong it's easy enough (and safe) to not assume 408 means the server is reached.
