### PR TITLE
More efficient recipe loading

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -16,6 +16,7 @@
 package org.openrewrite.config;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Contributor;
 import org.openrewrite.Recipe;
 import org.openrewrite.RecipeException;
@@ -27,16 +28,88 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparingInt;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static org.openrewrite.config.ResourceLoader.RecipeDetail.CONTRIBUTORS;
+import static org.openrewrite.config.ResourceLoader.RecipeDetail.EXAMPLES;
 
 public class Environment {
     private final Collection<? extends ResourceLoader> resourceLoaders;
     private final Collection<? extends ResourceLoader> dependencyResourceLoaders;
+
+    public @Nullable Recipe loadRecipe(String recipeName, ResourceLoader.RecipeDetail... details) {
+        Recipe recipe = null;
+        for (ResourceLoader loader : resourceLoaders) {
+            recipe = loader.loadRecipe(recipeName, details);
+            if (recipe != null) {
+                break;
+            }
+        }
+        if (recipe == null) {
+            return null;
+        }
+
+        boolean includeExamples = ResourceLoader.RecipeDetail.EXAMPLES.includedIn(details);
+        boolean includeContributors = ResourceLoader.RecipeDetail.CONTRIBUTORS.includedIn(details);
+
+        Map<String, List<Contributor>> recipeToContributors = new HashMap<>();
+        Map<String, List<RecipeExample>> recipeExamples = new HashMap<>();
+        if (includeContributors || includeExamples) {
+            for (ResourceLoader r : resourceLoaders) {
+                if (r instanceof YamlResourceLoader) {
+                    if (includeExamples) {
+                        recipeExamples.putAll(r.listRecipeExamples());
+                    }
+                    if (includeContributors) {
+                        recipeToContributors.putAll(r.listContributors());
+                    }
+                }
+            }
+        }
+
+        Map<String, Recipe> dependencyRecipes = new HashMap<>();
+        for (ResourceLoader dependencyResourceLoader : dependencyResourceLoaders) {
+            for (Recipe listedRecipe : dependencyResourceLoader.listRecipes()) {
+                dependencyRecipes.putIfAbsent(listedRecipe.getName(), listedRecipe);
+            }
+        }
+        for (Recipe dependency : dependencyRecipes.values()) {
+            if (dependency instanceof DeclarativeRecipe) {
+                ((DeclarativeRecipe) dependency).initialize(dependencyRecipes::get, recipeToContributors);
+            }
+        }
+
+        if (includeContributors && recipeToContributors.containsKey(recipe.getName())) {
+            recipe.setContributors(recipeToContributors.get(recipe.getName()));
+        }
+
+        if (includeExamples && recipeExamples.containsKey(recipe.getName())) {
+            recipe.setExamples(recipeExamples.get(recipe.getName()));
+        }
+
+        if (recipe instanceof DeclarativeRecipe) {
+            Function<String, @Nullable Recipe> loadFunction = key -> {
+                if (dependencyRecipes.containsKey(key)) {
+                    return dependencyRecipes.get(key);
+                }
+                for (ResourceLoader resourceLoader : resourceLoaders) {
+                    Recipe r = resourceLoader.loadRecipe(key, details);
+                    if (r != null) {
+                        return r;
+                    }
+                }
+                return null;
+            };
+            ((DeclarativeRecipe) recipe).initialize(loadFunction, recipeToContributors);
+        }
+        return recipe;
+    }
 
     public List<Recipe> listRecipes() {
         List<Recipe> dependencyRecipes = new ArrayList<>();
@@ -141,8 +214,27 @@ public class Environment {
         return result;
     }
 
+    @Deprecated
     public Recipe activateRecipes(Iterable<String> activeRecipes) {
-        Map<String, Recipe> recipesByName = listRecipes().stream().collect(toMap(Recipe::getName, identity()));
+        List<String> asList = new ArrayList<>();
+        for (String activeRecipe : activeRecipes) {
+            asList.add(activeRecipe);
+        }
+        return activateRecipes(asList);
+    }
+
+    public Recipe activateRecipes(Collection<String> activeRecipes) {
+        List<Recipe> recipes;
+        if (activeRecipes.isEmpty()) {
+            recipes = emptyList();
+        } else if (activeRecipes.size() == 1) {
+            Recipe recipe = loadRecipe(activeRecipes.iterator().next(), CONTRIBUTORS, EXAMPLES);
+            recipes = recipe == null ? emptyList() : singletonList(recipe);
+        } else {
+            recipes = listRecipes();
+        }
+
+        Map<String, Recipe> recipesByName = recipes.stream().collect(toMap(Recipe::getName, identity()));
         List<String> recipesNotFound = new ArrayList<>();
         List<Recipe> activatedRecipes = new ArrayList<>();
         for (String activeRecipe : activeRecipes) {

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -31,7 +31,6 @@ import java.util.*;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparingInt;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
@@ -161,7 +160,10 @@ public class Environment {
             recipes = emptyList();
         } else if (activeRecipes.size() == 1) {
             Recipe recipe = loadRecipe(activeRecipes.iterator().next(), CONTRIBUTORS, EXAMPLES);
-            recipes = recipe == null ? emptyList() : singletonList(recipe);
+            if (recipe != null) {
+                return recipe;
+            }
+            recipes = listRecipes();
         } else {
             recipes = listRecipes();
         }

--- a/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/ResourceLoader.java
@@ -15,15 +15,42 @@
  */
 package org.openrewrite.config;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Contributor;
 import org.openrewrite.Recipe;
 import org.openrewrite.style.NamedStyles;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public interface ResourceLoader {
+
+    enum RecipeDetail {
+        CONTRIBUTORS,
+        MAINTAINERS,
+        EXAMPLES;
+
+        boolean includedIn(RecipeDetail... include) {
+            for (RecipeDetail detail : include) {
+                if (detail == this) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    default @Nullable Recipe loadRecipe(String recipeName, RecipeDetail... details) {
+        return listRecipes().stream()
+                .filter(r -> r.getName().equals(recipeName))
+                .peek(r -> {
+                    if (!RecipeDetail.CONTRIBUTORS.includedIn(details)) {
+                        r.setContributors(null);
+                    }
+                })
+                .findFirst()
+                .orElse(null);
+    }
+
     Collection<Recipe> listRecipes();
 
     Collection<RecipeDescriptor> listRecipeDescriptors();

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -69,6 +69,7 @@ public class YamlResourceLoader implements ResourceLoader {
 
     @Nullable
     private Map<String, List<RecipeExample>> recipeNameToExamples;
+
     private final RecipeLoader recipeLoader;
 
     @Getter

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -15,14 +15,8 @@
  */
 package org.openrewrite.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import lombok.Getter;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
@@ -48,6 +42,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.RecipeSerializer.maybeAddKotlinModule;
 import static org.openrewrite.Tree.randomId;
@@ -74,6 +69,7 @@ public class YamlResourceLoader implements ResourceLoader {
 
     @Nullable
     private Map<String, List<RecipeExample>> recipeNameToExamples;
+    private final RecipeLoader recipeLoader;
 
     @Getter
     private enum ResourceType {
@@ -165,6 +161,7 @@ public class YamlResourceLoader implements ResourceLoader {
         this.dependencyResourceLoaders = dependencyResourceLoaders;
         this.mapper = ObjectMappers.propertyBasedMapper(classLoader);
         this.classLoader = classLoader;
+        this.recipeLoader = new RecipeLoader(classLoader);
 
         mapperCustomizer.accept(mapper);
         maybeAddKotlinModule(mapper);
@@ -184,21 +181,42 @@ public class YamlResourceLoader implements ResourceLoader {
         }
     }
 
+    private final Map<ResourceType, Collection<Map<String, Object>>> resourceCache = new EnumMap<>(ResourceType.class);
+
     private Collection<Map<String, Object>> loadResources(ResourceType resourceType) {
-        Collection<Map<String, Object>> resources = new ArrayList<>();
-        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-        for (Object resource : yaml.loadAll(yamlSource)) {
-            if (resource instanceof Map) {
-                @SuppressWarnings("unchecked") Map<String, Object> resourceMap = (Map<String, Object>) resource;
-                if (resourceType == ResourceType.fromSpec((String) resourceMap.get("type"))) {
-                    resources.add(resourceMap);
+        return resourceCache.computeIfAbsent(resourceType, rt -> {
+            Collection<Map<String, Object>> resources = new ArrayList<>();
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+            for (Object resource : yaml.loadAll(yamlSource)) {
+                if (resource instanceof Map) {
+                    @SuppressWarnings("unchecked") Map<String, Object> resourceMap = (Map<String, Object>) resource;
+                    if (resourceType == ResourceType.fromSpec((String) resourceMap.get("type"))) {
+                        resources.add(resourceMap);
+                    }
                 }
             }
-        }
-        return resources;
+            return resources;
+        });
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+    public @Nullable Recipe loadRecipe(String recipeName, RecipeDetail... details) {
+        Collection<Map<String, Object>> resources = loadResources(ResourceType.Recipe);
+        Map<String, List<Contributor>> contributors = RecipeDetail.CONTRIBUTORS.includedIn(details) ? listContributors() : emptyMap();
+        for (Map<String, Object> recipeResource : resources) {
+            if (!recipeResource.containsKey("name") || !recipeName.equals(recipeResource.get("name"))) {
+                continue;
+            }
+            return mapToRecipe(recipeResource, contributors);
+        }
+        try {
+            return recipeLoader.load(recipeName, null);
+        } catch (IllegalArgumentException | NoClassDefFoundError ignored) {
+            // handled by caller
+        }
+        return null;
+    }
+
     @Override
     public Collection<Recipe> listRecipes() {
         Collection<Map<String, Object>> resources = loadResources(ResourceType.Recipe);
@@ -209,86 +227,93 @@ public class YamlResourceLoader implements ResourceLoader {
                 continue;
             }
 
-            @Language("markdown") String name = (String) r.get("name");
+            DeclarativeRecipe recipe = mapToRecipe(r, contributors);
+            recipes.add(recipe);
+        }
+        return recipes;
+    }
 
-            @Language("markdown")
-            String displayName = (String) r.get("displayName");
-            if (displayName == null) {
-                displayName = name;
-            }
+    @SuppressWarnings("unchecked")
+    private DeclarativeRecipe mapToRecipe(Map<String, Object> yaml, Map<String, List<Contributor>> contributors) {
+        @Language("markdown") String name = (String) yaml.get("name");
 
-            @Language("markdown")
-            String description = (String) r.get("description");
+        @Language("markdown")
+        String displayName = (String) yaml.get("displayName");
+        if (displayName == null) {
+            displayName = name;
+        }
 
-            Set<String> tags = Collections.emptySet();
-            List<String> rawTags = (List<String>) r.get("tags");
-            if (rawTags != null) {
-                tags = new HashSet<>(rawTags);
-            }
+        @Language("markdown")
+        String description = (String) yaml.get("description");
 
-            String estimatedEffortPerOccurrenceStr = (String) r.get("estimatedEffortPerOccurrence");
-            Duration estimatedEffortPerOccurrence = null;
-            if (estimatedEffortPerOccurrenceStr != null) {
-                estimatedEffortPerOccurrence = Duration.parse(estimatedEffortPerOccurrenceStr);
-            }
+        Set<String> tags = Collections.emptySet();
+        List<String> rawTags = (List<String>) yaml.get("tags");
+        if (rawTags != null) {
+            tags = new HashSet<>(rawTags);
+        }
 
-            List<Object> rawMaintainers = (List<Object>) r.getOrDefault("maintainers", emptyList());
-            List<Maintainer> maintainers;
-            if (rawMaintainers.isEmpty()) {
-                maintainers = emptyList();
-            } else {
-                maintainers = new ArrayList<>(rawMaintainers.size());
-                for (Object rawMaintainer : rawMaintainers) {
-                    if (rawMaintainer instanceof Map) {
-                        Map<String, Object> maintainerMap = (Map<String, Object>) rawMaintainer;
-                        String maintainerName = (String) maintainerMap.get("maintainer");
-                        String logoString = (String) maintainerMap.get("logo");
-                        URI logo = (logoString == null) ? null : URI.create(logoString);
-                        maintainers.add(new Maintainer(maintainerName, logo));
-                    }
+        String estimatedEffortPerOccurrenceStr = (String) yaml.get("estimatedEffortPerOccurrence");
+        Duration estimatedEffortPerOccurrence = null;
+        if (estimatedEffortPerOccurrenceStr != null) {
+            estimatedEffortPerOccurrence = Duration.parse(estimatedEffortPerOccurrenceStr);
+        }
+
+        List<Object> rawMaintainers = (List<Object>) yaml.getOrDefault("maintainers", emptyList());
+        List<Maintainer> maintainers;
+        if (rawMaintainers.isEmpty()) {
+            maintainers = emptyList();
+        } else {
+            maintainers = new ArrayList<>(rawMaintainers.size());
+            for (Object rawMaintainer : rawMaintainers) {
+                if (rawMaintainer instanceof Map) {
+                    Map<String, Object> maintainerMap = (Map<String, Object>) rawMaintainer;
+                    String maintainerName = (String) maintainerMap.get("maintainer");
+                    String logoString = (String) maintainerMap.get("logo");
+                    URI logo = (logoString == null) ? null : URI.create(logoString);
+                    maintainers.add(new Maintainer(maintainerName, logo));
                 }
             }
-            DeclarativeRecipe recipe = new DeclarativeRecipe(
-                    name,
-                    displayName,
-                    description,
-                    tags,
-                    estimatedEffortPerOccurrence,
-                    source,
-                    (boolean) r.getOrDefault("causesAnotherCycle", false),
-                    maintainers);
+        }
+        DeclarativeRecipe recipe = new DeclarativeRecipe(
+                name,
+                displayName,
+                description,
+                tags,
+                estimatedEffortPerOccurrence,
+                source,
+                (boolean) yaml.getOrDefault("causesAnotherCycle", false),
+                maintainers);
 
-            List<Object> recipeList = (List<Object>) r.get("recipeList");
-            if (recipeList == null) {
-                throw new RecipeException("Invalid Recipe [" + name + "] recipeList is null");
-            }
-            for (int i = 0; i < recipeList.size(); i++) {
+        List<Object> recipeList = (List<Object>) yaml.get("recipeList");
+        if (recipeList == null) {
+            throw new RecipeException("Invalid Recipe [" + name + "] recipeList is null");
+        }
+        for (int i = 0; i < recipeList.size(); i++) {
+            loadRecipe(
+                    name,
+                    i,
+                    recipeList.get(i),
+                    recipe::addUninitialized,
+                    recipe::addUninitialized,
+                    recipe::addValidation
+            );
+        }
+        List<Object> preconditions = (List<Object>) yaml.get("preconditions");
+        if (preconditions != null) {
+            for (int i = 0; i < preconditions.size(); i++) {
                 loadRecipe(
                         name,
                         i,
-                        recipeList.get(i),
-                        recipe::addUninitialized,
-                        recipe::addUninitialized,
-                        recipe::addValidation
-                );
+                        preconditions.get(i),
+                        recipe::addUninitializedPrecondition,
+                        recipe::addUninitializedPrecondition,
+                        recipe::addValidation);
             }
-            List<Object> preconditions = (List<Object>) r.get("preconditions");
-            if (preconditions != null) {
-                for (int i = 0; i < preconditions.size(); i++) {
-                    loadRecipe(
-                            name,
-                            i,
-                            preconditions.get(i),
-                            recipe::addUninitializedPrecondition,
-                            recipe::addUninitializedPrecondition,
-                            recipe::addValidation);
-                }
-            }
-            recipe.setContributors(contributors.get(recipe.getName()));
-            recipes.add(recipe);
         }
-
-        return recipes;
+        if (contributors.containsKey(recipe.getName())) {
+            recipe.setContributors(contributors.get(recipe.getName()));
+        }
+        return recipe;
     }
 
     @SuppressWarnings("unchecked")
@@ -300,18 +325,7 @@ public class YamlResourceLoader implements ResourceLoader {
                     Consumer<Validated<Object>> addValidation) {
         if (recipeData instanceof String) {
             String recipeName = (String) recipeData;
-            try {
-                addRecipe.accept(new RecipeLoader(classLoader).load(recipeName, null));
-            } catch (IllegalArgumentException ignored) {
-                // it's probably declarative
-                addLazyLoadRecipe.accept(recipeName);
-            } catch (NoClassDefFoundError e) {
-                addInvalidRecipeValidation(
-                        addValidation,
-                        recipeName,
-                        null,
-                        "Recipe class " + recipeName + " cannot be found");
-            }
+            addLazyLoadRecipe.accept(recipeName);
         } else if (recipeData instanceof Map) {
             Map.Entry<String, Object> nameAndConfig = ((Map<String, Object>) recipeData).entrySet().iterator().next();
             String recipeName = nameAndConfig.getKey();

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -324,7 +324,7 @@ class YamlResourceLoaderTest implements RewriteTest {
 
     @Test
     void loadRecipeWithRecipeDataStringThatThrowsNoClassDefFoundError() {
-        assertRecipeWithRecipeDataThatThrowsNoClassDefFoundError(
+        assertRecipeLazyLoaded(
           RecipeWithBadStaticInitializer.class.getName());
     }
 
@@ -335,6 +335,7 @@ class YamlResourceLoaderTest implements RewriteTest {
     }
 
     private void assertRecipeWithRecipeDataThatThrowsNoClassDefFoundError(Object recipeData) {
+        final List<String> lazyLoadRecipes = new ArrayList<>();
         final List<Validated<Object>> invalidRecipes = new ArrayList<>();
         YamlResourceLoader resourceLoader = createYamlResourceLoader();
 
@@ -342,13 +343,28 @@ class YamlResourceLoaderTest implements RewriteTest {
           "org.company.CustomRecipe",
           0,
           recipeData,
+          lazyLoadRecipes::add,
           recipe -> {
           },
-          recipe -> {
-          },
-          validated -> invalidRecipes.add(validated));
+          invalidRecipes::add);
 
         assertEquals(1, invalidRecipes.size());
+    }
+
+    private void assertRecipeLazyLoaded(Object recipeData) {
+        final List<String> lazyLoadRecipes = new ArrayList<>();
+        YamlResourceLoader resourceLoader = createYamlResourceLoader();
+
+        resourceLoader.loadRecipe(
+          "org.company.CustomRecipe",
+          0,
+          recipeData,
+          lazyLoadRecipes::add,
+          recipe -> {
+          },
+          v -> {});
+
+        assertThat(lazyLoadRecipes).isNotEmpty();
     }
 
     private YamlResourceLoader createYamlResourceLoader() {


### PR DESCRIPTION
Adds a new `ResourceLoader#loadRecipe(String)` method to allow loading a single recipe. This allows the resource loader to only load a specific recipe. The `YamlResourceLoader` caches the parsed YAML so that any referenced recipes can be demand-loaded more quickly. Additional improvements:

* The `loadRecipe()` method allows specifying which "details" should get loaded (maintainers, contributors, and examples)
* Java recipes referenced from YAML are attempted to be loaded using reflection before reverting to the more powerful Jackson `ObjectMapper`