### PR TITLE
Introducing artifactChecksumCache in MavenWrapper

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
@@ -81,7 +81,7 @@ public class MavenWrapper {
     String distributionUri;
     Checksum distributionChecksum;
 
-    private final static Cache<String, Checksum> artifactChecksumCache = Caffeine.newBuilder().maximumSize(20).build();
+    private final static Cache<URI, Checksum> artifactChecksumCache = Caffeine.newBuilder().maximumSize(20).build();
 
     public static MavenWrapper create(
             @Nullable String wrapperVersion,
@@ -153,12 +153,12 @@ public class MavenWrapper {
     }
 
     private static Checksum retrieveChecksumUsingCache(RemoteFile remote, ExecutionContext ctx) {
-        Checksum ret = artifactChecksumCache.getIfPresent(remote.getUri().toString());
+        Checksum ret = artifactChecksumCache.getIfPresent(remote.getUri());
         if (ret != null) {
             return ret;
         }
         ret = Checksum.sha256(remote, ctx).getChecksum();
-        artifactChecksumCache.put(remote.getUri().toString(), ret);
+        artifactChecksumCache.put(remote.getUri(), ret);
         return ret;
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenWrapper.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.maven.utilities;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Checksum;
@@ -23,10 +25,9 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.internal.MavenPomDownloader;
-import org.openrewrite.maven.tree.GroupArtifact;
-import org.openrewrite.maven.tree.MavenMetadata;
-import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.*;
 import org.openrewrite.remote.Remote;
+import org.openrewrite.remote.RemoteFile;
 import org.openrewrite.semver.LatestRelease;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
@@ -37,6 +38,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -78,6 +80,8 @@ public class MavenWrapper {
     String distributionVersion;
     String distributionUri;
     Checksum distributionChecksum;
+
+    private final static Cache<String, Checksum> artifactChecksumCache = Caffeine.newBuilder().maximumSize(20).build();
 
     public static MavenWrapper create(
             @Nullable String wrapperVersion,
@@ -131,25 +135,31 @@ public class MavenWrapper {
                     .orElseThrow(() -> new IllegalStateException("Expected to find at least one Maven distribution version to select from."));
             String resolvedDistributionUri = getDownloadUriFor(repository, distributionGroupArtifact, resolvedDistributionVersion, "bin", "zip");
 
-            Remote wrapperJar = (Remote) Checksum.sha256(
-                    Remote.builder(WRAPPER_JAR_LOCATION).build(URI.create(resolvedWrapperUri)), ctx);
-
-            Remote mavenDistribution = (Remote) Checksum.sha256(Remote.builder(Paths.get(""))
-                    .build(URI.create(resolvedDistributionUri)), ctx);
-
+            Checksum wrapperJarChecksum = retrieveChecksumUsingCache(Remote.builder(WRAPPER_JAR_LOCATION).build(URI.create(resolvedWrapperUri)), ctx);
+            Checksum mavenDistributionChecksum = retrieveChecksumUsingCache(Remote.builder(Paths.get("")).build(URI.create(resolvedDistributionUri)), ctx);
             return new MavenWrapper(
                     resolvedWrapperVersion,
                     resolvedWrapperUri,
-                    requireNonNull(wrapperJar.getChecksum()),
+                    requireNonNull(wrapperJarChecksum),
                     resolvedWrapperDistributionUri,
                     wrapperDistributionType,
                     resolvedDistributionVersion,
                     resolvedDistributionUri,
-                    requireNonNull(mavenDistribution.getChecksum())
+                    requireNonNull(mavenDistributionChecksum)
             );
         } catch (MavenDownloadingException e) {
             throw new RuntimeException("Could not get Maven versions at: " + repository.getUri(), e);
         }
+    }
+
+    private static Checksum retrieveChecksumUsingCache(RemoteFile remote, ExecutionContext ctx) {
+        Checksum ret = artifactChecksumCache.getIfPresent(remote.getUri().toString());
+        if (ret != null) {
+            return ret;
+        }
+        ret = Checksum.sha256(remote, ctx).getChecksum();
+        artifactChecksumCache.put(remote.getUri().toString(), ret);
+        return ret;
     }
 
     public String getWrapperUrl() {


### PR DESCRIPTION
## What's changed?

Adding a cache for artifacts checksums to `MavenWrapper` code.

## What's your motivation?

The initial trigger for this was to speed up the CI builds of this project. In a non-scientific test locally, `UpdateMavenWrapperTest` (which happens to be one of the slowest tests in the whole suite) goes from ~44s to ~11s with this change.

When taking the whole context, I think it will have positive impact on running `UpdateMavenWrapper` recipe on multiple projects at once (or against a project with multiple `pom.xml` files) too.
