### PR TITLE
Fixes the YAML parser issue when unicode characters used.

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -245,8 +245,8 @@ public class YamlParser implements org.openrewrite.Parser {
                             tag = createTag(tagPrefix, Markers.EMPTY, tagName, tagSuffix);
                         }
 
-                        // Decrementing the value by 1 if fmt contains any Unicode character
-                        valueStart -= (int) fmt.codePoints().filter(Character::isSupplementaryCodePoint).count();
+                        // Adjust `valueStart` by subtracting the count of supplementary Unicode characters in `fmt`.
+                        valueStart -= fmt.codePoints().map(c -> Character.isSupplementaryCodePoint(c) ? 1 : 0).sum();
 
                         String scalarValue;
                         switch (scalar.getScalarStyle()) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -245,6 +245,9 @@ public class YamlParser implements org.openrewrite.Parser {
                             tag = createTag(tagPrefix, Markers.EMPTY, tagName, tagSuffix);
                         }
 
+                        // Decrementing the value by 1 if fmt contains any Unicode character
+                        valueStart -= (int) fmt.codePoints().filter(Character::isSupplementaryCodePoint).count();
+
                         String scalarValue;
                         switch (scalar.getScalarStyle()) {
                             case DOUBLE_QUOTED:

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -342,30 +342,30 @@ class YamlParserTest implements RewriteTest {
 
     @Test
     void withUnicodeCharacters() {
-            - name: Elephant
-            - #🦍COMMENT: unicode
-            - action: Do something
+        rewriteRun(
+          yaml(
+            """
+              - name: Elephant
+              - #🦍COMMENT: unicode
+              - action: Do something
+            """)
+        );
+    }
+
+    @Test
     void withUnicodeCharactersInSingleLine() {
-            - name: Elephant
-            - #🦍COMMENT: 🐶unicode
-            - action: Do something
+        rewriteRun(
+          yaml(
+            """
+              - name: Elephant
+              - #🦍COMMENT: 🐶unicode
+              - action: Do something
+            """)
+        );
+    }
+
+    @Test
     void withoutUnicodeCharacters() {
-            - name: Elephant
-            - #COMMENT: unicode
-            - action: Do something
-    void withMultipleUnicodeCharacters() {
-            - name: Rat
-            - #🐀COMMENT: unicode
-            - color: Black
-            - #🦍COMMENT: unicode
-            - action: Escape
-    void withMultipleUnicodeCharactersPerLine() {
-            - name: Rat
-            - #🐀COMMENT: 🦍unicode
-            - color: Black
-            - #🦍COMMENT: 🎱unicode
-            - action: Escape
-    void testWithoutUnicodeCharacters() {
         rewriteRun(
           yaml(
             """
@@ -377,7 +377,7 @@ class YamlParserTest implements RewriteTest {
     }
 
     @Test
-    void testWithMultipleUnicodeCharacters() {
+    void withMultipleUnicodeCharacters() {
         rewriteRun(
           yaml(
             """
@@ -391,7 +391,7 @@ class YamlParserTest implements RewriteTest {
     }
 
     @Test
-    void testWithMultipleUnicodeCharactersPerLine() {
+    void withMultipleUnicodeCharactersPerLine() {
         rewriteRun(
           yaml(
             """

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -395,11 +395,11 @@ class YamlParserTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-              - name: Rat
-              - #🐀COMMENT: 🦍unicode
-              - color: Black
-              - #🦍COMMENT: 🎱unicode
-              - action: Escape
+            - name: Rat
+            - #🐀COMMENT: 🦍unicode
+            - color: Black
+            - #🦍COMMENT: 🎱unicode
+            - action: Escape
             """)
         );
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -357,9 +357,9 @@ class YamlParserTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-              - name: Elephant
-              - #🦍COMMENT: 🐶unicode
-              - action: Do something
+            - name: Elephant
+            - #🦍COMMENT: 🐶unicode
+            - action: Do something
             """)
         );
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -369,9 +369,9 @@ class YamlParserTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-              - name: Elephant
-              - #COMMENT: unicode
-              - action: Do something
+            - name: Elephant
+            - #COMMENT: unicode
+            - action: Do something
             """)
         );
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -341,30 +341,30 @@ class YamlParserTest implements RewriteTest {
     }
 
     @Test
-    void testWithUnicodeCharacters() {
-        rewriteRun(
-          yaml(
-            """
-              - name: Elephant
-              - #🦍COMMENT: unicode
-              - action: Do something
-            """)
-        );
-    }
-
-    @Test
-    void testWithUnicodeCharactersInSingleLine() {
-        rewriteRun(
-          yaml(
-            """
-              - name: Elephant
-              - #🦍COMMENT: 🐶unicode
-              - action: Do something
-            """)
-        );
-    }
-
-    @Test
+    void withUnicodeCharacters() {
+            - name: Elephant
+            - #🦍COMMENT: unicode
+            - action: Do something
+    void withUnicodeCharactersInSingleLine() {
+            - name: Elephant
+            - #🦍COMMENT: 🐶unicode
+            - action: Do something
+    void withoutUnicodeCharacters() {
+            - name: Elephant
+            - #COMMENT: unicode
+            - action: Do something
+    void withMultipleUnicodeCharacters() {
+            - name: Rat
+            - #🐀COMMENT: unicode
+            - color: Black
+            - #🦍COMMENT: unicode
+            - action: Escape
+    void withMultipleUnicodeCharactersPerLine() {
+            - name: Rat
+            - #🐀COMMENT: 🦍unicode
+            - color: Black
+            - #🦍COMMENT: 🎱unicode
+            - action: Escape
     void testWithoutUnicodeCharacters() {
         rewriteRun(
           yaml(

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -381,11 +381,11 @@ class YamlParserTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-              - name: Rat
-              - #🐀COMMENT: unicode
-              - color: Black
-              - #🦍COMMENT: unicode
-              - action: Escape
+            - name: Rat
+            - #🐀COMMENT: unicode
+            - color: Black
+            - #🦍COMMENT: unicode
+            - action: Escape
             """)
         );
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -345,9 +345,9 @@ class YamlParserTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-              - name: Elephant
-              - #🦍COMMENT: unicode
-              - action: Do something
+            - name: Elephant
+            - #🦍COMMENT: unicode
+            - action: Do something
             """)
         );
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -339,4 +339,68 @@ class YamlParserTest implements RewriteTest {
           yaml(yaml)
         );
     }
+
+    @Test
+    void testWithUnicodeCharacters() {
+        rewriteRun(
+          yaml(
+            """
+              - name: Elephant
+              - #🦍COMMENT: unicode
+              - action: Do something
+            """)
+        );
+    }
+
+    @Test
+    void testWithUnicodeCharactersInSingleLine() {
+        rewriteRun(
+          yaml(
+            """
+              - name: Elephant
+              - #🦍COMMENT: 🐶unicode
+              - action: Do something
+            """)
+        );
+    }
+
+    @Test
+    void testWithoutUnicodeCharacters() {
+        rewriteRun(
+          yaml(
+            """
+              - name: Elephant
+              - #COMMENT: unicode
+              - action: Do something
+            """)
+        );
+    }
+
+    @Test
+    void testWithMultipleUnicodeCharacters() {
+        rewriteRun(
+          yaml(
+            """
+              - name: Rat
+              - #🐀COMMENT: unicode
+              - color: Black
+              - #🦍COMMENT: unicode
+              - action: Escape
+            """)
+        );
+    }
+
+    @Test
+    void testWithMultipleUnicodeCharactersPerLine() {
+        rewriteRun(
+          yaml(
+            """
+              - name: Rat
+              - #🐀COMMENT: 🦍unicode
+              - color: Black
+              - #🦍COMMENT: 🎱unicode
+              - action: Escape
+            """)
+        );
+    }
 }


### PR DESCRIPTION
1. Added code to adjust the `valueStart` when it contains unicode chracters.
2. closes #5177 