### PR TITLE
Add missing `asGroupArtifactVersion` to the `ResolvedGroupArtifactVersion`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedGroupArtifactVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedGroupArtifactVersion.java
@@ -49,8 +49,12 @@ public class ResolvedGroupArtifactVersion implements Serializable {
         return new GroupArtifact(groupId, artifactId);
     }
 
+    public GroupArtifactVersion asGroupArtifactVersion() {
+        return new GroupArtifactVersion(groupId, artifactId, version);
+    }
+
     public ResolvedGroupArtifactVersion withGroupArtifact(GroupArtifact ga) {
-        if(Objects.equals(ga.getGroupId(), groupId) && Objects.equals(ga.getArtifactId(), artifactId)) {
+        if (Objects.equals(ga.getGroupId(), groupId) && Objects.equals(ga.getArtifactId(), artifactId)) {
             return this;
         }
         return new ResolvedGroupArtifactVersion(repository, ga.getGroupId(), ga.getArtifactId(), version, datedSnapshotVersion);


### PR DESCRIPTION
## What's changed?
Extra method to go from `ResolvedGroupArtifactVersion` to `GroupArtifactVersion`.

## What's your motivation?
Some methods like MavenPomDownloader.download needs a group artifact version. If your code has a resolved variant, it's nice if you can 'downgrade' it to a gav.
