### PR TITLE
Determine parenthesis level for `ConstructorCallExpression` and `ConstantExpression` when using Groovy 2

### DIFF
--- a/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -49,44 +49,44 @@ class GroovyParserTest implements RewriteTest {
     @Test
     void shouldBeAbleToParseParenthesisedConstructorCallExpressions() {
         rewriteRun(
-            groovy(
-                """
-                (new BigDecimal(10))
-                """
-            )
+                groovy(
+                        """
+                        (new BigDecimal(10))
+                        """
+                )
         );
     }
 
     @Test
     void shouldBeAbleToParseParenthesisedSlashyStringConstantExpressions() {
         rewriteRun(
-            groovy(
-                """
-                ((/test/))
-                """
-            )
+                groovy(
+                        """
+                        ((/test/))
+                        """
+                )
         );
     }
 
     @Test
     void shouldBeAbleToParseParenthesisedQuotedConstantExpressions() {
         rewriteRun(
-            groovy(
-                """
-                (("test"))
-                """
-            )
+                groovy(
+                        """
+                        (("test"))
+                        """
+                )
         );
     }
 
     @Test
     void shouldBeAbleToParseParenthesisedIntegerConstantExpressions() {
         rewriteRun(
-            groovy(
-                """
-                ((100))
-                """
-            )
+                groovy(
+                        """
+                        (100)
+                        """
+                )
         );
     }
 

--- a/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/groovy2Test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -45,4 +45,49 @@ class GroovyParserTest implements RewriteTest {
                 )
         );
     }
+
+    @Test
+    void shouldBeAbleToParseParenthesisedConstructorCallExpressions() {
+        rewriteRun(
+            groovy(
+                """
+                (new BigDecimal(10))
+                """
+            )
+        );
+    }
+
+    @Test
+    void shouldBeAbleToParseParenthesisedSlashyStringConstantExpressions() {
+        rewriteRun(
+            groovy(
+                """
+                ((/test/))
+                """
+            )
+        );
+    }
+
+    @Test
+    void shouldBeAbleToParseParenthesisedQuotedConstantExpressions() {
+        rewriteRun(
+            groovy(
+                """
+                (("test"))
+                """
+            )
+        );
+    }
+
+    @Test
+    void shouldBeAbleToParseParenthesisedIntegerConstantExpressions() {
+        rewriteRun(
+            groovy(
+                """
+                ((100))
+                """
+            )
+        );
+    }
+
 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2459,20 +2459,27 @@ public class GroovyParserVisitor {
         } else if (rawIpl instanceof Integer) {
             // On Java 8 _INSIDE_PARENTHESES_LEVEL is a regular Integer
             return (Integer) rawIpl;
-        } else if (node instanceof MethodCallExpression && !isOlderThanGroovy3()) {
-            // Only for groovy 3+, because lower versions do always return `-1` for objectExpression.lineNumber / objectExpression.columnNumber
-            MethodCallExpression expr = (MethodCallExpression) node;
-            return determineParenthesisLevel(expr, expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
-        } else if (node instanceof BinaryExpression) {
-            BinaryExpression expr = (BinaryExpression) node;
-            return determineParenthesisLevel(expr, expr.getLeftExpression().getLineNumber(), expr.getLineNumber(), expr.getLeftExpression().getColumnNumber(), expr.getColumnNumber());
-        } else if (node instanceof ConstantExpression && isOlderThanGroovy3()) {
-            ConstantExpression expr = (ConstantExpression) node;
-            return determineParenthesisLevel(expr, expr.getLineNumber(), expr.getLastLineNumber(), expr.getColumnNumber(), expr.getLastColumnNumber());
-        } else if (node instanceof ConstructorCallExpression && isOlderThanGroovy3()) {
-            ConstructorCallExpression expr = (ConstructorCallExpression) node;
-            return determineParenthesisLevel(expr, expr.getArguments().getLineNumber(), expr.getLineNumber(), expr.getArguments().getColumnNumber(), expr.getColumnNumber()) - 1;
         }
+
+        if (isOlderThanGroovy3()) {
+            if (node instanceof ConstantExpression) {
+                ConstantExpression expr = (ConstantExpression) node;
+                return determineParenthesisLevel(expr, expr.getLineNumber(), expr.getLastLineNumber(), expr.getColumnNumber(), expr.getLastColumnNumber());
+            } else if (node instanceof ConstructorCallExpression) {
+                ConstructorCallExpression expr = (ConstructorCallExpression) node;
+                return determineParenthesisLevel(expr, expr.getArguments().getLineNumber(), expr.getLineNumber(), expr.getArguments().getColumnNumber(), expr.getColumnNumber()) - 1;
+            } else if (node instanceof BinaryExpression) {
+                BinaryExpression expr = (BinaryExpression) node;
+                return determineParenthesisLevel(expr, expr.getLeftExpression().getLineNumber(), expr.getLineNumber(), expr.getLeftExpression().getColumnNumber(), expr.getColumnNumber());
+            }
+        } else {
+            if (node instanceof MethodCallExpression) {
+                // Only for groovy 3+, because lower versions do always return `-1` for objectExpression.lineNumber / objectExpression.columnNumber
+                MethodCallExpression expr = (MethodCallExpression) node;
+                return determineParenthesisLevel(expr, expr.getObjectExpression().getLineNumber(), expr.getLineNumber(), expr.getObjectExpression().getColumnNumber(), expr.getColumnNumber());
+            }
+        }
+
         return null;
     }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2466,6 +2466,12 @@ public class GroovyParserVisitor {
         } else if (node instanceof BinaryExpression) {
             BinaryExpression expr = (BinaryExpression) node;
             return determineParenthesisLevel(expr, expr.getLeftExpression().getLineNumber(), expr.getLineNumber(), expr.getLeftExpression().getColumnNumber(), expr.getColumnNumber());
+        } else if (node instanceof ConstantExpression && isOlderThanGroovy3()) {
+            ConstantExpression expr = (ConstantExpression) node;
+            return determineParenthesisLevel(expr, expr.getLineNumber(), expr.getLastLineNumber(), expr.getColumnNumber(), expr.getLastColumnNumber());
+        } else if (node instanceof ConstructorCallExpression && isOlderThanGroovy3()) {
+            ConstructorCallExpression expr = (ConstructorCallExpression) node;
+            return determineParenthesisLevel(expr, expr.getArguments().getLineNumber(), expr.getLineNumber(), expr.getArguments().getColumnNumber(), expr.getColumnNumber()) - 1;
         }
         return null;
     }
@@ -2514,7 +2520,7 @@ public class GroovyParserVisitor {
                 if (delimiter == null) {
                     if (source.charAt(i) == '(') {
                         count++;
-                    } else if (source.charAt(i) == ')') {
+                    } else if (source.charAt(i) == ')' && !(node instanceof ConstantExpression)) {
                         count--;
                     }
                 } else {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added logic to determine the parenthesis level for `ConstructorCallExpression`s and `ConstantExpression`s when using Groovy 2.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- #5236 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Not sure if it's the best idea to make use of the `determineParenthesisLevel` method for `ConstantExpression` as I think we just need to count the opening brackets at the start, and we could break early if we find a character that's not an opening bracket.

I've only added this for Groovy 2 since I think `_INSIDE_PARENTHESES_LEVEL` is set on these expressions when using Groovy 3.

I also subtract one from the result of `determineParenthesisLevel` to account for the brackets in `new Class(...)`. Are there any cases this doesn't work?

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
