### PR TITLE
Adopt JSpecify in `EmptyBlockStyle` & `OperatorWrapStyle` without breaking `CheckstyleConfigLoaderTest`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Checkstyle.java
@@ -73,7 +73,7 @@ public class Checkstyle extends NamedStyles {
     public static final EmptyBlockStyle.BlockPolicy defaultBlockPolicy = EmptyBlockStyle.BlockPolicy.TEXT;
 
     public static EmptyBlockStyle emptyBlock() {
-        return new EmptyBlockStyle(defaultBlockPolicy, true, true, true, true,
+        return new EmptyBlockStyle(EmptyBlockStyle.BlockPolicy.TEXT, true, true, true, true,
                 true, true, true, true, true, true, true, true);
     }
 
@@ -118,7 +118,7 @@ public class Checkstyle extends NamedStyles {
     public static final OperatorWrapStyle.WrapOption defaultOperatorWrapStyleOption = OperatorWrapStyle.WrapOption.NL;
 
     public static OperatorWrapStyle operatorWrapStyle() {
-        return new OperatorWrapStyle(defaultOperatorWrapStyleOption, true, true, true, true, true,
+        return new OperatorWrapStyle(OperatorWrapStyle.WrapOption.NL, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true,
                 false, false, false, false, false, false,

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/EmptyBlockStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/EmptyBlockStyle.java
@@ -17,7 +17,7 @@ package org.openrewrite.java.style;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.internal.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.openrewrite.internal.lang.NullFields;
 import org.openrewrite.style.Style;
 import org.openrewrite.style.StyleHelper;

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/OperatorWrapStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/OperatorWrapStyle.java
@@ -17,7 +17,7 @@ package org.openrewrite.java.style;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.internal.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.openrewrite.internal.lang.NullFields;
 import org.openrewrite.style.Style;
 import org.openrewrite.style.StyleHelper;


### PR DESCRIPTION
## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/pull/4820#pullrequestreview-2525657292

## Anything in particular you'd like reviewers to focus on?
Without this change we were getting
```
java.lang.ExceptionInInitializerError
	at org.openrewrite.java.style.CheckstyleConfigLoader.loadCheckstyleConfig(CheckstyleConfigLoader.java:63)
	at org.openrewrite.java.style.CheckstyleConfigLoader.loadCheckstyleConfig(CheckstyleConfigLoader.java:54)
	at org.openrewrite.java.style.CheckstyleConfigLoaderTest.needBraces(CheckstyleConfigLoaderTest.java:245)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.NullPointerException: wrapOption is marked non-null but is null
	at org.openrewrite.java.style.OperatorWrapStyle.<init>(OperatorWrapStyle.java:25)
	at org.openrewrite.java.style.Checkstyle.operatorWrapStyle(Checkstyle.java:125)
	at org.openrewrite.java.style.Checkstyle.<init>(Checkstyle.java:54)
	at org.openrewrite.java.style.Checkstyle.<clinit>(Checkstyle.java:29)
	... 6 more
```

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
Keep as is; or remove fields; but these fields are further referenced elsewhere, so I didn't want to go that route. 

## Any additional context
- https://github.com/openrewrite/rewrite/pull/4415
- https://github.com/openrewrite/rewrite/pull/4820