### PR TITLE
`DataTableStore` so that RewriteRpc does not need to push `ExecutionContext` or `DataTable` over the wire.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/CursorValidatingExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/CursorValidatingExecutionContextView.java
@@ -59,7 +59,6 @@ public class CursorValidatingExecutionContextView extends DelegatingExecutionCon
                 key.equals(PANIC) ||
                 key.equals(ExecutionContext.CURRENT_CYCLE) ||
                 key.equals(ExecutionContext.CURRENT_RECIPE) ||
-                key.equals(ExecutionContext.DATA_TABLES) ||
                 key.equals(WorkingDirectoryExecutionContextView.WORKING_DIRECTORY_ROOT) ||
                 key.equals(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT) ||
                 key.startsWith("org.openrewrite.maven") // MavenExecutionContextView stores metrics

--- a/rewrite-core/src/main/java/org/openrewrite/DataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/DataTableStore.java
@@ -1,0 +1,13 @@
+package org.openrewrite;
+
+public interface DataTableStore {
+    <Row> void insertRow(DataTable<Row> dataTable, ExecutionContext ctx, Row row);
+
+    /**
+     * Enable or disable the acceptance of new rows into the store. This allows, for example,
+     * data table insertions to be disabled during {@link Preconditions} evaluation.
+     *
+     * @param accept Whether to accept new rows.
+     */
+    void acceptRows(boolean accept);
+}

--- a/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ExecutionContext.java
@@ -16,29 +16,21 @@
 package org.openrewrite;
 
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.rpc.RpcCodec;
-import org.openrewrite.rpc.RpcReceiveQueue;
-import org.openrewrite.rpc.RpcSendQueue;
-import org.openrewrite.rpc.request.Visit;
 import org.openrewrite.scheduling.RecipeRunCycle;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.*;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 /**
  * Passes messages between individual visitors or parsing operations and allows errors to be propagated
  * back to the process controlling parsing or recipe execution.
  */
-public interface ExecutionContext extends RpcCodec<ExecutionContext> {
+public interface ExecutionContext {
     String CURRENT_CYCLE = "org.openrewrite.currentCycle";
     String CURRENT_RECIPE = "org.openrewrite.currentRecipe";
-    String DATA_TABLES = "org.openrewrite.dataTables";
+    String DATA_TABLE_STORE = "org.openrewrite.dataTableStore";
     String RUN_TIMEOUT = "org.openrewrite.runTimeout";
     String REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
     String SCANNING_MUTATION_VALIDATION = "org.openrewrite.test.scanningMutationValidation";
@@ -119,67 +111,5 @@ public interface ExecutionContext extends RpcCodec<ExecutionContext> {
 
     default RecipeRunCycle<?> getCycleDetails() {
         return requireNonNull(getMessage(CURRENT_CYCLE));
-    }
-
-    /**
-     * The after state will change if any messages have changed by a call to clone in the
-     * {@link Visit.Handler} implementation.
-     */
-    @Override
-    default void rpcSend(ExecutionContext after, RpcSendQueue q) {
-        // The after state will change if any messages have changed by a call to clone
-        q.getAndSend(after, ctx -> {
-            Map<String, Object> messages = new HashMap<>(ctx.getMessages() == null ?
-                    emptyMap() : ctx.getMessages());
-            // The remote side will manage its own recipe and cycle state.
-            messages.remove(CURRENT_CYCLE);
-            messages.remove(CURRENT_RECIPE);
-            messages.remove(DATA_TABLES);
-            return messages;
-        });
-
-        Map<DataTable<?>, List<?>> dt = after.getMessage(DATA_TABLES);
-        q.getAndSendList(after, sendWholeList(dt == null ? null : dt.keySet()), DataTable::getName, null);
-        if (dt != null) {
-            for (List<?> rowSet : dt.values()) {
-                q.getAndSendList(after, sendWholeList(rowSet),
-                        row -> Integer.toString(System.identityHashCode(row)),
-                        null);
-            }
-
-        }
-    }
-
-    @Override
-    default ExecutionContext rpcReceive(ExecutionContext before, RpcReceiveQueue q) {
-        Map<String, Object> messages = q.receive(before.getMessages());
-        for (Map.Entry<String, Object> e : messages.entrySet()) {
-            before.putMessage(e.getKey(), e.getValue());
-        }
-
-        List<DataTable<?>> dataTables = q.receiveList(emptyList(), null);
-        //noinspection ConstantValue
-        if (dataTables != null) {
-            for (DataTable<?> dataTable : dataTables) {
-                List<?> rows = q.receiveList(emptyList(), null);
-                before.computeMessage(ExecutionContext.DATA_TABLES, rows, ConcurrentHashMap::new, (extract, allDataTables) -> {
-                    //noinspection unchecked
-                    List<Object> dataTablesOfType = (List<Object>) allDataTables.computeIfAbsent(dataTable, c -> new ArrayList<>());
-                    dataTablesOfType.addAll(rows);
-                    return allDataTables;
-                });
-            }
-        }
-        return before;
-    }
-
-    static <T> Function<ExecutionContext, @Nullable List<T>> sendWholeList(@Nullable Collection<T> list) {
-        AtomicBoolean retrievedAfter = new AtomicBoolean(false);
-        return ctx -> {
-            if (!retrievedAfter.getAndSet(true)) {
-                return list == null ? null : new ArrayList<>(list);
-            }
-            return null;
-        };
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class InMemoryExecutionContext implements ExecutionContext, Cloneable {
+public class InMemoryExecutionContext implements ExecutionContext {
     @Nullable
     private Map<String, Object> messages;
 
@@ -89,15 +89,5 @@ public class InMemoryExecutionContext implements ExecutionContext, Cloneable {
     @Override
     public BiConsumer<Throwable, ExecutionContext> getOnTimeout() {
         return onTimeout;
-    }
-
-    @SuppressWarnings("MethodDoesntCallSuperMethod")
-    @Override
-    public InMemoryExecutionContext clone() {
-        InMemoryExecutionContext clone = new InMemoryExecutionContext();
-        clone.messages = new ConcurrentHashMap<>(messages);
-        clone.messages.computeIfPresent(DATA_TABLES, (key, dt) ->
-                new ConcurrentHashMap<>(((Map<?, ?>) dt)));
-        return clone;
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/RecipeRun.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeRun.java
@@ -18,108 +18,15 @@ package org.openrewrite;
 import lombok.Value;
 import lombok.With;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.config.ColumnDescriptor;
-import org.openrewrite.config.DataTableDescriptor;
 
-import java.io.*;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static java.util.Collections.emptyList;
-import static org.openrewrite.internal.RecipeIntrospectionUtils.dataTableDescriptorFromDataTable;
 
 @Value
 public class RecipeRun {
 
     @With
     Changeset changeset;
-
-    @With
-    Map<DataTable<?>, List<?>> dataTables;
-
-    public @Nullable DataTable<?> getDataTable(String name) {
-        for (DataTable<?> dataTable : dataTables.keySet()) {
-            if (dataTable.getName().equals(name)) {
-                return dataTable;
-            }
-        }
-        return null;
-    }
-
-    public <E> @Nullable List<E> getDataTableRows(String name) {
-        for (Map.Entry<DataTable<?>, List<?>> dataTableAndRows : dataTables.entrySet()) {
-            if (dataTableAndRows.getKey().getName().equals(name)) {
-                //noinspection unchecked
-                return (List<E>) dataTableAndRows.getValue();
-            }
-        }
-        return emptyList();
-    }
-
-    public void exportDatatablesToCsv(Path filePath, ExecutionContext ctx) {
-        try {
-            Files.createDirectories(filePath);
-        } catch (IOException e) {
-            ctx.getOnError().accept(e);
-        }
-        for (Map.Entry<DataTable<?>, List<?>> entry : dataTables.entrySet()) {
-            DataTable<?> dataTable = entry.getKey();
-            List<?> rows = entry.getValue();
-            File csv = filePath.resolve(dataTable.getName() + ".csv").toFile();
-            try (PrintWriter printWriter = new PrintWriter(new FileOutputStream(csv, false))) {
-                exportCsv(ctx, dataTable, printWriter::println, rows);
-            } catch (FileNotFoundException e) {
-                ctx.getOnError().accept(e);
-            }
-        }
-    }
-
-    public static void exportCsv(final ExecutionContext ctx, final DataTable<?> dataTable, final Consumer<String> output,
-            final List<?> rows) {
-        DataTableDescriptor descriptor = dataTableDescriptorFromDataTable(dataTable);
-        List<String> fieldNames = new ArrayList<>();
-        List<String> fieldTitles = new ArrayList<>();
-        List<String> fieldDescriptions = new ArrayList<>();
-
-        for (ColumnDescriptor columnDescriptor : descriptor.getColumns()) {
-            fieldNames.add(columnDescriptor.getName());
-            fieldTitles.add(formatForCsv(columnDescriptor.getDisplayName()));
-            fieldDescriptions.add(formatForCsv(columnDescriptor.getDescription()));
-        }
-
-        output.accept(String.join(",", fieldTitles));
-        output.accept(String.join(",", fieldDescriptions));
-        exportRowData(output, rows, fieldNames, ctx);
-    }
-
-    private static void exportRowData(Consumer<String> output, List<?> rows, List<String> fieldNames,
-            ExecutionContext ctx) {
-        for (Object row : rows) {
-            List<String> rowValues = new ArrayList<>();
-            for (String fieldName : fieldNames) {
-                try {
-                    Field field = row.getClass().getDeclaredField(fieldName);
-                    field.setAccessible(true);
-                    rowValues.add(formatForCsv(field.get(row)));
-                } catch (NoSuchFieldException | IllegalAccessException e) {
-                    ctx.getOnError().accept(e);
-                }
-            }
-            output.accept(String.join(",", rowValues));
-        }
-    }
-
-    private static String formatForCsv(@Nullable Object data) {
-        if (data != null) {
-            // Assume every column value is printable with toString
-            return String.format("\"%s\"", data.toString().replace("\"", "\"\""));
-        } else {
-            return "\"\"";
-        }
-    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyMap;
 import static org.openrewrite.Recipe.PANIC;
 import static org.openrewrite.scheduling.WorkingDirectoryExecutionContextView.WORKING_DIRECTORY_ROOT;
 
@@ -39,10 +38,7 @@ public class RecipeScheduler {
                                  int minCycles) {
         try {
             LargeSourceSet after = runRecipeCycles(recipe, sourceSet, ctx, maxCycles, minCycles);
-            return new RecipeRun(
-                    after.getChangeset(),
-                    ctx.getMessage(ExecutionContext.DATA_TABLES, emptyMap())
-            );
+            return new RecipeRun(after.getChangeset());
         } finally {
             Path workingDirectoryRoot = ctx.getMessage(WORKING_DIRECTORY_ROOT);
             if (workingDirectoryRoot != null) {

--- a/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryDataTableStore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/InMemoryDataTableStore.java
@@ -1,0 +1,28 @@
+package org.openrewrite.internal;
+
+import org.openrewrite.DataTable;
+import org.openrewrite.DataTableStore;
+import org.openrewrite.ExecutionContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class InMemoryDataTableStore implements DataTableStore {
+    private final AtomicBoolean acceptRows = new AtomicBoolean(true);
+    private final Map<Object, List<Object>> rows = new ConcurrentHashMap<>();
+
+    @Override
+    public <Row> void insertRow(DataTable<Row> dataTable, ExecutionContext ctx, Row row) {
+        if (acceptRows.get()) {
+            rows.computeIfAbsent(dataTable, k -> new ArrayList<>()).add(row);
+        }
+    }
+
+    @Override
+    public void acceptRows(boolean accept) {
+        acceptRows.set(accept);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -21,14 +21,12 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.internal.InMemoryDataTableStore;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
@@ -107,13 +105,8 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
     }
 
     private void addRowToDataTable(ExecutionContext ctx, Row row) {
-        //noinspection DuplicatedCode
-        ctx.computeMessage(ExecutionContext.DATA_TABLES, row, ConcurrentHashMap::new, (extract, allDataTables) -> {
-            //noinspection unchecked
-            List<Row> dataTablesOfType = (List<Row>) allDataTables.computeIfAbsent(this, c -> new ArrayList<>());
-            dataTablesOfType.add(row);
-            return allDataTables;
-        });
+        ctx.computeMessage(ExecutionContext.DATA_TABLE_STORE, row, InMemoryDataTableStore::new, (extract, dataTableStore) -> dataTableStore)
+                .insertRow(this, ctx, row);
     }
 
     @Value

--- a/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/DataTableTest.java
@@ -94,4 +94,27 @@ class DataTableTest implements RewriteTest {
             }
         }
     }
+
+    @Test
+    void noRowsFromPrecondition() {
+        rewriteRun(
+          spec -> spec
+            .recipe(toRecipe(r -> Preconditions.check(toRecipe(r2 -> new PlainTextVisitor<>() {
+                final WordTable wordTable = new WordTable(r2);
+
+                @Override
+                public PlainText visitText(PlainText text, ExecutionContext ctx) {
+                    int i = 0;
+                    for (String s : text.getText().split(" ")) {
+                        wordTable.insertRow(ctx, new WordTable.Row(i++, s));
+                    }
+                    return text;
+                }
+            }), TreeVisitor.noop())))
+            .afterRecipe(run -> {
+                assertThat(run.getDataTables().keySet()).noneMatch(dt -> dt instanceof WordTable);
+            }),
+          text("hello world")
+        );
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
 import org.openrewrite.config.Environment;
+import org.openrewrite.internal.InMemoryDataTableStore;
 import org.openrewrite.table.TextMatches;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.text.PlainText;
@@ -49,6 +50,7 @@ class RewriteRpcTest implements RewriteTest {
 
     RewriteRpc server;
     RewriteRpc client;
+    DataTableStore dataTableStore = new InMemoryDataTableStore();
 
     @BeforeEach
     void before() throws IOException {
@@ -59,11 +61,13 @@ class RewriteRpcTest implements RewriteTest {
 
         JsonRpc serverJsonRpc = new JsonRpc(new TraceMessageHandler("server",
           new HeaderDelimitedMessageHandler(serverIn, serverOut)));
-        server = new RewriteRpc(serverJsonRpc, env).batchSize(1).timeout(Duration.ofMinutes(10));
+        server = new RewriteRpc(serverJsonRpc, env).batchSize(1).timeout(Duration.ofMinutes(10))
+          .executionContext(ctx -> ctx.putMessage(ExecutionContext.DATA_TABLE_STORE, dataTableStore));
 
         JsonRpc clientJsonRpc = new JsonRpc(new TraceMessageHandler("client",
           new HeaderDelimitedMessageHandler(clientIn, clientOut)));
-        client = new RewriteRpc(clientJsonRpc, env).batchSize(1).timeout(Duration.ofMinutes(10));
+        client = new RewriteRpc(clientJsonRpc, env).batchSize(1).timeout(Duration.ofMinutes(10))
+          .executionContext(ctx -> ctx.putMessage(ExecutionContext.DATA_TABLE_STORE, dataTableStore));
     }
 
     @AfterEach

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -1103,7 +1103,7 @@ class AddDependencyTest implements RewriteTest {
             toRecipe()
               .withDisplayName("Add dependency")
               .withName("Uses AddDependencyVisitor directly to validate that it will not add a dependency multiple times")
-              .withGetVisitor(() -> new AddDependencyVisitor(
+              .withGetVisitor(r -> new AddDependencyVisitor(
                 "com.google.guava",
                 "guava",
                 "29.0-jre",

--- a/rewrite-test/src/main/java/org/openrewrite/test/AdHocRecipe.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/AdHocRecipe.java
@@ -27,6 +27,7 @@ import org.openrewrite.internal.StringUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -50,7 +51,7 @@ public class AdHocRecipe extends Recipe {
 
     @With
     @Nullable
-    transient Supplier<TreeVisitor<?, ExecutionContext>> getVisitor;
+    transient Function<Recipe, TreeVisitor<?, ExecutionContext>> getVisitor;
 
     @With
     @Nullable
@@ -96,6 +97,6 @@ public class AdHocRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return requireNonNull(getVisitor).get();
+        return requireNonNull(getVisitor).apply(this);
     }
 }

--- a/rewrite-test/src/main/java/org/openrewrite/test/AdHocScanningRecipe.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/AdHocScanningRecipe.java
@@ -26,6 +26,7 @@ import org.openrewrite.internal.StringUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 @Value
@@ -45,10 +46,11 @@ public class AdHocScanningRecipe extends ScanningRecipe<Void> {
     Boolean causesAnotherCycle;
 
     @With
-    Supplier<TreeVisitor<?, ExecutionContext>> getVisitor;
-
     @Nullable
+    transient Function<Recipe, TreeVisitor<?, ExecutionContext>> getVisitor;
+
     @With
+    @Nullable
     Supplier<Collection<SourceFile>> generator;
 
     @With
@@ -90,7 +92,7 @@ public class AdHocScanningRecipe extends ScanningRecipe<Void> {
     }
 
     @Override
-    public @Nullable Void getInitialValue(ExecutionContext ctx) {
+    public Void getInitialValue(ExecutionContext ctx) {
         return null;
     }
 
@@ -106,6 +108,9 @@ public class AdHocScanningRecipe extends ScanningRecipe<Void> {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Void acc) {
-        return getVisitor.get();
+        if (getVisitor == null) {
+            return super.getVisitor(acc);
+        }
+        return getVisitor.apply(this);
     }
 }


### PR DESCRIPTION
## What's changed?

`ExecutionContext` should refer to `DataTableStore` rather than directly storing rows on itself in memory. By default, Java-only recipe execution can still use an `InMemoryDataTableStore` that essentially behaves as it does now.

However, this will enable us to inject a different implementation into recipe runs that use `RewriteRpc` so that each process can push rows to a single store without necessarily passing these rows over the wire as control passes between the processes.

This will also ultimately help solve large data table downloading in the SaaS.

`DataTableStore` has an `acceptRows` method on it that can be used by `Preconditions` implementations to essentially shut off the flow of rows into the store by recipes being used as preconditions.

The implementation of https://github.com/openrewrite/rewrite-maven-plugin/pull/751 would have to change accordingly.