### PR TITLE
Parser error on multiline javadoc comment

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -393,4 +393,24 @@ class JavaParserTest implements RewriteTest {
             """));
     }
 
+    @Test
+    void mutliLinePackageComment() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              package com.abc;
+              public class Server {
+                /**
+                 * @see com.abc.Server#load(
+                 * java.lang.
+                 * String)
+                 */
+                public void load(String str) {
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This PR provides a test case to demonstrate a parsing error that occurs on javadoc comments:
```
[When parsing and printing the source code back to text without modifications, the printed source didn't match the original source code. This means there is a bug in the parser implementation itself. Please open an issue to report this, providing a sample of the code that generated this error for "com/abc/Server.java":
diff --git a/com/abc/Server.java b/com/abc/Server.java
index 8023007..29f2d3d 100644
--- a/com/abc/Server.java
+++ b/com/abc/Server.java
@@ -2,8 +2,7 @@ 
 public class Server {
   /**
    * @see com.abc.Server#load(
-   * java.lang.
-   * String)
+   * java.lang.Stringng)
    */
   public void load(String str) {
   }
] 
expected: 
  "package com.abc;
  public class Server {
    /**
     * @see com.abc.Server#load(
     * java.lang.
     * String)
     */
    public void load(String str) {
    }
  }"
 but was: 
  "package com.abc;
  public class Server {
    /**
     * @see com.abc.Server#load(
     * java.lang.Stringng)
     */
    public void load(String str) {
    }
  }"
```


## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
