### PR TITLE
Add Groovy context-free template

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -249,11 +249,12 @@ public class GroovyParser implements Parser {
         /**
          * This is an internal API which is subject to removal or change.
          */
-        public Builder addClasspathEntry(Path classpath) {
-            if (this.classpath.isEmpty()) {
-                this.classpath = Collections.singletonList(classpath);
-            } else {
-                this.classpath.add(classpath);
+        public Builder addClasspathEntry(Path entry) {
+            if (classpath.isEmpty()) {
+                classpath = Collections.singletonList(entry);
+            } else if (!classpath.contains(entry)) {
+                classpath = new ArrayList<>(classpath);
+                classpath.add(entry);
             }
             return this;
         }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParser.java
@@ -246,6 +246,18 @@ public class GroovyParser implements Parser {
             return this;
         }
 
+        /**
+         * This is an internal API which is subject to removal or change.
+         */
+        public Builder addClasspathEntry(Path classpath) {
+            if (this.classpath.isEmpty()) {
+                this.classpath = Collections.singletonList(classpath);
+            } else {
+                this.classpath.add(classpath);
+            }
+            return this;
+        }
+
         @SuppressWarnings("unused")
         public Builder typeCache(JavaTypeCache typeCache) {
             this.typeCache = typeCache;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.kotlin;
+package org.openrewrite.groovy;
 
 import org.openrewrite.Cursor;
+import org.openrewrite.groovy.internal.template.GroovySubstitutions;
+import org.openrewrite.groovy.internal.template.GroovyTemplateParser;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.internal.template.Substitutions;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaCoordinates;
-import org.openrewrite.kotlin.internal.template.KotlinSubstitutions;
-import org.openrewrite.kotlin.internal.template.KotlinTemplateParser;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-public class KotlinTemplate extends JavaTemplate {
-    private KotlinTemplate(boolean contextSensitive, KotlinParser.Builder parser, String code, Set<String> imports, Consumer<String> onAfterVariableSubstitution, Consumer<String> onBeforeParseTemplate) {
+public class GroovyTemplate extends JavaTemplate {
+    private GroovyTemplate(boolean contextSensitive, GroovyParser.Builder parser, String code, Set<String> imports, Consumer<String> onAfterVariableSubstitution, Consumer<String> onBeforeParseTemplate) {
         super(
                 code,
                 onAfterVariableSubstitution,
-                new KotlinTemplateParser(
+                new GroovyTemplateParser(
                         contextSensitive,
                         augmentClasspath(parser),
                         onAfterVariableSubstitution,
@@ -43,13 +43,13 @@ public class KotlinTemplate extends JavaTemplate {
         );
     }
 
-    private static KotlinParser.Builder augmentClasspath(KotlinParser.Builder parserBuilder) {
+    private static GroovyParser.Builder augmentClasspath(GroovyParser.Builder parserBuilder) {
         return parserBuilder.addClasspathEntry(getTemplateClasspathDir());
     }
 
     @Override
     protected Substitutions substitutions(Object[] parameters) {
-        return new KotlinSubstitutions(getCode(), parameters);
+        return new GroovySubstitutions(getCode(), parameters);
     }
 
     public static <J2 extends J> J2 apply(String template, Cursor scope, JavaCoordinates coordinates, Object... parameters) {
@@ -70,7 +70,7 @@ public class KotlinTemplate extends JavaTemplate {
         private final String code;
         private final Set<String> imports = new HashSet<>();
 
-        private KotlinParser.Builder parser = KotlinParser.builder();
+        private GroovyParser.Builder parser = GroovyParser.builder();
 
         private Consumer<String> onAfterVariableSubstitution = s -> {
         };
@@ -106,7 +106,7 @@ public class KotlinTemplate extends JavaTemplate {
             }
         }
 
-        Builder parser(KotlinParser.Builder parser) {
+        Builder parser(GroovyParser.Builder parser) {
             this.parser = parser;
             return this;
         }
@@ -124,8 +124,8 @@ public class KotlinTemplate extends JavaTemplate {
         }
 
         @Override
-        public KotlinTemplate build() {
-            return new KotlinTemplate(false, parser.clone(), code, imports,
+        public GroovyTemplate build() {
+            return new GroovyTemplate(false, parser.clone(), code, imports,
                     onAfterVariableSubstitution, onBeforeParseTemplate);
         }
     }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyBlockStatementTemplateGenerator.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyBlockStatementTemplateGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.internal.template;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.internal.template.BlockStatementTemplateGenerator;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class GroovyBlockStatementTemplateGenerator extends BlockStatementTemplateGenerator {
+    public GroovyBlockStatementTemplateGenerator(Set<String> imports, boolean contextSensitive) {
+        super(imports, contextSensitive);
+    }
+
+    @Override
+    protected void contextFreeTemplate(Cursor cursor, J j, Collection<JavaType.GenericTypeVariable> typeVariables, StringBuilder before, StringBuilder after) {
+        if (j instanceof J.MethodInvocation) {
+            before.insert(0, "class Template {\n");
+            JavaType.Method methodType = ((J.MethodInvocation) j).getMethodType();
+            if (methodType == null || methodType.getReturnType() != JavaType.Primitive.Void) {
+                before.append("Object o = ");
+            }
+            after.append(";\n}");
+        } else if (j instanceof Expression && !(j instanceof J.Assignment)) {
+            before.insert(0, "class Template {\n");
+            before.append("Object o = ");
+            after.append(";\n}");
+        } else if (j instanceof J.ClassDeclaration || j instanceof G.ClassDeclaration) {
+            throw new IllegalArgumentException(
+                    "Templating a class declaration requires context from which package declaration and imports may be reached. " +
+                    "Mark this template as context-sensitive by calling GroovyTemplate.Builder#contextSensitive().");
+        } else if (j instanceof Statement && !(j instanceof J.Import) && !(j instanceof J.Package)) {
+            before.insert(0, "class Template {{\n");
+            after.append("\n}}");
+        } else {
+            throw new IllegalArgumentException(
+                    "Groovy templating is currently only implemented for context-free expressions and statements and not for `" + j.getClass() + "` instances.");
+        }
+
+        before.insert(0, TEMPLATE_INTERNAL_IMPORTS);
+        for (String anImport : imports) {
+            before.insert(0, anImport);
+        }
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovySubstitutions.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovySubstitutions.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.internal.template;
+
+import org.openrewrite.java.internal.template.Substitutions;
+
+public class GroovySubstitutions extends Substitutions {
+    public GroovySubstitutions(String code, Object[] parameters) {
+        super(code, parameters);
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyTemplateParser.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/GroovyTemplateParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.internal.template;
+
+import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.java.internal.template.AnnotationTemplateGenerator;
+import org.openrewrite.java.internal.template.JavaTemplateParser;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class GroovyTemplateParser extends JavaTemplateParser {
+    public GroovyTemplateParser(boolean contextSensitive, GroovyParser.Builder parser, Consumer<String> onAfterVariableSubstitution, Consumer<String> onBeforeParseTemplate, Set<String> imports) {
+        super(
+                parser,
+                onAfterVariableSubstitution,
+                onBeforeParseTemplate,
+                imports,
+                contextSensitive,
+                new GroovyBlockStatementTemplateGenerator(imports, contextSensitive),
+                new AnnotationTemplateGenerator(imports)
+        );
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/package-info.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/internal/template/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+@NonNullFields
+package org.openrewrite.groovy.internal.template;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateMatchTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateMatchTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class GroovyTemplateMatchTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void matchBinary() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new GroovyVisitor<>() {
+              @Override
+              public J visitBinary(J.Binary binary, ExecutionContext ctx) {
+                  return GroovyTemplate.matches("1 == #{any(int)}", getCursor()) ?
+                    SearchResult.found(binary) : super.visitBinary(binary, ctx);
+              }
+          })),
+          groovy(
+            """
+              class Test {
+                  boolean b1 = 1 == 2
+                  def b2 = 1 == 3
+              
+                  boolean b3 = 2 == 1
+                  def b4 = 2 == 2 + 3
+              }
+              """,
+            """
+              class Test {
+                  boolean b1 = /*~~>*/1 == 2
+                  def b2 = /*~~>*/1 == 3
+              
+                  boolean b3 = 2 == 1
+                  def b4 = 2 == 2 + 3
+              }
+              """
+          ));
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class GroovyTemplateTest implements RewriteTest {
+
+    @DocumentExample
+    @Test
+    void replaceContextFreeStatement() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new GroovyVisitor<>() {
+              @Override
+              public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                  return GroovyTemplate.builder("println(\"foo\")")
+                    .build()
+                    .apply(getCursor(), multiVariable.getCoordinates().replace());
+              }
+          })),
+          groovy(
+            """
+              class Test {
+                  def foo() {
+                      boolean b1 = 1 == 2
+                  }
+              }
+              """,
+            """
+              class Test {
+                  def foo() {
+                      println("foo")
+                  }
+              }
+              """
+          ));
+    }
+}

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -314,11 +314,12 @@ public class KotlinParser implements Parser {
         /**
          * This is an internal API which is subject to removal or change.
          */
-        public Builder addClasspathEntry(Path classpath) {
-            if (this.classpath.isEmpty()) {
-                this.classpath = Collections.singletonList(classpath);
-            } else {
-                this.classpath.add(classpath);
+        public Builder addClasspathEntry(Path entry) {
+            if (classpath.isEmpty()) {
+                classpath = Collections.singletonList(entry);
+            } else if (!classpath.contains(entry)) {
+                classpath = new ArrayList<>(classpath);
+                classpath.add(entry);
             }
             return this;
         }


### PR DESCRIPTION
## What's changed?
Adding a context-free template for Groovy.

## What's your motivation?
Learning, mimicking the KotlinTemplate, possible usage for template support (context-free template cache and parameterization) for `G` types with respect to Gradle more specifically

## Anything in particular you'd like reviewers to focus on?
Nothing in particular

## Anyone you would like to review specifically?
@knutwannheden 

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
Started with mimicking the KotlinTemplate in it's current state. I did override the `KotlinTemplate#contextSensitive` method to throw an exception as discussed previously with Knut given Kotlin -- and Groovy via this PR -- only support context-free templates. So requesting a context-sensitive template is an end user error at this time.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
