### PR TITLE
Pinning com.gradle:develocity-gradle-plugin to 3.

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -32,7 +32,8 @@ recipeDependencies {
     parserClasspath("org.gradle:gradle-resources:latest.release")
     parserClasspath("org.gradle:gradle-testing-base:latest.release")
     parserClasspath("org.gradle:gradle-testing-jvm:latest.release")
-    parserClasspath("com.gradle:develocity-gradle-plugin:latest.release")
+    // No particular reason to hold back upgrading this beyond 3.x, but it takes some effort: https://github.com/openrewrite/rewrite/issues/5270
+    parserClasspath("com.gradle:develocity-gradle-plugin:3.+")
 }
 
 //val rewriteVersion = rewriteRecipe.rewriteVersion.get()
@@ -54,7 +55,8 @@ dependencies {
 
     compileOnly("org.codehaus.groovy:groovy:latest.release")
     compileOnly(gradleApi())
-    compileOnly("com.gradle:develocity-gradle-plugin:latest.release")
+    // No particular reason to hold back upgrading this beyond 3.x, but it takes some effort: https://github.com/openrewrite/rewrite/issues/5270
+    compileOnly("com.gradle:develocity-gradle-plugin:3.+")
 
     testImplementation(project(":rewrite-test")) {
         // because gradle-api fatjars this implementation already


### PR DESCRIPTION
## What's changed?

Pinning `com.gradle:develocity-gradle-plugin` to 3.x.

## What's your motivation?

Fix the broken CI as explained in #5270.
