### PR TITLE
Pin develocity-gradle-plugin to 3.+ for `RewriteSettings.groovy`

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 
     compileOnly("org.codehaus.groovy:groovy:latest.release")
     compileOnly(gradleApi())
-    compileOnly("com.gradle:develocity-gradle-plugin:latest.release")
+    compileOnly("com.gradle:develocity-gradle-plugin:3.+")
 
     testImplementation(project(":rewrite-test")) {
         // because gradle-api fatjars this implementation already


### PR DESCRIPTION
## What's your motivation?
There's been a new 4.0 release https://plugins.gradle.org/plugin/com.gradle.develocity/4.0

Which now breaks compilation:
```
> Task :rewrite-gradle:compileGroovy FAILED
startup failed:
/home/runner/work/rewrite/rewrite/rewrite-gradle/src/main/groovy/RewriteSettings.groovy: 19: unable to resolve class com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
 @ line 19, column 1.
   import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
   ^

/home/runner/work/rewrite/rewrite/rewrite-gradle/src/main/groovy/RewriteSettings.groovy: 20: unable to resolve class com.gradle.scan.plugin.BuildScanExtension
 @ line 20, column 1.
   import com.gradle.scan.plugin.BuildScanExtension
   ^

/home/runner/work/rewrite/rewrite/rewrite-gradle/src/main/groovy/RewriteSettings.groovy: 29: unable to resolve class com.gradle.scan.plugin.BuildScanExtension
 @ line 29, column 71.
   =Closure.DELEGATE_ONLY, value=BuildScanE
```