### PR TITLE
Add support for Groovy `!in` operator

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -935,6 +935,9 @@ public class GroovyParserVisitor {
                     case "in":
                         gBinaryOp = G.Binary.Type.In;
                         break;
+                    case "!in":
+                        gBinaryOp = G.Binary.Type.NotIn;
+                        break;
                     case "<=>":
                         gBinaryOp = G.Binary.Type.Spaceship;
                         break;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -148,6 +148,9 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
             case In:
                 keyword = "in";
                 break;
+            case NotIn:
+                keyword = "!in";
+                break;
             case Spaceship:
                 keyword = "<=>";
                 break;

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -793,6 +793,7 @@ public interface G extends J {
             Find,
             Match,
             In,
+            NotIn,
             Access,
             Spaceship
         }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -65,6 +65,18 @@ class BinaryTest implements RewriteTest {
     }
 
     @Test
+    void notIn() {
+        rewriteRun(
+          groovy(
+            """
+              def a = []
+              boolean b = 42 !in a;
+              """
+          )
+        );
+    }
+
+    @Test
     void withVariable() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## What's changed?

The Groovy parser currently recognizes the [membership operator](https://docs.groovy-lang.org/latest/html/documentation/core-operators.html#_membership_operator) `in`. Groovy supports a negated form of this operator `!in`, which the parser currently does not recognize. 

When `!in` is used in a `settings.gradle` or `build.gradle` file, OpenRewrite gets an error like this: 

```
Caused by: java.lang.IllegalStateException: Unknown binary expression BinaryExpression
```

This PR adds `!in` to the set of recognized binary operators. 

## What's your motivation?
Allow existing `settings.gradle` and `build.gradle` files to be parsed and processed without modification. 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
