### PR TITLE
Use `maybeParenthesize()` for parameter substitution

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -93,6 +93,34 @@ class JavaTemplateTest implements RewriteTest {
         );
     }
 
+    @Test
+    void addParenthesesToParameter() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+                @Override
+                public J visitBinary(J.Binary binary, ExecutionContext ctx) {
+                    return JavaTemplate.builder("#{any(int)} * 3")
+                      .build()
+                      .apply(getCursor(), binary.getCoordinates().replace(), binary);
+                }
+            }))
+            .cycles(1)
+            .expectedCyclesThatMakeChanges(1),
+          java(
+            """
+              public class A {
+                  int a = 1 + 2;
+              }
+              """,
+            """
+              public class A {
+                  int a = (1 + 2) * 3;
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2090")
     @Test
     void assignmentWithinIfPredicate() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/ParenthesizeVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ParenthesizeVisitor.java
@@ -155,7 +155,7 @@ public class ParenthesizeVisitor<P> extends JavaVisitor<P> {
         return TypeUtils.isAssignableTo("java.lang.String", type);
     }
 
-    private boolean needsParentheses(Expression expr, J parent) {
+    private boolean needsParentheses(Expression expr, Object parent) {
         return parent instanceof J.Unary ||
                (parent instanceof J.MethodInvocation &&
                 expr.isScope(((J.MethodInvocation) parent).getSelect()));

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.internal.template;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
@@ -52,11 +53,13 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
     @Override
     public TreeVisitor<? extends J, Integer> getMixin() {
         return new JavaVisitor<Integer>() {
+            private boolean substituted;
+
             @Override
             public J visitAnnotation(J.Annotation annotation, Integer integer) {
                 if (loc == ANNOTATION_PREFIX && mode == JavaCoordinates.Mode.REPLACEMENT &&
-                    annotation.isScope(insertionPoint)) {
-                    List<J.Annotation> gen = substitutions.unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
+                    isScope(annotation)) {
+                    List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
                     if (gen.isEmpty()) {
                         throw new IllegalStateException("Unable to parse annotation from template: \n" +
                                                         substitutedTemplate +
@@ -64,8 +67,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     }
                     return gen.get(0).withPrefix(annotation.getPrefix());
                 } else if (loc == ANNOTATION_ARGUMENTS && mode == JavaCoordinates.Mode.REPLACEMENT &&
-                           annotation.isScope(insertionPoint)) {
-                    List<J.Annotation> gen = substitutions.unsubstitute(templateParser.parseAnnotations(getCursor(), "@Example(" + substitutedTemplate + ")"));
+                           isScope(annotation)) {
+                    List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), "@Example(" + substitutedTemplate + ")"));
                     return annotation.withArguments(gen.get(0).getArguments());
                 }
 
@@ -76,8 +79,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             public J visitBlock(J.Block block, Integer p) {
                 switch (loc) {
                     case BLOCK_END: {
-                        if (block.isScope(insertionPoint)) {
-                            List<Statement> gen = substitutions.unsubstitute(templateParser.parseBlockStatements(
+                        if (isScope(block)) {
+                            List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(
                                     new Cursor(getCursor(), insertionPoint),
                                     Statement.class,
                                     substitutedTemplate, emptySet(), loc, mode));
@@ -107,8 +110,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     }
                     case STATEMENT_PREFIX: {
                         return block.withStatements(ListUtils.flatMap(block.getStatements(), statement -> {
-                            if (statement.isScope(insertionPoint)) {
-                                List<Statement> gen = substitutions.unsubstitute(templateParser.parseBlockStatements(
+                            if (isScope(statement)) {
+                                List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(
                                         new Cursor(getCursor(), insertionPoint),
                                         Statement.class,
                                         substitutedTemplate, emptySet(), loc, mode));
@@ -138,10 +141,10 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitClassDeclaration(J.ClassDeclaration classDecl, Integer p) {
-                if (classDecl.isScope(insertionPoint)) {
+                if (isScope(classDecl)) {
                     switch (loc) {
                         case ANNOTATIONS: {
-                            List<J.Annotation> gen = substitutions.unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
+                            List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
                             J.ClassDeclaration c = classDecl;
                             if (mode == JavaCoordinates.Mode.REPLACEMENT) {
                                 c = c.withLeadingAnnotations(gen);
@@ -159,7 +162,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return autoFormat(c, c.getName(), p, getCursor().getParentOrThrow());
                         }
                         case EXTENDS: {
-                            TypeTree anExtends = substitutions.unsubstitute(templateParser.parseExtends(getCursor(), substitutedTemplate));
+                            TypeTree anExtends = unsubstitute(templateParser.parseExtends(getCursor(), substitutedTemplate));
                             J.ClassDeclaration c = classDecl.withExtends(anExtends);
 
                             //noinspection ConstantConditions
@@ -167,7 +170,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return c;
                         }
                         case IMPLEMENTS: {
-                            List<TypeTree> implementings = substitutions.unsubstitute(templateParser.parseImplements(getCursor(), substitutedTemplate));
+                            List<TypeTree> implementings = unsubstitute(templateParser.parseImplements(getCursor(), substitutedTemplate));
                             List<JavaType.FullyQualified> implementsTypes = implementings.stream()
                                     .map(TypedTree::getType)
                                     .map(TypeUtils::asFullyQualified)
@@ -191,7 +194,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     getCursor().getParentOrThrow());
                         }
                         case TYPE_PARAMETERS: {
-                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
+                            List<J.TypeParameter> typeParameters = unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
                             return classDecl.withTypeParameters(typeParameters);
                         }
                     }
@@ -203,8 +206,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             public J visitExpression(Expression expression, Integer p) {
                 if ((loc == EXPRESSION_PREFIX ||
                      loc == STATEMENT_PREFIX && expression instanceof Statement) &&
-                    expression.isScope(insertionPoint)) {
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                    isScope(expression)) {
+                    return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
                                     emptyList(), loc))
@@ -215,15 +218,15 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitFieldAccess(J.FieldAccess fa, Integer p) {
-                if (loc == FIELD_ACCESS_PREFIX && fa.isScope(insertionPoint)) {
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                if (loc == FIELD_ACCESS_PREFIX && isScope(fa)) {
+                    return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
                                     emptyList(), loc))
                             .withPrefix(fa.getPrefix()), p);
-                } else if (loc == STATEMENT_PREFIX && fa.isScope(insertionPoint)) {
+                } else if (loc == STATEMENT_PREFIX && isScope(fa)) {
                     // NOTE: while `J.FieldAccess` inherits from `Statement` they can only ever be used as expressions
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                    return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
                                     emptyList(), loc))
@@ -235,8 +238,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             @Override
             public J visitIdentifier(J.Identifier ident, Integer p) {
                 // ONLY for backwards compatibility, otherwise the same as expression replacement
-                if (loc == IDENTIFIER_PREFIX && ident.isScope(insertionPoint)) {
-                    return autoFormat(substitutions.unsubstitute(templateParser.parseExpression(
+                if (loc == IDENTIFIER_PREFIX && isScope(ident)) {
+                    return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
                                     emptyList(), loc))
@@ -247,18 +250,18 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitLambda(J.Lambda lambda, Integer p) {
-                if (loc == LAMBDA_PARAMETERS_PREFIX && lambda.getParameters().isScope(insertionPoint)) {
-                    return lambda.withParameters(substitutions.unsubstitute(templateParser.parseLambdaParameters(getCursor(), substitutedTemplate)));
+                if (loc == LAMBDA_PARAMETERS_PREFIX && isScope(lambda.getParameters())) {
+                    return lambda.withParameters(unsubstitute(templateParser.parseLambdaParameters(getCursor(), substitutedTemplate)));
                 }
                 return maybeReplaceStatement(lambda, J.class, 0);
             }
 
             @Override
             public J visitMethodDeclaration(J.MethodDeclaration method, Integer p) {
-                if (method.isScope(insertionPoint)) {
+                if (isScope(method)) {
                     switch (loc) {
                         case ANNOTATIONS: {
-                            List<J.Annotation> gen = substitutions.unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
+                            List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
                             J.MethodDeclaration m = method;
                             if (mode == JavaCoordinates.Mode.REPLACEMENT) {
                                 m = method.withLeadingAnnotations(gen);
@@ -280,7 +283,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     getCursor().getParentOrThrow());
                         }
                         case BLOCK_PREFIX: {
-                            List<Statement> gen = substitutions.unsubstitute(templateParser.parseBlockStatements(getCursor(), Statement.class,
+                            List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(getCursor(), Statement.class,
                                     substitutedTemplate, emptySet(), loc, mode));
                             J.Block body = method.getBody();
                             if (body == null) {
@@ -290,7 +293,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return method.withBody(autoFormat(body, p, getCursor()));
                         }
                         case METHOD_DECLARATION_PARAMETERS: {
-                            List<Statement> parameters = substitutions.unsubstitute(templateParser.parseParameters(getCursor(), substitutedTemplate));
+                            List<Statement> parameters = unsubstitute(templateParser.parseParameters(getCursor(), substitutedTemplate));
 
                             // Update the J.MethodDeclaration's type information to reflect its new parameter list
                             JavaType.Method type = method.getMethodType();
@@ -348,7 +351,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return method.withParameters(parameters).withMethodType(type).withName(method.getName().withType(type));
                         }
                         case THROWS: {
-                            J.MethodDeclaration m = method.withThrows(substitutions.unsubstitute(templateParser.parseThrows(getCursor(), substitutedTemplate)));
+                            J.MethodDeclaration m = method.withThrows(unsubstitute(templateParser.parseThrows(getCursor(), substitutedTemplate)));
 
                             // Update method type information to reflect the new checked exceptions
                             JavaType.Method type = m.getMethodType();
@@ -368,7 +371,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                             return m;
                         }
                         case TYPE_PARAMETERS: {
-                            List<J.TypeParameter> typeParameters = substitutions.unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
+                            List<J.TypeParameter> typeParameters = unsubstitute(templateParser.parseTypeParameters(getCursor(), substitutedTemplate));
                             J.MethodDeclaration m = method.withTypeParameters(typeParameters);
                             if (m.getName().getType() != null) {
                                 m = m.withName(method.getName().withType(m.getMethodType()));
@@ -383,14 +386,14 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, Integer integer) {
-                if ((loc == METHOD_INVOCATION_ARGUMENTS || loc == METHOD_INVOCATION_NAME) && method.isScope(insertionPoint)) {
+                if ((loc == METHOD_INVOCATION_ARGUMENTS || loc == METHOD_INVOCATION_NAME) && isScope(method)) {
                     J.MethodInvocation m;
                     if (loc == METHOD_INVOCATION_ARGUMENTS) {
-                        m = substitutions.unsubstitute(templateParser.parseMethodArguments(getCursor(), substitutedTemplate, substitutions.getTypeVariablesReferencedByParameters(), loc));
+                        m = unsubstitute(templateParser.parseMethodArguments(getCursor(), substitutedTemplate, substitutions.getTypeVariablesReferencedByParameters(), loc));
                         m = autoFormat(m, 0);
                         m = method.withArguments(m.getArguments()).withMethodType(m.getMethodType());
                     } else {
-                        m = substitutions.unsubstitute(templateParser.parseMethod(getCursor(), substitutedTemplate, substitutions.getTypeVariablesReferencedByParameters(), loc));
+                        m = unsubstitute(templateParser.parseMethod(getCursor(), substitutedTemplate, substitutions.getTypeVariablesReferencedByParameters(), loc));
                         m = autoFormat(m, 0);
                         m = method.withName(m.getName()).withArguments(m.getArguments()).withMethodType(m.getMethodType());
                     }
@@ -432,8 +435,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitPackage(J.Package pkg, Integer integer) {
-                if (loc == PACKAGE_PREFIX && pkg.isScope(insertionPoint)) {
-                    return pkg.withExpression(substitutions.unsubstitute(templateParser.parsePackage(getCursor(), substitutedTemplate)));
+                if (loc == PACKAGE_PREFIX && isScope(pkg)) {
+                    return pkg.withExpression(unsubstitute(templateParser.parsePackage(getCursor(), substitutedTemplate)));
                 }
                 return super.visitPackage(pkg, integer);
             }
@@ -444,9 +447,9 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             }
 
             private <J3 extends J> J3 maybeReplaceStatement(Statement statement, Class<J3> expected, Integer p) {
-                if (loc == STATEMENT_PREFIX && statement.isScope(insertionPoint)) {
+                if (loc == STATEMENT_PREFIX && isScope(statement)) {
                     if (mode == JavaCoordinates.Mode.REPLACEMENT) {
-                        List<J3> gen = substitutions.unsubstitute(templateParser.parseBlockStatements(getCursor(),
+                        List<J3> gen = unsubstitute(templateParser.parseBlockStatements(getCursor(),
                                 expected, substitutedTemplate, substitutions.getTypeVariablesReferencedByParameters(), loc, mode));
                         if (gen.size() != 1) {
                             // for some languages with optional semicolons, templates may generate a statement
@@ -479,7 +482,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                 if (multiVariable.isScope(insertionPoint)) {
                     if (loc == ANNOTATIONS) {
                         J.VariableDeclarations v = multiVariable;
-                        final List<J.Annotation> gen = substitutions.unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
+                        final List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
                         if (mode == JavaCoordinates.Mode.REPLACEMENT) {
                             v = v.withLeadingAnnotations(gen);
                             if (v.getTypeExpression() instanceof J.AnnotatedType) {
@@ -497,6 +500,26 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     }
                 }
                 return super.visitVariableDeclarations(multiVariable, p);
+            }
+
+            private boolean isScope(J test) {
+                return !substituted && test.isScope(insertionPoint);
+            }
+
+            private <J2 extends J> @Nullable J2 unsubstitute(J2 j) {
+                try {
+                    return substitutions.unsubstitute(j);
+                } finally {
+                    substituted = true;
+                }
+            }
+
+            private <J2 extends J> List<J2> unsubstitute(List<J2> js) {
+                try {
+                    return substitutions.unsubstitute(js);
+                } finally {
+                    substituted = true;
+                }
             }
         };
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -426,7 +426,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitNewClass(J.NewClass newClass, Integer p) {
-                if (newClass.isScope(insertionPoint)) {
+                if (isScope(newClass)) {
                     // allow a `J.NewClass` to also be replaced by an expression
                     return maybeReplaceStatement(newClass, J.class, p);
                 }
@@ -479,7 +479,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
 
             @Override
             public J visitVariableDeclarations(J.VariableDeclarations multiVariable, Integer p) {
-                if (multiVariable.isScope(insertionPoint)) {
+                if (isScope(multiVariable)) {
                     if (loc == ANNOTATIONS) {
                         J.VariableDeclarations v = multiVariable;
                         final List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openrewrite.java.ParenthesizeVisitor.maybeParenthesize;
+
 @RequiredArgsConstructor
 @ToString
 public class Substitutions {
@@ -320,8 +322,8 @@ public class Substitutions {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, Integer integer) {
                 J param = maybeParameter(method.getName());
-                if (param != null) {
-                    return param;
+                if (param instanceof Expression) {
+                    return maybeParenthesize((Expression) param, getCursor());
                 }
                 return super.visitMethodInvocation(method, integer);
             }
@@ -329,7 +331,9 @@ public class Substitutions {
             @Override
             public <T extends J> J visitParentheses(J.Parentheses<T> parens, Integer integer) {
                 J param = maybeParameter(parens.getTree());
-                if (param != null) {
+                if (param instanceof Expression) {
+                    return maybeParenthesize((Expression) param, getCursor());
+                } else if (param != null) {
                     return param;
                 }
                 return super.visitParentheses(parens, integer);
@@ -338,8 +342,8 @@ public class Substitutions {
             @Override
             public J visitLiteral(J.Literal literal, Integer integer) {
                 J param = maybeParameter(literal);
-                if (param != null) {
-                    return param;
+                if (param instanceof Expression) {
+                    return maybeParenthesize((Expression) param, getCursor());
                 }
                 return super.visitLiteral(literal, integer);
             }


### PR DESCRIPTION
This is for the case when a parameter supplied to a `JavaTemplate` requires parenthesizing when inserted into the LST of the template.

Consider the case when the `J.Binary` representing `1 + 2` gets substituted for the parameter in `#{any(int)} * 3`. Then you want to get `(1 + 2) * 3` instead of `1 + 2 * 3`. When you on the other hand literally want to get `1 + 2 * 3`, then you should probably have `1 + 2` as a string and thus as a plain `#{}` template parameter.

Also guards against an accidentally discovered `StackOverflowError` in `JavaTemplate`, when the insertion point itself is used as a template parameter. E.g. assume you have `1 + 2` in the source code and want to replace it with `#{any(int)} * 3` and use that `1 + 2` as the template parameter.