### PR TITLE
Allow concurrent creation of `LocalMavenArtifactCache`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/cache/LocalMavenArtifactCache.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/cache/LocalMavenArtifactCache.java
@@ -35,7 +35,7 @@ public class LocalMavenArtifactCache implements MavenArtifactCache {
     private final Path cache;
 
     public LocalMavenArtifactCache(Path cache) {
-        if (!cache.toFile().mkdirs() && !cache.toFile().exists()) { // 2nd exists is for concurrency
+        if (!cache.toFile().mkdirs() && !cache.toFile().exists()) {
             throw new IllegalStateException("Unable to find or create maven artifact cache at " + cache);
         }
         this.cache = cache;


### PR DESCRIPTION
By re-checking if the dir exists after a failure to create it allows multiple `LocalMavenArtifactCache` to be created at the same time with the same path.

If the dir exists the expression is false on the first `exists()`

If the dir does not exist and is created by the `mkdirs()` it resolves to false on that.

If the dir does not exist, then is created before `mkdirs()` can run and exists for the 2nd `exists()` it still resolves to false. Only if dir creation actually failed and it does not exist afterwards will we throw.
