### PR TITLE
Exclude TCK module from recipe-bom

### DIFF
--- a/rewrite-bom/build.gradle.kts
+++ b/rewrite-bom/build.gradle.kts
@@ -6,9 +6,15 @@ plugins {
 
 dependencies {
     constraints {
-        rootProject.subprojects.filter { it != project && !it.name.contains("benchmark") && it.name != "tools" }.sortedBy { it.name }.forEach {
-            api(it)
-        }
+        rootProject.subprojects
+            .filter {
+                it != project &&
+                        !it.name.contains("benchmark") &&
+                        !it.name.contains("tck") &&
+                        it.name != "tools"
+            }
+            .sortedBy { it.name }
+            .forEach { api(it) }
     }
 }
 


### PR DESCRIPTION
## What's changed?
Remove rewrite-java-tck from rewrite-bom

## What's your motivation?
No need for others to depend on, or procure this module.