### PR TITLE
Fix bug where `a` is not equal to `this.a` in a setter

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -782,4 +782,23 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void defensiveSetter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  String a;
+                  void setA(String a) {
+                      if(!a.equals(this.a)) {
+                          this.a = a;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -786,15 +786,27 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
     @Test
     void defensiveSetter() {
         rewriteRun(
-          //language=java
           java(
             """
               class A {
                   String a;
                   void setA(String a) {
-                      if(!a.equals(this.a)) {
+                      if (!a.equals(this.a)) {
                           this.a = a;
                       }
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class B {
+                  String b;
+                  void setB(String b) {
+                      if (b.equals(this.b)) {
+                          return;
+                      }
+                      this.b = b;
                   }
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -29,8 +29,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings({"UnnecessaryCallToStringValueOf", "AccessStaticViaInstance", "RedundantCast", "rawtypes", "UnnecessaryLocalVariable", "ComparatorCombinators", "SameParameterValue"})
 class SemanticallyEqualTest {
 
     private final JavaParser javaParser = JavaParser.fromJavaVersion().build();
@@ -337,6 +339,7 @@ class SemanticallyEqualTest {
         );
     }
 
+    @SuppressWarnings({"DataFlowIssue", "OptionalGetWithoutIsPresent", "Convert2Diamond"})
     @Nested
     class Generics {
         @Test
@@ -402,6 +405,45 @@ class SemanticallyEqualTest {
                 }
                 """
             );
+        }
+
+        @Test
+        void fieldNotEqualToShadowedNameVariable() {
+            J.CompilationUnit cu = javaParser.parse(
+                """
+                  class T {
+                      int a = 1;
+                      void m(int a) {
+                          this.a = a;
+                      }
+                  }
+                  """
+              ).findFirst()
+              .map(J.CompilationUnit.class::cast)
+              .get();
+            J.MethodDeclaration m = (J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(1);
+            J.Assignment a = (J.Assignment) m.getBody().getStatements().get(0);
+            assertFalse(SemanticallyEqual.areEqual(a.getVariable(), a.getAssignment()));
+            assertFalse(SemanticallyEqual.areEqual(((J.FieldAccess) a.getVariable()).getName(), a.getAssignment()));
+        }
+
+        @Test
+        void fieldsFromDifferentInstances() {
+            J.CompilationUnit cu = javaParser.parse(
+                """
+                  class T {
+                      int n;
+                      boolean m(T a, T b) {
+                          return a.n == b.n;
+                      }
+                  }
+                  """
+              ).findFirst()
+              .map(J.CompilationUnit.class::cast)
+              .get();
+            J.MethodDeclaration m = (J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(1);
+            J.Binary b = (J.Binary) ((J.Return) m.getBody().getStatements().get(0)).getExpression();
+            assertFalse(SemanticallyEqual.areEqual(b.getLeft(), b.getRight()));
         }
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -747,8 +747,7 @@ public class SemanticallyEqual {
                         return identifier;
                     }
                 }
-                if (!identifier.getSimpleName().equals(compareTo.getSimpleName()) ||
-                        identifier.getFieldType() != compareTo.getFieldType()) {
+                if (!identifier.getSimpleName().equals(compareTo.getSimpleName()) || !TypeUtils.isOfType(identifier.getFieldType(), compareTo.getFieldType())) {
                     isEqual.set(false);
                     return identifier;
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -747,7 +747,8 @@ public class SemanticallyEqual {
                         return identifier;
                     }
                 }
-                if (!identifier.getSimpleName().equals(compareTo.getSimpleName())) {
+                if (!identifier.getSimpleName().equals(compareTo.getSimpleName()) ||
+                        identifier.getFieldType() != compareTo.getFieldType()) {
                     isEqual.set(false);
                     return identifier;
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -161,6 +161,11 @@ public class TypeUtils {
             }
             return true;
         }
+        if(type1 instanceof JavaType.Variable && type2 instanceof JavaType.Variable) {
+            JavaType.Variable var1 = (JavaType.Variable) type1;
+            JavaType.Variable var2 = (JavaType.Variable) type2;
+            return isOfType((var1).getType(), var2.getType()) && isOfType(var1.getOwner(), var2.getOwner());
+        }
         return type1.equals(type2);
     }
 


### PR DESCRIPTION
## What's your motivation?
Fix incorrect change of `if(!a.equals(this.a))` to `if (false)`
