### PR TITLE
feat: merge categories which have matching roots

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/CategoryDescriptor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/CategoryDescriptor.java
@@ -52,4 +52,6 @@ public class CategoryDescriptor {
     int priority;
 
     boolean synthetic;
+
+    Set<String> rootPackages;
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -41,8 +41,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.RecipeSerializer.maybeAddKotlinModule;
 import static org.openrewrite.Tree.randomId;
@@ -529,7 +528,7 @@ public class YamlResourceLoader implements ResourceLoader {
                     boolean root = c.containsKey("root") && (Boolean) c.get("root");
                     int priority = c.containsKey("priority") ? (Integer) c.get("priority") : CategoryDescriptor.DEFAULT_PRECEDENCE;
 
-                    return new CategoryDescriptor(name, packageName, description, tags, root, priority, false);
+                    return new CategoryDescriptor(name, packageName, description, tags, root, priority, false, emptySet());
                 })
                 .collect(toList());
     }


### PR DESCRIPTION
## What's changed?
In the event we "org.openrewrite.java.test" and "io.moderne.java.test", we want the subcategories "java" and "test" to be merged.
-https://github.com/moderneinc/moderne-recipe-execution/issues/1270

## What's your motivation?
We are seeing duplicate entries in the market place and this is confusing. 

## Any additional context
To achieve the removal of these duplicate categories we decided to merge them in the tree. 
```
The path to a category below a category root today (before any changes) is <categoryRoot>.path.to.sub.category, 
for instance, org.openrewrite.path.to.subcategory. We will instead make that path be path.to.sub.category. 
That means we will merge paths of categories such as io.moderne.java and org.openrewrite.java into java. 
If there are subcategories such as io.moderne.java.spring and org.openrewrite.java.spring, these will
 also be merged into java.spring.
```

