### PR TITLE
SemanticallyEqual should use field names when comparing FieldAccess instances

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -278,6 +278,15 @@ class SemanticallyEqualTest {
             }
             """
         );
+        assertExpressionsNotEqual(
+          """
+           import java.math.BigDecimal;
+           class T {
+               BigDecimal a = BigDecimal.ONE;
+               BigDecimal b = BigDecimal.ZERO;
+           }
+           """
+        );
     }
 
     @ExpectedToFail

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -607,7 +607,8 @@ public class SemanticallyEqual {
                         isEqual.set(false);
                         return fieldAccess;
                     }
-                } else if (!TypeUtils.isOfType(fieldAccess.getType(), compareTo.getType()) ||
+                } else if (!fieldAccess.getSimpleName().equals(compareTo.getSimpleName()) ||
+                           !TypeUtils.isOfType(fieldAccess.getType(), compareTo.getType()) ||
                            !TypeUtils.isOfType(fieldType, compareTo.getName().getFieldType())) {
                     isEqual.set(false);
                     return fieldAccess;


### PR DESCRIPTION
## What's changed?

Fixing the `SemanticallyEqual` to consider two field accesses unequal if they use different field names (even if it's the same type):
```
               BigDecimal a = BigDecimal.ONE;
               BigDecimal b = BigDecimal.ZERO;
```
shouldn't be considered semantically equal.

## What's your motivation?

The actual trigger was failures of CI in rewrite-logging-frameworks, e.g. https://github.com/openrewrite/rewrite-logging-frameworks/actions/runs/14432137576/attempts/1
And these failures are believed to have been triggered by #5286.
