### PR TITLE
Validate newMethodName in ChangeMethodName

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodNameTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodNameTest.java
@@ -422,4 +422,70 @@ class ChangeMethodNameTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void ignoreInvalidMethodNames() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodName("com.abc.B static1(String)", "123", null, null)),
+          java(b, SourceSpec::skip),
+          java(
+            """
+              package com.abc;
+              
+              import java.util.ArrayList;
+              
+              class A {
+                 public void test() {
+                     com.abc.B.static1("boo");
+                     new java.util.ArrayList<String>().forEach(B::static1);
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ignoreBlankMethodNames() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodName("com.abc.B static1(String)", "\t", null, null)),
+          java(b, SourceSpec::skip),
+          java(
+            """
+              package com.abc;
+              
+              import java.util.ArrayList;
+              
+              class A {
+                 public void test() {
+                     com.abc.B.static1("boo");
+                     new java.util.ArrayList<String>().forEach(B::static1);
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ignoreReservedKeyWordMethodNames() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodName("com.abc.B static1(String)", "this", null, null)),
+          java(b, SourceSpec::skip),
+          java(
+            """
+              package com.abc;
+              
+              import java.util.ArrayList;
+              
+              class A {
+                 public void test() {
+                     com.abc.B.static1("boo");
+                     new java.util.ArrayList<String>().forEach(B::static1);
+                 }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaKeywordUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaKeywordUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+final class JavaKeywordUtils {
+    JavaKeywordUtils() {
+    }
+
+    private static final String[] RESERVED_WORDS = new String[]{
+          "abstract",
+          "assert",
+          "boolean",
+          "break",
+          "byte",
+          "case",
+          "catch",
+          "char",
+          "class",
+          "const",
+          "continue",
+          "default",
+          "do",
+          "double",
+          "else",
+          "enum",
+          "extends",
+          "final",
+          "finally",
+          "float",
+          "for",
+          "goto",
+          "if",
+          "implements",
+          "import",
+          "instanceof",
+          "int",
+          "interface",
+          "long",
+          "native",
+          "new",
+          "package",
+          "private",
+          "protected",
+          "public",
+          "return",
+          "short",
+          "static",
+          "strictfp",
+          "super",
+          "switch",
+          "synchronized",
+          "this",
+          "throw",
+          "throws",
+          "transient",
+          "try",
+          "void",
+          "volatile",
+          "while",
+    };
+
+    private static final Set<String> RESERVED_WORDS_SET = new HashSet<>(Arrays.asList(RESERVED_WORDS));
+
+    public static boolean isReserved(String word) {
+        return RESERVED_WORDS_SET.contains(word);
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
@@ -43,7 +43,7 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
 
     @Override
     public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, P p) {
-        if (!VariableNameUtils.JavaKeywords.isReserved(toName) && !StringUtils.isBlank(toName) && variable.equals(this.variable)) {
+        if (!JavaKeywordUtils.isReserved(toName) && !StringUtils.isBlank(toName) && variable.equals(this.variable)) {
             doAfterVisit(new RenameVariableVisitor(variable, toName));
             return variable;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/VariableNameUtils.java
@@ -64,7 +64,7 @@ public class VariableNameUtils {
 
             baseName = baseName.substring(0, baseName.length() - postFix.length());
             int count = postFix.length() == 0 ? 0 : Integer.parseInt(postFix.reverse().toString());
-            while (namesInScope.contains(newName) || JavaKeywords.isReserved(newName)) {
+            while (namesInScope.contains(newName) || JavaKeywordUtils.isReserved(newName)) {
                 newName = baseName + (count += 1);
             }
         }
@@ -291,70 +291,6 @@ public class VariableNameUtils {
         private boolean isValidImportName(@Nullable JavaType targetType, String name) {
             // Consider the id a valid field if the type is null since it is indistinguishable from a method name or class name.
             return targetType == null || (targetType instanceof JavaType.FullyQualified && ((JavaType.FullyQualified) targetType).getMembers().stream().anyMatch(o -> o.getName().equals(name)));
-        }
-    }
-
-    static final class JavaKeywords {
-        JavaKeywords() {
-        }
-
-        private static final String[] RESERVED_WORDS = new String[]{
-                "abstract",
-                "assert",
-                "boolean",
-                "break",
-                "byte",
-                "case",
-                "catch",
-                "char",
-                "class",
-                "const",
-                "continue",
-                "default",
-                "do",
-                "double",
-                "else",
-                "enum",
-                "extends",
-                "final",
-                "finally",
-                "float",
-                "for",
-                "goto",
-                "if",
-                "implements",
-                "import",
-                "instanceof",
-                "int",
-                "interface",
-                "long",
-                "native",
-                "new",
-                "package",
-                "private",
-                "protected",
-                "public",
-                "return",
-                "short",
-                "static",
-                "strictfp",
-                "super",
-                "switch",
-                "synchronized",
-                "this",
-                "throw",
-                "throws",
-                "transient",
-                "try",
-                "void",
-                "volatile",
-                "while",
-        };
-
-        private static final Set<String> RESERVED_WORDS_SET = new HashSet<>(Arrays.asList(RESERVED_WORDS));
-
-        public static boolean isReserved(String word) {
-            return RESERVED_WORDS_SET.contains(word);
         }
     }
 }


### PR DESCRIPTION
## What's changed?
Added validation to prevent changing a method name to
 - blank names
 - invalid patterns
 - reserved keywords

## What's your motivation?
Fixes:
 - https://github.com/openrewrite/rewrite-static-analysis/issues/426

## Anything in particular you'd like reviewers to focus on?
Are the tests sufficient? I don't think they explicitly cover every Visitor, but they do show the behavior

## Have you considered any alternatives or workarounds?
We could leave the JavaKeyword class, but it's a bit weird that we check methodNames against a `VariableNameUtils`
