### PR TITLE
feat: support JDK24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ concurrency:
 jobs:
   build:
     uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
-    with:
-      java_version: '24'
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       ossrh_username: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   build:
     uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
+    with:
+      java_version: '24'
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       ossrh_username: ${{ secrets.OSSRH_USERNAME }}

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("io.github.classgraph:classgraph:latest.release")
     implementation("org.ow2.asm:asm:latest.release")
+    implementation("org.openrewrite:rewrite-templating:latest.release")
 
     testImplementation(project(":rewrite-test"))
     "javaTck"(project(":rewrite-java-tck"))

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -54,7 +54,10 @@ tasks.withType<Javadoc> {
             "**/ReloadableJava21Parser**",
             "**/ReloadableJava21ParserVisitor**",
             "**/ReloadableJava21TypeMapping**",
-            "**/ReloadableJava21TypeSignatureBuilder**"
+            "**/ReloadableJava21TypeSignatureBuilder**",
+            "**/Javac**",
+            "**/JavacTreeMaker**",
+            "**/Permit**"
     )
 }
 

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("io.github.classgraph:classgraph:latest.release")
     implementation("org.ow2.asm:asm:latest.release")
-    implementation("org.openrewrite:rewrite-templating:latest.release")
 
     testImplementation(project(":rewrite-test"))
     "javaTck"(project(":rewrite-java-tck"))

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -48,8 +48,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
     private final JavaTypeCache typeCache;
 
     public JavaType type(com.sun.tools.javac.code.@Nullable Type type) {
-        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || matchesUnknownType(type)
-                || type instanceof NullType){
+        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || matchesUnknownType(type) ||
+                type instanceof NullType) {
             return JavaType.Class.Unknown.getInstance();
         }
 
@@ -734,8 +734,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
         for (Pair<Symbol.MethodSymbol, Attribute> attr : compound.values) {
             Object value = annotationElementValue(attr.snd.getValue());
             JavaType.Method element = requireNonNull(methodDeclarationType(attr.fst, annotType));
-            JavaType.Annotation.ElementValue elementValue = (value instanceof Object[] arrayValue) ?
-                    JavaType.Annotation.ArrayElementValue.from(element, (arrayValue)) :
+            JavaType.Annotation.ElementValue elementValue = value instanceof Object[] ?
+                    JavaType.Annotation.ArrayElementValue.from(element, ((Object[]) value)) :
                     JavaType.Annotation.SingleElementValue.from(element, value);
             elementValues.add(elementValue);
         }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -37,8 +37,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static org.openrewrite.java.template.internal.Javac.CTC_UNKNOWN;
-import static org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag.typeTag;
 import static org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.*;
 
 @RequiredArgsConstructor
@@ -49,8 +47,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
     private final JavaTypeCache typeCache;
 
     public JavaType type(com.sun.tools.javac.code.@Nullable Type type) {
-        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || CTC_UNKNOWN.equals(typeTag(type))
-                || type instanceof NullType) {
+        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || type instanceof Type.UnknownType ||
+                type instanceof NullType) {
             return JavaType.Class.Unknown.getInstance();
         }
 
@@ -491,8 +489,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             }
         }
 
-        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR
-                || CTC_UNKNOWN.equals(typeTag(symbol.type))) {
+        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR || symbol.type instanceof Type.UnknownType) {
             return null;
         }
 
@@ -557,7 +554,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                     exceptionTypes.add(javaType);
                 }
             }
-        } else if (CTC_UNKNOWN.equals(typeTag(selectType))) {
+        } else if (selectType instanceof Type.UnknownType) {
             returnType = JavaType.Unknown.getInstance();
         }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -481,8 +481,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                     if (targetClass.getSimpleName().equals("RecoveryErrorType")) {
                         Field field = targetClass.getDeclaredField("candidateSymbol");
                         field.setAccessible(true);
-                        Symbol originalSymbol = (Symbol) field.get(selectType);
-                        return methodInvocationType(selectType.getOriginalType(), originalSymbol);
+                        return methodInvocationType(selectType.getOriginalType(), (Symbol) field.get(selectType));
                     }
                 }
             } catch (Exception e) {
@@ -662,11 +661,11 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             }
 
             JavaType.FullyQualified resolvedDeclaringType = declaringType;
-            if (declaringType == null) {
-                if (methodSymbol.owner instanceof Symbol.ClassSymbol || methodSymbol.owner instanceof Symbol.TypeVariableSymbol) {
+            if (declaringType == null && (methodSymbol.owner instanceof Symbol.ClassSymbol
+                    || methodSymbol.owner instanceof Symbol.TypeVariableSymbol)) {
                     resolvedDeclaringType = TypeUtils.asFullyQualified(type(methodSymbol.owner.type));
                 }
-            }
+
 
             if (resolvedDeclaringType == null) {
                 return null;
@@ -709,6 +708,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
         try {
             classSymbol.complete();
         } catch (Symbol.CompletionFailure ignore) {
+            // Ignore
         }
     }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -37,6 +37,8 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
+import static org.openrewrite.java.template.internal.Javac.CTC_UNKNOWN;
+import static org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag.typeTag;
 import static org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.*;
 
 @RequiredArgsConstructor
@@ -47,8 +49,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
     private final JavaTypeCache typeCache;
 
     public JavaType type(com.sun.tools.javac.code.@Nullable Type type) {
-        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || type instanceof Type.UnknownType ||
-                type instanceof NullType) {
+        if (type == null || type instanceof Type.ErrorType || type instanceof Type.PackageType || CTC_UNKNOWN.equals(typeTag(type))
+                || type instanceof NullType) {
             return JavaType.Class.Unknown.getInstance();
         }
 
@@ -489,7 +491,8 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             }
         }
 
-        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR || symbol.type instanceof Type.UnknownType) {
+        if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR
+                || CTC_UNKNOWN.equals(typeTag(symbol.type))) {
             return null;
         }
 
@@ -554,7 +557,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
                     exceptionTypes.add(javaType);
                 }
             }
-        } else if (selectType instanceof Type.UnknownType) {
+        } else if (CTC_UNKNOWN.equals(typeTag(selectType))) {
             returnType = JavaType.Unknown.getInstance();
         }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
@@ -30,9 +30,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 
-import static org.openrewrite.java.template.internal.Javac.CTC_UNKNOWN;
-import static org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag.typeTag;
-
 class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
     private Set<String> typeVariableNameStack;
@@ -43,7 +40,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     private String signature(@Nullable Type type) {
-        if (type == null || CTC_UNKNOWN.equals(typeTag(type)) || type instanceof NullType) {
+        if (type == null || type instanceof Type.UnknownType || type instanceof NullType) {
             return "{undefined}";
         } else if (type instanceof Type.IntersectionClassType) {
             return intersectionSignature(type);

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static org.openrewrite.java.isolated.internal.JavacTreeMaker.TypeTag.matchesUnknownType;
+
 class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
     private Set<String> typeVariableNameStack;
@@ -40,7 +42,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     private String signature(@Nullable Type type) {
-        if (type == null || type instanceof Type.UnknownType || type instanceof NullType) {
+        if (type == null || matchesUnknownType(type) || type instanceof NullType) {
             return "{undefined}";
         } else if (type instanceof Type.IntersectionClassType) {
             return intersectionSignature(type);
@@ -78,6 +80,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
         try {
             classSymbol.complete();
         } catch (Symbol.CompletionFailure ignore) {
+            // Ignore
         }
     }
 
@@ -297,7 +300,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
             return resolvedArgumentTypes.toString();
         } else if (selectType instanceof Type.ForAll) {
             return methodArgumentSignature(((Type.ForAll) selectType).qtype);
-        } else if (selectType instanceof Type.JCNoType || selectType instanceof Type.UnknownType) {
+        } else if (selectType instanceof Type.JCNoType || matchesUnknownType(selectType)) {
             return "{undefined}";
         }
 

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeSignatureBuilder.java
@@ -30,6 +30,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static org.openrewrite.java.template.internal.Javac.CTC_UNKNOWN;
+import static org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag.typeTag;
+
 class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     @Nullable
     private Set<String> typeVariableNameStack;
@@ -40,7 +43,7 @@ class ReloadableJava21TypeSignatureBuilder implements JavaTypeSignatureBuilder {
     }
 
     private String signature(@Nullable Type type) {
-        if (type == null || type instanceof Type.UnknownType || type instanceof NullType) {
+        if (type == null || CTC_UNKNOWN.equals(typeTag(type)) || type instanceof NullType) {
             return "{undefined}";
         } else if (type instanceof Type.IntersectionClassType) {
             return intersectionSignature(type);

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/Javac.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/Javac.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2009-2019 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.openrewrite.java.isolated.internal;
+
+
+import org.openrewrite.java.isolated.internal.JavacTreeMaker.TypeTag;
+
+import static org.openrewrite.java.isolated.internal.JavacTreeMaker.TypeTag.typeTag;
+import static org.openrewrite.java.isolated.internal.JavacTreeMaker.TypeTag.typeTagPermissive;
+
+public final class Javac {
+    private Javac() {
+        // prevent instantiation
+    }
+
+    public static final TypeTag CTC_VOID = typeTag("VOID");
+    public static final TypeTag CTC_UNKNOWN = typeTagPermissive("UNKNOWN"); // UNKNOWN has been removed in JDK24, hence, we need to look it up permissively (just make it `null` if it does not exist).
+
+    static RuntimeException sneakyThrow(Throwable t) {
+        if (t == null) {
+            throw new NullPointerException("t");
+        }
+        Javac.sneakyThrow0(t);
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void sneakyThrow0(Throwable t) throws T {
+        throw (T) t;
+    }
+}

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/JavacTreeMaker.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/JavacTreeMaker.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2013-2020 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.openrewrite.java.isolated.internal;
+
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.openrewrite.java.isolated.internal.Javac.CTC_UNKNOWN;
+import static org.openrewrite.java.isolated.internal.Javac.CTC_VOID;
+import static org.openrewrite.java.isolated.internal.Javac.sneakyThrow;
+
+@SuppressWarnings("SameParameterValue")
+public class JavacTreeMaker {
+
+    private JavacTreeMaker() {
+    }
+
+    private static class SchroedingerType {
+        final Object value;
+
+        private SchroedingerType(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public int hashCode() {
+            return value == null ? -1 : value.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof SchroedingerType schroedingerType) {
+                return Objects.equals(value, schroedingerType.value);
+            }
+            return false;
+        }
+
+        static Object getFieldCached(ConcurrentMap<String, Object> cache, String className, String fieldName) {
+            Object value = cache.get(fieldName);
+            if (value != null) {
+                return value;
+            }
+            try {
+                value = Permit.getField(Class.forName(className), fieldName).get(null);
+            } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
+                //noinspection DataFlowIssue
+                throw sneakyThrow(e);
+            }
+
+            cache.putIfAbsent(fieldName, value);
+            return value;
+        }
+
+        private static final Field NOSUCHFIELDEX_MARKER;
+
+        static {
+            try {
+                NOSUCHFIELDEX_MARKER = Permit.getField(SchroedingerType.class, "NOSUCHFIELDEX_MARKER");
+            } catch (NoSuchFieldException e) {
+                //noinspection DataFlowIssue
+                throw sneakyThrow(e);
+            }
+        }
+
+        static Object getFieldCached(ConcurrentMap<Class<?>, Field> cache, Object ref, String fieldName) throws NoSuchFieldException {
+            Class<?> c = ref.getClass();
+            Field field = cache.get(c);
+            if (field == null) {
+                try {
+                    field = Permit.getField(c, fieldName);
+                } catch (NoSuchFieldException e) {
+                    cache.putIfAbsent(c, NOSUCHFIELDEX_MARKER);
+                    //noinspection DataFlowIssue
+                    throw sneakyThrow(e);
+                }
+                Permit.setAccessible(field);
+                Field old = cache.putIfAbsent(c, field);
+                if (old != null) {
+                    field = old;
+                }
+            }
+
+            if (field == NOSUCHFIELDEX_MARKER) {
+                throw new NoSuchFieldException(fieldName);
+            }
+            try {
+                return field.get(ref);
+            } catch (IllegalAccessException e) {
+                //noinspection DataFlowIssue
+                throw sneakyThrow(e);
+            }
+        }
+    }
+
+    public static final class TypeTag extends SchroedingerType {
+        private static final ConcurrentMap<String, Object> TYPE_TAG_CACHE = new ConcurrentHashMap<>();
+        private static final ConcurrentMap<Class<?>, Field> FIELD_CACHE = new ConcurrentHashMap<>();
+        private static final Method TYPE_TYPETAG_METHOD;
+
+        static {
+            Method m = null;
+            try {
+                m = Permit.getMethod(Type.class, "getTag");
+            } catch (NoSuchMethodException ignored) {
+                // Ignore the error
+            }
+            TYPE_TYPETAG_METHOD = m;
+        }
+
+        private TypeTag(Object value) {
+            super(value);
+        }
+
+        public static TypeTag typeTag(JCTree o) {
+            try {
+                return new TypeTag(getFieldCached(FIELD_CACHE, o, "typetag"));
+            } catch (NoSuchFieldException e) {
+                //noinspection DataFlowIssue
+                throw sneakyThrow(e);
+            }
+        }
+
+        public static TypeTag typeTag(Type t) {
+            if (t == null) {
+                return CTC_VOID;
+            }
+            try {
+                return new TypeTag(getFieldCached(FIELD_CACHE, t, "tag"));
+            } catch (NoSuchFieldException e) {
+                if (TYPE_TYPETAG_METHOD == null) {
+                    throw new IllegalStateException("Type " + t.getClass() + " has neither 'tag' nor getTag()");
+                }
+                try {
+                    return new TypeTag(TYPE_TYPETAG_METHOD.invoke(t));
+                } catch (IllegalAccessException ex) {
+                    throw sneakyThrow(ex);
+                } catch (InvocationTargetException ex) {
+                    throw sneakyThrow(ex.getCause());
+                }
+            }
+        }
+
+        public static TypeTag typeTag(String identifier) {
+            return new TypeTag(getFieldCached(TYPE_TAG_CACHE, "com.sun.tools.javac.code.TypeTag", identifier));
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        public static @Nullable TypeTag typeTagPermissive(String identifier) {
+            try {
+                return typeTag(identifier);
+            } catch (Exception e) {
+                //noinspection ConstantValue
+                if (e instanceof NoSuchFieldException) return null;
+                throw sneakyThrow(e);
+            }
+        }
+
+        public static boolean matchesUnknownType(com.sun.tools.javac.code.@Nullable Type type) {
+            if (type == null) {
+                return false;
+            }
+            JavacTreeMaker.TypeTag typeTag = JavacTreeMaker.TypeTag.typeTag(type);
+            return Optional.ofNullable(CTC_UNKNOWN).map(tag -> tag.equals(typeTag)).orElse(false);
+        }
+    }
+
+}

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/JavacTreeMaker.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/JavacTreeMaker.java
@@ -1,20 +1,4 @@
 /*
- * Copyright 2022 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
  * Copyright (C) 2013-2020 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/Permit.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/internal/Permit.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2018-2019 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.openrewrite.java.isolated.internal;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+// sunapi suppresses javac's warning about using Unsafe; 'all' suppresses eclipse's warning about the unspecified 'sunapi' key. Leave them both.
+// Yes, javac's definition of the word 'all' is quite contrary to what the dictionary says it means. 'all' does NOT include 'sunapi' according to javac.
+@SuppressWarnings({"sunapi", "all"})
+public final class Permit {
+    private Permit() {
+    }
+
+    public static <T extends AccessibleObject> T setAccessible(T accessor) {
+        accessor.setAccessible(true);
+        return accessor;
+    }
+
+    static class Fake {
+        boolean override;
+        Object accessCheckCache;
+    }
+
+    public static Method getMethod(Class<?> c, String mName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        Method m = null;
+        Class<?> oc = c;
+        while (c != null) {
+            try {
+                m = c.getDeclaredMethod(mName, parameterTypes);
+                break;
+            } catch (NoSuchMethodException e) {
+            }
+            c = c.getSuperclass();
+        }
+
+        if (m == null) {
+            throw new NoSuchMethodException(oc.getName() + " :: " + mName + "(args)");
+        }
+        return setAccessible(m);
+    }
+
+    public static Field getField(Class<?> c, String fName) throws NoSuchFieldException {
+        Field f = null;
+        Class<?> oc = c;
+        while (c != null) {
+            try {
+                f = c.getDeclaredField(fName);
+                break;
+            } catch (NoSuchFieldException e) {
+            }
+            c = c.getSuperclass();
+        }
+
+        if (f == null) {
+            throw new NoSuchFieldException(oc.getName() + " :: " + fName);
+        }
+
+        return setAccessible(f);
+    }
+
+    public static RuntimeException sneakyThrow(Throwable t) {
+        if (t == null) {
+            throw new NullPointerException("t");
+        }
+        return Permit.sneakyThrow0(t);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> T sneakyThrow0(Throwable t) throws T {
+        throw (T) t;
+    }
+}


### PR DESCRIPTION
## What's changed?
The PR updates the module `rewrite-java-21` to be compatible with JDK 24. The main change is eliminating the use of  `UnknownType`, as it has been removed from JDK 24.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/5211

## Have you considered any alternatives or workarounds?
It seems more straightforward to modify the `rewrite-java-21` module than to create a separate module with the new classes. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
