### PR TITLE
Semver not to choke on unusual version strings

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -28,7 +28,7 @@ public class Semver {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public static boolean isVersion(@Nullable String version) {
-        if (version == null) {
+        if (StringUtils.isBlank(version)) {
             return false;
         }
         return LatestRelease.RELEASE_PATTERN.matcher(version).matches();
@@ -96,9 +96,9 @@ public class Semver {
     }
 
     public static @Nullable String max(@Nullable String version1, @Nullable String version2) {
-        if (StringUtils.isBlank(version1) || !isVersion(version1)) {
+        if (!isVersion(version1)) {
             return StringUtils.isBlank(version2) ? null : version2;
-        } else if (StringUtils.isBlank(version2) || !isVersion(version2)) {
+        } else if (!isVersion(version2)) {
             return version1;
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/Semver.java
@@ -96,9 +96,9 @@ public class Semver {
     }
 
     public static @Nullable String max(@Nullable String version1, @Nullable String version2) {
-        if (StringUtils.isBlank(version1)) {
+        if (StringUtils.isBlank(version1) || !isVersion(version1)) {
             return StringUtils.isBlank(version2) ? null : version2;
-        } else if (StringUtils.isBlank(version2)) {
+        } else if (StringUtils.isBlank(version2) || !isVersion(version2)) {
             return version1;
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/semver/SemverTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/SemverTest.java
@@ -75,5 +75,8 @@ class SemverTest {
         assertThat(Semver.max("1.0.1RC", "1.0.1-release")).isEqualTo("1.0.1-release");
         assertThat(Semver.max("4.3.30.RELEASE", "4.3.30.RELEASE-2")).isEqualTo("4.3.30.RELEASE"); // Multiple labels with same version takes first label
         assertThat(Semver.max("4.3.30.RELEASE", "4.3.31.RELEASE")).isEqualTo("4.3.31.RELEASE");
+        assertThat(Semver.max("INVALID-2023.1.0.1", "1.0.2")).isEqualTo("1.0.2");
+        assertThat(Semver.max("INVALID-2023.1.0.3", "1.0.2")).isEqualTo("1.0.2");
+        assertThat(Semver.max("1.0.2", "INVALID-2023.1.0.3")).isEqualTo("1.0.2");
     }
 }


### PR DESCRIPTION
## What's changed?

A safety guard in `Semver`'s logic to compare two versions. Basically if one of them doesn't follow the usual pattern, then the pick the other one. In case of both of them being non-standard, just pick one of them deterministically (then it's hard to decide what is max).

## What's your motivation?

Address issue reported by users seeing exceptions being thrown, e.g.
`Error comparing version number SOMETHING-2003.1.0_1 to 1.0.2 in DependencyVulnerabilityCheck`

## Anything specific to review?

Yeah. I tried to be defensive and pragmatic about the scenario of two versions being non-standard. I have a hunch this is closer to user expectations. But at the same time the code looks a bit off with not checking `isVersion` consistently in all branches. Happy to take better suggestions.