### PR TITLE
Fix: Ensure onComplete is called for DelegatingRecipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Recipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Recipe.java
@@ -364,6 +364,9 @@ public abstract class Recipe implements Cloneable {
      */
     @Incubating(since = "8.48.0")
     public void onComplete(ExecutionContext ctx) {
+        if (this instanceof DelegatingRecipe) {
+            ((DelegatingRecipe) this).getDelegate().onComplete(ctx);
+        }
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
@@ -46,7 +46,7 @@ class RecipeRunTest implements RewriteTest {
 
 
     @Test
-    void testDelegateRecipeWithOnComplete() {
+    void delegateRecipeWithOnComplete() {
         ExecutionContext ctx = new InMemoryExecutionContext();
         rewriteRun(recipeSpec -> recipeSpec.recipe(new DelegatingRecipe()).executionContext(ctx).typeValidationOptions(TypeValidation.none()));
         assertThat(ctx.<String>getMessage("org.openrewrite.recipe.oncomplete")).isEqualTo("with delegate recipe.");

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
@@ -18,6 +18,7 @@ package org.openrewrite;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.table.SourcesFileResults;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 import org.openrewrite.text.FindAndReplace;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,5 +42,46 @@ class RecipeRunTest implements RewriteTest {
             """, """
             replacement
             """));
+    }
+
+
+    @Test
+    void testDelegateRecipeWithOnComplete() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        rewriteRun(recipeSpec -> recipeSpec.recipe(new DelegatingRecipe()).executionContext(ctx).typeValidationOptions(TypeValidation.none()));
+        assertThat(ctx.<String>getMessage("org.openrewrite.recipe.oncomplete")).isEqualTo("with delegate recipe.");
+    }
+
+    public static class DelegatingRecipe extends Recipe implements Recipe.DelegatingRecipe{
+
+        @Override
+        public String getDisplayName() {
+            return "Test delegate recipe";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Test onComplete with delegate recipe.";
+        }
+
+        @Override
+        public Recipe getDelegate() {
+            return new Recipe() {
+                @Override
+                public String getDisplayName() {
+                    return "Actual recipe";
+                }
+
+                @Override
+                public String getDescription() {
+                    return "Actual recipe with onComplete.";
+                }
+
+                @Override
+                public void onComplete(ExecutionContext ctx) {
+                    ctx.putMessage("org.openrewrite.recipe.oncomplete", "with delegate recipe.");
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
## What's changed?
Ensure onComplete method is invoked for DelegatingRecipe.

## What's your motivation?
Previously, the onComplete method was not called when a DeclarativeRecipe had a precondition, as the child recipes were wrapped in a DelegatingRecipe.

## Anyone you would like to review specifically?
@knutwannheden @timtebeek 


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
