### PR TITLE
Apply and enforce new lines around SourceSpec arguments

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/ExcludeFileFromGitignoreTest.java
@@ -560,7 +560,8 @@ class ExcludeFileFromGitignoreTest implements RewriteTest {
           text(
             """
               /gradle/**
-              """, """
+              """,
+                """
               /gradle/**
               !/gradle/wrapper/
               /gradle/wrapper/**

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeRunTest.java
@@ -39,9 +39,10 @@ class RecipeRunTest implements RewriteTest {
             }), text(
                 """
             replace_me
-            """, """
+            """,
+                """
             replacement
-            """));
+            """ ));
     }
 
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -279,7 +279,8 @@ class ChangeDependencyTest implements RewriteTest {
               dependencies {
                   runtimeOnly 'com.mysql:mysql-connector-j'
               }
-              """)
+              """
+          )
         );
     }
 
@@ -317,7 +318,8 @@ class ChangeDependencyTest implements RewriteTest {
               dependencies {
                   runtimeOnly group: 'com.mysql', name: 'mysql-connector-j'
               }
-              """)
+              """
+          )
         );
     }
 
@@ -355,7 +357,8 @@ class ChangeDependencyTest implements RewriteTest {
               dependencies {
                   runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeExtraPropertyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeExtraPropertyTest.java
@@ -54,7 +54,8 @@ class ChangeExtraPropertyTest implements RewriteTest {
               ext {
                   foo = "baz"
               }
-              """)
+              """
+          )
         );
     }
 
@@ -69,7 +70,8 @@ class ChangeExtraPropertyTest implements RewriteTest {
             """
               project.ext.foo = "baz"
               ext.foo = "baz"
-              """)
+              """
+          )
         );
     }
 
@@ -86,7 +88,8 @@ class ChangeExtraPropertyTest implements RewriteTest {
               ext {
                 foo = 'baz'
               }
-              """)
+              """
+          )
         );
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -285,7 +285,8 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                   'com.google.guava:guava-gwt:29.0-jre',
                   'com.google.guava:guava:30.1.1-jre')
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -503,7 +503,8 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                       }
                   }
               }
-              """, """
+              """,
+                """
               plugins {
                   id 'java'
               }
@@ -546,7 +547,8 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
               dependencies {
                   testImplementation 'org.apache.activemq:artemis-jakarta-server:2.28.0'
               }
-              """, """
+              """,
+                """
               plugins {
                   id 'info.solidsoft.pitest' version '1.15.0'
                   id 'java'
@@ -580,7 +582,8 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
               dependencies {
                   testImplementation 'org.apache.activemq:artemis-jakarta-server:2.28.0'
               }
-              """, """
+              """,
+                """
               plugins {
                   id 'info.solidsoft.pitest' version '1.15.0'
                   id 'java'
@@ -616,7 +619,8 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
               dependencies {
                   compileOnly 'org.apache.activemq:artemis-jakarta-server:2.28.0'
               }
-              """, """
+              """,
+                """
               plugins {
                   id 'info.solidsoft.pitest' version '1.15.0'
                   id 'java'

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/AddBuildPluginTest.java
@@ -160,7 +160,8 @@ class AddBuildPluginTest implements RewriteTest {
 
               dependencies {
               }
-              """, """
+              """,
+                """
               /*
                * License header
                */
@@ -191,7 +192,8 @@ class AddBuildPluginTest implements RewriteTest {
               // Comment
               dependencies {
               }
-              """, """
+              """,
+                """
               /*
                * License header
                */
@@ -219,7 +221,8 @@ class AddBuildPluginTest implements RewriteTest {
               /*
                * License header
                */
-              """, """
+              """,
+                """
               /*
                * License header
                */

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveBuildPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/RemoveBuildPluginTest.java
@@ -125,7 +125,8 @@ class RemoveBuildPluginTest implements RewriteTest {
                   classpath "org.openrewrite:plugin:6.1.6"
                 }
               }
-              """)
+              """
+          )
         );
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -76,7 +76,8 @@ class DependencyInsightTest implements RewriteTest {
               repositories {
                   gradlePluginPortal()
               }
-              """, spec -> spec.path("buildSrc/build.gradle")),
+              """,
+                spec -> spec.path("buildSrc/build.gradle")),
           groovy(
             """
               plugins{
@@ -85,7 +86,8 @@ class DependencyInsightTest implements RewriteTest {
               dependencies{
                   implementation 'com.google.guava:guava:31.1-jre'
               }
-              """, spec -> spec.path("buildSrc/src/main/groovy/convention-plugin.gradle")),
+              """,
+                spec -> spec.path("buildSrc/src/main/groovy/convention-plugin.gradle")),
           buildGradle(
             """
               plugins {
@@ -124,7 +126,8 @@ class DependencyInsightTest implements RewriteTest {
               repositories {
                   gradlePluginPortal()
               }
-              """, spec -> spec.path("buildSrc/build.gradle")),
+              """,
+                spec -> spec.path("buildSrc/build.gradle")),
           groovy(
             """
               plugins{
@@ -133,7 +136,8 @@ class DependencyInsightTest implements RewriteTest {
               dependencies{
                   implementation 'com.google.guava:guava:31.1-jre'
               }
-              """, spec -> spec.path("buildSrc/src/main/groovy/convention-plugin.gradle")),
+              """,
+                spec -> spec.path("buildSrc/src/main/groovy/convention-plugin.gradle")),
           buildGradle(
             """
               plugins {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -42,7 +42,8 @@ class FindDependencyTest implements RewriteTest {
           dependencies {
               api "org.openrewrite:rewrite-core:latest.release"
           }
-          """, """
+          """,
+                """
           plugins {
               id 'java-library'
           }
@@ -54,7 +55,7 @@ class FindDependencyTest implements RewriteTest {
           dependencies {
               /*~~>*/api "org.openrewrite:rewrite-core:latest.release"
           }
-          """));
+          """ ));
     }
 
     @Test
@@ -73,7 +74,8 @@ class FindDependencyTest implements RewriteTest {
           dependencies {
               api 'org.openrewrite:rewrite-core:latest.release'
           }
-          """, """
+          """,
+                """
           plugins {
               id 'java-library'
           }
@@ -85,7 +87,7 @@ class FindDependencyTest implements RewriteTest {
           dependencies {
               /*~~>*/api 'org.openrewrite:rewrite-core:latest.release'
           }
-          """));
+          """ ));
     }
 
     @Nested
@@ -119,7 +121,8 @@ class FindDependencyTest implements RewriteTest {
                     api "de.openrewrite:rewrite-core:${someVersion}"
                     implementation "de.openrewrite:rewrite-core:${someVersion}"
                 }
-                """, """
+                """,
+                    """
                 plugins {
                     id 'java-library'
                 }
@@ -143,7 +146,7 @@ class FindDependencyTest implements RewriteTest {
                     api "de.openrewrite:rewrite-core:${someVersion}"
                     implementation "de.openrewrite:rewrite-core:${someVersion}"
                 }
-                """));
+                """ ));
         }
 
         @Test
@@ -167,7 +170,7 @@ class FindDependencyTest implements RewriteTest {
                 dependencies {
                     api "org.openrewrite:${otherVersion}:${someVersion}"
                 }
-                """));
+                """ ));
         }
 
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeAttributionTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTypeAttributionTest.java
@@ -234,7 +234,8 @@ class GroovyTypeAttributionTest implements RewriteTest {
             class A {
                 /*~~>*/Test t
             }
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/GStringCurlyBracesTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/GStringCurlyBracesTest.java
@@ -41,7 +41,8 @@ class GStringCurlyBracesTest implements RewriteTest {
             """
             def name = 'world'
             "Hello ${name}!"
-            """)
+            """
+          )
         );
     }
 
@@ -56,7 +57,8 @@ class GStringCurlyBracesTest implements RewriteTest {
             """
             def to = [ you : 'world']
             "Hello ${to.you}!"
-            """)
+            """
+          )
         );
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -188,7 +188,8 @@ class BinaryTest implements RewriteTest {
           groovy(
             """
               def isString = "" instanceof java.lang.String
-              """)
+              """
+          )
         );
     }
 
@@ -202,7 +203,8 @@ class BinaryTest implements RewriteTest {
                   def value = 1
               }
               [ new A() ].findAll { it -> it.value == 1 } *. value = 2
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LabelsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LabelsTest.java
@@ -29,7 +29,8 @@ class LabelsTest implements RewriteTest {
           groovy(
                 """
             given: "hello"
-            """)
+            """
+          )
         );
     }
 
@@ -44,7 +45,8 @@ class LabelsTest implements RewriteTest {
             label2:
             label3:
             foo()
-            """)
+            """
+          )
         );
     }
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
@@ -30,7 +30,8 @@ class LambdaTest implements RewriteTest {
           groovy(
                 """
             def lambda = a -> a
-            """)
+            """
+          )
         );
     }
 
@@ -40,7 +41,8 @@ class LambdaTest implements RewriteTest {
           groovy(
                 """
             ( ) -> arg
-            """)
+            """
+          )
         );
     }
     @Test
@@ -49,7 +51,8 @@ class LambdaTest implements RewriteTest {
           groovy(
                 """
             ( String arg ) -> arg
-            """)
+            """
+          )
         );
     }
 
@@ -62,7 +65,8 @@ class LambdaTest implements RewriteTest {
             foo { String a ->
                 ( _ ) -> a
             }
-            """)
+            """
+          )
         );
     }
 
@@ -77,7 +81,8 @@ class LambdaTest implements RewriteTest {
                 a
                 a
             }
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -197,7 +197,8 @@ class LiteralTest implements RewriteTest {
           groovy(
                 """
             "$System.env.BAR_BAZ"
-            """)
+            """
+          )
         );
     }
 
@@ -207,7 +208,8 @@ class LiteralTest implements RewriteTest {
           groovy(
                 """
             "${}"
-            """)
+            """
+          )
         );
     }
 
@@ -217,7 +219,8 @@ class LiteralTest implements RewriteTest {
           groovy(
                 """
             " ${ " ${ " " } " } "
-            """)
+            """
+          )
         );
     }
 
@@ -227,7 +230,8 @@ class LiteralTest implements RewriteTest {
           groovy(
                 """
             " ${""}\\n${" "} "
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodDeclarationTest.java
@@ -194,16 +194,17 @@ class MethodDeclarationTest implements RewriteTest {
           groovy(
             """
               def foo(String[][] s) {}
-              """, spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
-                @Override
-                public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
-                    if (arrayType.getElementType() instanceof J.ArrayType) {
-                        assertThat(Objects.requireNonNull(arrayType.getElementType().getType()).toString()).isEqualTo("java.lang.String[]");
-                        assertThat(Objects.requireNonNull(arrayType.getType()).toString()).isEqualTo("java.lang.String[][]");
+              """,
+                spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
+                        if (arrayType.getElementType() instanceof J.ArrayType) {
+                            assertThat(Objects.requireNonNull(arrayType.getElementType().getType()).toString()).isEqualTo("java.lang.String[]");
+                            assertThat(Objects.requireNonNull(arrayType.getType()).toString()).isEqualTo("java.lang.String[][]");
+                        }
+                        return super.visitArrayType(arrayType, o);
                     }
-                    return super.visitArrayType(arrayType, o);
-                }
-            }.visit(cu, 0))
+                }.visit(cu, 0))
           )
         );
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TernaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TernaryTest.java
@@ -71,7 +71,8 @@ class TernaryTest implements RewriteTest {
                 """
             (System.env.SYS_USER != null && System.env.SYS_USER != '') ? System.env.SYS_USER : System.env.LOCAL_USER
             (System.env.SYS_PASSWORD != null && System.env.SYS_PASSWORD != '') ? System.env.SYS_PASSWORD : System.env.LOCAL_PASSWORD
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
@@ -124,7 +124,8 @@ class VariableDeclarationsTest implements RewriteTest {
           def d2 = 10_000D
           def f1 = 10_000f
           def f2 = 10_000.0F
-          """)
+          """
+          )
         );
     }
 

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
@@ -357,42 +357,43 @@ class JavaParserTypeMappingTest implements JavaTypeMappingTest, RewriteTest {
                   private @interface A2 {
                   }
               }
-              """, spec -> spec.afterRecipe(cu -> {
-                  AtomicBoolean firstDimension = new AtomicBoolean(false);
-                  AtomicBoolean secondDimension = new AtomicBoolean(false);
-                  new JavaIsoVisitor<Integer>() {
-                      @Override
-                      public J.ArrayType visitArrayType(J.ArrayType arrayType, Integer n) {
-                          assert arrayType.getType() instanceof JavaType.Array;
-                          JavaType.Array array = (JavaType.Array) arrayType.getType();
-                          if (arrayType.getElementType() instanceof J.ArrayType) {
-                              List<JavaType.FullyQualified> annotations = collectAnnotations(array, new ArrayList<>());
-                              assertThat(annotations).satisfiesExactly(
-                                  ann1 -> assertThat(ann1.getFullyQualifiedName()).isEqualTo("TypeAnnotationTest$A1"),
-                                  ann2 -> assertThat(ann2.getFullyQualifiedName()).isEqualTo("TypeAnnotationTest$A2")
-                              );
-                              firstDimension.set(true);
-                          } else {
-                              List<JavaType.FullyQualified> annotations = collectAnnotations(array, new ArrayList<>());
-                              assertThat(annotations).satisfiesExactly(
-                                ann -> assertThat(ann.getFullyQualifiedName()).isEqualTo("TypeAnnotationTest$A2")
-                              );
-                              secondDimension.set(true);
-                          }
-                          return super.visitArrayType(arrayType, n);
-                      }
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean firstDimension = new AtomicBoolean(false);
+                    AtomicBoolean secondDimension = new AtomicBoolean(false);
+                    new JavaIsoVisitor<Integer>() {
+                        @Override
+                        public J.ArrayType visitArrayType(J.ArrayType arrayType, Integer n) {
+                            assert arrayType.getType() instanceof JavaType.Array;
+                            JavaType.Array array = (JavaType.Array) arrayType.getType();
+                            if (arrayType.getElementType() instanceof J.ArrayType) {
+                                List<JavaType.FullyQualified> annotations = collectAnnotations(array, new ArrayList<>());
+                                assertThat(annotations).satisfiesExactly(
+                                        ann1 -> assertThat(ann1.getFullyQualifiedName()).isEqualTo("TypeAnnotationTest$A1"),
+                                        ann2 -> assertThat(ann2.getFullyQualifiedName()).isEqualTo("TypeAnnotationTest$A2")
+                                );
+                                firstDimension.set(true);
+                            } else {
+                                List<JavaType.FullyQualified> annotations = collectAnnotations(array, new ArrayList<>());
+                                assertThat(annotations).satisfiesExactly(
+                                        ann -> assertThat(ann.getFullyQualifiedName()).isEqualTo("TypeAnnotationTest$A2")
+                                );
+                                secondDimension.set(true);
+                            }
+                            return super.visitArrayType(arrayType, n);
+                        }
 
-                      private List<JavaType.FullyQualified> collectAnnotations(JavaType type, List<JavaType.FullyQualified> annotations) {
-                          if (type instanceof JavaType.Array) {
-                              annotations.addAll(((JavaType.Array) type).getAnnotations());
-                              collectAnnotations(((JavaType.Array) type).getElemType(), annotations);
-                          }
-                          return annotations;
-                      }
-                  }.visit(cu, 0);
-                  assertThat(firstDimension.get()).isTrue();
-                  assertThat(secondDimension.get()).isTrue();
-            })
+                        private List<JavaType.FullyQualified> collectAnnotations(JavaType type, List<JavaType.FullyQualified> annotations) {
+                            if (type instanceof JavaType.Array) {
+                                annotations.addAll(((JavaType.Array) type).getAnnotations());
+                                collectAnnotations(((JavaType.Array) type).getElemType(), annotations);
+                            }
+                            return annotations;
+                        }
+                    }.visit(cu, 0);
+                    assertThat(firstDimension.get()).isTrue();
+                    assertThat(secondDimension.get()).isTrue();
+                })
           )
         );
     }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/AnnotationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/AnnotationTest.java
@@ -45,14 +45,15 @@ class AnnotationTest implements RewriteTest {
             """
               @SuppressWarnings("ALL")
               public class A {}
-              """, spec -> spec.afterRecipe(cu -> {
-                  J.ClassDeclaration c = cu.getClasses().get(0);
-                  JavaType.Class type = (JavaType.Class) c.getType();
-                  JavaType.Annotation a = (JavaType.Annotation) type.getAnnotations().get(0);
-                  assertThat(a.getValues()).hasSize(1);
-                  assertThat(a.getValues().get(0).getValue()).isEqualTo(singletonList("ALL"));
-              }
-            )
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                            J.ClassDeclaration c = cu.getClasses().get(0);
+                            JavaType.Class type = (JavaType.Class) c.getType();
+                            JavaType.Annotation a = (JavaType.Annotation) type.getAnnotations().get(0);
+                            assertThat(a.getValues()).hasSize(1);
+                            assertThat(a.getValues().get(0).getValue()).isEqualTo(singletonList("ALL"));
+                        }
+                )
           )
         );
     }
@@ -359,31 +360,32 @@ class AnnotationTest implements RewriteTest {
                   private @interface A2 {
                   }
               }
-              """, spec -> spec.afterRecipe(cu -> {
-                AtomicBoolean firstDimension = new AtomicBoolean(false);
-                AtomicBoolean secondDimension = new AtomicBoolean(false);
-                new JavaIsoVisitor<>() {
-                    @Override
-                    public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
-                        if (arrayType.getElementType() instanceof J.ArrayType) {
-                            if (arrayType.getAnnotations() != null && !arrayType.getAnnotations().isEmpty()) {
-                                assertThat(arrayType.getAnnotations().get(0).getAnnotationType().toString()).isEqualTo("A1");
-                                assertThat(arrayType.toString()).isEqualTo("Integer @A1 [] @A2 [ ]");
-                                firstDimension.set(true);
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean firstDimension = new AtomicBoolean(false);
+                    AtomicBoolean secondDimension = new AtomicBoolean(false);
+                    new JavaIsoVisitor<>() {
+                        @Override
+                        public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
+                            if (arrayType.getElementType() instanceof J.ArrayType) {
+                                if (arrayType.getAnnotations() != null && !arrayType.getAnnotations().isEmpty()) {
+                                    assertThat(arrayType.getAnnotations().get(0).getAnnotationType().toString()).isEqualTo("A1");
+                                    assertThat(arrayType.toString()).isEqualTo("Integer @A1 [] @A2 [ ]");
+                                    firstDimension.set(true);
+                                }
+                            } else {
+                                if (arrayType.getAnnotations() != null && !arrayType.getAnnotations().isEmpty()) {
+                                    assertThat(arrayType.getAnnotations().get(0).getAnnotationType().toString()).isEqualTo("A2");
+                                    assertThat(arrayType.toString()).isEqualTo("Integer @A2 [ ]");
+                                    secondDimension.set(true);
+                                }
                             }
-                        } else {
-                            if (arrayType.getAnnotations() != null && !arrayType.getAnnotations().isEmpty()) {
-                                assertThat(arrayType.getAnnotations().get(0).getAnnotationType().toString()).isEqualTo("A2");
-                                assertThat(arrayType.toString()).isEqualTo("Integer @A2 [ ]");
-                                secondDimension.set(true);
-                            }
+                            return super.visitArrayType(arrayType, o);
                         }
-                        return super.visitArrayType(arrayType, o);
-                    }
-                }.visit(cu, 0);
-                assertThat(firstDimension.get()).isTrue();
-                assertThat(secondDimension.get()).isTrue();
-            })
+                    }.visit(cu, 0);
+                    assertThat(firstDimension.get()).isTrue();
+                    assertThat(secondDimension.get()).isTrue();
+                })
           )
         );
     }
@@ -404,25 +406,26 @@ class AnnotationTest implements RewriteTest {
                   private @interface A1 {
                   }
               }
-              """, spec -> spec.afterRecipe(cu -> {
-                AtomicBoolean firstDimension = new AtomicBoolean(false);
-                AtomicBoolean secondDimension = new AtomicBoolean(false);
-                new JavaIsoVisitor<>() {
-                    @Override
-                    public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
-                        if (arrayType.getElementType() instanceof J.ArrayType) {
-                            assertThat(arrayType.toString()).isEqualTo("Integer [] @A1 [ ]");
-                            firstDimension.set(true);
-                        } else {
-                            assertThat(arrayType.toString()).isEqualTo("Integer @A1 [ ]");
-                            secondDimension.set(true);
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean firstDimension = new AtomicBoolean(false);
+                    AtomicBoolean secondDimension = new AtomicBoolean(false);
+                    new JavaIsoVisitor<>() {
+                        @Override
+                        public J.ArrayType visitArrayType(J.ArrayType arrayType, Object o) {
+                            if (arrayType.getElementType() instanceof J.ArrayType) {
+                                assertThat(arrayType.toString()).isEqualTo("Integer [] @A1 [ ]");
+                                firstDimension.set(true);
+                            } else {
+                                assertThat(arrayType.toString()).isEqualTo("Integer @A1 [ ]");
+                                secondDimension.set(true);
+                            }
+                            return super.visitArrayType(arrayType, o);
                         }
-                        return super.visitArrayType(arrayType, o);
-                    }
-                }.visit(cu, 0);
-                assertThat(firstDimension.get()).isTrue();
-                assertThat(secondDimension.get()).isTrue();
-            })
+                    }.visit(cu, 0);
+                    assertThat(firstDimension.get()).isTrue();
+                    assertThat(secondDimension.get()).isTrue();
+                })
           )
         );
     }
@@ -444,26 +447,27 @@ class AnnotationTest implements RewriteTest {
               @A({@A, @A(@A)})
               class TypeAnnotationTest {
               }
-              """, spec -> spec.afterRecipe(cu -> {
-                J.ClassDeclaration c = cu.getClasses().get(1);
-                JavaType.Class type = (JavaType.Class) c.getType();
-                JavaType.Annotation a = (JavaType.Annotation) type.getAnnotations().get(0);
-                assertThat(a.getValues()).satisfiesExactly(
-                  v -> {
-                      assertThat(v.getElement()).isIn(a.getMethods());
-                      assertThat((List<JavaType.Annotation>) (((JavaType.Annotation.ArrayElementValue) v).getValues())).satisfiesExactly(
-                        a1 -> {
-                            assertThat(a1.getType()).isSameAs(a.getType());
-                            assertThat(a1.getValues()).isEmpty();
-                        },
-                        a2 -> {
-                            assertThat(a2.getType()).isSameAs(a.getType());
-                            assertThat(a2.getValues()).hasSize(1);
-                        }
-                      );
-                  }
-                );
-            })
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    J.ClassDeclaration c = cu.getClasses().get(1);
+                    JavaType.Class type = (JavaType.Class) c.getType();
+                    JavaType.Annotation a = (JavaType.Annotation) type.getAnnotations().get(0);
+                    assertThat(a.getValues()).satisfiesExactly(
+                            v -> {
+                                assertThat(v.getElement()).isIn(a.getMethods());
+                                assertThat((List<JavaType.Annotation>) (((JavaType.Annotation.ArrayElementValue) v).getValues())).satisfiesExactly(
+                                        a1 -> {
+                                            assertThat(a1.getType()).isSameAs(a.getType());
+                                            assertThat(a1.getValues()).isEmpty();
+                                        },
+                                        a2 -> {
+                                            assertThat(a2.getType()).isSameAs(a.getType());
+                                            assertThat(a2.getValues()).hasSize(1);
+                                        }
+                                );
+                            }
+                    );
+                })
           )
         );
     }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodInvocationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodInvocationTest.java
@@ -90,15 +90,16 @@ class MethodInvocationTest implements RewriteTest {
                             
                   public <TTTT> TTTT generic(TTTT n, TTTT... ns) { return n; }
               }
-              """, spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
-                @Override
-                public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Object o) {
-                    if ("ns".equals(variable.getSimpleName())) {
-                        assertThat(variable.getPrefix().getWhitespace()).isEqualTo(" ");
+              """,
+                spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                    @Override
+                    public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Object o) {
+                        if ("ns".equals(variable.getSimpleName())) {
+                            assertThat(variable.getPrefix().getWhitespace()).isEqualTo(" ");
+                        }
+                        return super.visitVariable(variable, o);
                     }
-                    return super.visitVariable(variable, o);
-                }
-            })
+                })
           )
         );
     }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -918,7 +918,8 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               public class Const {
                     public static final String HI = "hi";
               }
-              """),
+              """
+          ),
           java(
             """
               package org.example;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -2029,7 +2029,8 @@ class ChangeTypeTest implements RewriteTest {
               public class A {
                 public static String A = "A";
               }
-              """),
+              """
+          ),
           java(
             """
               package org.ab;
@@ -2038,7 +2039,8 @@ class ChangeTypeTest implements RewriteTest {
                 public static String A = "A";
                 public static String B = "B";
               }
-              """),
+              """
+          ),
           // language=java
           java(
             """
@@ -2119,7 +2121,8 @@ class ChangeTypeTest implements RewriteTest {
               a.property=java.lang.Integer
               c.property=java.lang.StringBuilder
               b.property=String
-              """, spec -> spec.path("application.properties"))
+              """,
+                spec -> spec.path("application.properties"))
         );
     }
 
@@ -2245,7 +2248,8 @@ class ChangeTypeTest implements RewriteTest {
                     return b.build();
                 }
               }
-              """, """
+              """,
+                """
               import foo.A;
               
               class Test {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/FindCommentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/FindCommentsTest.java
@@ -136,7 +136,8 @@ class FindCommentsTest implements RewriteTest {
               class Test {
               }
               """
-            , """
+            ,
+                """
               /*~~>*/// Example comment with foo
               class Test {
               }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -390,7 +390,8 @@ class JavaParserTest implements RewriteTest {
                 return null;
               }
             }
-            """));
+            """
+          ));
     }
 
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateMatchTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateMatchTest.java
@@ -451,7 +451,8 @@ class JavaTemplateMatchTest implements RewriteTest {
                       System.out.println(/*~~>*/(long) /*~~>*/1);
                   }
               }
-              """)
+              """
+          )
         );
     }
 
@@ -495,7 +496,8 @@ class JavaTemplateMatchTest implements RewriteTest {
                       }
                   }
               }
-              """)
+              """
+          )
         );
     }
 
@@ -530,7 +532,8 @@ class JavaTemplateMatchTest implements RewriteTest {
                       return i;
                   }
               }
-              """)
+              """
+          )
         );
     }
 
@@ -570,7 +573,8 @@ class JavaTemplateMatchTest implements RewriteTest {
                   }
                   int f = 1;
               }
-              """)
+              """
+          )
         );
     }
 
@@ -597,7 +601,8 @@ class JavaTemplateMatchTest implements RewriteTest {
               @SuppressWarnings(value = {/*~~>*/"a" + "b", "c"})
               class Test {
               }
-              """)
+              """
+          )
         );
     }
 
@@ -670,7 +675,8 @@ class JavaTemplateMatchTest implements RewriteTest {
               class Test {
                   static List<Object> EMPTY_LIST = /*~~>*/Collections.emptyList();
               }
-              """)
+              """
+          )
         );
     }
 
@@ -705,7 +711,8 @@ class JavaTemplateMatchTest implements RewriteTest {
                   static List<CharSequence> EXACT_MATCH_EXPLICIT   = /*~~>*/Collections.<CharSequence>emptyList();
                   static List<String> COLLECTION_OF_SUBTYPE        = Collections.emptyList(); // List of Dogs is not List of Animals
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -185,7 +185,8 @@ class JavaTemplateTest implements RewriteTest {
                       T x = doIt();
                   }
               }
-              """, """
+              """,
+                """
               import java.io.Serializable;
               
               abstract class Outer<T extends Serializable> {
@@ -918,7 +919,8 @@ class JavaTemplateTest implements RewriteTest {
               public class ArrayHelper {
                   public static Object[] of(Object... objects){ return null;}
               }
-              """, SourceSpec::skip
+              """,
+                SourceSpec::skip
           ),
           java(
             """
@@ -1332,13 +1334,15 @@ class JavaTemplateTest implements RewriteTest {
               class A {
                   String testMethod(@NotNull final String test) {}
               }
-              """, """
+              """,
+                """
               import lombok.NonNull;
               
               class A {
                   String testMethod(@NonNull final String test) {}
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest3Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest3Test.java
@@ -392,7 +392,8 @@ class JavaTemplateTest3Test implements RewriteTest {
                   public A acceptString(String s) { return this; }
                   public A someOtherMethod() { return this; }
               }
-              """, SourceSpec::skip
+              """,
+                SourceSpec::skip
           ),
           java(
             """
@@ -441,7 +442,8 @@ class JavaTemplateTest3Test implements RewriteTest {
                   public void method(int[] val) {}
                   public void method(int[] val1, String val2) {}
               }
-              """, SourceSpec::skip
+              """,
+                SourceSpec::skip
           ),
           java(
             """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/NoStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/NoStaticImportTest.java
@@ -112,7 +112,8 @@ class NoStaticImportTest implements RewriteTest {
                     }
                   }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -130,7 +131,8 @@ class NoStaticImportTest implements RewriteTest {
                     
                     boolean hasNext();
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -146,7 +148,8 @@ class NoStaticImportTest implements RewriteTest {
                         return false;
                     }
                 }
-                """),
+                """
+              ),
               java(
                     """
                 package org.example;
@@ -156,7 +159,8 @@ class NoStaticImportTest implements RewriteTest {
                         return foo();
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -176,7 +180,8 @@ class NoStaticImportTest implements RewriteTest {
                         method0();
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -193,7 +198,8 @@ class NoStaticImportTest implements RewriteTest {
                         super();
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -214,7 +220,8 @@ class NoStaticImportTest implements RewriteTest {
                         }
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -235,7 +242,8 @@ class NoStaticImportTest implements RewriteTest {
                         }
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -256,7 +264,8 @@ class NoStaticImportTest implements RewriteTest {
                         }
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -280,7 +289,8 @@ class NoStaticImportTest implements RewriteTest {
                         }.run();
                     }
                 }
-                """));
+                """
+              ));
         }
 
         @Test
@@ -304,7 +314,8 @@ class NoStaticImportTest implements RewriteTest {
                         }
                     }
                 }
-                """, """
+                """,
+                    """
                 package org.openrewrite.java;
                                 
                 public class Test {
@@ -317,7 +328,8 @@ class NoStaticImportTest implements RewriteTest {
                         }
                     }
                 }
-                """));
+                """
+              ));
         }
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -1749,7 +1749,8 @@ class RemoveUnusedImportsTest implements RewriteTest {
                     B9 b9 = r.theOther9();
                   }
               }
-              """));
+              """
+          ));
     }
 
     @Test

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ShortenFullyQualifiedTypeReferencesTest.java
@@ -476,7 +476,8 @@ class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
                   class A {
                   }
               }
-              """),
+              """
+          ),
           java(
             """
               import java.util.ArrayList;
@@ -486,7 +487,8 @@ class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
                       java.util.List<Integer> l2 = new ArrayList<>();
                   }
               }
-              """)
+              """
+          )
         );
     }
 
@@ -501,7 +503,8 @@ class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
                       }
                   }
               }
-              """),
+              """
+          ),
           java(
             """
               import java.util.ArrayList;
@@ -511,7 +514,8 @@ class ShortenFullyQualifiedTypeReferencesTest implements RewriteTest {
                       java.util.List<Integer> l2 = new ArrayList<>();
                   }
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodDeclarationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodDeclarationTest.java
@@ -46,7 +46,8 @@ class FindMethodDeclarationTest implements RewriteTest {
                   void a(String s) {
                   }
               }
-              """)
+              """
+          )
         );
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasJavaVersionTest.java
@@ -134,7 +134,8 @@ class HasJavaVersionTest implements RewriteTest {
                       /*~~>*/list.add("1");
                   }
               }
-              """, spec -> spec.markers(javaVersion(11)))
+              """,
+                spec -> spec.markers(javaVersion(11)))
         );
     }
 
@@ -173,7 +174,8 @@ class HasJavaVersionTest implements RewriteTest {
                       /*~~>*/list.add("1");
                   }
               }
-              """, spec -> spec.markers(javaVersion(11)))
+              """,
+                spec -> spec.markers(javaVersion(11)))
         );
     }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/search/DeclaresTypeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/search/DeclaresTypeTest.java
@@ -35,7 +35,8 @@ class DeclaresTypeTest implements RewriteTest {
                 """
         package com.sample;
         public class Foo{}
-        """, """
+        """,
+                """
         package com.sample;
         /*~~>*/public class Foo{}
         """));

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -45,12 +45,14 @@ public class AddImportTest implements RewriteTest {
             """
               package a.b
               class Original
-              """),
+              """
+          ),
           kotlin(
             """
               package a.b
               class Target
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.Original

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AnnotationMatcherTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AnnotationMatcherTest.java
@@ -34,20 +34,21 @@ class AnnotationMatcherTest implements RewriteTest {
             """
               @Deprecated("")
               class A
-              """, spec -> spec.afterRecipe(cu -> {
-                AtomicBoolean found = new AtomicBoolean(false);
-                AnnotationMatcher matcher = new AnnotationMatcher("@kotlin.Deprecated");
-                new KotlinIsoVisitor<AtomicBoolean>() {
-                    @Override
-                    public J.Annotation visitAnnotation(J.Annotation annotation, AtomicBoolean atomicBoolean) {
-                        if (matcher.matches(annotation)) {
-                            found.set(true);
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean found = new AtomicBoolean(false);
+                    AnnotationMatcher matcher = new AnnotationMatcher("@kotlin.Deprecated");
+                    new KotlinIsoVisitor<AtomicBoolean>() {
+                        @Override
+                        public J.Annotation visitAnnotation(J.Annotation annotation, AtomicBoolean atomicBoolean) {
+                            if (matcher.matches(annotation)) {
+                                found.set(true);
+                            }
+                            return super.visitAnnotation(annotation, atomicBoolean);
                         }
-                        return super.visitAnnotation(annotation, atomicBoolean);
-                    }
-                }.visit(cu, found);
-                assertThat(found.get()).isTrue();
-            })
+                    }.visit(cu, found);
+                    assertThat(found.get()).isTrue();
+                })
           )
         );
     }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -40,7 +40,8 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.Original
@@ -67,7 +68,8 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.Original
@@ -95,7 +97,8 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.`Original`
@@ -122,7 +125,8 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.Original as MyAlias
@@ -150,12 +154,14 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original<A>
-              """),
+              """
+          ),
           kotlin(
             """
               package x.y
               class Target<A>
-              """),
+              """
+          ),
           kotlin(
             """
               package example
@@ -184,12 +190,14 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original<A>
-              """),
+              """
+          ),
           kotlin(
             """
               package x.y
               class Target<A>
-              """),
+              """
+          ),
           kotlin(
             """
               package example
@@ -216,12 +224,14 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original<A>
-              """),
+              """
+          ),
           kotlin(
             """
               package x.y
               class Target<A>
-              """),
+              """
+          ),
           kotlin(
             """
               package example
@@ -246,7 +256,8 @@ class ChangeTypeTest implements RewriteTest {
             """
               package a.b
               class Original
-              """),
+              """
+          ),
           kotlin(
             """
               class A {
@@ -414,7 +425,8 @@ class ChangeTypeTest implements RewriteTest {
               package a.b
 
               open class Original
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.Original
@@ -443,7 +455,8 @@ class ChangeTypeTest implements RewriteTest {
               package a.b
 
               annotation class Original
-              """),
+              """
+          ),
           kotlin(
             """
               import a.b.Original

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -368,21 +368,22 @@ public class KotlinTypeMappingTest {
                   val newList = buildList {
                       addAll(listOf(""))
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    MethodMatcher methodMatcher = new MethodMatcher("kotlin.collections.MutableList addAll(..)");
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
-                            if (methodMatcher.matches(method)) {
-                                assertThat(method.getMethodType().toString()).isEqualTo("kotlin.collections.MutableList<Generic{E}>{name=addAll,return=kotlin.Boolean,parameters=[kotlin.collections.Collection<Generic{E}>]}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        MethodMatcher methodMatcher = new MethodMatcher("kotlin.collections.MutableList addAll(..)");
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+                                if (methodMatcher.matches(method)) {
+                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.collections.MutableList<Generic{E}>{name=addAll,return=kotlin.Boolean,parameters=[kotlin.collections.Collection<Generic{E}>]}");
+                                    found.set(true);
+                                }
+                                return super.visitMethodInvocation(method, found);
                             }
-                            return super.visitMethodInvocation(method, found);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -397,20 +398,21 @@ public class KotlinTypeMappingTest {
                   import java.lang.invoke.TypeDescriptor.OfField
 
                   abstract class Foo<T> : OfField<Foo<Any>>
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, AtomicBoolean found) {
-                            if ("Foo".equals(classDecl.getSimpleName())) {
-                                assertThat(classDecl.getImplements().get(0).getType().toString()).isEqualTo("java.lang.invoke.TypeDescriptor$OfField<Foo<kotlin.Any>>");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, AtomicBoolean found) {
+                                if ("Foo".equals(classDecl.getSimpleName())) {
+                                    assertThat(classDecl.getImplements().get(0).getType().toString()).isEqualTo("java.lang.invoke.TypeDescriptor$OfField<Foo<kotlin.Any>>");
+                                    found.set(true);
+                                }
+                                return super.visitClassDeclaration(classDecl, found);
                             }
-                            return super.visitClassDeclaration(classDecl, found);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -421,22 +423,23 @@ public class KotlinTypeMappingTest {
               kotlin(
                 """
                   val l = listOf ( "foo" to "1" , "bar" to 2 )
-                  """, spec -> spec.afterRecipe(cu -> {
-                    MethodMatcher methodMatcher = new MethodMatcher("kotlin.collections.CollectionsKt listOf(..)");
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
-                            if (methodMatcher.matches(method)) {
-                                assertThat(method.getMethodType().toString())
-                                  .isEqualTo("kotlin.collections.CollectionsKt{name=listOf,return=kotlin.collections.List<kotlin.Pair<kotlin.String, Generic{kotlin.Comparable<Generic{?}> & java.io.Serializable}>>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        MethodMatcher methodMatcher = new MethodMatcher("kotlin.collections.CollectionsKt listOf(..)");
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean found) {
+                                if (methodMatcher.matches(method)) {
+                                    assertThat(method.getMethodType().toString())
+                                            .isEqualTo("kotlin.collections.CollectionsKt{name=listOf,return=kotlin.collections.List<kotlin.Pair<kotlin.String, Generic{kotlin.Comparable<Generic{?}> & java.io.Serializable}>>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
+                                    found.set(true);
+                                }
+                                return super.visitMethodInvocation(method, found);
                             }
-                            return super.visitMethodInvocation(method, found);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -448,21 +451,23 @@ public class KotlinTypeMappingTest {
                 """
                   val block: Collection<Any>.() -> Unit = {}
                   val r = listOf("descriptor").block()
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        final MethodMatcher matcher = new MethodMatcher("kotlin.Function1 block(..)");
-                        @Override
-                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
-                            if (matcher.matches(method)) {
-                                assertThat(method.getMethodType().toString()).isEqualTo("kotlin.Function1<kotlin.collections.Collection<kotlin.Any>, kotlin.Unit>{name=block,return=kotlin.Unit,parameters=[kotlin.collections.Collection<kotlin.Any>]}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            final MethodMatcher matcher = new MethodMatcher("kotlin.Function1 block(..)");
+
+                            @Override
+                            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
+                                if (matcher.matches(method)) {
+                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.Function1<kotlin.collections.Collection<kotlin.Any>, kotlin.Unit>{name=block,return=kotlin.Unit,parameters=[kotlin.collections.Collection<kotlin.Any>]}");
+                                    found.set(true);
+                                }
+                                return super.visitMethodInvocation(method, atomicBoolean);
                             }
-                            return super.visitMethodInvocation(method, atomicBoolean);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -474,23 +479,24 @@ public class KotlinTypeMappingTest {
                 """
                   val map = mapOf(Pair("one", 1)) as? Map<*, *>
                   val s = map.orEmpty().entries.joinToString { (key, value) -> "$key: $value" }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicBoolean found) {
-                            if ("entries".equals(fieldAccess.getSimpleName())) {
-                                assertThat(fieldAccess.getName().getType().toString())
-                                  .isEqualTo("kotlin.collections.Set<kotlin.collections.Map$Entry<Generic{?}, kotlin.Any>>");
-                                assertThat(fieldAccess.getName().getFieldType().toString())
-                                  .isEqualTo("kotlin.collections.Map{name=entries,type=kotlin.collections.Set<kotlin.collections.Map$Entry<Generic{?}, kotlin.Any>>}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicBoolean found) {
+                                if ("entries".equals(fieldAccess.getSimpleName())) {
+                                    assertThat(fieldAccess.getName().getType().toString())
+                                            .isEqualTo("kotlin.collections.Set<kotlin.collections.Map$Entry<Generic{?}, kotlin.Any>>");
+                                    assertThat(fieldAccess.getName().getFieldType().toString())
+                                            .isEqualTo("kotlin.collections.Map{name=entries,type=kotlin.collections.Set<kotlin.collections.Map$Entry<Generic{?}, kotlin.Any>>}");
+                                    found.set(true);
+                                }
+                                return super.visitFieldAccess(fieldAccess, found);
                             }
-                            return super.visitFieldAccess(fieldAccess, found);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -519,20 +525,21 @@ public class KotlinTypeMappingTest {
                   fun method() {
                       println("foo")
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
-                            if ("println".equals(method.getSimpleName())) {
-                                assertThat(method.getMethodType().toString()).isEqualTo("kotlin.io.ConsoleKt{name=println,return=kotlin.Unit,parameters=[kotlin.Any]}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
+                                if ("println".equals(method.getSimpleName())) {
+                                    assertThat(method.getMethodType().toString()).isEqualTo("kotlin.io.ConsoleKt{name=println,return=kotlin.Unit,parameters=[kotlin.Any]}");
+                                    found.set(true);
+                                }
+                                return super.visitMethodInvocation(method, atomicBoolean);
                             }
-                            return super.visitMethodInvocation(method, atomicBoolean);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -552,20 +559,21 @@ public class KotlinTypeMappingTest {
                           else             ->    0.9
                       }
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public K.When visitWhen(K.When when, AtomicBoolean found) {
-                            if (when.getType() instanceof JavaType.GenericTypeVariable) {
-                                assertThat(when.getType().toString()).isEqualTo("Generic{kotlin.Comparable<Generic{?}> & java.io.Serializable}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public K.When visitWhen(K.When when, AtomicBoolean found) {
+                                if (when.getType() instanceof JavaType.GenericTypeVariable) {
+                                    assertThat(when.getType().toString()).isEqualTo("Generic{kotlin.Comparable<Generic{?}> & java.io.Serializable}");
+                                    found.set(true);
+                                }
+                                return super.visitWhen(when, found);
                             }
-                            return super.visitWhen(when, found);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -687,15 +695,16 @@ public class KotlinTypeMappingTest {
                       val b = 1 !in listOf(2)
                       val a = 1 !in Foo()
                   }
-                  """, spec -> spec.afterRecipe(cu -> new KotlinIsoVisitor<Integer>() {
-                      @Override
-                      public K.Binary visitBinary(K.Binary binary, Integer integer) {
-                          JavaType type = binary.getType();
-                          assertThat(type).isInstanceOf(JavaType.Class.class);
-                          assertThat(((JavaType.Class) type).getFullyQualifiedName()).isEqualTo("kotlin.Boolean");
-                          return binary;
-                      }
-                  }.visit(cu, 0))
+                  """,
+                    spec -> spec.afterRecipe(cu -> new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public K.Binary visitBinary(K.Binary binary, Integer integer) {
+                            JavaType type = binary.getType();
+                            assertThat(type).isInstanceOf(JavaType.Class.class);
+                            assertThat(((JavaType.Class) type).getFullyQualifiedName()).isEqualTo("kotlin.Boolean");
+                            return binary;
+                        }
+                    }.visit(cu, 0))
               )
             );
         }
@@ -714,18 +723,19 @@ public class KotlinTypeMappingTest {
                           return super.id
                       }
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Integer integer) {
-                            assertThat(fieldAccess.getType().toString()).isEqualTo("kotlin.Int");
-                            found.set(true);
-                            return super.visitFieldAccess(fieldAccess, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Integer integer) {
+                                assertThat(fieldAccess.getType().toString()).isEqualTo("kotlin.Int");
+                                found.set(true);
+                                return super.visitFieldAccess(fieldAccess, integer);
+                            }
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -741,19 +751,20 @@ public class KotlinTypeMappingTest {
                   class Foo {
                       val l: ArrayList<String> = ArrayList<String>()
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.ParameterizedType visitParameterizedType(J.ParameterizedType type, Integer integer) {
-                            assertThat(type.getType().toString()).isEqualTo("java.util.ArrayList<kotlin.String>");
-                            assertThat(type.getClazz().getType().toString()).isEqualTo("java.util.ArrayList");
-                            found.set(true);
-                            return super.visitParameterizedType(type, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.ParameterizedType visitParameterizedType(J.ParameterizedType type, Integer integer) {
+                                assertThat(type.getType().toString()).isEqualTo("java.util.ArrayList<kotlin.String>");
+                                assertThat(type.getClazz().getType().toString()).isEqualTo("java.util.ArrayList");
+                                found.set(true);
+                                return super.visitParameterizedType(type, integer);
+                            }
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -768,29 +779,30 @@ public class KotlinTypeMappingTest {
                   class SomeParameterized<T>
                   val SomeParameterized < Int > . receivedMember : Int
                       get ( ) = 42
-                  """, spec -> spec.afterRecipe(cu -> new KotlinIsoVisitor<Integer>() {
-                      @Override
-                      public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, Integer integer) {
-                          assertThat(classDecl.getType().toString()).isEqualTo("SomeParameterized<Generic{T}>");
-                          assertThat(classDecl.getName().getType().toString()).isEqualTo("SomeParameterized<Generic{T}>");
-                          return super.visitClassDeclaration(classDecl, integer);
-                      }
+                  """,
+                    spec -> spec.afterRecipe(cu -> new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, Integer integer) {
+                            assertThat(classDecl.getType().toString()).isEqualTo("SomeParameterized<Generic{T}>");
+                            assertThat(classDecl.getName().getType().toString()).isEqualTo("SomeParameterized<Generic{T}>");
+                            return super.visitClassDeclaration(classDecl, integer);
+                        }
 
-                      @Override
-                      public K.Property visitProperty(K.Property property, Integer integer) {
-                          assertThat(property.getReceiver().getType().toString()).isEqualTo("SomeParameterized<kotlin.Int>");
-                          assertThat(((J.ParameterizedType) property.getReceiver()).getClazz().getType().toString()).isEqualTo("SomeParameterized");
-                          return super.visitProperty(property, integer);
-                      }
+                        @Override
+                        public K.Property visitProperty(K.Property property, Integer integer) {
+                            assertThat(property.getReceiver().getType().toString()).isEqualTo("SomeParameterized<kotlin.Int>");
+                            assertThat(((J.ParameterizedType) property.getReceiver()).getClazz().getType().toString()).isEqualTo("SomeParameterized");
+                            return super.visitProperty(property, integer);
+                        }
 
-                      @Override
-                      public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer integer) {
-                          assertThat(variable.getVariableType().toString()).isEqualTo("openRewriteFile0Kt{name=receivedMember,type=kotlin.Int}");
-                          assertThat(variable.getName().getType().toString()).isEqualTo("kotlin.Int");
-                          assertThat(variable.getName().getFieldType().toString()).isEqualTo("openRewriteFile0Kt{name=receivedMember,type=kotlin.Int}");
-                          return super.visitVariable(variable, integer);
-                      }
-                  }.visit(cu, 0))
+                        @Override
+                        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer integer) {
+                            assertThat(variable.getVariableType().toString()).isEqualTo("openRewriteFile0Kt{name=receivedMember,type=kotlin.Int}");
+                            assertThat(variable.getName().getType().toString()).isEqualTo("kotlin.Int");
+                            assertThat(variable.getName().getFieldType().toString()).isEqualTo("openRewriteFile0Kt{name=receivedMember,type=kotlin.Int}");
+                            return super.visitVariable(variable, integer);
+                        }
+                    }.visit(cu, 0))
               )
             );
         }
@@ -804,50 +816,51 @@ public class KotlinTypeMappingTest {
                   fun foo() {
                       val ( a , b , c ) = Triple ( 1 , 2 , 3 )
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<AtomicBoolean>() {
-                        @Override
-                        public K.DestructuringDeclaration visitDestructuringDeclaration(K.DestructuringDeclaration destructuringDeclaration, AtomicBoolean found) {
-                            found.set(true);
-                            return super.visitDestructuringDeclaration(destructuringDeclaration, found);
-                        }
-
-                        @Override
-                        public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean found) {
-                            if ("Triple".equals(((J.Identifier) newClass.getClazz()).getSimpleName())) {
-                                assertThat(newClass.getClazz().getType().toString()).isEqualTo("kotlin.Triple");
-                                assertThat(newClass.getConstructorType().toString()).isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>{name=<constructor>,return=kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>,parameters=[kotlin.Int,kotlin.Int,kotlin.Int]}");
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public K.DestructuringDeclaration visitDestructuringDeclaration(K.DestructuringDeclaration destructuringDeclaration, AtomicBoolean found) {
+                                found.set(true);
+                                return super.visitDestructuringDeclaration(destructuringDeclaration, found);
                             }
-                            return super.visitNewClass(newClass, found);
-                        }
 
-                        @Override
-                        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, AtomicBoolean found) {
-                            switch (variable.getSimpleName()) {
-                                case "<destruct>" -> assertThat(variable.getName().getType().toString())
-                                  .isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>");
-                                case "a" -> {
-                                    assertThat(variable.getVariableType().toString())
-                                      .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=a,type=kotlin.Int}");
-                                    assertThat(variable.getInitializer()).isNull();
+                            @Override
+                            public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean found) {
+                                if ("Triple".equals(((J.Identifier) newClass.getClazz()).getSimpleName())) {
+                                    assertThat(newClass.getClazz().getType().toString()).isEqualTo("kotlin.Triple");
+                                    assertThat(newClass.getConstructorType().toString()).isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>{name=<constructor>,return=kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>,parameters=[kotlin.Int,kotlin.Int,kotlin.Int]}");
                                 }
-                                case "b" -> {
-                                    assertThat(variable.getVariableType().toString())
-                                      .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=b,type=kotlin.Int}");
-                                    assertThat(variable.getInitializer()).isNull();
-                                }
-                                case "c" -> {
-                                    assertThat(variable.getVariableType().toString())
-                                      .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=c,type=kotlin.Int}");
-                                    assertThat(variable.getInitializer()).isNull();
-                                }
+                                return super.visitNewClass(newClass, found);
                             }
-                            return super.visitVariable(variable, found);
-                        }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+
+                            @Override
+                            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, AtomicBoolean found) {
+                                switch (variable.getSimpleName()) {
+                                    case "<destruct>" -> assertThat(variable.getName().getType().toString())
+                                            .isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>");
+                                    case "a" -> {
+                                        assertThat(variable.getVariableType().toString())
+                                                .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=a,type=kotlin.Int}");
+                                        assertThat(variable.getInitializer()).isNull();
+                                    }
+                                    case "b" -> {
+                                        assertThat(variable.getVariableType().toString())
+                                                .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=b,type=kotlin.Int}");
+                                        assertThat(variable.getInitializer()).isNull();
+                                    }
+                                    case "c" -> {
+                                        assertThat(variable.getVariableType().toString())
+                                                .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=c,type=kotlin.Int}");
+                                        assertThat(variable.getInitializer()).isNull();
+                                    }
+                                }
+                                return super.visitVariable(variable, found);
+                            }
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -903,30 +916,31 @@ public class KotlinTypeMappingTest {
                           val use: Int = foo4
                       }
                   }
-                  """, spec -> spec.afterRecipe(cu -> new KotlinIsoVisitor<Integer>() {
-                      @Override
-                      public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer integer) {
-                          switch (variable.getSimpleName()) {
-                              case "foo1": {
-                                  assertThat(variable.getVariableType().toString()).isEqualTo("openRewriteFile0Kt{name=foo1,type=kotlin.Int}");
-                                  break;
-                              }
-                              case "foo2": {
-                                  assertThat(variable.getVariableType().toString()).isEqualTo("Foo{name=foo2,type=kotlin.Int}");
-                                  break;
-                              }
-                              case "foo3": {
-                                  assertThat(variable.getVariableType().toString()).isEqualTo("Foo{name=foo3,type=kotlin.Int}");
-                                  break;
-                              }
-                              case "foo4": {
-                                  assertThat(variable.getVariableType().toString()).isEqualTo("Foo{name=m,return=kotlin.Unit,parameters=[kotlin.Int]}{name=foo4,type=kotlin.Int}");
-                                  break;
-                              }
-                          }
-                          return super.visitVariable(variable, integer);
-                      }
-                  }.visit(cu, 0))
+                  """,
+                    spec -> spec.afterRecipe(cu -> new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer integer) {
+                            switch (variable.getSimpleName()) {
+                                case "foo1": {
+                                    assertThat(variable.getVariableType().toString()).isEqualTo("openRewriteFile0Kt{name=foo1,type=kotlin.Int}");
+                                    break;
+                                }
+                                case "foo2": {
+                                    assertThat(variable.getVariableType().toString()).isEqualTo("Foo{name=foo2,type=kotlin.Int}");
+                                    break;
+                                }
+                                case "foo3": {
+                                    assertThat(variable.getVariableType().toString()).isEqualTo("Foo{name=foo3,type=kotlin.Int}");
+                                    break;
+                                }
+                                case "foo4": {
+                                    assertThat(variable.getVariableType().toString()).isEqualTo("Foo{name=m,return=kotlin.Unit,parameters=[kotlin.Int]}{name=foo4,type=kotlin.Int}");
+                                    break;
+                                }
+                            }
+                            return super.visitVariable(variable, integer);
+                        }
+                    }.visit(cu, 0))
               )
             );
         }
@@ -978,37 +992,38 @@ public class KotlinTypeMappingTest {
                   interface D
 
                   class KotlinTypeGoat<T, S>  where   S : A, T : D, S : B, T : C
-                  """, spec -> spec.afterRecipe(cu -> {
-                      AtomicBoolean found = new AtomicBoolean(false);
-                      new KotlinIsoVisitor<AtomicBoolean>() {
-                          @Override
-                          public K.ClassDeclaration visitClassDeclaration(K.ClassDeclaration classDeclaration, AtomicBoolean atomicBoolean) {
-                              if ("KotlinTypeGoat".equals(classDeclaration.getClassDeclaration().getSimpleName())) {
-                                  List<J.TypeParameter> constraints = classDeclaration.getTypeConstraints().getConstraints();
-                                  for (int i = 0; i < constraints.size(); i++) {
-                                      J.TypeParameter p = constraints.get(i);
-                                      switch (i) {
-                                          case 0:
-                                              assertThat(p.getName().getType().toString()).isEqualTo("A");
-                                              break;
-                                          case 1:
-                                              assertThat(p.getName().getType().toString()).isEqualTo("D");
-                                              break;
-                                          case 2:
-                                              assertThat(p.getName().getType().toString()).isEqualTo("B");
-                                              break;
-                                          case 3:
-                                              assertThat(p.getName().getType().toString()).isEqualTo("C");
-                                              found.set(true);
-                                              break;
-                                      }
-                                  }
-                              }
-                              return super.visitClassDeclaration(classDeclaration, atomicBoolean);
-                          }
-                    }.visit(cu, found);
-                    assertThat(found.get()).isTrue();
-                })
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<AtomicBoolean>() {
+                            @Override
+                            public K.ClassDeclaration visitClassDeclaration(K.ClassDeclaration classDeclaration, AtomicBoolean atomicBoolean) {
+                                if ("KotlinTypeGoat".equals(classDeclaration.getClassDeclaration().getSimpleName())) {
+                                    List<J.TypeParameter> constraints = classDeclaration.getTypeConstraints().getConstraints();
+                                    for (int i = 0; i < constraints.size(); i++) {
+                                        J.TypeParameter p = constraints.get(i);
+                                        switch (i) {
+                                            case 0:
+                                                assertThat(p.getName().getType().toString()).isEqualTo("A");
+                                                break;
+                                            case 1:
+                                                assertThat(p.getName().getType().toString()).isEqualTo("D");
+                                                break;
+                                            case 2:
+                                                assertThat(p.getName().getType().toString()).isEqualTo("B");
+                                                break;
+                                            case 3:
+                                                assertThat(p.getName().getType().toString()).isEqualTo("C");
+                                                found.set(true);
+                                                break;
+                                        }
+                                    }
+                                }
+                                return super.visitClassDeclaration(classDeclaration, atomicBoolean);
+                            }
+                        }.visit(cu, found);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -1310,26 +1325,27 @@ public class KotlinTypeMappingTest {
                  class Test {
                      val sb = java.lang.StringBuilder().toString()
                  }
-                 """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean isFieldTargetNull = new AtomicBoolean(false);
-                    AtomicBoolean isStringBuilderTyped = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
-                            if ("lang".equals(identifier.getSimpleName())) {
-                                assertThat(identifier.getType()).isNull();
-                                isFieldTargetNull.set(true);
+                 """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean isFieldTargetNull = new AtomicBoolean(false);
+                        AtomicBoolean isStringBuilderTyped = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                if ("lang".equals(identifier.getSimpleName())) {
+                                    assertThat(identifier.getType()).isNull();
+                                    isFieldTargetNull.set(true);
+                                }
+                                if ("StringBuilder".equals(identifier.getSimpleName())) {
+                                    assertThat(identifier.getType().toString()).isEqualTo("java.lang.StringBuilder");
+                                    isStringBuilderTyped.set(true);
+                                }
+                                return super.visitIdentifier(identifier, integer);
                             }
-                            if ("StringBuilder".equals(identifier.getSimpleName())) {
-                                assertThat(identifier.getType().toString()).isEqualTo("java.lang.StringBuilder");
-                                isStringBuilderTyped.set(true);
-                            }
-                            return super.visitIdentifier(identifier, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(isFieldTargetNull.get()).isTrue();
-                    assertThat(isStringBuilderTyped.get()).isTrue();
-                })
+                        }.visit(cu, 0);
+                        assertThat(isFieldTargetNull.get()).isTrue();
+                        assertThat(isStringBuilderTyped.get()).isTrue();
+                    })
               )
             );
         }
@@ -1342,30 +1358,31 @@ public class KotlinTypeMappingTest {
                 """
                   @Suppress("UNUSED_PARAMETER")
                   fun foo(l: List<Pair<String, String>>) {}
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicInteger count = new AtomicInteger(0);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
-                            switch (identifier.getSimpleName()) {
-                                case "List" -> {
-                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.collections.List");
-                                    count.incrementAndGet();
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicInteger count = new AtomicInteger(0);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                switch (identifier.getSimpleName()) {
+                                    case "List" -> {
+                                        assertThat(identifier.getType().toString()).isEqualTo("kotlin.collections.List");
+                                        count.incrementAndGet();
+                                    }
+                                    case "Pair" -> {
+                                        assertThat(identifier.getType().toString()).isEqualTo("kotlin.Pair");
+                                        count.incrementAndGet();
+                                    }
+                                    case "String" -> {
+                                        assertThat(identifier.getType().toString()).isEqualTo("kotlin.String");
+                                        count.incrementAndGet();
+                                    }
                                 }
-                                case "Pair" -> {
-                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.Pair");
-                                    count.incrementAndGet();
-                                }
-                                case "String" -> {
-                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.String");
-                                    count.incrementAndGet();
-                                }
+                                return super.visitIdentifier(identifier, integer);
                             }
-                            return super.visitIdentifier(identifier, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(count.get()).isEqualTo(4);
-                })
+                        }.visit(cu, 0);
+                        assertThat(count.get()).isEqualTo(4);
+                    })
               )
             );
         }
@@ -1377,30 +1394,31 @@ public class KotlinTypeMappingTest {
               kotlin(
                 """
                   val m: MutableMap.MutableEntry<String, String>? = null
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicInteger count = new AtomicInteger(0);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
-                            switch (identifier.getSimpleName()) {
-                                case "MutableMap" -> {
-                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.collections.MutableMap<Generic{K}, Generic{V}>");
-                                    count.incrementAndGet();
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicInteger count = new AtomicInteger(0);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                switch (identifier.getSimpleName()) {
+                                    case "MutableMap" -> {
+                                        assertThat(identifier.getType().toString()).isEqualTo("kotlin.collections.MutableMap<Generic{K}, Generic{V}>");
+                                        count.incrementAndGet();
+                                    }
+                                    case "MutableEntry" -> {
+                                        assertThat(identifier.getType().toString()).isEqualTo("kotlin.collections.MutableMap$MutableEntry<kotlin.String, kotlin.String>");
+                                        count.incrementAndGet();
+                                    }
+                                    case "String" -> {
+                                        assertThat(identifier.getType().toString()).isEqualTo("kotlin.String");
+                                        count.incrementAndGet();
+                                    }
                                 }
-                                case "MutableEntry" -> {
-                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.collections.MutableMap$MutableEntry<kotlin.String, kotlin.String>");
-                                    count.incrementAndGet();
-                                }
-                                case "String" -> {
-                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.String");
-                                    count.incrementAndGet();
-                                }
+                                return super.visitIdentifier(identifier, integer);
                             }
-                            return super.visitIdentifier(identifier, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(count.get()).isEqualTo(4);
-                })
+                        }.visit(cu, 0);
+                        assertThat(count.get()).isEqualTo(4);
+                    })
               )
             );
         }
@@ -1414,23 +1432,24 @@ public class KotlinTypeMappingTest {
                   @file:Suppress("UNUSED_PARAMETER")
                   fun foo(a: Array<in String>) {}
                   fun bar(b: Array<out Number>) {}
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicInteger count = new AtomicInteger(0);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
-                            if ("String".equals(identifier.getSimpleName())) {
-                                assertThat(identifier.getType().toString()).isEqualTo("kotlin.String");
-                                count.incrementAndGet();
-                            } else if ("Number".equals(identifier.getSimpleName())) {
-                                assertThat(identifier.getType().toString()).isEqualTo("kotlin.Number");
-                                count.incrementAndGet();
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicInteger count = new AtomicInteger(0);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                if ("String".equals(identifier.getSimpleName())) {
+                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.String");
+                                    count.incrementAndGet();
+                                } else if ("Number".equals(identifier.getSimpleName())) {
+                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.Number");
+                                    count.incrementAndGet();
+                                }
+                                return super.visitIdentifier(identifier, integer);
                             }
-                            return super.visitIdentifier(identifier, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(count.get()).isEqualTo(2);
-                })
+                        }.visit(cu, 0);
+                        assertThat(count.get()).isEqualTo(2);
+                    })
               )
             );
         }
@@ -1442,21 +1461,22 @@ public class KotlinTypeMappingTest {
                 """
                  import java.lang.AutoCloseable
                  abstract class Test : AutoCloseable
-                 """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
-                            if ("AutoCloseable".equals(identifier.getSimpleName()) && identifier.getType() != null) {
-                                assertThat(((JavaType.Class) identifier.getType()).getMethods().get(0).toString())
-                                  .isEqualTo("java.lang.AutoCloseable{name=close,return=void,parameters=[]}");
-                                found.set(true);
+                 """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                if ("AutoCloseable".equals(identifier.getSimpleName()) && identifier.getType() != null) {
+                                    assertThat(((JavaType.Class) identifier.getType()).getMethods().get(0).toString())
+                                            .isEqualTo("java.lang.AutoCloseable{name=close,return=void,parameters=[]}");
+                                    found.set(true);
+                                }
+                                return super.visitIdentifier(identifier, integer);
                             }
-                            return super.visitIdentifier(identifier, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -1475,21 +1495,22 @@ public class KotlinTypeMappingTest {
                           // Body is required to reproduce issue
                       }
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.EnumValue visitEnumValue(J.EnumValue _enum, Integer integer) {
-                            if ("FOO".equals(_enum.getName().getSimpleName())) {
-                                assertThat(_enum.getInitializer().getConstructorType().toString())
-                                  .isEqualTo("Test{name=<constructor>,return=Test,parameters=[Code]}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.EnumValue visitEnumValue(J.EnumValue _enum, Integer integer) {
+                                if ("FOO".equals(_enum.getName().getSimpleName())) {
+                                    assertThat(_enum.getInitializer().getConstructorType().toString())
+                                            .isEqualTo("Test{name=<constructor>,return=Test,parameters=[Code]}");
+                                    found.set(true);
+                                }
+                                return super.visitEnumValue(_enum, integer);
                             }
-                            return super.visitEnumValue(_enum, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -1500,20 +1521,21 @@ public class KotlinTypeMappingTest {
               kotlin(
                 """
                  fun foo() :   suspend    ( param : Int )  -> Unit = { }
-                 """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
-                            if ("param".equals(identifier.getSimpleName()) && identifier.getType() != null) {
-                                assertThat(identifier.getType().toString()).isEqualTo("kotlin.Int");
-                                found.set(true);
+                 """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                if ("param".equals(identifier.getSimpleName()) && identifier.getType() != null) {
+                                    assertThat(identifier.getType().toString()).isEqualTo("kotlin.Int");
+                                    found.set(true);
+                                }
+                                return super.visitIdentifier(identifier, integer);
                             }
-                            return super.visitIdentifier(identifier, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -1525,18 +1547,19 @@ public class KotlinTypeMappingTest {
               kotlin(
                 """
                  val arr = arrayOf(1, 2, 3)
-                 """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer integer) {
-                            assertThat(method.getMethodType().toString()).isEqualTo("kotlin.Library{name=arrayOf,return=kotlin.Array<kotlin.Int>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
-                            found.set(true);
-                            return super.visitMethodInvocation(method, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                 """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer integer) {
+                                assertThat(method.getMethodType().toString()).isEqualTo("kotlin.Library{name=arrayOf,return=kotlin.Array<kotlin.Int>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
+                                found.set(true);
+                                return super.visitMethodInvocation(method, integer);
+                            }
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }
@@ -1550,20 +1573,21 @@ public class KotlinTypeMappingTest {
                      @Suppress("UNCHECKED_CAST")
                      requireNotNull("x")
                  }
-                 """, spec -> spec.afterRecipe(cu -> {
-                    AtomicInteger count = new AtomicInteger(0);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.NewClass visitNewClass(J.NewClass newClass, Integer integer) {
-                            assertThat(newClass.getMethodType().toString()).isEqualTo("java.util.function.Supplier{name=<constructor>,return=java.util.function.Supplier<kotlin.String>,parameters=[kotlin.Function0<Generic{T extends kotlin.Any}>]}");
-                            count.getAndIncrement();
-                            assertThat(newClass.getClazz().getType().toString()).isEqualTo("java.util.function.Supplier<kotlin.String>");
-                            count.getAndIncrement();
-                            return super.visitNewClass(newClass, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(count.get()).isEqualTo(2);
-                })
+                 """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicInteger count = new AtomicInteger(0);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.NewClass visitNewClass(J.NewClass newClass, Integer integer) {
+                                assertThat(newClass.getMethodType().toString()).isEqualTo("java.util.function.Supplier{name=<constructor>,return=java.util.function.Supplier<kotlin.String>,parameters=[kotlin.Function0<Generic{T extends kotlin.Any}>]}");
+                                count.getAndIncrement();
+                                assertThat(newClass.getClazz().getType().toString()).isEqualTo("java.util.function.Supplier<kotlin.String>");
+                                count.getAndIncrement();
+                                return super.visitNewClass(newClass, integer);
+                            }
+                        }.visit(cu, 0);
+                        assertThat(count.get()).isEqualTo(2);
+                    })
               )
             );
         }
@@ -1580,20 +1604,21 @@ public class KotlinTypeMappingTest {
                     @Suppress("UNUSED_PARAMETER")
                     fun mRef(a: Any) {}
                   }
-                  """, spec -> spec.afterRecipe(cu -> {
-                    AtomicBoolean found = new AtomicBoolean(false);
-                    new KotlinIsoVisitor<Integer>() {
-                        @Override
-                        public J.MemberReference visitMemberReference(J.MemberReference memberRef, Integer integer) {
-                            if ("A".equals(memberRef.getReference().getSimpleName())) {
-                                assertThat(memberRef.getMethodType().toString()).isEqualTo("A{name=<constructor>,return=A,parameters=[kotlin.Function1<kotlin.Function1<kotlin.Any, A>, A>]}");
-                                found.set(true);
+                  """,
+                    spec -> spec.afterRecipe(cu -> {
+                        AtomicBoolean found = new AtomicBoolean(false);
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.MemberReference visitMemberReference(J.MemberReference memberRef, Integer integer) {
+                                if ("A".equals(memberRef.getReference().getSimpleName())) {
+                                    assertThat(memberRef.getMethodType().toString()).isEqualTo("A{name=<constructor>,return=A,parameters=[kotlin.Function1<kotlin.Function1<kotlin.Any, A>, A>]}");
+                                    found.set(true);
+                                }
+                                return super.visitMemberReference(memberRef, integer);
                             }
-                            return super.visitMemberReference(memberRef, integer);
-                        }
-                    }.visit(cu, 0);
-                    assertThat(found.get()).isTrue();
-                })
+                        }.visit(cu, 0);
+                        assertThat(found.get()).isTrue();
+                    })
               )
             );
         }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/format/TabsAndIndentsTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/format/TabsAndIndentsTest.java
@@ -2118,7 +2118,8 @@ class TabsAndIndentsTest implements RewriteTest {
             package org.a
 
             open class A {}
-            """),
+            """
+          ),
           kotlin(
             """
               package org.b

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -54,7 +54,8 @@ class AnnotationTest implements RewriteTest {
               @Target(AnnotationTarget.FILE)
               @Retention(AnnotationRetention.SOURCE)
               annotation class Anno
-              """),
+              """
+          ),
           kotlin(
             //language=none
             """

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -159,11 +159,12 @@ class ClassDeclarationTest implements RewriteTest {
                   class Inner {
                   }
               }
-              """, spec -> spec.afterRecipe(cu -> {
-                assertThat(cu.getStatements().stream()
-                  .anyMatch(it -> it instanceof J.ClassDeclaration &&
-                    ((J.ClassDeclaration) it).getKind() == J.ClassDeclaration.Kind.Type.Interface)).isTrue();
-            })
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    assertThat(cu.getStatements().stream()
+                            .anyMatch(it -> it instanceof J.ClassDeclaration &&
+                                    ((J.ClassDeclaration) it).getKind() == J.ClassDeclaration.Kind.Type.Interface)).isTrue();
+                })
           )
         );
     }
@@ -471,7 +472,8 @@ class ClassDeclarationTest implements RewriteTest {
                     println ( "Hello, world!" )
                 }
             }
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/ImportTest.java
@@ -113,7 +113,8 @@ class ImportTest implements RewriteTest {
               import kotlin.collections.Set as S
               
               class T
-              """)
+              """
+          )
         );
     }
 
@@ -153,7 +154,8 @@ class ImportTest implements RewriteTest {
               import Foo as Bar
               
               class Test
-              """)
+              """
+          )
         );
     }
 
@@ -164,7 +166,8 @@ class ImportTest implements RewriteTest {
           kotlin(
             """
               import org.`should be equal to`
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/KTSTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/KTSTest.java
@@ -35,7 +35,8 @@ class KTSTest implements RewriteTest {
                 """
             var x = 5
             x += 1 /*C1*/
-            """)
+            """
+          )
         );
     }
 
@@ -45,7 +46,8 @@ class KTSTest implements RewriteTest {
           kotlinScript(
                 """
             println("foo")
-            """)
+            """
+          )
         );
     }
 
@@ -58,7 +60,8 @@ class KTSTest implements RewriteTest {
             for (item in items) {
                 println(item)
             }
-            """)
+            """
+          )
         );
     }
 
@@ -78,17 +81,18 @@ class KTSTest implements RewriteTest {
                     url = uri("https://maven.springframework.org/release")
                 }
             }
-            """, spec -> spec.afterRecipe(cu -> {
-              AtomicInteger count = new AtomicInteger();
-                new KotlinIsoVisitor<AtomicInteger>() {
-                    @Override
-                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicInteger i) {
-                        i.incrementAndGet();
-                        return super.visitMethodInvocation(method, i);
-                    }
-                }.visit(cu, count);
-                assertThat(count.get()).isEqualTo(7);
-          }))
+            """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicInteger count = new AtomicInteger();
+                    new KotlinIsoVisitor<AtomicInteger>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicInteger i) {
+                            i.incrementAndGet();
+                            return super.visitMethodInvocation(method, i);
+                        }
+                    }.visit(cu, count);
+                    assertThat(count.get()).isEqualTo(7);
+                }))
         );
     }
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
@@ -248,7 +248,8 @@ class MethodDeclarationTest implements RewriteTest {
               inline fun example (
                 crossinline block : ( ) -> Unit
               ) : Unit = Unit
-              """)
+              """
+          )
         );
     }
 
@@ -261,7 +262,8 @@ class MethodDeclarationTest implements RewriteTest {
               inline fun example (
                 noinline block : ( ) -> Unit
               ) : Unit = Unit
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
@@ -502,7 +502,8 @@ class MethodInvocationTest implements RewriteTest {
               fun test ( ) {
                 format (  *   arrayOf ( "foo" , "bar" ) )
               }
-              """)
+              """
+          )
         );
     }
 
@@ -517,7 +518,8 @@ class MethodInvocationTest implements RewriteTest {
                 val x = arrayOf ( "foo" , "bar" )
                 format ( "" , * x )
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -557,14 +557,15 @@ class VariableDeclarationTest implements RewriteTest {
           kotlin(
             """
               val l = 42
-              """, spec -> spec.afterRecipe(cu -> {
-                for (Statement statement : cu.getStatements()) {
-                    if (statement instanceof J.VariableDeclarations) {
-                        J.Modifier.hasModifier(((J.VariableDeclarations) statement).getModifiers(), J.Modifier.Type.Final);
-                        assertThat(J.Modifier.hasModifier(((J.VariableDeclarations) statement).getModifiers(), J.Modifier.Type.Final)).isTrue();
+              """,
+                spec -> spec.afterRecipe(cu -> {
+                    for (Statement statement : cu.getStatements()) {
+                        if (statement instanceof J.VariableDeclarations) {
+                            J.Modifier.hasModifier(((J.VariableDeclarations) statement).getModifiers(), J.Modifier.Type.Final);
+                            assertThat(J.Modifier.hasModifier(((J.VariableDeclarations) statement).getModifiers(), J.Modifier.Type.Final)).isTrue();
+                        }
                     }
-                }
-              }))
+                }))
         );
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeParentPomTest.java
@@ -1308,7 +1308,8 @@ class ChangeParentPomTest implements RewriteTest {
                         </dependency>
                       </dependencies>
                   </project>
-                  """)
+                  """
+              )
             );
         }
 
@@ -1367,7 +1368,8 @@ class ChangeParentPomTest implements RewriteTest {
                         </dependency>
                       </dependencies>
                   </project>
-                  """)
+                  """
+              )
             );
         }
     }
@@ -1539,7 +1541,8 @@ class ChangeParentPomTest implements RewriteTest {
                       </dependency>
                   </dependencies>
               </project>
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -311,7 +311,8 @@ class MavenDependencyFailuresTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -1505,21 +1505,22 @@ class MavenParserTest implements RewriteTest {
                           </profile>
                       </profiles>
                   </project>
-                  """, spec -> spec.afterRecipe(pomXml -> {
-                      Map<String, List<ResolvedDependency>> deps =
-                        pomXml.getMarkers()
-                          .findFirst(MavenResolutionResult.class)
-                          .orElseThrow()
-                          .getDependencies()
-                          .get(Scope.Compile)
-                          .stream()
-                          .collect(groupingBy(ResolvedDependency::getArtifactId));
+                  """,
+                    spec -> spec.afterRecipe(pomXml -> {
+                                Map<String, List<ResolvedDependency>> deps =
+                                        pomXml.getMarkers()
+                                                .findFirst(MavenResolutionResult.class)
+                                                .orElseThrow()
+                                                .getDependencies()
+                                                .get(Scope.Compile)
+                                                .stream()
+                                                .collect(groupingBy(ResolvedDependency::getArtifactId));
 
-                      assertThat(deps)
-                        .hasEntrySatisfying("commons-io", rds -> assertThat(rds)
-                          .singleElement().extracting(ResolvedDependency::getVersion).isEqualTo("2.11.0"));
-                  }
-                )
+                                assertThat(deps)
+                                        .hasEntrySatisfying("commons-io", rds -> assertThat(rds)
+                                                .singleElement().extracting(ResolvedDependency::getVersion).isEqualTo("2.11.0"));
+                            }
+                    )
               )
             );
         }
@@ -2144,7 +2145,8 @@ class MavenParserTest implements RewriteTest {
                 </modules>
               
               </project>
-              """, spec -> spec.path("pom.xml")),
+              """,
+                spec -> spec.path("pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2162,7 +2164,8 @@ class MavenParserTest implements RewriteTest {
                   <relativePath>../pom.xml</relativePath>
                 </parent>
               </project>
-              """, spec -> spec.path("rest/pom.xml"))
+              """,
+                spec -> spec.path("rest/pom.xml"))
         );
     }
 
@@ -2192,7 +2195,8 @@ class MavenParserTest implements RewriteTest {
                   <revision>0.0.0-SNAPSHOT</revision>
                 </properties>
               </project>
-              """, spec -> spec.path("pom.xml")),
+              """,
+                spec -> spec.path("pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2223,7 +2227,8 @@ class MavenParserTest implements RewriteTest {
                   </dependencies>
                 </dependencyManagement>
               </project>
-              """, spec -> spec.path("parent/pom.xml")),
+              """,
+                spec -> spec.path("parent/pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2253,7 +2258,8 @@ class MavenParserTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """, spec -> spec.path("app/pom.xml")),
+              """,
+                spec -> spec.path("app/pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2271,7 +2277,8 @@ class MavenParserTest implements RewriteTest {
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
               </project>
-              """, spec -> spec.path("rest/pom.xml")),
+              """,
+                spec -> spec.path("rest/pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2289,7 +2296,8 @@ class MavenParserTest implements RewriteTest {
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
               </project>
-              """, spec -> spec.path("web/pom.xml"))
+              """,
+                spec -> spec.path("web/pom.xml"))
         );
     }
 
@@ -2320,7 +2328,8 @@ class MavenParserTest implements RewriteTest {
                   <revision>0.0.0-SNAPSHOT</revision>
                 </properties>
               </project>
-              """, spec -> spec.path("pom.xml")),
+              """,
+                spec -> spec.path("pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2351,7 +2360,8 @@ class MavenParserTest implements RewriteTest {
                   </dependencies>
                 </dependencyManagement>
               </project>
-              """, spec -> spec.path("parent/pom.xml")),
+              """,
+                spec -> spec.path("parent/pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2387,7 +2397,8 @@ class MavenParserTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """, """
+              """,
+                """
               <?xml version="1.0" encoding="UTF-8"?>
               <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -2421,7 +2432,8 @@ class MavenParserTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """, spec -> spec.path("app/pom.xml")),
+              """,
+                spec -> spec.path("app/pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2439,7 +2451,8 @@ class MavenParserTest implements RewriteTest {
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
               </project>
-              """, spec -> spec.path("rest/pom.xml")),
+              """,
+                spec -> spec.path("rest/pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -2457,7 +2470,8 @@ class MavenParserTest implements RewriteTest {
                   <relativePath>../parent/pom.xml</relativePath>
                 </parent>
               </project>
-              """, spec -> spec.path("web/pom.xml"))
+              """,
+                spec -> spec.path("web/pom.xml"))
         );
     }
 
@@ -2501,7 +2515,8 @@ class MavenParserTest implements RewriteTest {
               
                 <artifactId>sub</artifactId>
               </project>
-              """, spec -> spec.path("sub/pom.xml"))
+              """,
+                spec -> spec.path("sub/pom.xml"))
         );
     }
 
@@ -3842,10 +3857,11 @@ class MavenParserTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """, spec -> spec.afterRecipe(pom -> {
-                MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
-                assertThat(resolution.findDependencies("ch.qos.logback", "logback-core", Scope.Compile)).isEmpty();
-            })
+              """,
+                spec -> spec.afterRecipe(pom -> {
+                    MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                    assertThat(resolution.findDependencies("ch.qos.logback", "logback-core", Scope.Compile)).isEmpty();
+                })
           ));
     }
 
@@ -3873,7 +3889,8 @@ class MavenParserTest implements RewriteTest {
                 </dependencies>
               </dependencyManagement>
             </project>
-            """),
+            """
+          ),
           mavenProject("sam-bom",
             pomXml(
               //language=xml

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ModernizeObsoletePomsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ModernizeObsoletePomsTest.java
@@ -97,7 +97,8 @@ class ModernizeObsoletePomsTest implements RewriteTest {
                   </resources>
               </build>
           </project>
-          """)
+          """
+          )
         );
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -260,7 +260,8 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
-              """, """
+              """,
+                """
               <project>
                 <modelVersion>4.0.0</modelVersion>
               

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveRedundantDependencyVersionsTest.java
@@ -1319,7 +1319,8 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                       </pluginManagement>
                   </build>
               </project>
-              """, SourceSpec::skip),
+              """,
+                SourceSpec::skip),
           mavenProject("child", pomXml(
               """
                 <project>
@@ -1399,7 +1400,8 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                       </pluginManagement>
                   </build>
               </project>
-              """, SourceSpec::skip),
+              """,
+                SourceSpec::skip),
           mavenProject("child", pomXml(
               """
                 <project>
@@ -1795,7 +1797,8 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                     </plugins>
                 </build>
             </project>
-            """, """
+            """,
+                """
             <project>
                 <parent>
                     <groupId>org.springframework.boot</groupId>
@@ -1851,7 +1854,8 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
                     </dependency>
                 </dependencies>
             </project>
-            """, """
+            """,
+                """
             <project>
                 <parent>
                     <groupId>org.springframework.boot</groupId>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -117,7 +117,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                       <release.version>17</release.version>
                   </properties>
               </project>
-              """)
+              """
+          )
         );
     }
 
@@ -161,7 +162,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                         <release.version>17</release.version>
                     </properties>
                 </project>
-                """),
+                """
+            ),
             mavenProject("example-child",
                 //language=xml
                 pomXml(
@@ -208,7 +210,8 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
                       </plugins>
                   </build>
               </project>
-              """),
+              """
+          ),
           mavenProject("example-child",
             //language=xml
             pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
@@ -73,7 +73,8 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                     </dependency>
                 </dependencies>
             </project>
-            """)
+            """
+          )
         );
     }
 
@@ -95,7 +96,8 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                     </dependency>
                 </dependencies>
             </project>
-            """)
+            """
+          )
         );
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UseMavenCompilerPluginReleaseConfigurationTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UseMavenCompilerPluginReleaseConfigurationTest.java
@@ -419,7 +419,8 @@ class UseMavenCompilerPluginReleaseConfigurationTest implements RewriteTest {
                 </build>
               
               </project>
-              """)
+              """
+          )
         );
     }
 
@@ -442,7 +443,8 @@ class UseMavenCompilerPluginReleaseConfigurationTest implements RewriteTest {
               
                 <packaging>pom</packaging>
               </project>
-              """),
+              """
+          ),
           mavenProject(
             "sample",
             //language=xml

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindDependencyTest.java
@@ -214,7 +214,8 @@ class FindDependencyTest implements RewriteTest {
                 </dependencies>
               </project>
               """
-            ,sourceSpecs -> sourceSpecs.path("pom.xml")),
+            ,
+                sourceSpecs -> sourceSpecs.path("pom.xml")),
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
@@ -248,7 +249,8 @@ class FindDependencyTest implements RewriteTest {
                 </dependencies>
               </project>
               """
-          ,sourceSpecs -> sourceSpecs.path("sample-module/pom.xml"))
+          ,
+                sourceSpecs -> sourceSpecs.path("sample-module/pom.xml"))
         );
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindManagedDependencyTest.java
@@ -62,7 +62,8 @@ class FindManagedDependencyTest implements RewriteTest {
                   </dependencies>
                 </dependencyManagement>
               </project>
-              """)
+              """
+          )
         );
     }
 
@@ -105,7 +106,8 @@ class FindManagedDependencyTest implements RewriteTest {
                 </dependencies>
               </dependencyManagement>
             </project>
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPluginTest.java
@@ -122,7 +122,8 @@ class FindPluginTest implements RewriteTest {
                           </plugins>
                       </build>
                   </project>
-                  """, sourceSpecs -> sourceSpecs.path("pom.xml")),
+                  """,
+                sourceSpecs -> sourceSpecs.path("pom.xml")),
           pomXml(
             """
                 <project>
@@ -142,7 +143,8 @@ class FindPluginTest implements RewriteTest {
                         </plugins>
                     </build>
                 </project>
-                """, sourceSpecs -> sourceSpecs.path("submodule.pom.xml")
+                """,
+                sourceSpecs -> sourceSpecs.path("submodule.pom.xml")
           )
         );
     }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyTest.java
@@ -246,7 +246,8 @@ class AddPropertyTest implements RewriteTest {
               # sam
               com.sam=true
               com.zoe=true
-              """)
+              """
+          )
         );
     }
 
@@ -281,7 +282,8 @@ class AddPropertyTest implements RewriteTest {
               com.seb=true
               # zoe
               com.zoe=true
-              """)
+              """
+          )
         );
     }
 
@@ -302,7 +304,8 @@ class AddPropertyTest implements RewriteTest {
               com.amy=true
               # sam
               com.sam=true
-              """)
+              """
+          )
         );
     }
 }

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/ChangePropertyValueTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/ChangePropertyValueTest.java
@@ -171,12 +171,14 @@ class ChangePropertyValueTest implements RewriteTest {
             multiple-prefixed=test[replaceme:1]test[replaceme:2]
             multiple-suffixed=[replaceme:1]test[replaceme:2]test
             multiple-both=test[replaceme:1]test[replaceme:2]test
-            """, """
+            """,
+                """
             multiple=[replaced:1][replaced:2]
             multiple-prefixed=test[replaced:1]test[replaced:2]
             multiple-suffixed=[replaced:1]test[replaced:2]test
             multiple-both=test[replaced:1]test[replaced:2]test
-            """)
+            """
+          )
         );
     }
 
@@ -190,7 +192,8 @@ class ChangePropertyValueTest implements RewriteTest {
             multiple-prefixed=test[replaceme:1]test[replaceme:2]
             multiple-suffixed=[replaceme:1]test[replaceme:2]test
             multiple-both=test[replaceme:1]test[replaceme:2]test
-            """)
+            """
+          )
         );
     }
 

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagValueTest.java
@@ -45,7 +45,8 @@ class ChangeTagValueTest implements RewriteTest {
               <dependency>
                   <version>2.0</version>
               </dependency>
-              """)
+              """
+          )
         );
     }
 
@@ -65,7 +66,8 @@ class ChangeTagValueTest implements RewriteTest {
               <dependency>
                   <version>2.0</version>
               </dependency>
-              """)
+              """
+          )
         );
     }
 
@@ -80,7 +82,8 @@ class ChangeTagValueTest implements RewriteTest {
               <dependency>
                   <version>3.0</version>
               </dependency>
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyValueTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyValueTest.java
@@ -32,9 +32,11 @@ class ChangePropertyValueTest implements RewriteTest {
           yaml(
                 """
             my.prop: foo
-            """, """
+            """,
+                """
             my.prop: bar
-            """)
+            """
+          )
         );
     }
 
@@ -42,13 +44,16 @@ class ChangePropertyValueTest implements RewriteTest {
     void simpleIndented() {
         rewriteRun(
           spec -> spec.recipe(new ChangePropertyValue("my.prop", "bar", null, null, null, null)),
-          yaml("""
+          yaml(
+                """
             my:
               prop: foo
-            """, """
+            """,
+                """
             my:
               prop: bar
-            """)
+            """
+          )
         );
     }
 
@@ -56,13 +61,16 @@ class ChangePropertyValueTest implements RewriteTest {
     void oldValue() {
         rewriteRun(
           spec -> spec.recipe(new ChangePropertyValue("my.prop", "bar", "foo", null, null, null)),
-          yaml("""
+          yaml(
+                """
             my:
               prop: foo
-            """, """
+            """,
+                """
             my:
               prop: bar
-            """)
+            """
+          )
         );
     }
 
@@ -70,10 +78,12 @@ class ChangePropertyValueTest implements RewriteTest {
     void badOldValue() {
         rewriteRun(
           spec -> spec.recipe(new ChangePropertyValue("my.prop", "bar", "fooz", null, null, null)),
-          yaml("""
+          yaml(
+                """
             my:
               prop: foo
-            """)
+            """
+          )
         );
     }
 
@@ -81,13 +91,16 @@ class ChangePropertyValueTest implements RewriteTest {
     void regex() {
         rewriteRun(
           spec -> spec.recipe(new ChangePropertyValue("my.prop", "bar$1", "f(o+)", true, null, null)),
-          yaml("""
+          yaml(
+                """
             my:
               prop: foooo
-            """, """
+            """,
+                """
             my:
               prop: baroooo
-            """)
+            """
+          )
         );
     }
 
@@ -95,10 +108,12 @@ class ChangePropertyValueTest implements RewriteTest {
     void regexDefaultOff() {
         rewriteRun(
           spec -> spec.recipe(new ChangePropertyValue("my.prop", "bar", ".+", null, null, null)),
-          yaml("""
+          yaml(
+                """
             my:
               prop: foo
-            """)
+            """
+          )
         );
     }
 
@@ -164,7 +179,8 @@ class ChangePropertyValueTest implements RewriteTest {
                   - replaceme should not be done
                 rules:
                   - replaceme
-              """, """
+              """,
+                """
               job-name1:
                 script:
                   - replaced
@@ -182,7 +198,8 @@ class ChangePropertyValueTest implements RewriteTest {
                   - replaceme should not be done
                 rules:
                   - replaceme
-              """)
+              """
+          )
         );
     }
 
@@ -201,7 +218,8 @@ class ChangePropertyValueTest implements RewriteTest {
                   - replaceme should be done
                 rules:
                   - replaceme
-              """, """
+              """,
+                """
               job-name:
                 script:
                   - replaced
@@ -210,7 +228,8 @@ class ChangePropertyValueTest implements RewriteTest {
                   - replaced should be done
                 rules:
                   - replaceme
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CreateYamlFileTest.java
@@ -227,7 +227,8 @@ class CreateYamlFileTest implements RewriteTest {
           yaml(
                 """
             foo: bar
-            """, spec -> spec.path("precondition.yml")),
+            """,
+                spec -> spec.path("precondition.yml")),
           yaml(
             null,
             """
@@ -259,7 +260,8 @@ class CreateYamlFileTest implements RewriteTest {
           yaml(
                 """
             foo: bar
-            """, spec -> spec.path("precondition.yml")),
+            """,
+                spec -> spec.path("precondition.yml")),
           yaml(
             null,
             """

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -1484,7 +1484,8 @@ class MergeYamlTest implements RewriteTest {
                 - name: newName
                   jobs:
                     - newJob
-              """)
+              """
+          )
         );
     }
 
@@ -1678,7 +1679,8 @@ class MergeYamlTest implements RewriteTest {
               script: |
                 #!/bin/bash
                 echo "hello"
-              """)
+              """
+          )
         );
     }
 
@@ -1719,7 +1721,8 @@ class MergeYamlTest implements RewriteTest {
                     #!/bin/bash
                     echo "hellow"
                   something: else
-              """)
+              """
+          )
         );
     }
 
@@ -1765,7 +1768,8 @@ class MergeYamlTest implements RewriteTest {
                          #!/bin/bash
                           echo "hello"
                              echo "hello"
-              """)
+              """
+          )
         );
     }
 
@@ -1823,7 +1827,8 @@ class MergeYamlTest implements RewriteTest {
                           text: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
                       env:
                         SLACK_BOT_TOKEN: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
-              """)
+              """
+          )
         );
     }
 
@@ -1859,7 +1864,8 @@ class MergeYamlTest implements RewriteTest {
                   script: |-
                     #!/bin/bash
                     echo "hello"
-              """)
+              """
+          )
         );
     }
 
@@ -1894,7 +1900,8 @@ class MergeYamlTest implements RewriteTest {
                   script: >
                     #!/bin/bash
                     echo "hello"
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ReplaceAliasWithAnchorValueTest.java
@@ -32,7 +32,8 @@ class ReplaceAliasWithAnchorValueTest implements RewriteTest {
     @Test
     void simpleCase() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
               bar:
                 &abc yo: friend
               baz:
@@ -51,7 +52,8 @@ class ReplaceAliasWithAnchorValueTest implements RewriteTest {
     @Test
     void aliasRefersToLastKnownAnchorValue() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
               definitions:
                 steps:
                   - step: &build-test
@@ -103,7 +105,8 @@ class ReplaceAliasWithAnchorValueTest implements RewriteTest {
     @Test
     void howAboutSequences() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
               stages:
                 - id: &id ping_api_endpoint
                   name: *id

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlParserTest.java
@@ -349,7 +349,8 @@ class YamlParserTest implements RewriteTest {
             - name: Elephant
             - #🦍COMMENT: unicode
             - action: Do something
-            """)
+            """
+          )
         );
     }
 
@@ -361,7 +362,8 @@ class YamlParserTest implements RewriteTest {
             - name: Elephant
             - #🦍COMMENT: 🐶unicode
             - action: Do something
-            """)
+            """
+          )
         );
     }
 
@@ -373,7 +375,8 @@ class YamlParserTest implements RewriteTest {
             - name: Elephant
             - #COMMENT: unicode
             - action: Do something
-            """)
+            """
+          )
         );
     }
 
@@ -387,7 +390,8 @@ class YamlParserTest implements RewriteTest {
             - color: Black
             - #🦍COMMENT: unicode
             - action: Escape
-            """)
+            """
+          )
         );
     }
 
@@ -401,7 +405,8 @@ class YamlParserTest implements RewriteTest {
             - color: Black
             - #🦍COMMENT: 🎱unicode
             - action: Escape
-            """)
+            """
+          )
         );
     }
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/cleanup/RemoveUnusedVisitorTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/cleanup/RemoveUnusedVisitorTest.java
@@ -32,7 +32,8 @@ class RemoveUnusedVisitorTest implements RewriteTest {
     @Test
     void unusedMappings() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
                 root:
                   a:
                     b:
@@ -49,7 +50,8 @@ class RemoveUnusedVisitorTest implements RewriteTest {
     @Test
     void unusedSequences() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
                 root:
                   -
                   - 0

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/format/IndentsTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/format/IndentsTest.java
@@ -41,7 +41,8 @@ class IndentsTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/3531")
     void multilineString() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
             foo:
               bar: >
                 A multiline string.
@@ -56,7 +57,8 @@ class IndentsTest implements RewriteTest {
     @Test
     void indentSequence() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
                   root:
                       - a: 0
                         b: 0
@@ -73,7 +75,8 @@ class IndentsTest implements RewriteTest {
     @Test
     void indents() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
                   apiVersion: storage.cnrm.cloud.google.com/v1beta1
                   kind: StorageBucket
                   spec:
@@ -103,7 +106,8 @@ class IndentsTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/1135")
     void maintainIndentSpacingOnMixedTypeSequences() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
                 steps:
                   - checkout
                   - run:
@@ -120,7 +124,8 @@ class IndentsTest implements RewriteTest {
     @Test
     void indentSequenceComments() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
               key:
               # a under-indented
                   # a over-indented
@@ -145,7 +150,8 @@ class IndentsTest implements RewriteTest {
     @Test
     void indentMappingComments() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
               key: # no change
               # under-indented
                   # over-indented
@@ -174,7 +180,8 @@ class IndentsTest implements RewriteTest {
     @Test
     void indentRootComments() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
                 # over-indented 1
               ---
                 # over-indented 2

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/search/FindKeyTest.java
@@ -29,7 +29,8 @@ class FindKeyTest implements RewriteTest {
     void findKey() {
         rewriteRun(
           spec -> spec.recipe(new FindKey("$.metadata.name")),
-          yaml("""
+          yaml(
+                """
                   apiVersion: v1
                   metadata:
                     name: monitoring-tools
@@ -50,7 +51,8 @@ class FindKeyTest implements RewriteTest {
     void findKeyWithSpecificName() {
         rewriteRun(
           spec -> spec.recipe(new FindKey("$.metadata[?(@.name == 'container')].name")),
-          yaml("""
+          yaml(
+                """
                   metadata:
                     name: container
                     namespace: container
@@ -69,7 +71,8 @@ class FindKeyTest implements RewriteTest {
     void findKeyWithMultipleBinaryExpressions() {
         rewriteRun(
           spec -> spec.recipe(new FindKey("$.foo.bar[?(@.types == 'something' && @.group == 'group' && @.category == 'match' && @.type == 'type')].pattern")),
-          yaml("""
+          yaml(
+                """
               foo:
                 bar:
                   -

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/ScalarTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/ScalarTest.java
@@ -42,21 +42,23 @@ class ScalarTest implements RewriteTest {
     @Test
     void multilineString() {
         rewriteRun(
-          yaml("""
+          yaml(
+                """
             foo:
               bar: >
                 A multiline string.
               baz:
                 quz: Another string.
-            """, spec -> spec.afterRecipe(doc -> new YamlIsoVisitor<>() {
-                @Override
-                public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Object o) {
-                    if ("baz".equals(entry.getKey().getValue())) {
-                        assertThat(entry.getPrefix()).isEqualTo("\n  ");
+            """,
+                spec -> spec.afterRecipe(doc -> new YamlIsoVisitor<>() {
+                    @Override
+                    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Object o) {
+                        if ("baz".equals(entry.getKey().getValue())) {
+                            assertThat(entry.getPrefix()).isEqualTo("\n  ");
+                        }
+                        return super.visitMappingEntry(entry, o);
                     }
-                    return super.visitMappingEntry(entry, o);
-                }
-            }.visit(doc, 0))
+                }.visit(doc, 0))
           )
         );
     }
@@ -67,10 +69,11 @@ class ScalarTest implements RewriteTest {
           yaml(
                 """
             foo # look mom, no mapping
-            """, spec -> spec.afterRecipe(documents -> {
-                Yaml.Block maybeScalar = documents.getDocuments().get(0).getBlock();
-                Assertions.assertThat(maybeScalar).isInstanceOf(Yaml.Scalar.class);
-          }))
+            """,
+                spec -> spec.afterRecipe(documents -> {
+                    Yaml.Block maybeScalar = documents.getDocuments().get(0).getBlock();
+                    Assertions.assertThat(maybeScalar).isInstanceOf(Yaml.Scalar.class);
+                }))
         );
     }
 }

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -60,6 +60,7 @@ preconditions:
 recipeList:
   - org.openrewrite.java.recipes.RewriteTestClassesShouldNotBePublic
   #- org.openrewrite.java.recipes.SelectRecipeExamples
+  - org.openrewrite.java.recipes.SourceSpecTextBlockNewLine
   - org.openrewrite.java.recipes.SourceSpecTextBlockIndentation
   - org.openrewrite.java.testing.cleanup.RemoveTestPrefix
   - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic


### PR DESCRIPTION
This helps adhere to the standards we've set elsewhere, and helps reduce the diff seen on the nightly recipe runs done here.