### PR TITLE
Workaround AnnotationMatcher NPE

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AnnotationMatcher.java
@@ -76,8 +76,8 @@ public class AnnotationMatcher {
 
     public boolean matches(J.Annotation annotation) {
         return matchesAnnotationName(annotation) &&
-                matchesSingleParameter(annotation) &&
-                matchesNamedParameters(annotation);
+               matchesSingleParameter(annotation) &&
+               matchesNamedParameters(annotation);
     }
 
     private boolean matchesAnnotationName(J.Annotation annotation) {
@@ -95,11 +95,17 @@ public class AnnotationMatcher {
                 return true;
             } else if (matchMetaAnnotations) {
                 for (JavaType.FullyQualified annotation : fqn.getAnnotations()) {
+                    //noinspection ConstantValue
+                    if (annotation == null) {
+                        // Workaround for parsing bug that caused these annotations
+                        // to sometimes be null.
+                        continue;
+                    }
                     if (seenAnnotations == null) {
                         seenAnnotations = new HashSet<>();
                     }
                     if (seenAnnotations.add(annotation.getFullyQualifiedName()) &&
-                            matchesAnnotationOrMetaAnnotation(annotation, seenAnnotations)) {
+                        matchesAnnotationOrMetaAnnotation(annotation, seenAnnotations)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
## What's changed?
Defensive coding around the possibility that `JavaType` annotations can be null.

## What's your motivation?
![image](https://github.com/user-attachments/assets/aca89863-b1f1-40ee-ac61-00e6a10bac57)

## Have you considered any alternatives or workarounds?
We need to root out what is causing an LST to be parsed in this way, so this is just a stopgap measure.