### PR TITLE
Improve performance of FindAnnotations precondition

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindAnnotations.java
@@ -67,25 +67,15 @@ public class FindAnnotations extends Recipe {
         return Preconditions.check(
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
-                    public J visit(@Nullable Tree tree, ExecutionContext ctx) {
-                        if (tree instanceof JavaSourceFile) {
-                            JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-                            for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
-                                if (annotationMatcher.matchesAnnotationOrMetaAnnotation(TypeUtils.asFullyQualified(type))) {
-                                    return SearchResult.found(cu);
-                                }
+                    public J preVisit(J tree, ExecutionContext ctx) {
+                        stopAfterPreVisit();
+                        JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+                        for (JavaType type : cu.getTypesInUse().getTypesInUse()) {
+                            if (annotationMatcher.matchesAnnotationOrMetaAnnotation(TypeUtils.asFullyQualified(type))) {
+                                return SearchResult.found(cu);
                             }
                         }
-                        return super.visit(tree, ctx);
-                    }
-
-                    @Override
-                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                        J.Annotation a = super.visitAnnotation(annotation, ctx);
-                        if (annotationMatcher.matches(annotation)) {
-                            a = SearchResult.found(a);
-                        }
-                        return a;
+                        return tree;
                     }
                 },
                 new JavaIsoVisitor<ExecutionContext>() {


### PR DESCRIPTION
## What's changed?
Evaluate the precondition without navigating down the tree.

## What's your motivation?
`JUnitUpgrade` is on the top 3 of worst performers in DevCenter and it uses `FindAnnotations` under the covers:

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/6f148d2c-b739-4a3e-ac78-2b05bf408450" />

## Anything in particular you'd like reviewers to focus on?
I don't think so, it looks like the other part of that precondition was just a holdover from an earlier time.