### PR TITLE
Remove warnings from Gradle build logFix

### DIFF
--- a/rewrite-kotlin/build.gradle.kts
+++ b/rewrite-kotlin/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("org.openrewrite.build.language-library")
@@ -34,11 +34,8 @@ dependencies {
     testImplementation("com.google.testing.compile:compile-testing:0.+")
 }
 
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
-}
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
 }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
@@ -21,7 +21,9 @@ package org.openrewrite.kotlin
 import java.lang.Object
 
 const val field = 10
+@Suppress("UNUSED_PARAMETER")
 fun function(arg: C) {
+    @Suppress("UNUSED_VARIABLE")
     val inFun = 10
 }
 

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -539,7 +539,10 @@ class KotlinTypeMapping(
             if (function.symbol is FirConstructorSymbol) "<constructor>" else methodName(function),
             null,
             paramNames,
-            null, null, null,
+            null,
+            null,
+            null,
+            null,
             null
         )
         typeCache.put(signature, method)
@@ -636,8 +639,11 @@ class KotlinTypeMapping(
             javaMethod.name.asString(),
             null,
             paramNames,
-            null, null, null,
-            defaultValues
+            null,
+            null,
+            null,
+            defaultValues,
+            null
         )
         typeCache.put(signature, method)
         val exceptionTypes: List<FullyQualified>? = null
@@ -715,11 +721,15 @@ class KotlinTypeMapping(
             when {
                 sym is FirConstructorSymbol ||
                         sym is FirSyntheticFunctionSymbol && sym.origin == FirDeclarationOrigin.SamConstructor -> "<constructor>"
+
                 else -> (sym as FirNamedFunctionSymbol).name.asString()
             },
             null,
             paramNames,
-            null, null, null,
+            null,
+            null,
+            null,
+            null,
             null
         )
         typeCache.put(signature, method)
@@ -1105,8 +1115,11 @@ class KotlinTypeMapping(
             "<constructor>",
             null,
             paramNames,
-            null, null, null,
-            defaultValues
+            null,
+            null,
+            null,
+            defaultValues,
+            null
         )
         typeCache.put(signature, method)
         val exceptionTypes: List<FullyQualified>? = null

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/internal/IrTreePrinterVisitor.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/internal/IrTreePrinterVisitor.kt
@@ -20,10 +20,10 @@ import org.openrewrite.kotlin.internal.PsiTreePrinter.TreePrinterContext
 
 open class IrTreePrinterVisitor(val IrPrinter : PsiTreePrinter.IrPrinter) : IrTreeVisitor<TreePrinterContext>() {
 
-    override fun visitElement(element: IrElement, ctx: TreePrinterContext) {
-        IrPrinter.printElement(element, ctx)
-        ctx.depth++
-        super.visitElement(element, ctx)
-        ctx.depth--
+    override fun visitElement(element: IrElement, data: TreePrinterContext) {
+        IrPrinter.printElement(element, data)
+        data.depth++
+        super.visitElement(element, data)
+        data.depth--
     }
 }

--- a/rewrite-kotlin/src/test/resources/KotlinTypeGoat.kt
+++ b/rewrite-kotlin/src/test/resources/KotlinTypeGoat.kt
@@ -21,7 +21,9 @@ package org.openrewrite.kotlin
 import java.lang.Object
 
 const val field = 10
+@Suppress("UNUSED_PARAMETER")
 fun function(arg: C) {
+    @Suppress("UNUSED_VARIABLE")
     val inFun = 10
 }
 


### PR DESCRIPTION
## What's changed?
- rename ctx to name in IrTreePrinterVisitor
- use Gradle DSL for JVM target configuration
- fix deprecation warnings in KotlinIrTypeMapping.kt
- fix deprecation warnings in KotlinTypeMapping.kt

## What's your motivation?
Prepare for Kotlin 2.x migration

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
