### PR TITLE
Add `tech` to root categories so Picnic shows as a top-level category.

### DIFF
--- a/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
+++ b/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
@@ -40,3 +40,7 @@ type: specs.openrewrite.org/v1beta/category
 packageName: ai
 root: true
 ---
+type: specs.openrewrite.org/v1beta/category
+packageName: tech
+root: true
+---


### PR DESCRIPTION
## What's changed?
New core category.

## What's your motivation?
It's weird to see "Tech" as a category:

<img width="507" alt="image" src="https://github.com/user-attachments/assets/034ee1e1-dc75-42fe-a2d8-f95c012a0497" />