### PR TITLE
Added option.release as a field that can set the java version.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
@@ -132,7 +132,10 @@ public class UpdateJavaCompatibility extends Recipe {
                 } else if (a.getVariable() instanceof J.FieldAccess) {
                     J.FieldAccess fieldAccess = (J.FieldAccess) a.getVariable();
                     if (compatibilityType == null) {
-                        if (!("sourceCompatibility".equals(fieldAccess.getSimpleName()) || "targetCompatibility".equals(fieldAccess.getSimpleName()) || ("release".equals(fieldAccess.getSimpleName()) && fieldAccess.getTarget() instanceof J.Identifier && "options".equals(((J.Identifier) fieldAccess.getTarget()).getSimpleName())))) {
+                        if (!("sourceCompatibility".equals(fieldAccess.getSimpleName()) || "targetCompatibility".equals(fieldAccess.getSimpleName()) ||
+                                ("release".equals(fieldAccess.getSimpleName()) &&
+                                        ((fieldAccess.getTarget() instanceof J.Identifier && "options".equals(((J.Identifier) fieldAccess.getTarget()).getSimpleName()))
+                                                || (fieldAccess.getTarget() instanceof J.FieldAccess && "options".equals(((J.FieldAccess) fieldAccess.getTarget()).getSimpleName())))))) {
                             return a;
                         }
                     } else if (!(compatibilityType.toString().toLowerCase() + "Compatibility").equals(fieldAccess.getSimpleName())) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
@@ -132,7 +132,7 @@ public class UpdateJavaCompatibility extends Recipe {
                 } else if (a.getVariable() instanceof J.FieldAccess) {
                     J.FieldAccess fieldAccess = (J.FieldAccess) a.getVariable();
                     if (compatibilityType == null) {
-                        if (!("sourceCompatibility".equals(fieldAccess.getSimpleName()) || "targetCompatibility".equals(fieldAccess.getSimpleName()))) {
+                        if (!("sourceCompatibility".equals(fieldAccess.getSimpleName()) || "targetCompatibility".equals(fieldAccess.getSimpleName()) || ("release".equals(fieldAccess.getSimpleName()) && fieldAccess.getTarget() instanceof J.Identifier && "options".equals(((J.Identifier) fieldAccess.getTarget()).getSimpleName())))) {
                             return a;
                         }
                     } else if (!(compatibilityType.toString().toLowerCase() + "Compatibility").equals(fieldAccess.getSimpleName())) {
@@ -217,7 +217,7 @@ public class UpdateJavaCompatibility extends Recipe {
             }
 
             private int getMajorVersion(@Nullable String version) {
-                if(version == null) {
+                if (version == null) {
                     return -1;
                 }
                 try {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
@@ -449,6 +449,8 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
               compileJava {
                   options.release = 8
               }
+              
+              compileJava.options.release = 8
               """,
             """
               plugins {
@@ -466,6 +468,8 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
               compileJava {
                   options.release = 11
               }
+              
+              compileJava.options.release = 11
               """
           )
         );

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
@@ -426,4 +426,48 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release")
+    void releaseValueGetsUpdated() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+              
+              tasks.withType(JavaCompile) {
+                  options.release = 8
+              }
+              
+              tasks.withType(JavaCompile).configureEach {
+                  options.release = 8
+              }
+              
+              compileJava {
+                  options.release = 8
+              }
+              """,
+            """
+              plugins {
+                  id "java"
+              }
+
+              tasks.withType(JavaCompile) {
+                  options.release = 11
+              }
+              
+              tasks.withType(JavaCompile).configureEach {
+                  options.release = 11
+              }
+              
+              compileJava {
+                  options.release = 11
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
This fixes one of the issues that our customers has been facing with Java version migration. 

according to [Gradle documentation](https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release), this property can also be used to set java compile version. 

What I am not sure about is if we do not want to go more in depth than just adapting all `options.release = ... `
What happens if i have another extension that also uses `options.release`? That one will also be changed with current code. 
I do not see a lot of risk there(and this risk is also there for the other properties `sourceCompatibility` and `targetCompatibility`). For this reason I've only added some assurance check by verifying the `target` is `options` instead of just putting all `release` assignments to the mentioned version. 

I've added a test for multiple ways of configuring the property (as we only use the internal assignment to match): 
```groovy
tasks.withType(JavaCompile) {
    options.release = ...
}

tasks.withType(JavaCompile).configureEach {
    options.release = ...
}

compileJava {
    options.release = ...
}

compileJava.options.release = ...
```

NOTE: After releasing this one, we also must release the [rewrite-migrate-java](https://github.com/openrewrite/rewrite-migrate-java) module for this change to take effect