### PR TITLE
Add `software` to root categories so Amazon shows as a top-level category

### DIFF
--- a/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
+++ b/rewrite-core/src/main/resources/META-INF/rewrite/core-categories.yml
@@ -44,3 +44,8 @@ type: specs.openrewrite.org/v1beta/category
 packageName: tech
 root: true
 ---
+type: specs.openrewrite.org/v1beta/category
+# Amazon prefixes their recipes with software.amazon
+packageName: software
+root: true
+---


### PR DESCRIPTION
## What's changed?
`software` added as a root category.

## What's your motivation?

So Amazon recipes show up as a top-level category.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/807925fc-5282-4d3b-ad37-c670fed5f102" />

