### PR TITLE
Add annotations to the type attribution for method parameters

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodDeclarationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodDeclarationTest.java
@@ -15,9 +15,15 @@
  */
 package org.openrewrite.java.tree;
 
+import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 class MethodDeclarationTest implements RewriteTest {
@@ -61,6 +67,39 @@ class MethodDeclarationTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void parameterAnnotations() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("jspecify")),
+          java(
+            """
+              import org.jspecify.annotations.Nullable;
+              
+              class Test {
+                  public @Nullable Object foo(@Nullable String s) {
+                      return s;
+                  }
+              }
+              """,
+            sourceSpecs -> sourceSpecs.afterRecipe(cu -> {
+                J.MethodDeclaration foo = (J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0);
+                assertTypeIsAnnotatedAs((JavaType.Class) foo.getReturnTypeExpression().getType(), "org.jspecify.annotations.Nullable");
+                assertTypeIsAnnotatedAs(((JavaType.Class) foo.getMethodType().getReturnType()), "org.jspecify.annotations.Nullable");
+                assertTypeIsAnnotatedAs((JavaType.Class) ((J.VariableDeclarations) foo.getParameters().get(0)).getVariables().get(0).getType(), "org.jspecify.annotations.Nullable");
+                assertTypeIsAnnotatedAs(((JavaType.Class) foo.getMethodType().getParameterTypes().get(0)), "org.jspecify.annotations.Nullable");
+            })
+          )
+        );
+    }
+
+    private static void assertTypeIsAnnotatedAs(JavaType.Class type, String... annotations) {
+        List<ThrowingConsumer<JavaType.FullyQualified>> array = Stream.of(annotations)
+          .<ThrowingConsumer<JavaType.FullyQualified>>map(ann -> a -> assertThat(a.getFullyQualifiedName()).isEqualTo(ann))
+          .toList();
+        //noinspection unchecked
+        assertThat(type.getAnnotations()).satisfiesExactly(array.toArray(new ThrowingConsumer[0]));
     }
 
     @Test


### PR DESCRIPTION
The type attribution for method return types and method parameters currently lack annotations. Recipes might require these annotations to perform their task.
