### PR TITLE
Support Scanning Recipes as preconditions in DeclarativeRecipe.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
+++ b/rewrite-core/src/main/java/org/openrewrite/RecipeScheduler.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite;
 
+import org.openrewrite.config.DeclarativeRecipe;
 import org.openrewrite.scheduling.RecipeRunCycle;
 import org.openrewrite.scheduling.WatchableExecutionContext;
 import org.openrewrite.table.RecipeRunStats;
@@ -127,7 +128,17 @@ public class RecipeScheduler {
 
     private boolean hasScanningRecipe(Recipe recipe) {
         if (recipe instanceof ScanningRecipe) {
-            return true;
+            // DeclarativeRecipe is technically a ScanningRecipe, but it only needs the
+            // scanning phase if it or one of its sub-recipes or preconditions is a ScanningRecipe
+            if(recipe instanceof DeclarativeRecipe) {
+                for (Recipe precondition : ((DeclarativeRecipe) recipe).getPreconditions()) {
+                    if (hasScanningRecipe(precondition)) {
+                        return true;
+                    }
+                }
+            } else {
+                return true;
+            }
         }
         for (Recipe r : recipe.getRecipeList()) {
             if (hasScanningRecipe(r)) {

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -337,18 +337,6 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         return Preconditions.or(conditions.toArray(new TreeVisitor[0]));
     }
 
-    private static boolean isScanningRecipe(Recipe recipe) {
-        if (recipe instanceof ScanningRecipe) {
-            return true;
-        }
-        for (Recipe r : recipe.getRecipeList()) {
-            if (isScanningRecipe(r)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private static List<Recipe> decorateWithPreconditionBellwether(PreconditionBellwether bellwether, List<Recipe> recipeList) {
         List<Recipe> mappedRecipeList = new ArrayList<>(recipeList.size());
         for (Recipe recipe : recipeList) {

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -32,7 +32,7 @@ import static java.util.Collections.emptyList;
 import static org.openrewrite.Validated.invalid;
 
 @RequiredArgsConstructor
-public class DeclarativeRecipe extends Recipe {
+public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumulator> {
     @Getter
     private final String name;
 
@@ -82,7 +82,7 @@ public class DeclarativeRecipe extends Recipe {
     private Validated<Object> validation = Validated.none();
 
     @JsonIgnore
-    private Validated<Object> initValidation = null;
+    private Validated<Object> initValidation = Validated.none();
 
     @Override
     public Duration getEstimatedEffortPerOccurrence() {
@@ -91,7 +91,6 @@ public class DeclarativeRecipe extends Recipe {
     }
 
     public void initialize(Collection<Recipe> availableRecipes, Map<String, List<Contributor>> recipeToContributors) {
-        initValidation = Validated.none();
         Map<String, Recipe> recipeMap = new HashMap<>();
         availableRecipes.forEach(r -> recipeMap.putIfAbsent(r.getName(), r));
         initialize(uninitializedRecipes, recipeList, recipeMap::get, recipeToContributors);
@@ -99,7 +98,6 @@ public class DeclarativeRecipe extends Recipe {
     }
 
     public void initialize(Function<String, @Nullable Recipe> availableRecipes, Map<String, List<Contributor>> recipeToContributors) {
-        initValidation = Validated.none();
         initialize(uninitializedRecipes, recipeList, availableRecipes, recipeToContributors);
         initialize(uninitializedPreconditions, preconditions, availableRecipes, recipeToContributors);
     }
@@ -132,6 +130,45 @@ public class DeclarativeRecipe extends Recipe {
                 initialized.add(recipe);
             }
         }
+    }
+
+    @SuppressWarnings("NotNullFieldNotInitialized")
+    @JsonIgnore
+    private transient Accumulator accumulator;
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        Accumulator acc = new Accumulator();
+        for (Recipe precondition : preconditions) {
+            if(precondition instanceof ScanningRecipe) {
+                acc.recipeToAccumulator.put(precondition, ((ScanningRecipe<?>) precondition).getInitialValue(ctx));
+            }
+        }
+        accumulator = acc;
+        return acc;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                for (Recipe precondition : preconditions) {
+                    if (precondition instanceof ScanningRecipe) {
+                        ScanningRecipe preconditionRecipe = (ScanningRecipe) precondition;
+                        Object preconditionAcc = acc.recipeToAccumulator.get(precondition);
+                        preconditionRecipe.getScanner(preconditionAcc)
+                                .visit(tree, ctx);
+                    }
+                }
+                return tree;
+            }
+        };
+    }
+
+    public static class Accumulator {
+        Map<Recipe, Object> recipeToAccumulator = new HashMap<>();
     }
 
     @Value
@@ -269,13 +306,9 @@ public class DeclarativeRecipe extends Recipe {
 
         List<Supplier<TreeVisitor<?, ExecutionContext>>> andPreconditions = new ArrayList<>();
         for (Recipe precondition : preconditions) {
-            if (isScanningRecipe(precondition)) {
-                throw new IllegalArgumentException(
-                        getName() + " declares the ScanningRecipe " + precondition.getName() + " as a precondition." +
-                        "ScanningRecipe cannot be used as Preconditions.");
-            }
             andPreconditions.add(() -> orVisitors(precondition));
         }
+        //noinspection unchecked
         PreconditionBellwether bellwether = new PreconditionBellwether(Preconditions.and(andPreconditions.toArray(new Supplier[]{})));
         List<Recipe> recipeListWithBellwether = new ArrayList<>(recipeList.size() + 1);
         recipeListWithBellwether.add(bellwether);
@@ -283,14 +316,22 @@ public class DeclarativeRecipe extends Recipe {
         return recipeListWithBellwether;
     }
 
-    private static TreeVisitor<?, ExecutionContext> orVisitors(Recipe recipe) {
-        if (recipe.getRecipeList().isEmpty()) {
-            return recipe.getVisitor();
-        }
+    private TreeVisitor<?, ExecutionContext> orVisitors(Recipe recipe) {
         List<TreeVisitor<?, ExecutionContext>> conditions = new ArrayList<>();
+        if(recipe instanceof ScanningRecipe) {
+            //noinspection rawtypes
+            ScanningRecipe scanning = (ScanningRecipe) recipe;
+            //noinspection unchecked
+            conditions.add(scanning.getVisitor(accumulator.recipeToAccumulator.get(scanning)));
+        } else {
+            conditions.add(recipe.getVisitor());
+        }
         conditions.add(recipe.getVisitor());
         for (Recipe r : recipe.getRecipeList()) {
             conditions.add(orVisitors(r));
+        }
+        if(conditions.isEmpty()) {
+            return recipe.getVisitor();
         }
         //noinspection unchecked
         return Preconditions.or(conditions.toArray(new TreeVisitor[0]));

--- a/rewrite-core/src/main/java/org/openrewrite/search/RepositoryContainsFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/RepositoryContainsFile.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @SuppressWarnings("unused")
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class RepositoryContainsFiles extends ScanningRecipe<AtomicBoolean> {
+public class RepositoryContainsFile extends ScanningRecipe<AtomicBoolean> {
 
     @Option(displayName = "File pattern",
             description = "A glob expression representing a file path to search for (relative to the project root). Blank/null matches all." +
@@ -40,7 +40,7 @@ public class RepositoryContainsFiles extends ScanningRecipe<AtomicBoolean> {
 
     @Override
     public String getDisplayName() {
-        return "Repository contains files";
+        return "Repository contains file";
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/search/RepositoryContainsFiles.java
+++ b/rewrite-core/src/main/java/org/openrewrite/search/RepositoryContainsFiles.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.marker.SearchResult;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SuppressWarnings("unused")
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RepositoryContainsFiles extends ScanningRecipe<AtomicBoolean> {
+
+    @Option(displayName = "File pattern",
+            description = "A glob expression representing a file path to search for (relative to the project root). Blank/null matches all." +
+                          "Multiple patterns may be specified, separated by a semicolon `;`. " +
+                          "If multiple patterns are supplied any of the patterns matching will be interpreted as a match.",
+            required = false,
+            example = ".github/workflows/*.yml")
+    @Nullable
+    String filePattern;
+
+    @Override
+    public String getDisplayName() {
+        return "Repository contains files";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Intended to be used primarily as a precondition for other recipes, this recipe checks if a repository " +
+               "contains a specific file or files matching a pattern. If present all files in the repository are marked " +
+               "with a `SearchResult` marker. If you want to get only the matching file as a search result, use `FindSourceFiles` instead.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ZERO;
+    }
+
+    @Override
+    public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+        return new AtomicBoolean(false);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (acc.get()) {
+                    return tree;
+                }
+                Tree t = new FindSourceFiles(filePattern).getVisitor().visit(tree, ctx);
+                if (t != tree) {
+                    acc.set(true);
+                }
+                return tree;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean acc) {
+        if (!acc.get()) {
+            return TreeVisitor.noop();
+        }
+        //noinspection NullableProblems
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(Tree tree, ExecutionContext executionContext) {
+                if(tree.getMarkers().findFirst(SearchResult.class).isPresent()) {
+                    return tree;
+                }
+                return tree.withMarkers(tree.getMarkers().add(new SearchResult(Tree.randomId(), "Repository contains file matching pattern: " + filePattern)));
+            }
+        };
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -274,7 +274,7 @@ class DeclarativeRecipeTest implements RewriteTest {
               name: org.openrewrite.ScanningPreconditionTest
               description: Test.
               preconditions:
-                - org.openrewrite.search.RepositoryContainsFiles:
+                - org.openrewrite.search.RepositoryContainsFile:
                     filePattern: sam.txt
               recipeList:
                 - org.openrewrite.text.FindAndReplace:
@@ -295,7 +295,7 @@ class DeclarativeRecipeTest implements RewriteTest {
               name: org.openrewrite.ScanningPreconditionTest
               description: Test.
               preconditions:
-                - org.openrewrite.search.RepositoryContainsFiles:
+                - org.openrewrite.search.RepositoryContainsFile:
                     filePattern: sam.txt
               recipeList:
                 - org.openrewrite.text.FindAndReplace:

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -253,16 +253,56 @@ class DeclarativeRecipeTest implements RewriteTest {
                    relativeFileName: test.txt
                    fileContents: "test"
               """, "org.openrewrite.PreconditionTest")
-            .afterRecipe(run -> {
-                assertThat(run.getChangeset().getAllResults()).anySatisfy(
-                  s -> {
-                      assertThat(s.getAfter()).isNotNull();
-                      assertThat(s.getAfter().getSourcePath()).isEqualTo(Paths.get("test.txt"));
-                  }
-                );
-            })
+            .afterRecipe(run -> assertThat(run.getChangeset().getAllResults()).anySatisfy(
+              s -> {
+                  //noinspection DataFlowIssue
+                  assertThat(s.getAfter()).isNotNull();
+                  assertThat(s.getAfter().getSourcePath()).isEqualTo(Paths.get("test.txt"));
+              }
+            ))
             .expectedCyclesThatMakeChanges(1),
           text("1")
+        );
+    }
+
+    @Test
+    void scanningPreconditionMet() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.ScanningPreconditionTest
+              description: Test.
+              preconditions:
+                - org.openrewrite.search.RepositoryContainsFiles:
+                    filePattern: sam.txt
+              recipeList:
+                - org.openrewrite.text.FindAndReplace:
+                    find: foo
+                    replace: bar
+              """, "org.openrewrite.ScanningPreconditionTest"),
+          text("sam", spec -> spec.path("sam.txt")),
+          text("foo", "bar")
+        );
+    }
+
+    @Test
+    void scanningPreconditionNotMet() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.ScanningPreconditionTest
+              description: Test.
+              preconditions:
+                - org.openrewrite.search.RepositoryContainsFiles:
+                    filePattern: sam.txt
+              recipeList:
+                - org.openrewrite.text.FindAndReplace:
+                    find: foo
+                    replace: bar
+              """, "org.openrewrite.ScanningPreconditionTest"),
+          text("foo")
         );
     }
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/ModuleHasPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/ModuleHasPlugin.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ModuleHasPlugin extends ScanningRecipe<ModuleHasPlugin.Accumulator> {
+
+    @Override
+    public String getDisplayName() {
+        return "Module has plugin";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Searches for Gradle Projects (modules) that have a plugin matching the specified id or implementing class. " +
+               "Places a `SearchResult` marker on all sources within a project with a matching plugin. " +
+               "This recipe is intended to be used as a precondition for other recipes. " +
+               "For example this could be used to limit the application of a spring boot migration to only projects " +
+               "that apply the spring dependency management plugin, limiting unnecessary upgrading. " +
+               "If the search result you want is instead just the build.gradle(.kts) file applying the plugin, use the `FindPlugins` recipe instead.";
+    }
+
+    @Option(displayName = "Plugin id",
+            description = "The unique identifier used to apply a plugin in the `plugins` block. " +
+                          "Note that this alone is insufficient to search for plugins applied by fully qualified class name and the `buildscript` block.",
+            example = "`com.jfrog.bintray`")
+    String pluginId;
+
+    @Option(displayName = "Plugin class",
+            description = "The fully qualified name of a class implementing a Gradle plugin. ",
+            required = false,
+            example = "com.jfrog.bintray.gradle.BintrayPlugin")
+    @Nullable
+    String pluginClass;
+
+    @Value
+    public static class Accumulator {
+        Set<JavaProject> projectsWithDependency;
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator(new HashSet<>());
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                assert tree != null;
+                tree.getMarkers()
+                        .findFirst(JavaProject.class)
+                        .ifPresent(jp -> {
+                            Tree t = new FindPlugins(pluginId, pluginClass).getVisitor().visit(tree, ctx);
+                            if (t != tree) {
+                                acc.getProjectsWithDependency().add(jp);
+                            }
+                        });
+                return tree;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                assert tree != null;
+                Optional<JavaProject> maybeJp = tree.getMarkers().findFirst(JavaProject.class);
+                if (!maybeJp.isPresent()) {
+                    return tree;
+                }
+                JavaProject jp = maybeJp.get();
+                if (acc.getProjectsWithDependency().contains(jp)) {
+                    return SearchResult.found(tree, "Module has plugin: " + pluginId);
+                }
+                return tree;
+            }
+        };
+    }
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/ModuleHasPluginTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/ModuleHasPluginTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.*;
+
+class ModuleHasPluginTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ModuleHasPlugin("org.openrewrite.rewrite", "org.openrewrite.gradle.RewritePlugin"));
+    }
+
+    @DocumentExample
+    @Test
+    void findPlugin() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject("multi-project-build",
+            settingsGradle("""
+              include 'project-applies-openrewrite-plugin'
+              include 'other-project'
+              """),
+            mavenProject("project-applies-openrewrite-plugin",
+              buildGradle(
+                """
+                  plugins {
+                      id 'java'
+                      id 'org.openrewrite.rewrite' version '6.18.0'
+                  }
+                  """,
+                """
+                  /*~~(Module has plugin: org.openrewrite.rewrite)~~>*/plugins {
+                      id 'java'
+                      id 'org.openrewrite.rewrite' version '6.18.0'
+                  }
+                  """
+              ),
+              srcMainJava(
+                java("""
+                    class A {}
+                    """,
+                  """
+                    /*~~(Module has plugin: org.openrewrite.rewrite)~~>*/class A {}
+                    """)
+              )
+            ),
+            mavenProject("other-project",
+              buildGradle(
+                """
+                  plugins {
+                      id 'java'
+                  }
+                  """
+              ),
+              srcMainJava(
+                java("""
+                  class B {}
+                  """)
+              )
+            )
+          )
+        );
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ModuleHasPlugin.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ModuleHasPlugin.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.java.marker.JavaProject;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ModuleHasPlugin extends ScanningRecipe<ModuleHasPlugin.Accumulator> {
+
+    @Override
+    public String getDisplayName() {
+        return "Module has plugin";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Searches for Maven modules that have a plugin matching the specified groupId and artifactId. " +
+               "Places a `SearchResult` marker on all sources within a module with a matching plugin. " +
+               "This recipe is intended to be used as a precondition for other recipes. " +
+               "For example this could be used to limit the application of a spring boot migration to only projects " +
+               "that apply the spring boot plugin, limiting unnecessary upgrading. " +
+               "If the search result you want is instead just the build.gradle(.kts) file applying the plugin, use the `FindPlugins` recipe instead.";
+    }
+
+    @Option(displayName = "Group",
+            description = "The first part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'.",
+            example = "org.openrewrite.maven")
+    String groupId;
+
+    @Option(displayName = "Artifact",
+            description = "The second part of a dependency coordinate 'org.openrewrite.maven:rewrite-maven-plugin:VERSION'.",
+            example = "rewrite-maven-plugin")
+    String artifactId;
+
+    @Value
+    public static class Accumulator {
+        Set<JavaProject> projectsWithDependency;
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator(new HashSet<>());
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                assert tree != null;
+                tree.getMarkers()
+                        .findFirst(JavaProject.class)
+                        .ifPresent(jp -> {
+                            Tree t = new FindPlugin(groupId, artifactId).getVisitor().visit(tree, ctx);
+                            if (t != tree) {
+                                acc.getProjectsWithDependency().add(jp);
+                            }
+                        });
+                return tree;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                assert tree != null;
+                Optional<JavaProject> maybeJp = tree.getMarkers().findFirst(JavaProject.class);
+                if (!maybeJp.isPresent()) {
+                    return tree;
+                }
+                JavaProject jp = maybeJp.get();
+                if (acc.getProjectsWithDependency().contains(jp)) {
+                    return SearchResult.found(tree, "Module has plugin: " + groupId + ":" + artifactId);
+                }
+                return tree;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Back in rewrite 7 we had two kinds of preconditions: Repository level and file level. Repository level were uncommon but could be used to express things like "Run this recipe only if a particular type is in use or dependency is present". We lost that in the jump to rewrite 8, supporting only file-level preconditions. Until now.

With these changes a DeclarativeRecipe can use a scanning recipe as a precondition. This allows for not only repository level preconditions, but for any arbitrary granularity between file and repository. So this mechanism allows you to express nuanced preconditions like "only run this recipe on java sources gradle projects which apply a particular plugin".

