### PR TITLE
Do not bring named parameters out of their containing MapExpression when in an Map with a prefixed space.

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
@@ -189,6 +189,64 @@ class GradleParserTest implements RewriteTest {
     }
 
     @Test
+    void dependencyNotations() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+              
+                  // String notation
+                  implementation "org.openrewrite:rewrite-java:latest.release"
+                  implementation ("org.openrewrite:rewrite-java:latest.release")
+                  implementation ("org.openrewrite:rewrite-java:latest.release") { transitive = false }
+                  implementation ("org.openrewrite:rewrite-java:latest.release") {
+                      transitive = false
+                  }
+                  implementation ( "org.openrewrite:rewrite-java:latest.release" )
+                  implementation ( "org.openrewrite:rewrite-java:latest.release" ) { transitive = false }
+                  implementation ( "org.openrewrite:rewrite-java:latest.release" ) {
+                      transitive = false
+                  }
+              
+                  // Map notation
+                  implementation group: "org.openrewrite", name: "rewrite-java", version: "latest.release"
+                  implementation(group: "org.openrewrite", name: "rewrite-java", version: "latest.release")
+                  implementation(group: "org.openrewrite", name: "rewrite-java", version: "latest.release") { transitive = false }
+                  implementation(group: "org.openrewrite", name: "rewrite-java", version: "latest.release") {
+                      transitive = false
+                  }
+                  implementation( group: "org.openrewrite", name: "rewrite-java", version: "latest.release" )
+                  implementation( group: "org.openrewrite", name: "rewrite-java", version: "latest.release" ) { transitive = false }
+                  implementation( group: "org.openrewrite", name: "rewrite-java", version: "latest.release" ) {
+                      transitive = false
+                  }
+                  
+                  // Map literal notation
+                  implementation([group: "org.openrewrite", name: "rewrite-java", version: "latest.release"])
+                  implementation([group: "org.openrewrite", name: "rewrite-java", version: "latest.release"]) { transitive = false }
+                  implementation([group: "org.openrewrite", name: "rewrite-java", version: "latest.release"]) {
+                      transitive = false
+                  }
+                  implementation( [group: "org.openrewrite", name: "rewrite-java", version: "latest.release"] )
+                  implementation( [group: "org.openrewrite", name: "rewrite-java", version: "latest.release"] ) { transitive = false }
+                  implementation( [group: "org.openrewrite", name: "rewrite-java", version: "latest.release"] ) {
+                      transitive = false
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void kotlinDsl() {
         rewriteRun(
           buildGradleKts(

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -719,7 +719,6 @@ public class GroovyParserVisitor {
                 // If it is wrapped in "[]" then this isn't a named arguments situation, and we should not lift the parameters out of the enclosing MapExpression
                 saveCursor = cursor;
                 whitespace();
-                cursor = saveCursor;
                 if ('[' != source.charAt(cursor)) {
                     // Bring named parameters out of their containing MapExpression so that they can be parsed correctly
                     MapExpression namedArgExpressions = (MapExpression) unparsedArgs.get(0);
@@ -729,6 +728,7 @@ public class GroovyParserVisitor {
                                             unparsedArgs.subList(1, unparsedArgs.size()).stream())
                                     .collect(toList());
                 }
+                cursor = saveCursor;
             }
 
             if (unparsedArgs.isEmpty()) {


### PR DESCRIPTION
## What's changed?
- Fixes #5349 

## What's your motivation?
There was already a check in place to bypass this issue. However, the cursor reset was misplaced so it only worked when there was no whitespace in front of the `[`. Now that should be fixed!

## Anything in particular you'd like reviewers to focus on?
Do I break something else? I do not see what would be impacted as we already had similar thing when not prefixed with whitespace.

## Anyone you would like to review specifically?
@jevanlingen as you have added that if-statement, hoping you can quickly spot dangers, if any!

## Have you considered any alternatives or workarounds?
Not really

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
