### PR TITLE
Allow JContainer content modifications through the JRIghtPadded elements rather than only on the internal Expressions

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -46,9 +46,12 @@ class DependencyUseStringNotationTest implements RewriteTest {
               }  
                 
               dependencies {
-                  api( group: 'org.openrewrite', name: 'rewrite-gradle', version: 'latest.release' )
                   api(group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release')
                   implementation group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release'
+                  api( group: 'org.openrewrite', name: 'rewrite-java', version: 'latest.release' ) {
+                      transitive = false
+                  }
+                  api( group: 'org.openrewrite', name: 'rewrite-gradle', version: 'latest.release' )
               }
               """,
             """
@@ -61,9 +64,12 @@ class DependencyUseStringNotationTest implements RewriteTest {
               }
                 
               dependencies {
-                  api( "org.openrewrite:rewrite-gradle:latest.release" )
                   api("org.openrewrite:rewrite-core:latest.release")
                   implementation "org.openrewrite:rewrite-core:latest.release"
+                  api( "org.openrewrite:rewrite-java:latest.release" ) {
+                      transitive = false
+                  }
+                  api( "org.openrewrite:rewrite-gradle:latest.release" )
               }
               """
           )
@@ -86,6 +92,11 @@ class DependencyUseStringNotationTest implements RewriteTest {
               dependencies {
                   api(group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release', classifier: 'sources')
                   implementation group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release', classifier: 'sources'
+                  // The whitespaces are also kept
+                  api( group: 'org.openrewrite', name: 'rewrite-java', version: 'latest.release', classifier: 'sources' ) {
+                      transitive = false
+                  }
+                  api( group: 'org.openrewrite', name: 'rewrite-gradle', version: 'latest.release', classifier: 'sources' )
               }
               """,
             """
@@ -100,6 +111,11 @@ class DependencyUseStringNotationTest implements RewriteTest {
               dependencies {
                   api("org.openrewrite:rewrite-core:latest.release:sources")
                   implementation "org.openrewrite:rewrite-core:latest.release:sources"
+                  // The whitespaces are also kept
+                  api( "org.openrewrite:rewrite-java:latest.release:sources" ) {
+                      transitive = false
+                  }
+                  api( "org.openrewrite:rewrite-gradle:latest.release:sources" )
               }
               """
           )

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -46,8 +46,8 @@ class DependencyUseStringNotationTest implements RewriteTest {
               }  
                 
               dependencies {
-                  api(group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release')
                   api( group: 'org.openrewrite', name: 'rewrite-gradle', version: 'latest.release' )
+                  api(group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release')
                   implementation group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release'
               }
               """,

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -47,6 +47,7 @@ class DependencyUseStringNotationTest implements RewriteTest {
                 
               dependencies {
                   api(group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release')
+                  api( group: 'org.openrewrite', name: 'rewrite-gradle', version: 'latest.release' )
                   implementation group: 'org.openrewrite', name: 'rewrite-core', version: 'latest.release'
               }
               """,
@@ -61,6 +62,7 @@ class DependencyUseStringNotationTest implements RewriteTest {
                 
               dependencies {
                   api("org.openrewrite:rewrite-core:latest.release")
+                  api( "org.openrewrite:rewrite-gradle:latest.release" )
                   implementation "org.openrewrite:rewrite-core:latest.release"
               }
               """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -61,8 +61,8 @@ class DependencyUseStringNotationTest implements RewriteTest {
               }
                 
               dependencies {
-                  api("org.openrewrite:rewrite-core:latest.release")
                   api( "org.openrewrite:rewrite-gradle:latest.release" )
+                  api("org.openrewrite:rewrite-core:latest.release")
                   implementation "org.openrewrite:rewrite-core:latest.release"
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
@@ -4034,6 +4035,10 @@ public interface J extends Tree {
             return getPadding().withArguments(JContainer.withElements(this.arguments, arguments));
         }
 
+        //TODO: should be in MethodCall interface?
+        public MethodInvocation withArguments(Function<List<JRightPadded<Expression>>, List<JRightPadded<Expression>>> arguments) {
+            return getPadding().withArguments(JContainer.build(arguments.apply(this.arguments.getPadding().getElements())));
+        }
 
         @Getter
         JavaType.@Nullable Method methodType;


### PR DESCRIPTION
## What's changed?
Added a new method in MethodCall J objects so they can workn with the previous JRightPadded elements to keep certain stuff properly formatted.

## What's your motivation?
Trailing whitespaces are not consistenly kept like leading ones in all cases.
Fixes: #5342 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@shanman190 @timtebeek @knutwannheden 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
This is a draft to have easier discussions on the code/output

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
