### PR TITLE
Override `asVisitor(VisitFunction2)` in Annotated Trait

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/trait/Annotated.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/trait/Annotated.java
@@ -19,11 +19,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
+import org.openrewrite.trait.VisitFunction2;
 
 import java.util.Optional;
 
@@ -85,6 +89,19 @@ public class Annotated implements Trait<J.Annotation> {
 
         public Matcher(Class<?> annotationType) {
             this.matcher = new AnnotationMatcher(annotationType);
+        }
+
+        @Override
+        public <P> TreeVisitor<? extends Tree, P> asVisitor(VisitFunction2<Annotated, P> visitor) {
+            return new JavaVisitor<P>() {
+                @Override
+                public J visitAnnotation(J.Annotation annotation, P p) {
+                    Annotated annotated = test(getCursor());
+                    return annotated != null ?
+                            (J) visitor.visit(annotated, p) :
+                            super.visitAnnotation(annotation, p);
+                }
+            };
         }
 
         @Override

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.trait;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
@@ -25,7 +24,7 @@ import static org.openrewrite.java.trait.Traits.annotated;
 
 class AnnotatedTest implements RewriteTest {
 
-    @RepeatedTest(50)
+    @Test
     void attributes() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.trait;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
@@ -24,7 +25,7 @@ import static org.openrewrite.java.trait.Traits.annotated;
 
 class AnnotatedTest implements RewriteTest {
 
-    @Test
+    @RepeatedTest(50)
     void attributes() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
@@ -74,7 +75,7 @@ class AnnotatedTest implements RewriteTest {
           java(
             //language=java
             """
-              import java.lang.annotation.ElementType; 
+              import java.lang.annotation.ElementType;
               import java.lang.annotation.Retention;
               import java.lang.annotation.RetentionPolicy;
               import java.lang.annotation.Target;


### PR DESCRIPTION
As it's documented as a recommendation for performance improvements:
https://github.com/openrewrite/rewrite/blob/a98d83d698dda9971c93a0767b7f85d5866f306d/rewrite-core/src/main/java/org/openrewrite/trait/SimpleTraitMatcher.java#L62-L73