### PR TITLE
Java - not unwrapping parens around switch expressions

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UnwrapParenthesesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UnwrapParenthesesTest.java
@@ -268,6 +268,7 @@ class UnwrapParenthesesTest implements RewriteTest {
                     }).length();
                }
             }
-            """));
+            """
+          ));
     }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UnwrapParenthesesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UnwrapParenthesesTest.java
@@ -254,4 +254,20 @@ class UnwrapParenthesesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void parensAroundSwitchAreNecessary() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+            public class Foo {
+                public int foo(int i) {
+                    return (switch(i) {
+                        default -> "foo";
+                    }).length();
+               }
+            }
+            """));
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/UnwrapParentheses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UnwrapParentheses.java
@@ -29,7 +29,7 @@ public class UnwrapParentheses<P> extends JavaVisitor<P> {
 
     @Override
     public <T extends J> J visitParentheses(J.Parentheses<T> parens, P p) {
-        if (scope.isScope(parens) && isUnwrappable(getCursor())) {
+        if (scope.isScope(parens) && isUnwrappable(getCursor()) && !(parens.getTree() instanceof J.SwitchExpression)) {
             J tree = parens.getTree().withPrefix(parens.getPrefix());
             if (tree.getPrefix().isEmpty()) {
                 Object parent = getCursor().getParentOrThrow().getValue();


### PR DESCRIPTION
## What's changed?

Changing `UnwrapParentheses` not to remove parenthesis around switch expressions.

## What's your motivation?

- fixes https://github.com/openrewrite/rewrite-static-analysis/issues/534
