### PR TITLE
Groovy - safety check for variable names starting with type names (e.g. int)

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2085,8 +2085,11 @@ public class GroovyParserVisitor {
             String typeName = "";
 
             if (!expression.isDynamicTyped() && source.startsWith(expression.getOriginType().getUnresolvedName(), cursor)) {
-                typeName = expression.getOriginType().getUnresolvedName();
-                skip(typeName);
+                if (cursor + expression.getOriginType().getUnresolvedName().length() < source.length()
+                    && !Character.isJavaIdentifierPart(source.charAt(cursor + expression.getOriginType().getUnresolvedName().length()))) {
+                    typeName = expression.getOriginType().getUnresolvedName();
+                    skip(typeName);
+                }
             }
             J.Identifier ident = new J.Identifier(randomId(),
                     EMPTY,

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/AssignmentTest.java
@@ -196,4 +196,15 @@ class AssignmentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void staticTypeWithTypeAsPrefix() {
+        rewriteRun(
+          groovy(
+            """
+            int a = 1    ,
+            intB = 2
+            """
+          ));
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding an additional safety check in Groovy parser wrt assignment statements with variable names starting with type names (e.g. `intsomething`)

## What's your motivation?

- fixes #5335 
