### PR TITLE
Use Java primitives in Kotlin model to match types

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3641,15 +3641,51 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     }
 
     private JavaType.@Nullable Variable variableType(PsiElement psi, @Nullable FirElement parent) {
-        return psiElementAssociations.variableType(psi, parent);
+        JavaType.Variable psiType = psiElementAssociations.variableType(psi, parent);
+        return psiType == null ? null : psiType.withType(mapPrimitiveType(psiType.getType()));
     }
 
     private JavaType.@Nullable Method methodDeclarationType(PsiElement psi) {
-        return psiElementAssociations.methodDeclarationType(psi);
+        JavaType.Method psiType = psiElementAssociations.methodDeclarationType(psi);
+        return psiType == null ? null : psiType.withParameterTypes(mapPrimitiveTypes(psiType.getParameterTypes()));
     }
 
     private JavaType.@Nullable Method methodInvocationType(PsiElement psi) {
-        return psiElementAssociations.methodInvocationType(psi);
+        JavaType.Method psiType = psiElementAssociations.methodInvocationType(psi);
+        return psiType == null ? null : psiType.withParameterTypes(mapPrimitiveTypes(psiType.getParameterTypes()));
+    }
+
+    private static List<JavaType> mapPrimitiveTypes(List<JavaType> types) {
+        return ListUtils.map(types, KotlinTreeParserVisitor::mapPrimitiveType);
+    }
+
+    private static JavaType mapPrimitiveType(JavaType type) {
+        if (type instanceof JavaType.Class) {
+            String fullyQualifiedName = ((JavaType.Class) type).getFullyQualifiedName();
+            switch (fullyQualifiedName) {
+                case "kotlin.Boolean":
+                    return JavaType.Primitive.Boolean;
+                case "kotlin.Byte":
+                    return JavaType.Primitive.Byte;
+                case "kotlin.Char":
+                    return JavaType.Primitive.Char;
+                case "kotlin.Double":
+                    return JavaType.Primitive.Double;
+                case "kotlin.Float":
+                    return JavaType.Primitive.Float;
+                case "kotlin.Int":
+                    return JavaType.Primitive.Int;
+                case "kotlin.Long":
+                    return JavaType.Primitive.Long;
+                case "kotlin.Short":
+                    return JavaType.Primitive.Short;
+                case "kotlin.String":
+                    return JavaType.Primitive.String;
+                case "kotlin.Void":
+                    return JavaType.Primitive.Void;
+            }
+        }
+        return type;
     }
 
     /*====================================================================

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/MethodMatcherTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/MethodMatcherTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.MethodMatcher;
@@ -53,6 +55,41 @@ class MethodMatcherTest implements RewriteTest {
               /*~~>*/fun function() {}
               fun usesFunction() {
                   function()
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "java.lang.Math max(int, int)",
+      "java.lang.Math max(..)"
+    })
+    void matchesMethodPatternOfJavaMethodWithAnyArgument(String methodPattern) {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              private final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, true);
+
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext p) {
+                  if (methodMatcher.matches(method)) {
+                      return SearchResult.found(method);
+                  }
+                  return super.visitMethodInvocation(method, p);
+              }
+          })),
+          kotlin(
+            """
+              import java.lang.Math
+              fun max(a: Int, b: Int) : Int {
+                  return Math.max(a, b)
+              }
+              """,
+            """
+              import java.lang.Math
+              fun max(a: Int, b: Int) : Int {
+                  return /*~~>*/Math.max(a, b)
               }
               """
           )

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/UseStaticImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/UseStaticImportTest.java
@@ -45,7 +45,7 @@ class UseStaticImportTest implements RewriteTest {
     @Test
     void withImports() {
         rewriteRun(
-          spec -> spec.recipe(new UseStaticImport("java.lang.Integer valueOf(kotlin.Int)")),
+          spec -> spec.recipe(new UseStaticImport("java.lang.Integer valueOf(int)")),
           kotlin(
             """
               import java.util.Collections


### PR DESCRIPTION
## What's changed?
Add type mapping from Kotlin primitive types to their Java counterparts, and use those in the type system.

## What's your motivation?
As described in https://github.com/openrewrite/rewrite-kotlin/pull/626 we had up to now mapped any primitive as a Kotlin primitive, even when those classes come from Java. That's problematic when say a method matcher for a Java method has a primitive type declared for the matcher. Those would then fail to match when used from Kotlin. While that's perhaps not very common, it's nonetheless important as we look to cover both with a single set of recipes, and for new recipes developed.

## Anything in particular you'd like reviewers to focus on?
Should we continue to use Kotlin primitives types when methods are defined in Kotlin? How do we tell those apart? Can we make that work on 1.9? Would it help to move to 2.0 or 2.1?

## Any additional context
- Continues https://github.com/openrewrite/rewrite-kotlin/pull/626