### PR TITLE
Default to no inference on Types

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -155,7 +155,7 @@ public class TypeUtils {
         if (type1 instanceof JavaType.Annotation && type2 instanceof JavaType.Annotation) {
             return isOfType((JavaType.Annotation) type1, (JavaType.Annotation) type2);
         }
-        return new Types(false).isOfType(type1, type2);
+        return new Types().isOfType(type1, type2);
     }
 
     private static boolean isOfType(JavaType.Annotation annotation1, JavaType.Annotation annotation2) {
@@ -278,7 +278,7 @@ public class TypeUtils {
     }
 
     public static boolean isAssignableTo(@Nullable JavaType to, @Nullable JavaType from) {
-        return new Types(false).isAssignableTo(to, from);
+        return new Types().isAssignableTo(to, from);
     }
 
     public static boolean isAssignableTo(String to, @Nullable JavaType from) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Types.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Types.java
@@ -25,6 +25,10 @@ public class Types {
     private final Set<TypePair> visiting = new HashSet<>();
     private final boolean infer;
 
+    public Types() {
+        this(false);
+    }
+
     public Types(boolean infer) {
         this.infer = infer;
     }


### PR DESCRIPTION
## What's changed?
Add a no args constructor to Types that defaults to not using inference.

## What's your motivation?
Make it easier to reuse without having to think of an explicit argument to pass in.

## Have you considered any alternatives or workarounds?
Considered adding a `Types.withInference()` static method instead of `new Types(true)`, but figured for the single use we see today likely not worth adding just yet.

## Any additional context
- Follow up from https://github.com/openrewrite/rewrite/pull/5348