### PR TITLE
Replace `J.MethodInvocation`s with constant

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ReplaceMethodInvocationWithConstant.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ReplaceMethodInvocationWithConstant.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.trait.MethodAccess;
+import org.openrewrite.java.trait.Traits;
+import org.openrewrite.java.tree.CoordinateBuilder;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.trait.VisitFunction;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ReplaceMethodInvocationWithConstant extends Recipe {
+
+    @Option(displayName = "Method pattern",
+            description = "A pattern to match method invocations to replace. " + MethodMatcher.METHOD_PATTERN_DESCRIPTION,
+            example = "java.lang.StringBuilder append(java.lang.String)")
+    String methodPattern;
+
+    @Option(displayName = "Replacement",
+            description = "The constant to replace the method invocation with.",
+            example = "null")
+    String replacement;
+
+    @Override
+    public String getDisplayName() {
+        return "Replace method invocation with constant";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace all method invocations matching the method pattern with the specified constant.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(methodPattern),
+                Traits.methodAccess(methodPattern).asVisitor(replaceWith(replacement)));
+    }
+
+    private VisitFunction<MethodAccess> replaceWith(String replacement) {
+        return new VisitFunction<MethodAccess>() {
+            final JavaTemplate replacementTemplate = JavaTemplate.builder(replacement).build();
+
+            @Override
+            public Tree visit(MethodAccess ma) {
+                return replacementTemplate.apply(ma.getCursor(), coordinateOf(ma).replace());
+            }
+
+            CoordinateBuilder.Expression coordinateOf(MethodAccess ma) {
+                return ((Expression) ma.getCursor().getValue()).getCoordinates();
+            }
+        };
+    }
+
+
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/ReplaceMethodInvocationWithConstantTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ReplaceMethodInvocationWithConstantTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReplaceMethodInvocationWithConstantTest implements RewriteTest {
+
+    private final Recipe REPLACE_WITH_NULL = new ReplaceMethodInvocationWithConstant("java.lang.System#getSecurityManager()", "null");
+    private final Recipe REPLACE_WITH_INTEGER = new ReplaceMethodInvocationWithConstant("Test#getValue()", "4711");
+
+    @Test
+    void replaceNothing() {
+        rewriteRun(
+          recipeSpec -> recipeSpec.recipe(REPLACE_WITH_INTEGER),
+          java(
+            """
+              class Test {
+                  void test() {
+                      int value = 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Nested
+    class InMethod {
+        @Test
+        @SuppressWarnings("removal")
+        void withNull() {
+            rewriteRun(
+              recipeSpec -> recipeSpec.recipe(REPLACE_WITH_NULL),
+              java(
+                """
+                  class Test {
+                      void test() {
+                          SecurityManager securityManager = System.getSecurityManager();
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      void test() {
+                          SecurityManager securityManager = null;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void withInteger() {
+            rewriteRun(
+              recipeSpec -> recipeSpec.recipe(REPLACE_WITH_INTEGER),
+              java(
+                """
+                  class Test {
+                      void test() {
+                          int value = getValue();
+                      }
+                      int getValue() {
+                          return 42;
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      void test() {
+                          int value = 4711;
+                      }
+                      int getValue() {
+                          return 42;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
+    class InField {
+        @Test
+        @SuppressWarnings("removal")
+        void withNull() {
+            rewriteRun(
+              recipeSpec -> recipeSpec.recipe(REPLACE_WITH_NULL),
+              java(
+                """
+                  class Test {
+                      SecurityManager securityManager = System.getSecurityManager();
+                  }
+                  """,
+                """
+                  class Test {
+                      SecurityManager securityManager = null;
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void withInteger() {
+            rewriteRun(
+              recipeSpec -> recipeSpec.recipe(REPLACE_WITH_INTEGER),
+              java(
+                """
+                  class Test {
+                      int value = getValue();
+                      static int getValue() {
+                          return 42;
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      int value = 4711;
+                      static int getValue() {
+                          return 42;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/ReplaceMethodInvocationWithConstantTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ReplaceMethodInvocationWithConstantTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
 
@@ -45,6 +46,7 @@ class ReplaceMethodInvocationWithConstantTest implements RewriteTest {
 
     @Nested
     class InMethod {
+        @DocumentExample
         @Test
         @SuppressWarnings("removal")
         void withNull() {


### PR DESCRIPTION


## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a recipe to replace MethodInvocations with a constant values.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
See `System.getSecurtiyManager()` it always returns `null`from java 24. This recipe replaces the values and enable cleanup recipes.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
