### PR TITLE
Add Maven plugin dependency with implied groupId

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddPluginDependencyTest.java
@@ -258,4 +258,52 @@ class AddPluginDependencyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void impliedGroupId() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPluginDependency(
+            "org.apache.maven.plugins", "maven-surefire-plugin",
+            "org.openrewrite.recipe", "rewrite-spring", "1.0.0")),
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>maven-surefire-plugin</artifactId>
+                              <version>2.20.1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <artifactId>maven-surefire-plugin</artifactId>
+                              <version>2.20.1</version>
+                              <dependencies>
+                                  <dependency>
+                                      <groupId>org.openrewrite.recipe</groupId>
+                                      <artifactId>rewrite-spring</artifactId>
+                                      <version>1.0.0</version>
+                                  </dependency>
+                              </dependencies>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Previously these would not match; now that we use `isPluginTag(pluginGroupId, pluginArtifactId)` they do. Potentially could affect other recipes to, but not explored as part of this PR. As reported via Slack, and created as an example to serve if new cases are found.