### PR TITLE
Restore TypeUtils.isOfType behaviour

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
@@ -1033,4 +1033,288 @@ class RenameVariableTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void hiddenVariablesHierarchyRenameBase() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                  J target = getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
+                  if ("hidden".equals(multiVariable.getVariables().get(0).getSimpleName()) &&
+                    target instanceof J.ClassDeclaration && ((J.ClassDeclaration) target).getSimpleName().equals("Base")) {
+                      doAfterVisit(new RenameVariable<>(multiVariable.getVariables().get(0), "changed"));
+                  }
+                  return super.visitVariableDeclarations(multiVariable, ctx);
+              }
+          })),
+          java(
+            """
+              class Base {
+                  protected Base visible;
+                  protected Base hidden;
+              
+                  Base base() {
+                      return hidden;
+                  }
+              }
+              
+              class Middle extends Base {
+                  Middle middle() {
+                      return (Middle) hidden;
+                  }
+              }
+              
+              class Extended extends Middle {
+                  private Base hidden;
+              
+                  Extended extended() {
+                      return (Extended) hidden;
+                  }
+              
+                  public Extended test(Base hidden) {
+                      this.hidden = super.hidden;
+                      this.hidden = hidden.hidden;
+                      this.hidden = ((Middle) hidden).hidden;
+                      this.hidden = ((Extended) hidden).hidden;
+                      base().hidden = this;
+                      middle().hidden = this;
+                      extended().hidden = this;
+                      super.hidden = visible.hidden;
+                      visible.hidden = hidden;
+                      hidden.hidden.hidden = hidden.hidden = this.hidden = hidden;
+                      return this;
+                  }
+              }
+              """,
+            """
+              class Base {
+                  protected Base visible;
+                  protected Base changed;
+              
+                  Base base() {
+                      return changed;
+                  }
+              }
+              
+              class Middle extends Base {
+                  Middle middle() {
+                      return (Middle) changed;
+                  }
+              }
+              
+              class Extended extends Middle {
+                  private Base hidden;
+              
+                  Extended extended() {
+                      return (Extended) hidden;
+                  }
+              
+                  public Extended test(Base hidden) {
+                      this.hidden = super.changed;
+                      this.hidden = hidden.changed;
+                      this.hidden = ((Middle) hidden).changed;
+                      this.hidden = ((Extended) hidden).hidden;
+                      base().changed = this;
+                      middle().changed = this;
+                      extended().hidden = this;
+                      super.changed = visible.changed;
+                      visible.changed = hidden;
+                      hidden.changed.changed = hidden.changed = this.hidden = hidden;
+                      return this;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void hiddenVariablesHierarchyRenameExtended() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                  J target = getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
+                  if ("hidden".equals(multiVariable.getVariables().get(0).getSimpleName()) &&
+                    target instanceof J.ClassDeclaration && ((J.ClassDeclaration) target).getSimpleName().equals("Extended")) {
+                      doAfterVisit(new RenameVariable<>(multiVariable.getVariables().get(0), "changed"));
+                  }
+                  return super.visitVariableDeclarations(multiVariable, ctx);
+              }
+          })),
+          java(
+            """
+              class Base {
+                  protected Base visible;
+                  protected Base hidden;
+              
+                  Base base() {
+                      return hidden;
+                  }
+              }
+              
+              class Middle extends Base {
+                  Middle middle() {
+                      return (Middle) hidden;
+                  }
+              }
+              
+              class Extended extends Middle {
+                  private Base hidden;
+              
+                  Extended extended() {
+                      return (Extended) hidden;
+                  }
+              
+                  public Extended test(Base hidden) {
+                      this.hidden = super.hidden;
+                      this.hidden = hidden.hidden;
+                      this.hidden = ((Middle) hidden).hidden;
+                      this.hidden = ((Extended) hidden).hidden;
+                      base().hidden = this;
+                      middle().hidden = this;
+                      extended().hidden = this;
+                      super.hidden = visible.hidden;
+                      visible.hidden = hidden;
+                      hidden.hidden.hidden = hidden.hidden = this.hidden = hidden;
+                      return this;
+                  }
+              }
+              """,
+            """
+              class Base {
+                  protected Base visible;
+                  protected Base hidden;
+              
+                  Base base() {
+                      return hidden;
+                  }
+              }
+              
+              class Middle extends Base {
+                  Middle middle() {
+                      return (Middle) hidden;
+                  }
+              }
+              
+              class Extended extends Middle {
+                  private Base changed;
+              
+                  Extended extended() {
+                      return (Extended) changed;
+                  }
+              
+                  public Extended test(Base hidden) {
+                      this.changed = super.hidden;
+                      this.changed = hidden.hidden;
+                      this.changed = ((Middle) hidden).hidden;
+                      this.changed = ((Extended) hidden).changed;
+                      base().hidden = this;
+                      middle().hidden = this;
+                      extended().changed = this;
+                      super.hidden = visible.hidden;
+                      visible.hidden = hidden;
+                      hidden.hidden.hidden = hidden.hidden = this.changed = hidden;
+                      return this;
+                  }
+              }
+              """)
+        );
+    }
+
+    @Test
+    void hiddenVariablesHierarchyRenameLocal() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                  J target = getCursor().getParentTreeCursor().getValue();
+                  if ("hidden".equals(multiVariable.getVariables().get(0).getSimpleName()) &&
+                    target instanceof J.MethodDeclaration) {
+                      doAfterVisit(new RenameVariable<>(multiVariable.getVariables().get(0), "changed"));
+                  }
+                  return super.visitVariableDeclarations(multiVariable, ctx);
+              }
+          })),
+          java(
+            """
+              class Base {
+                  protected Base visible;
+                  protected Base hidden;
+              
+                  Base base() {
+                      return hidden;
+                  }
+              }
+              
+              class Middle extends Base {
+                  Middle middle() {
+                      return (Middle) hidden;
+                  }
+              }
+              
+              class Extended extends Middle {
+                  private Base hidden;
+              
+                  Extended extended() {
+                      return (Extended) hidden;
+                  }
+              
+                  public Extended test(Base hidden) {
+                      this.hidden = super.hidden;
+                      this.hidden = hidden.hidden;
+                      this.hidden = ((Middle) hidden).hidden;
+                      this.hidden = ((Extended) hidden).hidden;
+                      base().hidden = this;
+                      middle().hidden = this;
+                      extended().hidden = this;
+                      super.hidden = visible.hidden;
+                      visible.hidden = hidden;
+                      hidden.hidden.hidden = hidden.hidden = this.hidden = hidden;
+                      return this;
+                  }
+              }
+              """,
+            """
+              class Base {
+                  protected Base visible;
+                  protected Base hidden;
+              
+                  Base base() {
+                      return hidden;
+                  }
+              }
+              
+              class Middle extends Base {
+                  Middle middle() {
+                      return (Middle) hidden;
+                  }
+              }
+              
+              class Extended extends Middle {
+                  private Base hidden;
+              
+                  Extended extended() {
+                      return (Extended) hidden;
+                  }
+              
+                  public Extended test(Base changed) {
+                      this.hidden = super.hidden;
+                      this.hidden = changed.hidden;
+                      this.hidden = ((Middle) changed).hidden;
+                      this.hidden = ((Extended) changed).hidden;
+                      base().hidden = this;
+                      middle().hidden = this;
+                      extended().hidden = this;
+                      super.hidden = visible.hidden;
+                      visible.hidden = changed;
+                      changed.hidden.hidden = changed.hidden = this.hidden = changed;
+                      return this;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
@@ -1219,7 +1219,8 @@ class RenameVariableTest implements RewriteTest {
                       return this;
                   }
               }
-              """)
+              """
+          )
         );
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
@@ -153,8 +153,7 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
         }
 
         /**
-         * FieldAccess targets the variable if its target is an Identifier and either
-         * its target Type equals variable.Name.FieldType.Owner.
+         * FieldAccess targets the variable if its target type equals variable.Name.FieldType.Owner.
          */
         private boolean fieldAccessTargetsVariable(J.FieldAccess fieldAccess) {
             if (renameVariable.getName().getFieldType() != null &&

--- a/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
@@ -90,7 +90,11 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
             }
             Cursor parent = getCursor().getParentTreeCursor();
             if (ident.getSimpleName().equals(renameVariable.getSimpleName())) {
-                if (parent.getValue() instanceof J.FieldAccess) {
+                if (ident.getFieldType() != null && TypeUtils.isOfType(ident.getFieldType(), renameVariable.getVariableType())) {
+                    parent.putMessage("renamed", true);
+                    return ident.withFieldType(ident.getFieldType().withName(newName)).withSimpleName(newName);
+                } else if (parent.getValue() instanceof J.FieldAccess &&
+                        !ident.equals(((J.FieldAccess) parent.getValue()).getTarget())) {
                     if (fieldAccessTargetsVariable(parent.getValue())) {
                         if (ident.getFieldType() != null) {
                             ident = ident.withFieldType(ident.getFieldType().withName(newName));
@@ -150,47 +154,16 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
 
         /**
          * FieldAccess targets the variable if its target is an Identifier and either
-         * its target FieldType equals variable.Name.FieldType
-         * or its target Type equals variable.Name.FieldType.Owner
-         * or if FieldAccess targets a TypCast and either
-         * its type equals variable.Name.FieldType
-         * or its type equals variable.Name.FieldType.Owner.
-         * In case the FieldAccess targets another FieldAccess, the target is followed
-         * until it is either an Identifier or a TypeCast.
+         * its target Type equals variable.Name.FieldType.Owner.
          */
         private boolean fieldAccessTargetsVariable(J.FieldAccess fieldAccess) {
-            if (renameVariable.getName().getFieldType() != null) {
-                Expression target = getTarget(fieldAccess);
-                JavaType targetType = resolveType(target.getType());
+            if (renameVariable.getName().getFieldType() != null &&
+                    fieldAccess.getTarget().getType() != null) {
+                JavaType targetType = resolveType(fieldAccess.getTarget().getType());
                 JavaType.Variable variableNameFieldType = renameVariable.getName().getFieldType();
-                if (targetType != null && targetType.equals(variableNameFieldType.getOwner())) {
-                    return true;
-                }
-                if (target instanceof J.TypeCast) {
-                    return TypeUtils.isOfType(variableNameFieldType, targetType);
-                } else if (target instanceof J.Identifier) {
-                    return TypeUtils.isOfType(variableNameFieldType, ((J.Identifier) target).getFieldType());
-                }
+                return TypeUtils.isOfType(resolveType(variableNameFieldType.getOwner()), targetType);
             }
             return false;
-        }
-
-        private @Nullable Expression getTarget(J.FieldAccess fieldAccess) {
-            Expression target = fieldAccess.getTarget();
-            if (target instanceof J.Identifier) {
-                return target;
-            }
-            if (target instanceof J.FieldAccess) {
-                return getTarget((J.FieldAccess) target);
-            }
-            if (target instanceof J.Parentheses<?>) {
-                J tree = ((J.Parentheses<?>) target).getTree();
-                if (tree instanceof J.TypeCast) {
-                    return (J.TypeCast) tree;
-                }
-                return null;
-            }
-            return null;
         }
 
         private @Nullable JavaType resolveType(@Nullable JavaType type) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -483,18 +483,6 @@ public class TypeUtils {
         return Optional.empty();
     }
 
-    public static Optional<JavaType.Variable> findDeclaredField(JavaType.@Nullable FullyQualified clazz, String name) {
-        if (clazz == null) {
-            return Optional.empty();
-        }
-        for (JavaType.Variable variable : clazz.getMembers()) {
-            if (variable.getName().equals(name)) {
-                return Optional.of(variable);
-            }
-        }
-        return findDeclaredField(clazz.getSupertype(), name);
-    }
-
     private static boolean methodHasSignature(JavaType.FullyQualified clazz, JavaType.Method m, String name, List<JavaType> argTypes) {
         if (!name.equals(m.getName())) {
             return false;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -123,7 +123,10 @@ public class TypeUtils {
         if (type1 == type2) {
             return true;
         }
-        if (type1 instanceof JavaType.Method && type2 instanceof JavaType.Method) {
+        if (type1 instanceof JavaType.Method || type2 instanceof JavaType.Method) {
+            if (!(type1 instanceof JavaType.Method) || !(type2 instanceof JavaType.Method)) {
+                return false;
+            }
             JavaType.Method method1 = (JavaType.Method) type1;
             JavaType.Method method2 = (JavaType.Method) type2;
             if (!method1.getName().equals(method2.getName()) ||
@@ -147,12 +150,18 @@ public class TypeUtils {
             }
             return true;
         }
-        if(type1 instanceof JavaType.Variable && type2 instanceof JavaType.Variable) {
+        if (type1 instanceof JavaType.Variable || type2 instanceof JavaType.Variable) {
+            if (!(type1 instanceof JavaType.Variable) || !(type2 instanceof JavaType.Variable)) {
+                return false;
+            }
             JavaType.Variable var1 = (JavaType.Variable) type1;
             JavaType.Variable var2 = (JavaType.Variable) type2;
             return isOfType((var1).getType(), var2.getType()) && isOfType(var1.getOwner(), var2.getOwner());
         }
-        if (type1 instanceof JavaType.Annotation && type2 instanceof JavaType.Annotation) {
+        if (type1 instanceof JavaType.Annotation || type2 instanceof JavaType.Annotation) {
+            if (!(type1 instanceof JavaType.Annotation) || !(type2 instanceof JavaType.Annotation)) {
+                return false;
+            }
             return isOfType((JavaType.Annotation) type1, (JavaType.Annotation) type2);
         }
         return new Types().isOfType(type1, type2);
@@ -472,6 +481,18 @@ public class TypeUtils {
             }
         }
         return Optional.empty();
+    }
+
+    public static Optional<JavaType.Variable> findDeclaredField(JavaType.@Nullable FullyQualified clazz, String name) {
+        if (clazz == null) {
+            return Optional.empty();
+        }
+        for (JavaType.Variable variable : clazz.getMembers()) {
+            if (variable.getName().equals(name)) {
+                return Optional.of(variable);
+            }
+        }
+        return findDeclaredField(clazz.getSupertype(), name);
     }
 
     private static boolean methodHasSignature(JavaType.FullyQualified clazz, JavaType.Method m, String name, List<JavaType> argTypes) {


### PR DESCRIPTION
## What's changed?
- Fix previous https://github.com/openrewrite/rewrite/pull/5348 unintended change, which cause regression https://github.com/openrewrite/rewrite/pull/5369
- Added more tests for `RenameVariable` and fix small issue.

## What's changed?
The original `TypeUtils.isOfType()` performed full checks (name, owner, parameters, etc.) for `JavaType.Method`, `JavaType.Variable`, and `JavaType.Annotation`. The new `Types.isOfType()` implementation normalizes these types to their expression type, aligning with `isAssignableTo` logic, to be used in `JavaTemplateSemanticallyEquals`. This causes some cases to now return `true` where the old logic returned `false`.

This change preserves backward compatibility by:
- Keeping the old behavior in `TypeUtils.isOfType()`
- Letting `Types.isOfType()` adopt the normalized type approach

## Anything in particular you'd like reviewers to focus on?
The original `TypeUtils.isOfType()` had surprising edge cases:
- **Null handling**: Returns `false` if one type is `Unknown` but `true` if both are `null`
- **Method checks**: Validates _everything_ (name, return type, exceptions, type arguments)
- **Field checks**: Only verifies owner and type (_ignores field names_)

Is type normalization in `Types.isOfType()` the right approach, or should we keep the original behaviour there, or fix it instead.

---

I'm not sure what was the intended logic in `fieldAccessTargetsVariable`. In this test:
```
class Base {
    protected Base visible;
    protected Base hidden;

    Base base() {
        return hidden;
    }
}

class Middle extends Base {
    Middle middle() {
        return (Middle) hidden; // Case 2
    }
}

class Extended extends Middle {
    private Base hidden;

    public Extended test(Base hidden) {
        hidden.hidden = hidden; // Case 1
        return this;
    }
}
```
When renaming `Base.hidden` to `Base.changed`. 
- In `Extended.test()` `hidden.hidden` got both replaced to `changed.changed`. (Case 1)
- And it did not change the `hidden` in `Middle.middle()` method. (Case 2)

For case 1. I had to change the logic to ensure only identifiers whose parent was `FieldAccess` were changed, if they were the actual field and not the `target`. This lead to some simplification in the rules, only check for the `target` type to be the `owner` of the field. This pass all existing tests, except for the `Middle.middle()` case. But could there be any edge case?

To fix the `Middle.middle()` case 2. I have to introduce a check, if the Identifier fieldType is the actual variable to be rename, apply the rename. But that make the previous code never to be executed.

## Anyone you would like to review specifically?
@timtebeek and @Jenson3210 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
