### PR TITLE
Fix some matching scenarios

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateGenericsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateGenericsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.Objects;
@@ -79,6 +80,42 @@ class JavaTemplateGenericsTest implements RewriteTest {
                       System.out.printf(any());
                   }
                   static native <T> T any();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void expressionTest() {
+        var template = JavaTemplate.builder("!#{iterable:any(java.lang.Iterable<T>)}.iterator().hasNext()")
+          .genericTypes("T")
+          .build();
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.Unary visitUnary(J.Unary unary, ExecutionContext executionContext) {
+                  return template.matches(getCursor()) ? SearchResult.found(unary) : super.visitUnary(unary, executionContext);
+              }
+          })),
+          java(
+            """
+              import java.util.List;
+              
+              class Test {
+                  boolean test() {
+                      return !List.of("1").iterator().hasNext();
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              
+              class Test {
+                  boolean test() {
+                      return /*~~>*/!List.of("1").iterator().hasNext();
+                  }
               }
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -81,9 +81,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     case BLOCK_END: {
                         if (isScope(block)) {
                             List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(
-                                    new Cursor(getCursor(), insertionPoint),
-                                    Statement.class,
-                                    substitutedTemplate, emptySet(), loc, mode));
+                                    new Cursor(getCursor(), insertionPoint), Statement.class, substitutedTemplate,
+                                    substitutions.getTypeVariables(), loc, mode));
 
                             if (coordinates.getComparator() != null) {
                                 J.Block b = block;
@@ -112,9 +111,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                         return block.withStatements(ListUtils.flatMap(block.getStatements(), statement -> {
                             if (isScope(statement)) {
                                 List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(
-                                        new Cursor(getCursor(), insertionPoint),
-                                        Statement.class,
-                                        substitutedTemplate, emptySet(), loc, mode));
+                                        new Cursor(getCursor(), insertionPoint), Statement.class, substitutedTemplate,
+                                        substitutions.getTypeVariables(), loc, mode));
 
                                 Cursor parent = getCursor();
                                 for (int i = 0; i < gen.size(); i++) {
@@ -210,7 +208,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
-                                    emptyList(), loc))
+                                    substitutions.getTypeVariables(),
+                                    loc))
                             .withPrefix(expression.getPrefix()), p);
                 }
                 return expression;
@@ -222,14 +221,16 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
-                                    emptyList(), loc))
+                                    substitutions.getTypeVariables(),
+                                    loc))
                             .withPrefix(fa.getPrefix()), p);
                 } else if (loc == STATEMENT_PREFIX && isScope(fa)) {
                     // NOTE: while `J.FieldAccess` inherits from `Statement` they can only ever be used as expressions
                     return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
-                                    emptyList(), loc))
+                                    substitutions.getTypeVariables(),
+                                    loc))
                             .withPrefix(fa.getPrefix()), p);
                 }
                 return super.visitFieldAccess(fa, p);
@@ -242,7 +243,8 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     return autoFormat(unsubstitute(templateParser.parseExpression(
                                     getCursor(),
                                     substitutedTemplate,
-                                    emptyList(), loc))
+                                    substitutions.getTypeVariables(),
+                                    loc))
                             .withPrefix(ident.getPrefix()), p);
                 }
                 return super.visitIdentifier(ident, p);
@@ -284,7 +286,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                         }
                         case BLOCK_PREFIX: {
                             List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(getCursor(), Statement.class,
-                                    substitutedTemplate, emptySet(), loc, mode));
+                                    substitutedTemplate, substitutions.getTypeVariables(), loc, mode));
                             J.Block body = method.getBody();
                             if (body == null) {
                                 body = EMPTY_BLOCK;

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -929,6 +929,7 @@ public class SemanticallyEqual {
                     return memberRef;
                 }
 
+                visit(memberRef.getContaining(), compareTo.getContaining());
                 visitList(memberRef.getTypeParameters(), compareTo.getTypeParameters());
             }
             return memberRef;


### PR DESCRIPTION
## What's changed?
Small fixes for JavaTemplate.matches()

- Some paths didn't use the generic type information while generating the code for the template.
- Member reference was not checking the containing expressions, this lead to match but didn't capture the parameters.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
