### PR TITLE
Fix managed dependency equality around nullable classifier & type

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -312,8 +312,8 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
         for (ResolvedManagedDependency d : getResolutionResult().getPom().getDependencyManagement()) {
             if (groupId.equals(d.getGroupId()) &&
                 artifactId.equals(d.getArtifactId()) &&
-                (classifier == null || classifier.equals(d.getClassifier())) &&
-                (type == null || type.equals(d.getType()))) {
+                Objects.equals(classifier, d.getClassifier()) &&
+                Objects.equals(type, d.getType())) {
                 return d;
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -293,7 +293,7 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
                 .orElse(getResolutionResult().getPom().getGroupId()));
         String artifactId = getResolutionResult().getPom().getValue(tag.getChildValue("artifactId").orElse(""));
         String classifier = getResolutionResult().getPom().getValue(tag.getChildValue("classifier").orElse(null));
-        String type = getResolutionResult().getPom().getValue(tag.getChildValue("type").orElse(null));
+        String type = getResolutionResult().getPom().getValue(tag.getChildValue("type").orElse("jar"));
         if (groupId != null && artifactId != null) {
             return findManagedDependency(groupId, artifactId, classifier, type);
         }
@@ -305,10 +305,10 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     }
 
     private @Nullable ResolvedManagedDependency findManagedDependency(String groupId, String artifactId, @Nullable String classifier) {
-        return findManagedDependency(groupId, artifactId, classifier, null);
+        return findManagedDependency(groupId, artifactId, classifier, "jar");
     }
 
-    private @Nullable ResolvedManagedDependency findManagedDependency(String groupId, String artifactId, @Nullable String classifier, @Nullable String type) {
+    private @Nullable ResolvedManagedDependency findManagedDependency(String groupId, String artifactId, @Nullable String classifier, String type) {
         for (ResolvedManagedDependency d : getResolutionResult().getPom().getDependencyManagement()) {
             if (groupId.equals(d.getGroupId()) &&
                 artifactId.equals(d.getArtifactId()) &&

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveDuplicateDependenciesTest.java
@@ -554,4 +554,36 @@ class RemoveDuplicateDependenciesTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4868")
+    @Test
+    void retainWithAndWithoutClassifier() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.adobe.aio.cloudmanager</groupId>
+                              <artifactId>aio-lib-cloudmanager</artifactId>
+                              <classifier>java8</classifier>
+                              <version>2.0.0</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>com.adobe.aio.cloudmanager</groupId>
+                              <artifactId>aio-lib-cloudmanager</artifactId>
+                              <version>2.0.0</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/resources/junit-platform.properties
+++ b/rewrite-maven/src/test/resources/junit-platform.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
## What's changed?
Use `Objects.equals` to compare classifier and type for managed dependencies, as those can occur twice with mismatched & nullable values, which led to a number of confusing issues:
- fixes https://github.com/openrewrite/rewrite/issues/4868
- https://rewriteoss.slack.com/archives/C01A843MWG5/p1746248419279009

## Anything in particular you'd like reviewers to focus on?
Wondering if anything else might now fail to match because we came to rely on faulty resolve. I guess/hope not.

## Have you considered any alternatives or workarounds?
Fix this in `RemoveDuplicateDependencies` where this was first reported, and separately when it comes to missing managed dependency versions when parsing/downloading.