### PR TITLE
Adopt `@EnabledForJreRange` over `@Tag`

### DIFF
--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -82,9 +82,7 @@ testing {
             targets {
                 all {
                     testTask.configure {
-                        useJUnitPlatform {
-                            excludeTags("java17", "java21")
-                        }
+                        useJUnitPlatform()
                         testClassesDirs += files(javaTck.files.map { zipTree(it) })
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)

--- a/rewrite-java-17/build.gradle.kts
+++ b/rewrite-java-17/build.gradle.kts
@@ -1,8 +1,5 @@
 @file:Suppress("UnstableApiUsage")
 
-import org.gradle.internal.impldep.org.junit.platform.launcher.TagFilter.excludeTags
-
-
 plugins {
     id("org.openrewrite.build.language-library")
     id("jvm-test-suite")
@@ -71,9 +68,7 @@ testing {
             targets {
                 all {
                     testTask.configure {
-                        useJUnitPlatform {
-                            excludeTags("java21")
-                        }
+                        useJUnitPlatform()
                         testClassesDirs += files(javaTck.files.map { zipTree(it) })
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -36,28 +36,28 @@ tasks.withType<JavaCompile> {
 
     options.release.set(null as Int?) // remove `--release 8` set in `org.openrewrite.java-base`
     options.compilerArgs.addAll(
-            listOf(
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-            )
+        listOf(
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        )
     )
 }
 
 //Javadoc compiler will complain about the use of the internal types.
 tasks.withType<Javadoc> {
     exclude(
-            "**/ReloadableJava21JavadocVisitor**",
-            "**/ReloadableJava21Parser**",
-            "**/ReloadableJava21ParserVisitor**",
-            "**/ReloadableJava21TypeMapping**",
-            "**/ReloadableJava21TypeSignatureBuilder**",
-            "**/Javac**",
-            "**/JavacTreeMaker**",
-            "**/Permit**"
+        "**/ReloadableJava21JavadocVisitor**",
+        "**/ReloadableJava21Parser**",
+        "**/ReloadableJava21ParserVisitor**",
+        "**/ReloadableJava21TypeMapping**",
+        "**/ReloadableJava21TypeSignatureBuilder**",
+        "**/Javac**",
+        "**/JavacTreeMaker**",
+        "**/Permit**"
     )
 }
 

--- a/rewrite-java-8/build.gradle.kts
+++ b/rewrite-java-8/build.gradle.kts
@@ -79,9 +79,7 @@ testing {
             targets {
                 all {
                     testTask.configure {
-                        useJUnitPlatform {
-                            excludeTags("java11", "java17", "java21")
-                        }
+                        useJUnitPlatform()
                         testClassesDirs += files(javaTck.files.map { zipTree(it) })
                         jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
                         shouldRunAfter(test)

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/MinimumJava11.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/MinimumJava11.java
@@ -15,7 +15,8 @@
  */
 package org.openrewrite.java;
 
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -26,6 +27,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})
-@Tag("java11")
+@EnabledForJreRange(min = JRE.JAVA_11)
 public @interface MinimumJava11 {
 }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/MinimumJava17.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/MinimumJava17.java
@@ -15,7 +15,8 @@
  */
 package org.openrewrite.java;
 
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -26,6 +27,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})
-@Tag("java17")
+@EnabledForJreRange(min = JRE.JAVA_17)
 public @interface MinimumJava17 {
 }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/MinimumJava21.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/MinimumJava21.java
@@ -15,7 +15,8 @@
  */
 package org.openrewrite.java;
 
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -26,6 +27,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})
-@Tag("java21")
+@EnabledForJreRange(min = JRE.JAVA_21)
 public @interface MinimumJava21 {
 }


### PR DESCRIPTION
## What's changed?
Drop the use of Tags to exclude tests from running on certain Java versions, in favor of JUnit's built in `@EnabledForJreRange`. 

## What's your motivation?
The later also allows us to run with a max range, which could come in handy with an eye towards Java 25.