### PR TITLE
ParenthesizeVisitor to always parenthesize switch expressions

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ParenthesizeVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ParenthesizeVisitorTest.java
@@ -511,6 +511,9 @@ class ParenthesizeVisitorTest implements RewriteTest {
               
                       // Assignment inside other expressions
                       int result6 = (a = b) + c;
+
+                      // Switch expression
+                      int result7 = (switch(a) { default -> "one";}).length();
                   }
               }
               """,
@@ -539,6 +542,9 @@ class ParenthesizeVisitorTest implements RewriteTest {
               
                       // Assignment inside other expressions
                       int result6 = (a = b) + c;
+
+                      // Switch expression
+                      int result7 = (switch(a) { default -> "one";}).length();
                   }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/ParenthesizeVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ParenthesizeVisitor.java
@@ -51,7 +51,8 @@ public class ParenthesizeVisitor<P> extends JavaVisitor<P> {
               newTree instanceof J.Ternary ||
               newTree instanceof J.Assignment ||
               newTree instanceof J.InstanceOf ||
-              newTree instanceof J.TypeCast)) {
+              newTree instanceof J.TypeCast ||
+              newTree instanceof J.SwitchExpression)) {
             return newTree;
         }
 
@@ -157,8 +158,8 @@ public class ParenthesizeVisitor<P> extends JavaVisitor<P> {
 
     private boolean needsParentheses(Expression expr, Object parent) {
         return parent instanceof J.Unary ||
-               (parent instanceof J.MethodInvocation &&
-                expr.isScope(((J.MethodInvocation) parent).getSelect()));
+               (parent instanceof J.MethodInvocation && expr.isScope(((J.MethodInvocation) parent).getSelect())) ||
+                (expr instanceof J.SwitchExpression);
     }
 
     private boolean needsParenthesesForPrecedence(J.Binary inner, J.Binary outer) {
@@ -324,6 +325,11 @@ public class ParenthesizeVisitor<P> extends JavaVisitor<P> {
         }
 
         return a;
+    }
+
+    @Override
+    public J visitSwitchExpression(J.SwitchExpression switch_, P p) {
+        return parenthesize((Expression) super.visitSwitchExpression(switch_, p));
     }
 
     private boolean isInAddSubGroup(J.Binary.Type operator) {


### PR DESCRIPTION
## What's changed?

ParenthesizeVisitor to always parenthesize switch expressions, like we did in #5359 for `UnwrapParentheses`.

## What's your motivation?

Address the suggestion raised in https://github.com/openrewrite/rewrite/pull/5359#issuecomment-2841782436
