### PR TITLE
Fix RecipeRunStats showing "0.99" in the percentile columns rather than the actual values

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -76,10 +76,10 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
                     Long.valueOf(editor.count()).intValue(),
                     sourceFileChanged.size(),
                     scanner == null ? 0 : (long) scanner.totalTime(TimeUnit.NANOSECONDS),
-                    scanner == null ? 0 : scanner.takeSnapshot().percentileValues()[0].percentile(),
+                    scanner == null ? 0 : scanner.takeSnapshot().percentileValues()[0].value(TimeUnit.NANOSECONDS),
                     scanner == null ? 0 : (long) scanner.max(TimeUnit.NANOSECONDS),
                     (long) editor.totalTime(TimeUnit.NANOSECONDS),
-                    editor.takeSnapshot().percentileValues()[0].percentile(),
+                    editor.takeSnapshot().percentileValues()[0].value(TimeUnit.NANOSECONDS),
                     (long) editor.max(TimeUnit.NANOSECONDS)
             );
             addRowToDataTable(ctx, row);
@@ -94,7 +94,7 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
                         Long.valueOf(scanner.count()).intValue(),
                         sourceFileChanged.size(),
                         (long) scanner.totalTime(TimeUnit.NANOSECONDS),
-                        scanner.takeSnapshot().percentileValues()[0].percentile(),
+                        scanner.takeSnapshot().percentileValues()[0].value(TimeUnit.NANOSECONDS),
                         (long) scanner.max(TimeUnit.NANOSECONDS),
                         0L,
                         0.0,
@@ -130,27 +130,27 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
                 description = "The number of source files which were changed in the recipe run. Includes files created, deleted, and edited.")
         Integer sourceFilesChanged;
 
-        @Column(displayName = "Cumulative scanning time",
+        @Column(displayName = "Cumulative scanning time (ns)",
                 description = "The total time spent across the scanning phase of this recipe.")
         Long scanTotalTime;
 
-        @Column(displayName = "99th percentile scanning time",
+        @Column(displayName = "99th percentile scanning time (ns)",
                 description = "99 out of 100 scans completed in this amount of time.")
         Double scanP99;
 
-        @Column(displayName = "Max scanning time",
+        @Column(displayName = "Max scanning time (ns)",
                 description = "The max time scanning any one source file.")
         Long scanMax;
 
-        @Column(displayName = "Cumulative edit time",
+        @Column(displayName = "Cumulative edit time (ns)",
                 description = "The total time spent across the editing phase of this recipe.")
         Long editTotalTime;
 
-        @Column(displayName = "99th percentile edit time",
+        @Column(displayName = "99th percentile edit time (ns)",
                 description = "99 out of 100 edits completed in this amount of time.")
         Double editP99;
 
-        @Column(displayName = "Max edit time",
+        @Column(displayName = "Max edit time (ns)",
                 description = "The max time editing any one source file.")
         Long editMax;
     }

--- a/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/RecipeRunStats.java
@@ -132,26 +132,26 @@ public class RecipeRunStats extends DataTable<RecipeRunStats.Row> {
 
         @Column(displayName = "Cumulative scanning time (ns)",
                 description = "The total time spent across the scanning phase of this recipe.")
-        Long scanTotalTime;
+        Long scanTotalTimeNs;
 
         @Column(displayName = "99th percentile scanning time (ns)",
                 description = "99 out of 100 scans completed in this amount of time.")
-        Double scanP99;
+        Double scanP99Ns;
 
         @Column(displayName = "Max scanning time (ns)",
                 description = "The max time scanning any one source file.")
-        Long scanMax;
+        Long scanMaxNs;
 
         @Column(displayName = "Cumulative edit time (ns)",
                 description = "The total time spent across the editing phase of this recipe.")
-        Long editTotalTime;
+        Long editTotalTimeNs;
 
         @Column(displayName = "99th percentile edit time (ns)",
                 description = "99 out of 100 edits completed in this amount of time.")
-        Double editP99;
+        Double editP99Ns;
 
         @Column(displayName = "Max edit time (ns)",
                 description = "The max time editing any one source file.")
-        Long editMax;
+        Long editMaxNs;
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/table/RecipeRunStatsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/table/RecipeRunStatsTest.java
@@ -81,10 +81,10 @@ class RecipeRunStatsTest implements RewriteTest {
                 .as("Test framework will invoke the recipe once when it is expected to make a change, " +
                     "then once again when it is expected to make no change")
                 .isEqualTo(2);
-              assertThat(row.getEditMax()).isGreaterThan(0);
-              assertThat(row.getEditTotalTime())
+              assertThat(row.getEditMaxNs()).isGreaterThan(0);
+              assertThat(row.getEditTotalTimeNs())
                 .as("Cumulative time should be greater than any single visit time")
-                .isGreaterThan(row.getEditMax());
+                .isGreaterThan(row.getEditMaxNs());
           }),
           text("samuel", "sam")
         );


### PR DESCRIPTION
Also note in the column headings that the units are in nanoseconds
