### PR TITLE
Throw for unhandled `ParseError` in `RewriteTest` to avoid `ClassCastException`

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -485,14 +485,15 @@ public interface RewriteTest extends SourceSpecs {
             SourceFile source = specForSourceFile.getKey();
             if (source instanceof ParseError) {
                 ParseError parseError = (ParseError) source;
-                if (parseError.getErroneous() != null) {
-                    assertContentEquals(
-                            parseError,
-                            parseError.getText(),
-                            parseError.getErroneous().printAll(),
-                            "Bug in source parser or printer resulted in the following difference for"
-                    );
+                if (parseError.getErroneous() == null) {
+                    throw parseError.toException();
                 }
+                assertContentEquals(
+                        parseError,
+                        parseError.getText(),
+                        parseError.getErroneous().printAll(),
+                        "Bug in source parser or printer resulted in the following difference for"
+                );
             }
 
             for (Result result : allResults) {


### PR DESCRIPTION
## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/5387

## Anything in particular you'd like reviewers to focus on?
With parsers mostly moving into this project I don't expect this to pose much of a problem downstream, especially since those already handled by the expected unmapped erroneous nodes are not affected. If I've overlooked anything let me know.

## Have you considered any alternatives or workarounds?
I'm not sure what even triggers that `assertContentEquals` these days, especially as that was introduced over  a year before we added errorneous handling, and setting a breakpoint and running rewrite-java-test tests does not trip that breakpoint. 🤔 

## Any additional context
- https://github.com/openrewrite/rewrite/commit/92dbac23f4e3941c38a7e4fcf717f68264e0ba04
- #4412 