### PR TITLE
Added Java parser tests for constructors, with some statements before super/this

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.MinimumJava21;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -94,6 +95,7 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Issue("https://openjdk.org/jeps/513")
+    @MinimumJava21
     @Test
     void validationBeforeThisConstructor() {
         rewriteRun(
@@ -114,6 +116,7 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Issue("https://openjdk.org/jeps/513")
+    @MinimumJava21
     @Test
     void validationBeforeSuperConstructor() {
         rewriteRun(
@@ -133,6 +136,7 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Issue("https://openjdk.org/jeps/513")
+    @MinimumJava21
     @Test
     void assignmentBeforeThisConstructor() {
         rewriteRun(
@@ -152,6 +156,7 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Issue("https://openjdk.org/jeps/513")
+    @MinimumJava21
     @Test
     void assignmentBeforeSuperConstructor() {
         rewriteRun(

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
@@ -1,0 +1,156 @@
+package org.openrewrite.java.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ConstructorTest implements RewriteTest {
+
+    @Test
+    void noConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void defaultConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  public A() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  public A() {}
+                  public A(String a) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void thisCallingConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  public A() {}
+                  public A(String a) {
+                      this();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void superCallingConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  public A() {}
+                  public A(String a) {
+                      super();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Test
+    void validationBeforeThisConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  public A() {}
+                  public A(String a) {
+                      if (a.equals("foo")) {
+                          throw new RuntimeException();
+                      }
+                      this();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Test
+    void validationBeforeSuperConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  public A(String a) {
+                      if (a.equals("foo")) {
+                          throw new RuntimeException();
+                      }
+                      super();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Test
+    void assignmentBeforeThisConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  String stringA;
+                  public A() {}
+                  public A(String a) {
+                      stringA = a;
+                      this();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Test
+    void assignmentBeforeSuperConstructor() {
+        rewriteRun(
+          java(
+            """
+              public class A {
+                  String stringA;
+                  public A(String a) {
+                      stringA = a;
+                      super();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
@@ -21,7 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class ConstructorTest implements RewriteTest {
+class ConstructorTest implements RewriteTest {
 
     @Test
     void noConstructor() {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ConstructorTest.java
@@ -93,7 +93,7 @@ class ConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Issue("https://openjdk.org/jeps/513")
     @Test
     void validationBeforeThisConstructor() {
         rewriteRun(
@@ -113,7 +113,7 @@ class ConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Issue("https://openjdk.org/jeps/513")
     @Test
     void validationBeforeSuperConstructor() {
         rewriteRun(
@@ -132,7 +132,7 @@ class ConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Issue("https://openjdk.org/jeps/513")
     @Test
     void assignmentBeforeThisConstructor() {
         rewriteRun(
@@ -151,7 +151,7 @@ class ConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/1144")
+    @Issue("https://openjdk.org/jeps/513")
     @Test
     void assignmentBeforeSuperConstructor() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Add a parser test for contructors, testing common constructors, but specifically adding tests for constructors with statement before calling `this(..)` or `super(..)`.

## What's your motivation?
Research for:
- https://github.com/moderneinc/customer-requests/issues/1144
