### PR TITLE
PropertyPlaceholderHelper Not Handling Lack of Separation Between Placeholders

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
@@ -121,7 +121,7 @@ public class PropertyPlaceholderHelper {
                 }
 
                 // Proceed with unprocessed value.
-                startIndex = result.indexOf(placeholderPrefix, endIndex + placeholderSuffix.length());
+                startIndex = result.indexOf(placeholderPrefix, endIndex);
                 visitedPlaceholders.remove(originalPlaceholder);
             } else {
                 startIndex = -1;

--- a/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PropertyPlaceholderHelperTest {
 
     @Test
-    void dashed() {
+    void space() {
         var helper = new PropertyPlaceholderHelper("%%{", "}", null);
         var s = helper.replacePlaceholders("%%{k1} %%{k2}", k -> switch (k) {
             case "k1" -> "hi";
@@ -30,5 +30,16 @@ class PropertyPlaceholderHelperTest {
             default -> throw new UnsupportedOperationException();
         });
         assertThat(s).isEqualTo("hi jon");
+    }
+
+    @Test
+    void noSpace() {
+        var helper = new PropertyPlaceholderHelper("%%{", "}", null);
+        var s = helper.replacePlaceholders("%%{k1}%%{k2}", k -> switch (k) {
+            case "k1" -> "hi";
+            case "k2" -> "jon";
+            default -> throw new UnsupportedOperationException();
+        });
+        assertThat(s).isEqualTo("hijon");
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/PropertyPlaceholderHelperTest.java
@@ -22,7 +22,40 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PropertyPlaceholderHelperTest {
 
     @Test
-    void space() {
+    void nested() {
+        var helper = new PropertyPlaceholderHelper("%%{", "}", null);
+        var s = helper.replacePlaceholders("%%{%%{k1}}", k -> switch (k) {
+            case "k1" -> "k2";
+            case "k2" -> "jon";
+            default -> throw new UnsupportedOperationException();
+        });
+        assertThat(s).isEqualTo("jon");
+    }
+
+    @Test
+    void notOnlyPlaceholders() {
+        var helper = new PropertyPlaceholderHelper("%%{", "}", null);
+        var s = helper.replacePlaceholders("Oh, %%{k1} there %%{k2}!", k -> switch (k) {
+            case "k1" -> "hi";
+            case "k2" -> "jon";
+            default -> throw new UnsupportedOperationException();
+        });
+        assertThat(s).isEqualTo("Oh, hi there jon!");
+    }
+
+    @Test
+    void dashedSeparation() {
+        var helper = new PropertyPlaceholderHelper("%%{", "}", null);
+        var s = helper.replacePlaceholders("%%{k1}-%%{k2}", k -> switch (k) {
+            case "k1" -> "hi";
+            case "k2" -> "jon";
+            default -> throw new UnsupportedOperationException();
+        });
+        assertThat(s).isEqualTo("hi-jon");
+    }
+
+    @Test
+    void spaceSeparation() {
         var helper = new PropertyPlaceholderHelper("%%{", "}", null);
         var s = helper.replacePlaceholders("%%{k1} %%{k2}", k -> switch (k) {
             case "k1" -> "hi";
@@ -33,7 +66,7 @@ class PropertyPlaceholderHelperTest {
     }
 
     @Test
-    void noSpace() {
+    void noSeparation() {
         var helper = new PropertyPlaceholderHelper("%%{", "}", null);
         var s = helper.replacePlaceholders("%%{k1}%%{k2}", k -> switch (k) {
             case "k1" -> "hi";
@@ -41,5 +74,29 @@ class PropertyPlaceholderHelperTest {
             default -> throw new UnsupportedOperationException();
         });
         assertThat(s).isEqualTo("hijon");
+    }
+
+    @Test
+    void withValueSeparatorAndValueReplacement() {
+        var helper = new PropertyPlaceholderHelper("%%{", "}", ",");
+        var s = helper.replacePlaceholders("%%{k1,oh} %%{k2}", k -> switch (k) {
+            case "k1" -> "hi";
+            case "k2" -> "jon";
+            // Note: this needs to not throw an exception because there won't be a match for "k1,oh" as a placeholder
+            default -> null;
+        });
+        assertThat(s).isEqualTo("hi jon");
+    }
+
+    @Test
+    void withValueSeparatorAndNullReplacement() {
+        var helper = new PropertyPlaceholderHelper("%%{", "}", ",");
+        var s = helper.replacePlaceholders("%%{k1,oh}%%{k2}", k -> switch (k) {
+            case "k1" -> null;
+            case "k2" -> "jon";
+            // Note: this needs to not throw an exception because there won't be a match for "k1,oh" as a placeholder
+            default -> null;
+        });
+        assertThat(s).isEqualTo("ohjon");
     }
 }


### PR DESCRIPTION
- #5334 

Previously not having any separation between placeholders when invoking `replacePlaceholders` on `PropertyPlaceholderHelper` would result in only the first placeholder being replaced.

## What's changed?
- Changed the calculation of the new start index after a replacement occurs to start searching at just the new end index  (was previously adding the size of the placeholder suffix to the new end index for the search start)

### Checklist
- [X] Figuring out why it fails to replace the second placeholder when there's no separation between placeholders (wrapped in their prefix and suffix)
- [X] I've added the unit test provided for reproduction of the bug
- [X] Added additional tests to cover other functionality present in the `PropertyPlaceholderHelper`, including nested placeholders and use of a non-null `valueSeparator` parameter.
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
