### PR TITLE
Paving the core concepts for LockFile creation recipe

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ListUtils.java
@@ -350,7 +350,7 @@ public final class ListUtils {
      * @return A new list with expanded or modified elements, or the original list if unchanged.
      */
     @Contract("null, _ -> null; !null, _ -> !null")
-    public static <T> @Nullable List<T> flatMap(@Nullable List<T> ls, Function<T, Object> flatMap) {
+    public static <T> @Nullable List<T> flatMap(@Nullable List<T> ls, Function<T, @Nullable Object> flatMap) {
         return flatMap(ls, (i, t) -> flatMap.apply(t));
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/PlainText.java
@@ -43,10 +43,12 @@ import static org.openrewrite.internal.ListUtils.nullIfEmpty;
 @Value
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class PlainText implements SourceFileWithReferences, Tree, RpcCodec<PlainText> {
 
     @Builder.Default
     @With
+    @EqualsAndHashCode.Include
     UUID id = Tree.randomId();
 
     @With

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -372,7 +372,7 @@ class DeclarativeRecipeTest implements RewriteTest {
           )
         );
         rewriteRun(
-          spec -> spec.recipe(root).cycles(10).cycles(3).expectedCyclesThatMakeChanges(3),
+          spec -> spec.recipe(root).cycles(10).cycles(3).expectedCyclesThatMakeChanges(2),
           text("1", "1+1+1")
         );
         assertThat(cycleCount).hasValue(3);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
@@ -26,6 +26,8 @@ import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
 import org.openrewrite.test.UncheckedConsumer;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextParser;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -177,5 +179,30 @@ public class Assertions {
         gradle.path("settings.gradle.kts");
         spec.accept(gradle);
         return gradle;
+    }
+
+    static SourceSpecs lockFile(@Nullable String before) {
+        return lockFile(before, s -> {
+        });
+    }
+
+    static SourceSpecs lockFile(@Nullable String before, Consumer<SourceSpec<PlainText>> spec) {
+        SourceSpec<PlainText> lockFile = new SourceSpec<>(PlainText.class, null, PlainTextParser.builder(), before, null);
+        lockFile.path("gradle.lockfile");
+        spec.accept(lockFile);
+        return lockFile;
+    }
+
+    static SourceSpecs lockFile(@Nullable String before, @Nullable String after) {
+        return lockFile(before, after, s -> {
+        });
+    }
+
+    static SourceSpecs lockFile(@Nullable String before, @Nullable String after,
+                            Consumer<SourceSpec<PlainText>> spec) {
+        SourceSpec<PlainText> lockFile = new SourceSpec<>(PlainText.class, null, PlainTextParser.builder(), before, s-> after);
+        lockFile.path("gradle.lockfile");
+        spec.accept(lockFile);
+        return lockFile;
     }
 }


### PR DESCRIPTION
In order to support the changes made here, I am also preparing `withToolingApi` support. 
However, to add a clean unit test for this in the gradle-tooling module, I need to have the Assertions available. 

Furthermore, there is a bug I think in the PlainText. 
When the adapted for loop in RewriteTest executes for a plainText file, instead of updating the map, it adds the new one. 
This is because the equals contract is not the same as CompilationUnit's. 
adapted that also in this PR

Lastly, I made the flatMap method Function parameter adhere to the contract of the method which it is delegating to. 
If the flatmap function returns null, the entry will be deleted. 
However, the function does not support null, the bifunction which gets called does.

@sambsnyd 