### PR TITLE
Update gradle lockfiles (step 1 of many)

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/Assertions.java
@@ -181,24 +181,24 @@ public class Assertions {
         return gradle;
     }
 
-    static SourceSpecs lockFile(@Nullable String before) {
+    public static SourceSpecs lockFile(@Nullable String before) {
         return lockFile(before, s -> {
         });
     }
 
-    static SourceSpecs lockFile(@Nullable String before, Consumer<SourceSpec<PlainText>> spec) {
+    public static SourceSpecs lockFile(@Nullable String before, Consumer<SourceSpec<PlainText>> spec) {
         SourceSpec<PlainText> lockFile = new SourceSpec<>(PlainText.class, null, PlainTextParser.builder(), before, null);
         lockFile.path("gradle.lockfile");
         spec.accept(lockFile);
         return lockFile;
     }
 
-    static SourceSpecs lockFile(@Nullable String before, @Nullable String after) {
+    public static SourceSpecs lockFile(@Nullable String before, @Nullable String after) {
         return lockFile(before, after, s -> {
         });
     }
 
-    static SourceSpecs lockFile(@Nullable String before, @Nullable String after,
+    public static SourceSpecs lockFile(@Nullable String before, @Nullable String after,
                             Consumer<SourceSpec<PlainText>> spec) {
         SourceSpec<PlainText> lockFile = new SourceSpec<>(PlainText.class, null, PlainTextParser.builder(), before, s-> after);
         lockFile.path("gradle.lockfile");

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateDependencyLockFile.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateDependencyLockFile.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.maven.tree.GroupArtifact;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
+
+import java.util.*;
+
+import static java.util.Collections.emptyList;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UpdateDependencyLockFile extends ScanningRecipe<UpdateDependencyLockFile.Accumulator> {
+    private static final String[] EMPTY = new String[0];
+
+    @Override
+    public String getDisplayName() {
+        return "Update gradle dependency lock file";
+    }
+
+    @Override
+    public String getDescription() {
+        //language=markdown
+        return "Update the version of a dependency in a gradle lockfile.";
+    }
+
+    public static class Accumulator {
+        Map<String, GradleProject> modules = new HashMap<>();
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        //noinspection BooleanMethodIsAlwaysInverted
+        return new JavaVisitor<ExecutionContext>() {
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return (sourceFile instanceof G.CompilationUnit && sourceFile.getSourcePath().toString().endsWith(".gradle")) ||
+                        (sourceFile instanceof K.CompilationUnit && sourceFile.getSourcePath().toString().endsWith(".gradle.kts"));
+            }
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    tree.getMarkers().findFirst(GradleProject.class).ifPresent(project -> {
+                        String path = project.getPath();
+                        if (path.startsWith(":")) {
+                            path = path.substring(1);
+                        }
+                        if (!path.isEmpty()) {
+                            path += "/";
+                        }
+                        acc.modules.put(path.replaceAll(":", "/") + "gradle.lockfile", project);
+                    });
+                }
+                return super.visit(tree, ctx);
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        if (acc.modules.isEmpty()) {
+            return TreeVisitor.noop();
+        }
+        return Preconditions.check(new FindSourceFiles("**/gradle.lockfile"), new PlainTextVisitor<ExecutionContext>() {
+            private final Map<GroupArtifactVersion, SortedSet<String>> lockedVersions = new HashMap<>();
+            private final Map<GroupArtifact, List<GroupArtifactVersion>> lockedArtifacts = new HashMap<>();
+            private final SortedSet<String> empty = new TreeSet<>();
+            private final List<String> comments = new ArrayList<>();
+
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
+                return sourceFile instanceof PlainText;
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext executionContext) {
+                if (tree == null) {
+                    return null;
+                }
+                PlainText plainText = (PlainText) tree;
+                GradleProject gradleProject = acc.modules.get(plainText.getSourcePath().toString());
+                if (gradleProject == null) {
+                    return tree;
+                }
+                String text = plainText.getText();
+                if (StringUtils.isBlank(text)) {
+                    return plainText;
+                }
+
+                gradleProject.getConfigurations().forEach(conf -> {
+                    if (conf.isCanBeResolved()) {
+                        if (conf.getResolved().isEmpty()) {
+                            empty.add(conf.getName());
+                        } else {
+                            conf.getResolved().forEach(resolved -> {
+                                GroupArtifactVersion gav = resolved.getGav().asGroupArtifactVersion();
+                                lockedVersions.computeIfAbsent(gav, k -> new TreeSet<>()).add(conf.getName());
+                                lockedArtifacts.computeIfAbsent(gav.asGroupArtifact(), k -> new ArrayList<>()).add(gav);
+                            });
+                        }
+                    }
+                });
+
+                Arrays.stream(text.split("\n")).forEach(lock -> {
+                    if (isComment(lock)) {
+                        comments.add(lock);
+                    }
+                });
+
+                SortedSet<String> locks = new TreeSet<>();
+                lockedVersions.forEach((gav, configurations) -> {
+                    String lock = asLock(gav, configurations);
+                    if (lock != null) {
+                        locks.add(lock);
+                    }
+                });
+
+                StringBuilder sb = new StringBuilder();
+                if (comments != null && !comments.isEmpty()) {
+                    sb.append(String.join("\n", comments));
+                }
+                if (comments != null && !comments.isEmpty() && locks != null && !locks.isEmpty()) {
+                    sb.append("\n");
+                }
+                if (locks != null && !locks.isEmpty()) {
+                    sb.append(String.join("\n", locks));
+                }
+                sb.append("\n")
+                        .append(asLock(null, empty));
+
+                PlainText newLockFileContent = plainText.withText(sb.toString());
+                if (newLockFileContent == plainText) {
+                    return tree;
+                }
+                return newLockFileContent;
+            }
+        });
+    }
+
+    private @Nullable String asLock(@Nullable GroupArtifactVersion gav, @Nullable Set<String> configurations) {
+        TreeSet<String> sortedConfigurations = new TreeSet<>(configurations == null ? emptyList() : configurations);
+        if (gav == null) {
+            return "empty=" + String.join(",", sortedConfigurations);
+        }
+        if (sortedConfigurations.isEmpty()) {
+            return null;
+        }
+        return String.format("%s=%s", gav, String.join(",", sortedConfigurations));
+    }
+
+    private static boolean isComment(String entry) {
+        return entry.startsWith("# ");
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateDependencyLockFile.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateDependencyLockFile.java
@@ -18,16 +18,14 @@ package org.openrewrite.gradle;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.gradle.marker.GradleProject;
-import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.StringUtils;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.kotlin.tree.K;
-import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.semver.DependencyMatcher;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
@@ -37,137 +35,90 @@ import static java.util.Collections.emptyList;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class UpdateDependencyLockFile extends ScanningRecipe<UpdateDependencyLockFile.Accumulator> {
+public class UpdateDependencyLockFile extends PlainTextVisitor<ExecutionContext> {
     private static final String[] EMPTY = new String[0];
 
-    @Override
-    public String getDisplayName() {
-        return "Update gradle dependency lock file";
+    UpgradeDependencyVersion.DependencyVersionState acc;
+    DependencyMatcher dependencyMatcher;
+
+    UpdateDependencyLockFile(UpgradeDependencyVersion.DependencyVersionState acc, String groupId, String artifactId) {
+        this.acc = acc;
+        this.dependencyMatcher = new DependencyMatcher(groupId, artifactId, null);
     }
 
     @Override
-    public String getDescription() {
-        //language=markdown
-        return "Update the version of a dependency in a gradle lockfile.";
-    }
-
-    public static class Accumulator {
-        Map<String, GradleProject> modules = new HashMap<>();
+    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
+        return sourceFile instanceof PlainText;
     }
 
     @Override
-    public Accumulator getInitialValue(ExecutionContext ctx) {
-        return new Accumulator();
-    }
+    public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext executionContext) {
+        Map<GroupArtifactVersion, SortedSet<String>> lockedVersions = new HashMap<>();
+        SortedSet<String> empty = new TreeSet<>();
+        List<String> comments = new ArrayList<>();
 
-    @Override
-    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
-        //noinspection BooleanMethodIsAlwaysInverted
-        return new JavaVisitor<ExecutionContext>() {
-            @Override
-            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-                return (sourceFile instanceof G.CompilationUnit && sourceFile.getSourcePath().toString().endsWith(".gradle")) ||
-                        (sourceFile instanceof K.CompilationUnit && sourceFile.getSourcePath().toString().endsWith(".gradle.kts"));
-            }
-
-            @Override
-            public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
-                if (tree instanceof JavaSourceFile) {
-                    tree.getMarkers().findFirst(GradleProject.class).ifPresent(project -> {
-                        String path = project.getPath();
-                        if (path.startsWith(":")) {
-                            path = path.substring(1);
-                        }
-                        if (!path.isEmpty()) {
-                            path += "/";
-                        }
-                        acc.modules.put(path.replaceAll(":", "/") + "gradle.lockfile", project);
-                    });
-                }
-                return super.visit(tree, ctx);
-            }
-        };
-    }
-
-    @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
-        if (acc.modules.isEmpty()) {
-            return TreeVisitor.noop();
+        if (tree == null) {
+            return null;
         }
-        return Preconditions.check(new FindSourceFiles("**/gradle.lockfile"), new PlainTextVisitor<ExecutionContext>() {
-            private final Map<GroupArtifactVersion, SortedSet<String>> lockedVersions = new HashMap<>();
-            private final Map<GroupArtifact, List<GroupArtifactVersion>> lockedArtifacts = new HashMap<>();
-            private final SortedSet<String> empty = new TreeSet<>();
-            private final List<String> comments = new ArrayList<>();
+        PlainText plainText = (PlainText) tree;
+        GradleProject gradleProject = acc.getModules().get(plainText.getSourcePath().toString());
+        if (gradleProject == null) {
+            return tree;
+        }
+        String text = plainText.getText();
+        if (StringUtils.isBlank(text)) {
+            return plainText;
+        }
 
-            @Override
-            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
-                return sourceFile instanceof PlainText;
-            }
-
-            @Override
-            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext executionContext) {
-                if (tree == null) {
-                    return null;
-                }
-                PlainText plainText = (PlainText) tree;
-                GradleProject gradleProject = acc.modules.get(plainText.getSourcePath().toString());
-                if (gradleProject == null) {
-                    return tree;
-                }
-                String text = plainText.getText();
-                if (StringUtils.isBlank(text)) {
-                    return plainText;
-                }
-
-                gradleProject.getConfigurations().forEach(conf -> {
-                    if (conf.isCanBeResolved()) {
-                        if (conf.getResolved().isEmpty()) {
-                            empty.add(conf.getName());
-                        } else {
-                            conf.getResolved().forEach(resolved -> {
-                                GroupArtifactVersion gav = resolved.getGav().asGroupArtifactVersion();
-                                lockedVersions.computeIfAbsent(gav, k -> new TreeSet<>()).add(conf.getName());
-                                lockedArtifacts.computeIfAbsent(gav.asGroupArtifact(), k -> new ArrayList<>()).add(gav);
-                            });
+        gradleProject.getConfigurations().forEach(conf -> {
+            if (conf.isCanBeResolved()) {
+                if (conf.getResolved().isEmpty()) {
+                    empty.add(conf.getName());
+                } else {
+                    for (ResolvedDependency resolved : conf.getDirectResolved()) {
+                        GroupArtifactVersion gav = resolved.getGav().asGroupArtifactVersion();
+                        if (dependencyMatcher.matches(gav.getGroupId(), gav.getArtifactId())) {
+                            Object result = acc.getGaToNewVersion().get(gav.asGroupArtifact());
+                            if (result != null && !(result instanceof Exception)) {
+                                lockedVersions.computeIfAbsent(gav.withVersion((String) result), k -> new TreeSet<>()).add(conf.getName());
+                                continue;
+                            }
                         }
+                        lockedVersions.computeIfAbsent(gav, k -> new TreeSet<>()).add(conf.getName());
                     }
-                });
-
-                Arrays.stream(text.split("\n")).forEach(lock -> {
-                    if (isComment(lock)) {
-                        comments.add(lock);
-                    }
-                });
-
-                SortedSet<String> locks = new TreeSet<>();
-                lockedVersions.forEach((gav, configurations) -> {
-                    String lock = asLock(gav, configurations);
-                    if (lock != null) {
-                        locks.add(lock);
-                    }
-                });
-
-                StringBuilder sb = new StringBuilder();
-                if (comments != null && !comments.isEmpty()) {
-                    sb.append(String.join("\n", comments));
                 }
-                if (comments != null && !comments.isEmpty() && locks != null && !locks.isEmpty()) {
-                    sb.append("\n");
-                }
-                if (locks != null && !locks.isEmpty()) {
-                    sb.append(String.join("\n", locks));
-                }
-                sb.append("\n")
-                        .append(asLock(null, empty));
-
-                PlainText newLockFileContent = plainText.withText(sb.toString());
-                if (newLockFileContent == plainText) {
-                    return tree;
-                }
-                return newLockFileContent;
             }
         });
+
+        Arrays.stream(text.split("\n")).forEach(lock -> {
+            if (isComment(lock)) {
+                comments.add(lock);
+            }
+        });
+
+        SortedSet<String> locks = new TreeSet<>();
+        lockedVersions.forEach((gav, configurations) -> {
+            String lock = asLock(gav, configurations);
+            if (lock != null) {
+                locks.add(lock);
+            }
+        });
+
+        StringBuilder sb = new StringBuilder();
+        if (comments != null && !comments.isEmpty()) {
+            sb.append(String.join("\n", comments));
+        }
+        if (comments != null && !comments.isEmpty() && locks != null && !locks.isEmpty()) {
+            sb.append("\n");
+        }
+        if (locks != null && !locks.isEmpty()) {
+            sb.append(String.join("\n", locks));
+        }
+        sb.append("\n").append(asLock(null, empty));
+        if (plainText.getText().contentEquals(sb)) {
+            return tree;
+        }
+        return plainText.withText(sb.toString());
     }
 
     private @Nullable String asLock(@Nullable GroupArtifactVersion gav, @Nullable Set<String> configurations) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -141,6 +141,11 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     }
 
     @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new UpdateDependencyLockFile());
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getScanner(DependencyVersionState acc) {
 
         //noinspection BooleanMethodIsAlwaysInverted

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -856,7 +856,6 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             Pom pom = mpd.download(gav, null, null, gp.getMavenRepositories());
             ResolvedPom resolvedPom = pom.resolve(emptyList(), mpd, gp.getMavenRepositories(), ctx);
             List<ResolvedDependency> transitiveDependencies = resolvedPom.resolveDependencies(Scope.Runtime, mpd, ctx);
-//            Pom managingDependency = resolvedPom.getManagingPom(gav.asGroupArtifact());
             org.openrewrite.maven.tree.Dependency newRequested = org.openrewrite.maven.tree.Dependency.builder()
                     .gav(gav)
                     .build();
@@ -873,12 +872,6 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 GradleDependencyConfiguration newGdc = gdc
                         .withRequested(ListUtils.map(gdc.getRequested(), requested -> maybeUpdateDependency(requested, newRequested)))
                         .withDirectResolved(ListUtils.map(gdc.getDirectResolved(), resolved -> maybeUpdateResolvedDependency(resolved, newDep, new HashSet<>())));
-//                for (ResolvedManagedDependency resolvedDependency : resolvedPom.getDependencyManagement()) {
-//                    newGdc = newGdc.withDirectResolved(ListUtils.map(newGdc.getDirectResolved(), maybeUpdateManagedResolvedDependency(resolvedDependency.getGav())));
-//                }
-//                if (managingDependency != null) {
-//                    newGdc = newGdc.withDirectResolved(ListUtils.map(newGdc.getDirectResolved(), maybeUpdateManagedResolvedDependency(managingDependency.getGav())));
-//                }
                 anyChanged |= newGdc != gdc;
                 newNameToConfiguration.put(newGdc.getName(), newGdc);
             }
@@ -899,28 +892,6 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         }
         return dep;
     }
-
-//    private static Function<ResolvedDependency, ResolvedDependency> maybeUpdateManagedResolvedDependency(GroupArtifactVersion gav) {
-//        return resolved -> {
-//            ResolvedDependency newResolvedDependency = ResolvedDependency.builder()
-//                    .gav(resolved.getGav().withGroupArtifact(gav.asGroupArtifact()).withVersion(gav.getVersion()))
-//                    .requested(resolved.getRequested())
-//                    .dependencies(resolved.getDependencies())
-//                    .build();
-//            return maybeUpdateResolvedDependency(resolved, newResolvedDependency, new HashSet<>());
-//        };
-//    }
-//
-//    private static Function<ResolvedDependency, ResolvedDependency> maybeUpdateManagedResolvedDependency(ResolvedGroupArtifactVersion gav) {
-//        return resolved -> {
-//            ResolvedDependency newResolvedDependency = ResolvedDependency.builder()
-//                    .gav(gav.withGroupArtifact(gav.asGroupArtifact()).withVersion(gav.getVersion()))
-//                    .requested(resolved.getRequested())
-//                    .dependencies(resolved.getDependencies())
-//                    .build();
-//            return maybeUpdateResolvedDependency(resolved, newResolvedDependency, new HashSet<>());
-//        };
-//    }
 
     private static ResolvedDependency maybeUpdateResolvedDependency(
             ResolvedDependency dep,

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -56,6 +56,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Preconditions.not;
@@ -167,6 +168,11 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
             validated = validated.and(Semver.validate(version, versionPattern));
         }
         return validated;
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new UpdateDependencyLockFile());
     }
 
     @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -56,7 +56,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Preconditions.not;
@@ -168,11 +167,6 @@ public class UpgradeTransitiveDependencyVersion extends Recipe {
             validated = validated.and(Semver.validate(version, versionPattern));
         }
         return validated;
-    }
-
-    @Override
-    public List<Recipe> getRecipeList() {
-        return singletonList(new UpdateDependencyLockFile());
     }
 
     @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateDependencyLockFileTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateDependencyLockFileTest.java
@@ -1,0 +1,159 @@
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.test.SourceSpecs.text;
+
+class UpdateDependencyLockFileTest implements RewriteTest {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.beforeRecipe(withToolingApi());
+        }
+
+        @Test
+        @DocumentExample
+        void calculateGradleLock() {
+            rewriteRun(spec -> spec.recipe(new UpdateDependencyLockFile()),
+              buildGradle(
+                """
+                plugins {
+                    id 'java'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
+                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
+                }
+                """, spec -> spec.path("build.gradle")
+              ),
+              text(
+                """
+                  # This is a Gradle generated file for dependency locking.
+                  # Manual edits can break the build and are not advised.
+                  # This file is expected to be part of source control.
+                  com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  empty=annotationProcessor,testAnnotationProcessor
+                  
+                  """,
+                """
+                  # This is a Gradle generated file for dependency locking.
+                  # Manual edits can break the build and are not advised.
+                  # This file is expected to be part of source control.
+                  com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                  empty=annotationProcessor,testAnnotationProcessor
+                  """, spec -> spec.path("gradle.lockfile")
+              )
+            );
+        }
+
+    @Test
+    void multimodule() {
+        rewriteRun(spec -> spec.recipe(new UpdateDependencyLockFile()),
+          settingsGradle(
+            """
+            rootProject.name = 'test'
+            include 'module1'
+            include 'module2'
+            """, spec -> spec.path("settings.gradle")
+          ),
+          buildGradle(
+            """
+            subprojects {
+                apply plugin: 'java'
+            
+                repositories {
+                    mavenCentral()
+                }
+            }
+            """, spec -> spec.path("build.gradle")
+          ),
+          buildGradle(
+            """
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+                implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
+                implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
+            }
+            """, spec -> spec.path("module1/build.gradle")
+          ),buildGradle(
+            """
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+                implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.3'
+                implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+            }
+            """, spec -> spec.path("module2/build.gradle")
+          ),
+          text(
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              empty=
+              """, spec -> spec.path("gradle.lockfile")
+          ),
+          text(
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              
+              """,
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """, spec -> spec.path("module1/gradle.lockfile")
+          ),
+          text(
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              com.fasterxml.jackson.core:jackson-annotations:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-core:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-databind:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson:jackson-bom:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              
+              """,
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """, spec -> spec.path("module2/gradle.lockfile")
+          )
+        );
+    }
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateDependencyLockFileTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateDependencyLockFileTest.java
@@ -2,158 +2,155 @@ package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.gradle.Assertions.*;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.test.SourceSpecs.text;
 
 class UpdateDependencyLockFileTest implements RewriteTest {
 
-        @Override
-        public void defaults(RecipeSpec spec) {
-            spec.beforeRecipe(withToolingApi());
-        }
-
-        @Test
-        @DocumentExample
-        void calculateGradleLock() {
-            rewriteRun(spec -> spec.recipe(new UpdateDependencyLockFile()),
-              buildGradle(
-                """
-                plugins {
-                    id 'java'
-                }
-                repositories {
-                    mavenCentral()
-                }
-                dependencies {
-                    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
-                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
-                }
-                """, spec -> spec.path("build.gradle")
-              ),
-              text(
-                """
-                  # This is a Gradle generated file for dependency locking.
-                  # Manual edits can break the build and are not advised.
-                  # This file is expected to be part of source control.
-                  com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  empty=annotationProcessor,testAnnotationProcessor
-                  
-                  """,
-                """
-                  # This is a Gradle generated file for dependency locking.
-                  # Manual edits can break the build and are not advised.
-                  # This file is expected to be part of source control.
-                  com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-                  empty=annotationProcessor,testAnnotationProcessor
-                  """, spec -> spec.path("gradle.lockfile")
-              )
-            );
-        }
+    @Test
+    @DocumentExample
+    void calculateGradleLock() {
+        rewriteRun(spec ->
+                spec.beforeRecipe(withToolingApi())
+                        .recipe(new UpgradeDependencyVersion("some-group", "and-never-matching-artifact", null, null)),
+                buildGradle(
+                        """
+                                plugins {
+                                    id 'java'
+                                }
+                                repositories {
+                                    mavenCentral()
+                                }
+                                dependencies {
+                                    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+                                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
+                                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
+                                }
+                                """
+                ),
+                lockFile(
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                empty=annotationProcessor,testAnnotationProcessor
+                                
+                                """,
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                empty=annotationProcessor,testAnnotationProcessor
+                                """
+                )
+        );
+    }
 
     @Test
     void multimodule() {
-        rewriteRun(spec -> spec.recipe(new UpdateDependencyLockFile()),
-          settingsGradle(
-            """
-            rootProject.name = 'test'
-            include 'module1'
-            include 'module2'
-            """, spec -> spec.path("settings.gradle")
-          ),
-          buildGradle(
-            """
-            subprojects {
-                apply plugin: 'java'
-            
-                repositories {
-                    mavenCentral()
-                }
-            }
-            """, spec -> spec.path("build.gradle")
-          ),
-          buildGradle(
-            """
-            dependencies {
-                implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-                implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
-            }
-            """, spec -> spec.path("module1/build.gradle")
-          ),buildGradle(
-            """
-            dependencies {
-                implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-                implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.3'
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-            }
-            """, spec -> spec.path("module2/build.gradle")
-          ),
-          text(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              empty=
-              """, spec -> spec.path("gradle.lockfile")
-          ),
-          text(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              
-              """,
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              """, spec -> spec.path("module1/gradle.lockfile")
-          ),
-          text(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              
-              """,
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              """, spec -> spec.path("module2/gradle.lockfile")
-          )
+        rewriteRun(spec ->
+                spec.beforeRecipe(withToolingApi())
+                        .recipe(new UpgradeDependencyVersion("some-group", "and-never-matching-artifact", null, null)),
+                settingsGradle(
+                        """
+                                rootProject.name = 'test'
+                                include 'module1'
+                                include 'module2'
+                                """, spec -> spec.path("settings.gradle")
+                ),
+                buildGradle(
+                        """
+                                subprojects {
+                                    apply plugin: 'java'
+                                
+                                    repositories {
+                                        mavenCentral()
+                                    }
+                                }
+                                """, spec -> spec.path("build.gradle")
+                ),
+                buildGradle(
+                        """
+                                dependencies {
+                                    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+                                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
+                                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
+                                }
+                                """, spec -> spec.path("module1/build.gradle")
+                ), buildGradle(
+                        """
+                                dependencies {
+                                    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
+                                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.3'
+                                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+                                }
+                                """, spec -> spec.path("module2/build.gradle")
+                ),
+                text(
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                empty=
+                                """, spec -> spec.path("gradle.lockfile")
+                ),
+                text(
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                empty=annotationProcessor,testAnnotationProcessor
+                                
+                                """,
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                empty=annotationProcessor,testAnnotationProcessor
+                                """, spec -> spec.path("module1/gradle.lockfile")
+                ),
+                text(
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                com.fasterxml.jackson.core:jackson-annotations:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-core:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-databind:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson:jackson-bom:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                empty=annotationProcessor,testAnnotationProcessor
+                                
+                                """,
+                        """
+                                # This is a Gradle generated file for dependency locking.
+                                # Manual edits can break the build and are not advised.
+                                # This file is expected to be part of source control.
+                                com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+                                empty=annotationProcessor,testAnnotationProcessor
+                                """, spec -> spec.path("module2/gradle.lockfile")
+                )
         );
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1491,6 +1491,17 @@ class UpgradeDependencyVersionTest implements RewriteTest {
             include("moduleA")
             """
           ),
+          buildGradle(
+            """
+            """),
+          lockFile(
+            """
+            # This is a Gradle generated file for dependency locking.
+            # Manual edits can break the build and are not advised.
+            # This file is expected to be part of source control.
+            empty=
+            """, spec -> spec.path("gradle.lockfile")
+          ),
           //language=groovy
           buildGradle(
             """
@@ -1508,7 +1519,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               dependencies {
                   implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.27'
               }
-              """
+              """, spec -> spec.path("moduleA/build.gradle")
           ), lockFile(
             """
               # This is a Gradle generated file for dependency locking.
@@ -1525,7 +1536,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               org.apache.tomcat.embed:tomcat-embed-core:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
               org.apache.tomcat:tomcat-annotations-api:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
               empty=annotationProcessor,testAnnotationProcessor
-              """
+              """, spec -> spec.path("moduleA/gradle.lockfile")
           )
         );
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1429,4 +1429,104 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    //TODO In iteration 1 we are just bumping the one version in the lock file.
+    //     We will also do the transitive dependencies in next version.
+    //     One part at a time
+    @Test
+    void lockFileGetsUpdated() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "latest.patch", null)),
+          //language=groovy
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1'
+              }
+              """,
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.27'
+              }
+              """
+          ), lockFile(
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat:tomcat-annotations-api:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """,
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat:tomcat-annotations-api:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """
+          )
+        );
+    }
+
+    //TODO In iteration 1 we are just bumping the one version in the lock file.
+    //     We will also do the transitive dependencies in next version.
+    //     One part at a time
+    @Test
+    void multimoduleProject() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "latest.patch", null)),
+          settingsGradle(
+            """
+            rootProject.name = 'my-project'
+            include("moduleA")
+            """
+          ),
+          //language=groovy
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1'
+              }
+              """,
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.27'
+              }
+              """
+          ), lockFile(
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat:tomcat-annotations-api:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """,
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat:tomcat-annotations-api:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
A new recipe was added to maintain lockfiles of gradle

## What's your motivation?
In order to build sucsefully for projects where a lockfile is present after all kind of dependency adding recipes, we need to be able to modify the lockfile post-recipe runs. This attempt is the **first** step of many in introducing this capability. 
With this recipe we can already override single versions by GA. 
Next steps also include:
- bom's
- transitive dependency version overrides
- introduce it in UpgradeTransitiveDependency

## Anything in particular you'd like reviewers to focus on?
As this is the bases of many other recipe entrypoints, I tried to kept it rather "simple". Building the lockfile from scratch. 
For other recipes we will be able to introduce different concepts in the acc so that we can add dependencies in configurations etc... 

Now, I know it is probably not the best implementation atm, but I was really limited by the fact that I do not have access to the updated gradleproject post recipe run while visiting the lockfile. I could only come up with scanning recipe (hence I introduced it in UpgradeDependencyVersion first), but any feedback is welcomed! 

## Anyone you would like to review specifically?
@sambsnyd @shanman190 @timtebeek 

## Have you considered any alternatives or workarounds?
Very open to suggestions! Having the framework write the lockfile during deserialization of sourcefiles would probably be an easier code, but opens us up to all kinds of these ocncepts leaking through the recipe stages. 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
