### PR TITLE
Add fallback when attempting to load `lombok.launch.ShadowClassLoader`

### DIFF
--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
@@ -59,8 +59,13 @@ public class LombokSupport {
         }
 
         String oldValue = System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
+        Class<?> shadowLoaderClass;
         try {
-            Class<?> shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader);
+            shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader);
+        } catch (Exception e) {
+            shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader.getParent());
+        }
+        try {
             Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
                     Class.forName("java.lang.ClassLoader"),
                     Class.forName("java.lang.String"),

--- a/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
+++ b/rewrite-java-lombok/src/main/java/org/openrewrite/java/lombok/LombokSupport.java
@@ -59,13 +59,16 @@ public class LombokSupport {
         }
 
         String oldValue = System.setProperty("shadow.override.lombok", String.join(File.pathSeparator, overrideClasspath));
-        Class<?> shadowLoaderClass;
+
         try {
-            shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader);
-        } catch (Exception e) {
-            shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader.getParent());
-        }
-        try {
+            // Attempt to carefully load the `lombok.launch.ShadowClassLoader` present in `rewrite-java-lombok`
+            // but as a fallback attempt to load it through the parent class loader
+            Class<?> shadowLoaderClass;
+            try {
+                shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader);
+            } catch (Exception e) {
+                shadowLoaderClass = Class.forName("lombok.launch.ShadowClassLoader", true, parserClassLoader.getParent());
+            }
             Constructor<?> shadowLoaderConstructor = shadowLoaderClass.getDeclaredConstructor(
                     Class.forName("java.lang.ClassLoader"),
                     Class.forName("java.lang.String"),


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a fallback when loading `lombok.launch.ShadowClassLoader` with the parserClassLoader fails

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Lombok integration seemingly not working with Maven

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
