### PR TITLE
RemoveRedundantDependencyVersions recipe removes direct dependencies if dependency is pulled in transitively

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
@@ -309,6 +309,124 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
+    void removeDirectDependencyWithLowerVersionNumberIfDependencyIsLoadedTransitivelyWithHigherVersionNumber() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  // BOM `spring-boot-dependencies:3.3.3` describes `spring-webmvc:6.1.12`
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.springframework.boot:spring-boot-starter-web-services:3.3.3")
+                  implementation("org.springframework:spring-webmvc:6.1.11")
+              }
+              """,
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  // BOM `spring-boot-dependencies:3.3.3` describes `spring-webmvc:6.1.12`
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.springframework.boot:spring-boot-starter-web-services")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDirectDependencyIfDependencyIsLoadedTransitivelyWithSameVersion() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  // BOM `spring-boot-dependencies:3.3.3` describes `spring-webmvc:6.1.12`
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.springframework.boot:spring-boot-starter-web-services:3.3.3")
+                  implementation("org.springframework:spring-webmvc:6.1.12")
+              }
+              """,
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  // BOM `spring-boot-dependencies:3.3.3` describes `spring-webmvc:6.1.12`
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.springframework.boot:spring-boot-starter-web-services")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepDirectDependencyWithHigherVersionNumberIfDependencyIsLoadedTransitivelyWithLowerVersionNumber() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  // BOM `spring-boot-dependencies:3.3.3` describes `spring-webmvc:6.1.12`
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.springframework.boot:spring-boot-starter-web-services:3.3.3")
+                  implementation("org.springframework:spring-webmvc:6.1.13")
+              }
+              """,
+            """
+              plugins {
+                  id "java-library"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  // BOM `spring-boot-dependencies:3.3.3` describes `spring-webmvc:6.1.12`
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.springframework.boot:spring-boot-starter-web-services")
+                  implementation("org.springframework:spring-webmvc:6.1.13")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void transitiveConfiguration() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
## What's changed?
Redundant direct dependencies are removed as well.

## Anything in particular you'd like reviewers to focus on?
Interestingly, the recipe did remove direct dependencies with a lower version number already. This was actually a side effect by removing redundant constraints. I just added an extra check to see if the version 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
