### PR TITLE
Mark methods overridden from classes as `isOverride()`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTypeTest.java
@@ -179,4 +179,28 @@ class JavaTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/apache/maven/pull/2291")
+    @Test
+    void overrideFromClass() {
+        rewriteRun(
+          java(
+            """
+              import java.io.FileNotFoundException;
+              class A {
+                  @Override
+                  public String toString() {
+                      return "A";
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(
+              ((J.MethodDeclaration)
+                cu.getClasses().get(0)
+                  .getBody().getStatements().get(0))
+                .getMethodType().isOverride())
+              .isTrue())
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -1392,6 +1392,11 @@ public interface JavaType {
 
             Stack<FullyQualified> interfaces = new Stack<>();
             interfaces.addAll(declaringType.getInterfaces());
+            FullyQualified supertype = declaringType.getSupertype();
+            while (supertype != null) {
+                interfaces.add(supertype);
+                supertype = supertype.getSupertype();
+            }
 
             while (!interfaces.isEmpty()) {
                 FullyQualified declaring = interfaces.pop();


### PR DESCRIPTION
Quite surprised we didn't mark these before; we only looked at interfaces. it seems.