### PR TITLE
catching exceptions in isLocalAndHasNoChanges

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/Result.java
+++ b/rewrite-core/src/main/java/org/openrewrite/Result.java
@@ -267,10 +267,14 @@ public class Result {
     }
 
     public static boolean isLocalAndHasNoChanges(@Nullable SourceFile before, @Nullable SourceFile after) {
-        return (before == after) ||
-               (before != null && after != null &&
-                // Remote source files are fetched on `printAll`, let's avoid that cost.
-                !(before instanceof Remote) && !(after instanceof Remote) &&
-                before.printAll().equals(after.printAll()));
+        try {
+            return (before == after) ||
+                    (before != null && after != null &&
+                            // Remote source files are fetched on `printAll`, let's avoid that cost.
+                            !(before instanceof Remote) && !(after instanceof Remote) &&
+                            before.printAll().equals(after.printAll()));
+        } catch (Exception e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

Adding a try-catch around print for `isLocalAndHasNoChanges`.

## What's your motivation?

To fix the broken recipe runs for Javascript code:
```
java.lang.UnsupportedOperationException: TODO decide how we will instantiate the JavaScriptRewriteRPC process
  org.openrewrite.javascript.tree.JS$CompilationUnit.printer(JS.java:198)
  org.openrewrite.Tree.print(Tree.java:81)
  org.openrewrite.SourceFile.printAll(SourceFile.java:102)
  org.openrewrite.SourceFile.printAll(SourceFile.java:98)
  org.openrewrite.SourceFile.printAll(SourceFile.java:106)
  org.openrewrite.Result.isLocalAndHasNoChanges(Result.java:274)
  org.openrewrite.Result.getTimeSavings(Result.java:142)
```

The time-savings is somewhat secondary feature and the failure to calculate the savings, shouldn't break the whole flow.
