### PR TITLE
Resolve managed dependency with 'RELEASE' or 'LATEST' versions.

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.maven.http.OkHttpSender;
 import org.openrewrite.maven.internal.MavenParsingException;
@@ -3997,6 +3999,41 @@ class MavenParserTest implements RewriteTest {
                                     );
                         }
                 )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"latest", "release"})
+    void latestOrReleaseVersionInDependencyManagement(String version) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              
+                <dependencyManagement>
+                  <dependencies>
+                     <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-dependencies</artifactId>
+                      <version>%s</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                  </dependency>
+                </dependencies>
+              </project>
+              """.formatted(version)
           )
         );
     }


### PR DESCRIPTION
## What's changed?
The path to search for `maven-metadata.xml` when LATEST or RELEASE  is used if changed from 
`https://uri/group/subgroup/artifact/<VERSION/LATEST/RELEASE>/maven-metadata.xml`
to 
`https://uri/group/subgroup/artifact/maven-metadata.xml`

## What's your motivation?
- Fixes #4983

## Anything in particular you'd like reviewers to focus on?
I do not think we have to do this for the local m2 cache files also as we want to know latest/release version from the "latest" updates. 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files 
    ==> my formatter made more changes, but reverted these as I only want the focus on the functional change during this review
