### PR TITLE
mapAsync to enforce order of execution

### DIFF
--- a/rewrite-javascript/rewrite/src/util.ts
+++ b/rewrite-javascript/rewrite/src/util.ts
@@ -15,8 +15,8 @@
  */
 export async function mapAsync<T, U>(arr: T[], fn: (t: T, i: number) => Promise<U | undefined>): Promise<U[]> {
     const results: U[] = [];
-    for await (const [i, item] of arr.entries()) {
-        const result = await fn(item, i);
+    for (let i = 0; i < arr.length; i++) {
+        const result = await fn(arr[i], i);
         if (result !== undefined) {
             results.push(result);
         }

--- a/rewrite-javascript/rewrite/src/util.ts
+++ b/rewrite-javascript/rewrite/src/util.ts
@@ -15,8 +15,8 @@
  */
 export async function mapAsync<T, U>(arr: T[], fn: (t: T, i: number) => Promise<U | undefined>): Promise<U[]> {
     const results: U[] = [];
-    for (let i = 0; i < arr.length; i++) {
-        const result = await fn(arr[i], i);
+    for await (const [i, item] of arr.entries()) {
+        const result = await fn(item, i);
         if (result !== undefined) {
             results.push(result);
         }

--- a/rewrite-javascript/rewrite/test/util.test.ts
+++ b/rewrite-javascript/rewrite/test/util.test.ts
@@ -13,13 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export async function mapAsync<T, U>(arr: T[], fn: (t: T, i: number) => Promise<U | undefined>): Promise<U[]> {
-    const results: U[] = [];
-    for (let i = 0; i < arr.length; i++) {
-        const result = await fn(arr[i], i);
-        if (result !== undefined) {
-            results.push(result);
+
+import {describe} from "@jest/globals";
+import {mapAsync} from "../src";
+
+describe("mapAsync", () => {
+    test("sequential execution", async () => {
+        // given
+        let global = "";
+        const arr = ["four", "three", "six"];
+        function task(item: string, idx: number) {
+            return new Promise(resolve => {
+                setTimeout(() => {
+                    global = global + item;
+                    resolve("irrelevant");
+                }, item.length);
+            });
         }
-    }
-    return results;
-}
+
+        // when
+        await mapAsync(arr, task);
+
+        // test
+        expect(global).toEqual("fourthreesix");
+    });
+});


### PR DESCRIPTION
## What's changed?

Changing `mapAsync` implementation to one which guarantees order of execution.

## What's your motivation?

Otherwise the Javascript visitors get invalid `cursor` data when traversing an LST. As `mapAsync` is heavily used in visitors.

## Anything in particular you'd like reviewers to focus on?

The current code of `mapAsync` is not as nicely functional as it used to be. I don't know how to write it in a cleaner way.