### PR TITLE
Removing imports field in JS.CompilationUnit

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -279,7 +279,6 @@ export class JavaScriptParserVisitor {
             sourcePath: this.sourcePath,
             charsetName: bomAndTextEncoding.encoding,
             charsetBomMarked: bomAndTextEncoding.hasBom,
-            imports: [],
             statements: this.semicolonPaddedStatementList(node.statements),
             eof: this.prefix(node.endOfFileToken)
         };

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -51,7 +51,6 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         await q.getAndSend(cu, c => c.charsetBomMarked);
         await q.getAndSend(cu, c => c.checksum);
         await q.getAndSend(cu, c => c.fileAttributes);
-        await q.getAndSendList(cu, c => c.imports, imp => imp.element.id, imp => this.visitRightPadded(imp, q));
         await q.getAndSendList(cu, c => c.statements, stmt => stmt.element.id, stmt => this.visitRightPadded(stmt, q));
         await q.getAndSend(cu, c => c.eof, space => this.visitSpace(space, q));
         return cu;
@@ -533,7 +532,6 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         draft.charsetBomMarked = await q.receive(cu.charsetBomMarked);
         draft.checksum = await q.receive(cu.checksum);
         draft.fileAttributes = await q.receive(cu.fileAttributes);
-        draft.imports = await q.receiveListDefined(cu.imports, imp => this.visitRightPadded(imp, q));
         draft.statements = await q.receiveListDefined(cu.statements, stmt => this.visitRightPadded(stmt, q));
         draft.eof = await q.receive(cu.eof, space => this.visitSpace(space, q));
 

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -98,7 +98,6 @@ export namespace JS {
      */
     export interface CompilationUnit extends JS, SourceFile {
         readonly kind: typeof Kind.CompilationUnit;
-        readonly imports: J.RightPadded<J.Import>[];
         readonly statements: J.RightPadded<Statement>[];
         readonly eof: J.Space;
     }

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -94,7 +94,6 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
     protected async visitJsCompilationUnit(compilationUnit: JS.CompilationUnit, p: P): Promise<J | undefined> {
         return this.produceJavaScript<JS.CompilationUnit>(compilationUnit, p, async draft => {
-            draft.imports = await mapAsync(compilationUnit.imports, imp => this.visitRightPadded(imp, p));
             draft.statements = await mapAsync(compilationUnit.statements, stmt => this.visitRightPadded(stmt, p));
             draft.eof = await this.visitSpace(compilationUnit.eof, p);
         });


### PR DESCRIPTION
## What's changed?

Removing the `imports` field in `JS.CompilationUnit`.

## What's your motivation?

It's misleading as:
 - its value is always empty
 - the actual imports are parsed into `JS.CompilationUnit.statements` as per: https://github.com/openrewrite/rewrite/blob/cd550f67587817376df79c6a09cb15bd709a495b/rewrite-javascript/rewrite/src/javascript/parser.ts#L282-L283

The field serves no real purpose.