### PR TITLE
Add support for partially unfolding single line yaml properties with exclusions in UnfoldProperties

### DIFF
--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -245,6 +245,10 @@ class UnfoldPropertiesTest implements RewriteTest {
     }
 
     @Test
+    /* Currently "property matchers" operate on the full yaml property key (e.g. "root.group.sub1.group.org.key1").
+        this means a regex can match over actual properties. (e.g. "[?(@property.match(/^root.*sub1\./))]" matches "root.group.sub1").
+        This test shows the behavior. Should we prefer matching on the exact properties?
+     */
     void exclusionWithSingleLineAndGroupMatcherAndMatchAll() {
         rewriteRun(
           spec -> spec.recipe(new UnfoldProperties(List.of("$..[root.group][?(@property.match(/^sub.*group\\./))][?(@property.match(/.*/))]"))),
@@ -254,6 +258,7 @@ class UnfoldPropertiesTest implements RewriteTest {
               root.group.sub1.group.org.key2: value2
               root.group.sub2.group.org.keya: valuea
               root.group.sub2.group.com.keyb: valueb
+              root.group.sub3.org.group.com.c: valuec
               """,
             """
               root:
@@ -266,6 +271,10 @@ class UnfoldPropertiesTest implements RewriteTest {
                     group:
                       org.keya: valuea
                       com.keyb: valueb
+                  sub3:
+                    org:
+                      group:
+                        com.c: valuec
               """
           )
         );

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -226,6 +226,25 @@ class UnfoldPropertiesTest implements RewriteTest {
     }
 
     @Test
+    void exclusionWithParentAndMatchAll() {
+        rewriteRun(
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/.*/))]"))),
+          yaml(
+            """
+              logging.level.com.company.extern.service: DEBUG
+              logging.level.com.another.package: INFO
+              """,
+            """
+              logging:
+                level:
+                  com.company.extern.service: DEBUG
+                  com.another.package: INFO
+              """
+          )
+        );
+    }
+
+    @Test
     void mergeDuplicatedSections() {
         rewriteRun(
           yaml(

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -226,7 +226,7 @@ class UnfoldPropertiesTest implements RewriteTest {
     }
 
     @Test
-    void exclusionWithParentAndMatchAll() {
+    void exclusionWithSingleLineAndMatchAll() {
         rewriteRun(
           spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/.*/))]"))),
           yaml(
@@ -239,6 +239,33 @@ class UnfoldPropertiesTest implements RewriteTest {
                 level:
                   com.company.extern.service: DEBUG
                   com.another.package: INFO
+              """
+          )
+        );
+    }
+
+    @Test
+    void exclusionWithSingleLineAndGroupMatcherAndMatchAll() {
+        rewriteRun(
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[root.group][?(@property.match(/^sub.*group\\./))][?(@property.match(/.*/))]"))),
+          yaml(
+            """
+              root.group.sub1.group.org.key1: value1
+              root.group.sub1.group.org.key2: value2
+              root.group.sub2.group.org.keya: valuea
+              root.group.sub2.group.com.keyb: valueb
+              """,
+            """
+              root:
+                group:
+                  sub1:
+                    group:
+                      org.key1: value1
+                      org.key2: value2
+                  sub2:
+                    group:
+                      org.keya: valuea
+                      com.keyb: valueb
               """
           )
         );


### PR DESCRIPTION
## What's changed?
When breaking single line declarations in a yaml file into parts we reiterate over sub-declaration when we find matches.

## What's your motivation?
The recipe only matched entire keys.

When matching 
`a.b.c.d` agains `$..[a.b][c.d]` the recipe now takes in account that when $..[a.b] is matched we then need to delve deeper matching `c.d` against [c.d] to actually find the exclusion for a single line key.

## Anything in particular you'd like reviewers to focus on?
The solution does introduce some more recursion, but since this recipe only target yaml properties line by line I don't believe it will be a problem.