### PR TITLE
visitStatement called in JavaScript

### DIFF
--- a/rewrite-javascript/rewrite/src/java/visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/visitor.ts
@@ -102,6 +102,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitAssert(anAssert: J.Assert, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(anAssert, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Assert) {
+            return statement;
+        }
+        anAssert = statement as J.Assert;
+
         return this.produceJava<J.Assert>(anAssert, p, async draft => {
             draft.condition = await this.visitDefined(anAssert.condition, p) as Expression;
             draft.detail = await this.visitOptionalLeftPadded(anAssert.detail, p);
@@ -109,6 +115,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitAssignment(assignment: J.Assignment, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(assignment, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Assignment) {
+            return statement;
+        }
+        assignment = statement as J.Assignment;
+
         return this.produceJava<J.Assignment>(assignment, p, async draft => {
             draft.variable = await this.visitDefined(assignment.variable, p) as Expression;
             draft.assignment = await this.visitLeftPadded(assignment.assignment, p);
@@ -143,6 +155,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitBreak(breakStatement: J.Break, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(breakStatement, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Break) {
+            return statement;
+        }
+        breakStatement = statement as J.Break;
+
         return this.produceJava<J.Break>(breakStatement, p, async draft => {
             if (breakStatement.label) {
                 draft.label = await this.visitDefined(breakStatement.label, p) as J.Identifier;
@@ -151,6 +169,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitCase(aCase: J.Case, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(aCase, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Case) {
+            return statement;
+        }
+        aCase = statement as J.Case;
+
         return this.produceJava<J.Case>(aCase, p, async draft => {
             draft.caseLabels = await this.visitContainer(aCase.caseLabels, p);
             draft.statements = await this.visitContainer(aCase.statements, p);
@@ -162,6 +186,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitClassDeclaration(classDecl: J.ClassDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(classDecl, p);
+        if (!statement?.kind || statement.kind !== J.Kind.ClassDeclaration) {
+            return statement;
+        }
+        classDecl = statement as J.ClassDeclaration;
+
         return this.produceJava<J.ClassDeclaration>(classDecl, p, async draft => {
             draft.leadingAnnotations = await mapAsync(classDecl.leadingAnnotations, a => this.visitDefined<J.Annotation>(a, p));
             draft.modifiers = await mapAsync(classDecl.modifiers, m => this.visitDefined<J.Modifier>(m, p));
@@ -193,6 +223,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitContinue(continueStatement: J.Continue, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(continueStatement, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Continue) {
+            return statement;
+        }
+        continueStatement = statement as J.Continue;
+
         return this.produceJava<J.Continue>(continueStatement, p, async draft => {
             if (continueStatement.label) {
                 draft.label = await this.visitDefined(continueStatement.label, p) as J.Identifier;
@@ -215,6 +251,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitDoWhileLoop(doWhileLoop: J.DoWhileLoop, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(doWhileLoop, p);
+        if (!statement?.kind || statement.kind !== J.Kind.DoWhileLoop) {
+            return statement;
+        }
+        doWhileLoop = statement as J.DoWhileLoop;
+
         return this.produceJava<J.DoWhileLoop>(doWhileLoop, p, async draft => {
             draft.body = await this.visitRightPadded(doWhileLoop.body, p);
             draft.whileCondition = await this.visitLeftPadded(doWhileLoop.whileCondition, p);
@@ -222,6 +264,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitEmpty(empty: J.Empty, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(empty, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Empty) {
+            return statement;
+        }
+        empty = statement as J.Empty;
+
         return this.produceJava<J.Empty>(empty, p);
     }
 
@@ -236,16 +284,34 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitEnumValueSet(enumValueSet: J.EnumValueSet, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(enumValueSet, p);
+        if (!statement?.kind || statement.kind !== J.Kind.EnumValueSet) {
+            return statement;
+        }
+        enumValueSet = statement as J.EnumValueSet;
+
         return this.produceJava<J.EnumValueSet>(enumValueSet, p, async draft => {
             draft.enums = await mapAsync(enumValueSet.enums, e => this.visitRightPadded(e, p));
         });
     }
 
     protected async visitErroneous(erroneous: J.Erroneous, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(erroneous, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Erroneous) {
+            return statement;
+        }
+        erroneous = statement as J.Erroneous;
+
         return this.produceJava<J.Erroneous>(erroneous, p);
     }
 
     protected async visitFieldAccess(fieldAccess: J.FieldAccess, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(fieldAccess, p);
+        if (!statement?.kind || statement.kind !== J.Kind.FieldAccess) {
+            return statement;
+        }
+        fieldAccess = statement as J.FieldAccess;
+
         return this.produceJava<J.FieldAccess>(fieldAccess, p, async draft => {
             draft.target = await this.visitDefined(fieldAccess.target, p) as Expression;
             draft.name = await this.visitLeftPadded(fieldAccess.name, p);
@@ -254,6 +320,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitForEachLoop(forLoop: J.ForEachLoop, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(forLoop, p);
+        if (!statement?.kind || statement.kind !== J.Kind.ForEachLoop) {
+            return statement;
+        }
+        forLoop = statement as J.ForEachLoop;
+
         return this.produceJava<J.ForEachLoop>(forLoop, p, async draft => {
             draft.control = await this.visitDefined(forLoop.control, p) as J.ForEachLoop.Control;
             draft.body = await this.visitRightPadded(forLoop.body, p);
@@ -268,6 +340,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitForLoop(forLoop: J.ForLoop, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(forLoop, p);
+        if (!statement?.kind || statement.kind !== J.Kind.ForLoop) {
+            return statement;
+        }
+        forLoop = statement as J.ForLoop;
+
         return this.produceJava<J.ForLoop>(forLoop, p, async draft => {
             draft.control = await this.visitDefined(forLoop.control, p) as J.ForLoop.Control;
             draft.body = await this.visitRightPadded(forLoop.body, p);
@@ -291,6 +369,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitIf(iff: J.If, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(iff, p);
+        if (!statement?.kind || statement.kind !== J.Kind.If) {
+            return statement;
+        }
+        iff = statement as J.If;
+
         return this.produceJava<J.If>(iff, p, async draft => {
             draft.ifCondition = await this.visitDefined(iff.ifCondition, p) as J.ControlParentheses<Expression>;
             draft.thenPart = await this.visitRightPadded(iff.thenPart, p);
@@ -335,6 +419,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitLabel(label: J.Label, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(label, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Label) {
+            return statement;
+        }
+        label = statement as J.Label;
+
         return this.produceJava<J.Label>(label, p, async draft => {
             draft.label = await this.visitRightPadded(label.label, p);
             draft.statement = await this.visitDefined(label.statement, p) as Statement;
@@ -342,6 +432,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitLambda(lambda: J.Lambda, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(lambda, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Lambda) {
+            return statement;
+        }
+        lambda = statement as J.Lambda;
+
         return this.produceJava<J.Lambda>(lambda, p, async draft => {
             draft.parameters = await this.visitDefined(lambda.parameters, p) as J.Lambda.Parameters;
             draft.arrow = await this.visitSpace(lambda.arrow, p);
@@ -498,6 +594,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitReturn(ret: J.Return, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(ret, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Return) {
+            return statement;
+        }
+        ret = statement as J.Return;
+
         return this.produceJava<J.Return>(ret, p, async draft => {
             if (ret.expression) {
                 draft.expression = await this.visitDefined(ret.expression, p) as Expression;
@@ -506,6 +608,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitSwitch(aSwitch: J.Switch, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(aSwitch, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Switch) {
+            return statement;
+        }
+        aSwitch = statement as J.Switch;
+
         return this.produceJava<J.Switch>(aSwitch, p, async draft => {
             draft.selector = await this.visitDefined(aSwitch.selector, p) as J.ControlParentheses<Expression>;
             draft.cases = await this.visitDefined(aSwitch.cases, p) as J.Block;
@@ -521,6 +629,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitSynchronized(sync: J.Synchronized, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(sync, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Synchronized) {
+            return statement;
+        }
+        sync = statement as J.Synchronized;
+
         return this.produceJava<J.Synchronized>(sync, p, async draft => {
             draft.lock = await this.visitDefined(sync.lock, p) as J.ControlParentheses<Expression>;
             draft.body = await this.visitDefined(sync.body, p) as J.Block;
@@ -528,6 +642,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitTernary(ternary: J.Ternary, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(ternary, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Ternary) {
+            return statement;
+        }
+        ternary = statement as J.Ternary;
+
         return this.produceJava<J.Ternary>(ternary, p, async draft => {
             draft.condition = await this.visitDefined(ternary.condition, p) as Expression;
             draft.truePart = await this.visitLeftPadded(ternary.truePart, p);
@@ -537,12 +657,24 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitThrow(thrown: J.Throw, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(thrown, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Throw) {
+            return statement;
+        }
+        thrown = statement as J.Throw;
+
         return this.produceJava<J.Throw>(thrown, p, async draft => {
             draft.exception = await this.visitDefined(thrown.exception, p) as Expression;
         });
     }
 
     protected async visitTry(tryable: J.Try, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(tryable, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Try) {
+            return statement;
+        }
+        tryable = statement as J.Try;
+
         return this.produceJava<J.Try>(tryable, p, async draft => {
             draft.resources = await this.visitOptionalContainer(tryable.resources, p);
             draft.body = await this.visitDefined(tryable.body, p) as J.Block;
@@ -588,6 +720,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitUnary(unary: J.Unary, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(unary, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Unary) {
+            return statement;
+        }
+        unary = statement as J.Unary;
+
         return this.produceJava<J.Unary>(unary, p, async draft => {
             draft.operator = await this.visitLeftPadded(unary.operator, p);
             draft.expression = await this.visitDefined(unary.expression, p) as Expression;
@@ -596,6 +734,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitUnknown(unknown: J.Unknown, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(unknown, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Unknown) {
+            return statement;
+        }
+        unknown = statement as J.Unknown;
+
         return this.produceJava<J.Unknown>(unknown, p, async draft => {
             draft.source = await this.visitDefined(unknown.source, p) as J.UnknownSource;
         });
@@ -606,6 +750,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitVariableDeclarations(varDecls: J.VariableDeclarations, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(varDecls, p);
+        if (!statement?.kind || statement.kind !== J.Kind.VariableDeclarations) {
+            return statement;
+        }
+        varDecls = statement as J.VariableDeclarations;
+
         return this.produceJava<J.VariableDeclarations>(varDecls, p, async draft => {
             draft.leadingAnnotations = await mapAsync(varDecls.leadingAnnotations, a => this.visitDefined<J.Annotation>(a, p));
             draft.modifiers = await mapAsync(varDecls.modifiers, m => this.visitDefined<J.Modifier>(m, p));
@@ -632,6 +782,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitWhileLoop(whileLoop: J.WhileLoop, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(whileLoop, p);
+        if (!statement?.kind || statement.kind !== J.Kind.WhileLoop) {
+            return statement;
+        }
+        whileLoop = statement as J.WhileLoop;
+
         return this.produceJava<J.WhileLoop>(whileLoop, p, async draft => {
             draft.condition = await this.visitDefined(whileLoop.condition, p) as J.ControlParentheses<Expression>;
             draft.body = await this.visitRightPadded(whileLoop.body, p);
@@ -648,6 +804,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitYield(aYield: J.Yield, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(aYield, p);
+        if (!statement?.kind || statement.kind !== J.Kind.Yield) {
+            return statement;
+        }
+        aYield = statement as J.Yield;
+
         return this.produceJava<J.Yield>(aYield, p, async draft => {
             draft.value = await this.visitDefined(aYield.value, p) as Expression;
         });

--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -413,14 +413,15 @@ export class WrappingAndBracesVisitor extends JavaScriptVisitor<ExecutionContext
 
     public async visitStatement(statement: Statement, p: ExecutionContext): Promise<Statement> {
         const j = await super.visitStatement(statement, p) as Statement;
-        const parent = this.cursor.parent?.value;
-        if (parent?.kind === J.Kind.Block && j.kind !== J.Kind.EnumValueSet) {
-            if (!j.prefix.whitespace.includes("\n")) {
-                return produce(j, draft => {
-                    draft.prefix.whitespace = "\n" + draft.prefix.whitespace;
-                });
-            }
-        }
+        // TODO is it needed?
+        // const parent = this.cursor.parent?.value;
+        // if (parent?.kind === J.Kind.Block && j.kind !== J.Kind.EnumValueSet) {
+        //     if (!j.prefix.whitespace.includes("\n")) {
+        //         return produce(j, draft => {
+        //             draft.prefix.whitespace = "\n" + draft.prefix.whitespace;
+        //         });
+        //     }
+        // }
         return j;
     }
 

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -76,6 +76,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitArrowFunction(arrowFunction: JS.ArrowFunction, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(arrowFunction, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ArrowFunction) {
+            return statement;
+        }
+        arrowFunction = statement as JS.ArrowFunction;
+
         return this.produceJavaScript<JS.ArrowFunction>(arrowFunction, p, async draft => {
             draft.leadingAnnotations = await mapAsync(arrowFunction.leadingAnnotations, item => this.visitDefined<J.Annotation>(item, p));
             draft.modifiers = await mapAsync(arrowFunction.modifiers, item => this.visitDefined<J.Modifier>(item, p));
@@ -108,12 +114,24 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitDelete(delete_: JS.Delete, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(delete_, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.Delete) {
+            return statement;
+        }
+        delete_ = statement as JS.Delete;
+
         return this.produceJavaScript<JS.Delete>(delete_, p, async draft => {
             draft.expression = await this.visitDefined<Expression>(delete_.expression, p);
         });
     }
 
     protected async visitExpressionStatement(expressionStatement: JS.ExpressionStatement, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(expressionStatement, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ExpressionStatement) {
+            return statement;
+        }
+        expressionStatement = statement as JS.ExpressionStatement;
+
         return this.produceJavaScript<JS.ExpressionStatement>(expressionStatement, p, async draft => {
             draft.expression = await this.visitDefined<Expression>(expressionStatement.expression, p);
         });
@@ -198,6 +216,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitImportAttribute(importAttribute: JS.ImportAttribute, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(importAttribute, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ImportAttribute) {
+            return statement;
+        }
+        importAttribute = statement as JS.ImportAttribute;
+
         return this.produceJavaScript<JS.ImportAttribute>(importAttribute, p, async draft => {
             draft.name = await this.visitDefined<Expression>(importAttribute.name, p);
             draft.value = await this.visitLeftPadded(importAttribute.value, p);
@@ -257,6 +281,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(propertyAssignment, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.PropertyAssignment) {
+            return statement;
+        }
+        propertyAssignment = statement as JS.PropertyAssignment;
+
         return this.produceJavaScript<JS.PropertyAssignment>(propertyAssignment, p, async draft => {
             draft.name = await this.visitRightPadded(propertyAssignment.name, p);
             draft.initializer = propertyAssignment.initializer && await this.visitDefined<Expression>(propertyAssignment.initializer, p);
@@ -272,6 +302,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitScopedVariableDeclarations(scopedVariableDeclarations: JS.ScopedVariableDeclarations, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(scopedVariableDeclarations, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ScopedVariableDeclarations) {
+            return statement;
+        }
+        scopedVariableDeclarations = statement as JS.ScopedVariableDeclarations;
+
         return this.produceJavaScript<JS.ScopedVariableDeclarations>(scopedVariableDeclarations, p, async draft => {
             draft.modifiers = await mapAsync(scopedVariableDeclarations.modifiers, item => this.visitDefined<J.Modifier>(item, p));
             draft.scope = scopedVariableDeclarations.scope && await this.visitLeftPadded(scopedVariableDeclarations.scope, p);
@@ -280,12 +316,24 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitStatementExpression(statementExpression: JS.StatementExpression, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(statementExpression, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.StatementExpression) {
+            return statement;
+        }
+        statementExpression = statement as JS.StatementExpression;
+
         return this.produceJavaScript<JS.StatementExpression>(statementExpression, p, async draft => {
             draft.statement = await this.visitDefined<Statement>(statementExpression.statement, p);
         });
     }
 
     protected async visitTaggedTemplateExpression(taggedTemplateExpression: JS.TaggedTemplateExpression, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(taggedTemplateExpression, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.TaggedTemplateExpression) {
+            return statement;
+        }
+        taggedTemplateExpression = statement as JS.TaggedTemplateExpression;
+
         return this.produceJavaScript<JS.TaggedTemplateExpression>(taggedTemplateExpression, p, async draft => {
             draft.tag = taggedTemplateExpression.tag && await this.visitRightPadded(taggedTemplateExpression.tag, p);
             draft.typeArguments = taggedTemplateExpression.typeArguments && await this.visitContainer(taggedTemplateExpression.typeArguments, p);
@@ -295,6 +343,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitTemplateExpression(templateExpression: JS.TemplateExpression, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(templateExpression, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.TemplateExpression) {
+            return statement;
+        }
+        templateExpression = statement as JS.TemplateExpression;
+
         return this.produceJavaScript<JS.TemplateExpression>(templateExpression, p, async draft => {
             draft.head = await this.visitDefined<J.Literal>(templateExpression.head, p);
             draft.spans = await mapAsync(templateExpression.spans, item => this.visitRightPadded(item, p));
@@ -310,6 +364,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitTrailingTokenStatement(trailingTokenStatement: JS.TrailingTokenStatement, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(trailingTokenStatement, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.TrailingTokenStatement) {
+            return statement;
+        }
+        trailingTokenStatement = statement as JS.TrailingTokenStatement;
+
         return this.produceJavaScript<JS.TrailingTokenStatement>(trailingTokenStatement, p, async draft => {
             draft.expression = await this.visitRightPadded(trailingTokenStatement.expression, p);
             draft.type = trailingTokenStatement.type && await this.visitType(trailingTokenStatement.type, p);
@@ -324,6 +384,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitTypeDeclaration(typeDeclaration: JS.TypeDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(typeDeclaration, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.TypeDeclaration) {
+            return statement;
+        }
+        typeDeclaration = statement as JS.TypeDeclaration;
+
         return this.produceJavaScript<JS.TypeDeclaration>(typeDeclaration, p, async draft => {
             draft.modifiers = await mapAsync(typeDeclaration.modifiers, item => this.visitDefined<J.Modifier>(item, p));
             draft.name = await this.visitLeftPadded(typeDeclaration.name, p);
@@ -426,6 +492,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitWithStatement(withStatement: JS.WithStatement, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(withStatement, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.WithStatement) {
+            return statement;
+        }
+        withStatement = statement as JS.WithStatement;
+
         return this.produceJavaScript<JS.WithStatement>(withStatement, p, async draft => {
             draft.expression = await this.visitDefined<J.ControlParentheses<Expression>>(withStatement.expression, p);
             draft.body = await this.visitRightPadded(withStatement.body, p);
@@ -433,6 +505,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitIndexSignatureDeclaration(indexSignatureDeclaration: JS.IndexSignatureDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(indexSignatureDeclaration, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.IndexSignatureDeclaration) {
+            return statement;
+        }
+        indexSignatureDeclaration = statement as JS.IndexSignatureDeclaration;
+
         return this.produceJavaScript<JS.IndexSignatureDeclaration>(indexSignatureDeclaration, p, async draft => {
             draft.modifiers = await mapAsync(indexSignatureDeclaration.modifiers, item => this.visitDefined<J.Modifier>(item, p));
             draft.parameters = await this.visitContainer(indexSignatureDeclaration.parameters, p);
@@ -442,6 +520,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitComputedPropertyMethodDeclaration(computedPropMethod: JS.ComputedPropertyMethodDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(computedPropMethod, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ComputedPropertyMethodDeclaration) {
+            return statement;
+        }
+        computedPropMethod = statement as JS.ComputedPropertyMethodDeclaration;
+
         return this.produceJavaScript<JS.ComputedPropertyMethodDeclaration>(computedPropMethod, p, async draft => {
             draft.leadingAnnotations = await mapAsync(computedPropMethod.leadingAnnotations, item => this.visitDefined<J.Annotation>(item, p));
             draft.modifiers = await mapAsync(computedPropMethod.modifiers, item => this.visitDefined<J.Modifier>(item, p));
@@ -468,6 +552,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitNamespaceDeclaration(namespaceDeclaration: JS.NamespaceDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(namespaceDeclaration, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.NamespaceDeclaration) {
+            return statement;
+        }
+        namespaceDeclaration = statement as JS.NamespaceDeclaration;
+
         return this.produceJavaScript<JS.NamespaceDeclaration>(namespaceDeclaration, p, async draft => {
             draft.modifiers = await mapAsync(namespaceDeclaration.modifiers, item => this.visitDefined<J.Modifier>(item, p));
             draft.keywordType = await this.visitLeftPadded(namespaceDeclaration.keywordType, p);
@@ -491,6 +581,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitBindingElement(bindingElement: JS.BindingElement, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(bindingElement, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.BindingElement) {
+            return statement;
+        }
+        bindingElement = statement as JS.BindingElement;
+
         return this.produceJavaScript<JS.BindingElement>(bindingElement, p, async draft => {
             draft.propertyName = bindingElement.propertyName && await this.visitRightPadded(bindingElement.propertyName, p);
             draft.name = await this.visitDefined<TypedTree>(bindingElement.name, p);
@@ -500,6 +596,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitExportDeclaration(exportDeclaration: JS.ExportDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(exportDeclaration, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ExportDeclaration) {
+            return statement;
+        }
+        exportDeclaration = statement as JS.ExportDeclaration;
+
         return this.produceJavaScript<JS.ExportDeclaration>(exportDeclaration, p, async draft => {
             draft.modifiers = await mapAsync(exportDeclaration.modifiers, item => this.visitDefined<J.Modifier>(item, p));
             draft.typeOnly = await this.visitLeftPadded(exportDeclaration.typeOnly, p);
@@ -510,6 +612,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitExportAssignment(exportAssignment: JS.ExportAssignment, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(exportAssignment, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.ExportAssignment) {
+            return statement;
+        }
+        exportAssignment = statement as JS.ExportAssignment;
+
         return this.produceJavaScript<JS.ExportAssignment>(exportAssignment, p, async draft => {
             draft.expression = await this.visitLeftPadded<Expression>(exportAssignment.expression, p);
         });

--- a/rewrite-javascript/rewrite/test/java/visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/java/visitor.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ExecutionContext} from "../../src";
+import {J, JavaVisitor, Statement} from "../../src/java";
+import {fromVisitor, RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, typescript} from "../../src/javascript";
+
+describe('visitor', () => {
+    test('call visitStatement for subclasses', async () => {
+        // given
+        let global = "not visited yet";
+        const CustomVisitor = class extends JavaScriptVisitor<ExecutionContext> {
+            protected async visitStatement(statement: Statement, p: ExecutionContext): Promise<J | undefined> {
+                global = "visited " + statement.kind;
+                return await super.visitStatement(statement, p);
+            }
+        }
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new CustomVisitor());
+
+        // when
+        await spec.rewriteRun(
+            // TODO something is off with the rewriteRun logic, it doesn't work without the after, even if before==after
+            //language=typescript
+            typescript('class A {}', 'class A {}')
+        );
+
+        // test
+        expect(global).toEqual("visited org.openrewrite.java.tree.J$ClassDeclaration");
+    });
+});


### PR DESCRIPTION
## What's changed?
Changing the visitor logic in JavaScript to make sure the `visitStatement` method is also called for subclasses of `Statement`.

## What's your motivation?

- to provide feature parity in this aspect with Java
- avoid confusion, otherwise `visitStatement` doesn't do anything (as it's never called)

## How

The code has been written for one of the cases. And then multiplied with ChatGPT.

## Anything in particular you'd like reviewers to focus on?

Note: the same will need to be done with `Expression` and possibly other abstract classes.