### PR TITLE
Do not `AddDependency` for transitive dependency managed by a bom, even if `onlyIfUsing == null`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddDependency.java
@@ -279,6 +279,6 @@ public class AddDependency extends ScanningRecipe<AddDependency.Scanned> {
     }
 
     private boolean hasAcceptableTransitivity(ResolvedDependency d, Scanned acc) {
-        return d.isDirect() || Boolean.TRUE.equals(acceptTransitive) && !acc.scopeByProject.isEmpty();
+        return d.isDirect() || Boolean.TRUE.equals(acceptTransitive) && (onlyIfUsing == null || !acc.scopeByProject.isEmpty());
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -1472,7 +1472,8 @@ class AddDependencyTest implements RewriteTest {
     @Test
     void doNotAddDependencyTransitivelyProvidedByBom() {
         rewriteRun(
-          spec -> spec.recipe(addDependency("org.springframework:spring-webmvc:5.3.20")),
+          spec -> spec.recipe(new AddDependency("org.springframework", "spring-webmvc", "5.3.20",
+            null, null, null, null, null, null, null, null, true)),
           mavenProject(
             "project",
             pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -1469,10 +1469,11 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/pull/5433")
     @Test
     void doNotAddDependencyTransitivelyProvidedByBom() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependency("org.springframework", "spring-webmvc", "5.3.20",
+          spec -> spec.recipe(new AddDependency("org.springframework", "spring-webmvc", "5.3.31",
             null, null, null, null, null, null, null, null, true)),
           mavenProject(
             "project",

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -1470,6 +1470,43 @@ class AddDependencyTest implements RewriteTest {
     }
 
     @Test
+    void doNotAddDependencyTransitivelyProvidedByBom() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("org.springframework:spring-webmvc:5.3.20")),
+          mavenProject(
+            "project",
+            pomXml(
+              """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.springframework.boot</groupId>
+                              <artifactId>spring-boot-dependencies</artifactId>
+                              <version>2.7.18</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-web</artifactId>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+            )
+          )
+        );
+    }
+
+    @Test
     void addDependencyToParentPomWhenAggregatingPomIsNotParent() {
         rewriteRun(
           spec -> spec.recipe(new AddDependency(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -1477,30 +1477,30 @@ class AddDependencyTest implements RewriteTest {
             "project",
             pomXml(
               """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.mycompany.app</groupId>
-                  <artifactId>my-app</artifactId>
-                  <version>1</version>
-                  <dependencyManagement>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.springframework.boot</groupId>
-                              <artifactId>spring-boot-dependencies</artifactId>
-                              <version>2.7.18</version>
-                              <type>pom</type>
-                              <scope>import</scope>
-                          </dependency>
-                      </dependencies>
-                  </dependencyManagement>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.springframework.boot</groupId>
-                          <artifactId>spring-boot-starter-web</artifactId>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-dependencies</artifactId>
+                                <version>2.7.18</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-web</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
             )
           )
         );


### PR DESCRIPTION
## What's changed?
Added a unit test for `AddDependency` recipe to not add a transitive dependency when managed by a bom, with `acceptTransitive` set to true. This test is failing.
In the below test spring-boot-starter-web is managed by spring-boot-dependencies and transitively uses spring-webmvc, so the recipe should not add it.

## Anyone you would like to review specifically?
@timtebeek. I am not sure if any other argument to the recipe must be used for this case, so let me know. 

## Have you considered any alternatives or workarounds?
No, but do let me know if this can be done in any other way.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
