### PR TITLE
Removing workarounds for rewriteRun after checks

### DIFF
--- a/rewrite-javascript/rewrite/test/java/visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/java/visitor.test.ts
@@ -34,9 +34,8 @@ describe('visitor', () => {
 
         // when
         await spec.rewriteRun(
-            // TODO something is off with the rewriteRun logic, it doesn't work without the after, even if before==after
             //language=typescript
-            typescript('class A {}', 'class A {}')
+            typescript('class A {}')
         );
 
         // test

--- a/rewrite-javascript/rewrite/test/javascript/format/blank-lines-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/blank-lines-visitor.test.ts
@@ -105,10 +105,6 @@ describe('BlankLinesVisitor', () => {
             typescript(`
                  class A {
                  }
-                `,
-                `
-                 class A {
-                 }
                 `)
             // @formatter:on
         );


### PR DESCRIPTION
## What's changed?

Removing workaround for `rewriteRun` test failures in Javascript tests.

## What's your motivation?

The underlying test framework logic got fixed in https://github.com/openrewrite/rewrite/commit/74dd889242ec7190241a37c70a23fdb365e41799
so they are no longer needed.
