### PR TITLE
AddImport: Handle import ambiguity

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -115,21 +115,28 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                     packageName.equals(cu.getPackageDeclaration().getExpression().printTrimmed(getCursor()))) {
                 return cu;
             }
-
-            if (onlyIfReferenced && !hasReference(cu)) {
+            Optional<JavaType> typeReference = findTypeReference(cu);
+            if (onlyIfReferenced && !typeReference.isPresent()) {
                 return cu;
             }
 
-            if (!"Record".equals(typeName) && cu.getImports().stream().anyMatch(i -> {
-                String ending = i.getQualid().getSimpleName();
-                if (member == null) {
-                    return !i.isStatic() && i.getPackageName().equals(packageName) &&
-                            (ending.equals(typeName) || "*".equals(ending));
-                }
-                return i.isStatic() && i.getTypeName().equals(fullyQualifiedName) &&
-                        (ending.equals(member) || "*".equals(ending));
-            })) {
+            ImportStatus importStatus = checkImportsForType(cu.getImports());
+
+            if (importStatus == ImportStatus.EXPLICITLY_IMPORTED) {
                 return cu;
+            }
+
+            if (!"Record".equals(typeName) && importStatus == ImportStatus.IMPLICITLY_IMPORTED) {
+                return cu;
+            }
+
+            if (importStatus == ImportStatus.IMPORT_AMBIGUITY && typeReference.isPresent()) {
+                if (typeReference.get() instanceof JavaType.FullyQualified) {
+                    return new FullyQualifyTypeReference<P>((JavaType.FullyQualified) typeReference.get()).visit(cu, p);
+                }
+                if (typeReference.get() instanceof JavaType.Method || typeReference.get() instanceof JavaType.Variable) {
+                    return new FullyQualifyMemberReference<P>(typeReference.get()).visit(cu, p);
+                }
             }
 
             J.Import importToAdd = new J.Import(randomId(),
@@ -181,6 +188,39 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
         return j;
     }
 
+    private ImportStatus checkImportsForType(List<J.Import> imports) {
+        for (J.Import imp : imports) {
+            String ending = imp.getQualid().getSimpleName();
+            if (imp.isStatic() ^ member != null) {
+                continue;
+            }
+            if (imp.isStatic()) {
+                if (imp.getTypeName().equals(fullyQualifiedName)) {
+                    if (ending.equals(member)) {
+                        return ImportStatus.EXPLICITLY_IMPORTED;
+                    } else if ("*".equals(ending)) {
+                        return ImportStatus.IMPLICITLY_IMPORTED;
+                    }
+                }
+                if (ending.equals(member)) {
+                    return ImportStatus.IMPORT_AMBIGUITY;
+                }
+            } else {
+                if (imp.getPackageName().equals(packageName)) {
+                    if (typeName.equals(ending)) {
+                        return ImportStatus.EXPLICITLY_IMPORTED;
+                    } else if ("*".equals(ending)) {
+                        return ImportStatus.IMPLICITLY_IMPORTED;
+                    }
+                }
+                if (ending.equals(typeName)) {
+                    return ImportStatus.IMPORT_AMBIGUITY;
+                }
+            }
+        }
+        return ImportStatus.NOT_IMPORTED;
+    }
+
     private List<JRightPadded<J.Import>> checkCRLF(JavaSourceFile cu, List<JRightPadded<J.Import>> newImports) {
         GeneralFormatStyle generalFormatStyle = Optional.ofNullable(Style.from(GeneralFormatStyle.class, ((SourceFile) cu)))
                 .orElse(autodetectGeneralFormatStyle(cu));
@@ -193,12 +233,15 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
         return newImports;
     }
 
-    private boolean isTypeReference(NameTree t) {
-        boolean isTypRef = true;
-        if (t instanceof J.FieldAccess) {
-            isTypRef = isOfClassType(((J.FieldAccess) t).getTarget().getType(), fullyQualifiedName);
+    private Optional<JavaType> getTypeReference(NameTree t) {
+        if (!(t instanceof J.FieldAccess)) {
+           return Optional.ofNullable(t.getType());
+
         }
-        return isTypRef;
+        if (isOfClassType(((J.FieldAccess) t).getTarget().getType(), fullyQualifiedName)) {
+            return Optional.ofNullable(((J.FieldAccess) t).getTarget().getType());
+        }
+        return Optional.empty();
     }
 
     /**
@@ -212,16 +255,15 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
      * @return true if the import is referenced by the class either explicitly or through a method reference.
      */
     //Note that using anyMatch when a stream is empty ends up returning true, which is not the behavior needed here!
-    private boolean hasReference(JavaSourceFile compilationUnit) {
+    private Optional<JavaType> findTypeReference(JavaSourceFile compilationUnit) {
         if (member == null) {
             //Non-static imports, we just look for field accesses.
             for (NameTree t : FindTypes.find(compilationUnit, fullyQualifiedName)) {
-                if ((!(t instanceof J.FieldAccess) || !((J.FieldAccess) t).isFullyQualifiedClassReference(fullyQualifiedName)) &&
-                        isTypeReference(t)) {
-                    return true;
+                if (!(t instanceof J.FieldAccess) || !((J.FieldAccess) t).isFullyQualifiedClassReference(fullyQualifiedName)) {
+                    return getTypeReference(t);
                 }
             }
-            return false;
+            return Optional.empty();
         }
 
         // For static method imports, we are either looking for a specific method or a wildcard.
@@ -230,18 +272,23 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                 J.MethodInvocation mi = (J.MethodInvocation) invocation;
                 if (mi.getSelect() == null &&
                         ("*".equals(member) || mi.getName().getSimpleName().equals(member))) {
-                    return true;
+                    return Optional.ofNullable(mi.getMethodType());
                 }
             }
         }
 
         // Check whether there is static-style access of the field in question
-        AtomicReference<Boolean> hasStaticFieldAccess = new AtomicReference<>(false);
-        new FindStaticFieldAccess().visit(compilationUnit, hasStaticFieldAccess);
-        return hasStaticFieldAccess.get();
+        return Optional.ofNullable(new FindStaticFieldAccess().reduce(compilationUnit, new AtomicReference<>()).get());
     }
 
-    private class FindStaticFieldAccess extends JavaIsoVisitor<AtomicReference<Boolean>> {
+    private enum ImportStatus {
+        NOT_IMPORTED,
+        IMPLICITLY_IMPORTED,
+        EXPLICITLY_IMPORTED,
+        IMPORT_AMBIGUITY,
+    }
+
+    private class FindStaticFieldAccess extends JavaIsoVisitor<AtomicReference<JavaType>> {
         private boolean checkIsOfClassType(@Nullable JavaType type, String fullyQualifiedName) {
             if (isOfClassType(type, fullyQualifiedName)) {
                 return true;
@@ -250,23 +297,24 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
         }
 
         @Override
-        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, AtomicReference<Boolean> found) {
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, AtomicReference<JavaType> fieldAccess) {
             // If the type isn't used there's no need to proceed further
             for (JavaType.Variable varType : cu.getTypesInUse().getVariables()) {
-                if (checkIsOfClassType(varType.getType(), fullyQualifiedName)) {
-                    return super.visitCompilationUnit(cu, found);
+                if (checkIsOfClassType(varType.getOwner(), fullyQualifiedName)) {
+                    return super.visitCompilationUnit(cu, fieldAccess);
                 }
             }
             return cu;
         }
 
         @Override
-        public J.Identifier visitIdentifier(J.Identifier identifier, AtomicReference<Boolean> found) {
+        public J.Identifier visitIdentifier(J.Identifier identifier, AtomicReference<JavaType> fieldAccess) {
             assert getCursor().getParent() != null;
-            if (identifier.getSimpleName().equals(member) &&
-                    checkIsOfClassType(identifier.getType(), fullyQualifiedName) &&
+            if (identifier.getSimpleName().equals(member) && identifier.getFieldType() != null &&
+                    checkIsOfClassType(identifier.getFieldType().getOwner(), fullyQualifiedName) &&
                     !(getCursor().getParent().firstEnclosingOrThrow(J.class) instanceof J.FieldAccess)) {
-                found.set(true);
+                assert identifier.getType() != null;
+                fieldAccess.set(identifier.getFieldType());
             }
             return identifier;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/FullyQualifyMemberReference.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/FullyQualifyMemberReference.java
@@ -1,0 +1,78 @@
+package org.openrewrite.java;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import static java.util.Collections.emptyList;
+
+@AllArgsConstructor
+public class FullyQualifyMemberReference<P> extends JavaVisitor<P> {
+
+    private final JavaType memberToFullyQualify;
+
+    public J visitCompilationUnit(J.CompilationUnit cu, P p) {
+        if (memberToFullyQualify instanceof JavaType.Method || memberToFullyQualify instanceof JavaType.Variable) {
+            return super.visitCompilationUnit(cu, p);
+        }
+        return cu;
+    }
+
+    @Override
+    public J visitMethodInvocation(J.MethodInvocation methodInvocation, P p) {
+        J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(methodInvocation, p);
+        if (!(memberToFullyQualify instanceof JavaType.Method) || methodInvocation.getSelect() != null
+                || methodInvocation.getMethodType() == null) {
+            return mi;
+        }
+        JavaType.Method m = (JavaType.Method) memberToFullyQualify;
+        if (m.getName().equals(methodInvocation.getMethodType().getName())
+                && m.getDeclaringType().getFullyQualifiedName().equals(methodInvocation.getMethodType().getDeclaringType().getFullyQualifiedName())) {
+            return mi.withSelect(toIdentifier(m.getDeclaringType()));
+        }
+        return mi;
+    }
+
+    @Override
+    public J visitIdentifier(J.Identifier identifier, P p) {
+        if (!isUnqualifiedVarAccess(identifier) || !(this.memberToFullyQualify instanceof JavaType.Variable)) {
+            return super.visitIdentifier(identifier, p);
+        }
+
+        JavaType.Variable memberToFullyQualify = (JavaType.Variable) this.memberToFullyQualify;
+        JavaType.FullyQualified memberToFullyQualifyOwner = TypeUtils.asFullyQualified(memberToFullyQualify.getOwner());
+        JavaType.FullyQualified identifierOwner = TypeUtils.asFullyQualified(identifier.getFieldType().getOwner());
+
+        if (memberToFullyQualifyOwner == null || identifierOwner == null) {
+            return super.visitIdentifier(identifier, p);
+        }
+
+        if (memberToFullyQualifyOwner.getFullyQualifiedName().equals(identifierOwner.getFullyQualifiedName())
+                && memberToFullyQualify.getName().equals(identifier.getSimpleName())) {
+            return toFieldAccess(memberToFullyQualify, identifier);
+        }
+        return super.visitIdentifier(identifier, p);
+    }
+
+    private boolean isUnqualifiedVarAccess(J.Identifier identifier) {
+        return identifier.getFieldType() != null // is variable
+                && !(getCursor().getParentTreeCursor().getValue() instanceof J.FieldAccess); // not qualified
+    }
+
+    private J.Identifier toIdentifier(JavaType.FullyQualified fullyQualified) {
+        return new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(),
+                fullyQualified.getFullyQualifiedName(), fullyQualified, null);
+    }
+
+    private J.FieldAccess toFieldAccess(JavaType.Variable variableType, J.Identifier identifier) {
+        return new J.FieldAccess(
+                Tree.randomId(),
+                identifier.getPrefix(),
+                Markers.EMPTY,
+                toIdentifier(TypeUtils.asFullyQualified(variableType.getOwner())),
+                JLeftPadded.build(identifier.withPrefix(Space.EMPTY)),
+                variableType.getType()
+        );
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/FullyQualifyTypeReference.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/FullyQualifyTypeReference.java
@@ -1,0 +1,31 @@
+package org.openrewrite.java;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+@AllArgsConstructor
+public class FullyQualifyTypeReference<P> extends JavaVisitor<P> {
+    private final JavaType.FullyQualified typeToFullyQualify;
+
+    @Override
+    public J visitFieldAccess(J.FieldAccess fieldAccess, P p) {
+        if (fieldAccess.isFullyQualifiedClassReference(typeToFullyQualify.getFullyQualifiedName())) {
+            return fieldAccess;
+        }
+        return super.visitFieldAccess(fieldAccess, p);
+    }
+
+    @Override
+    public J visitIdentifier(J.Identifier identifier, P p) {
+        if (identifier.getFieldType() != null) {
+            return super.visitIdentifier(identifier, p);
+        }
+        JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(identifier.getType());
+        if (fullyQualified != null && typeToFullyQualify.getFullyQualifiedName().equals(fullyQualified.getFullyQualifiedName())) {
+            return identifier.withSimpleName(typeToFullyQualify.getFullyQualifiedName());
+        }
+        return super.visitIdentifier(identifier, p);
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/FullyQualifyMemberReferenceTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/FullyQualifyMemberReferenceTest.java
@@ -1,0 +1,223 @@
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class FullyQualifyMemberReferenceTest implements RewriteTest {
+
+    @Test
+    void fullyQualifyStaticMethod() {
+        // Create a method type for java.util.Collections.emptyList()
+        JavaType.Method emptyListMethod = createMethodType(
+            "java.util.Collections", "emptyList", "java.util.List"
+        );
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyMemberReference<>(emptyListMethod))),
+          java(
+            """
+            import static java.util.Collections.emptyList;
+            import java.util.List;
+
+            class Test {
+                List<String> list = emptyList();
+
+                void method() {
+                    // emptyList should be fully qualified
+                    List<Integer> empty = emptyList();
+                }
+            }
+            """,
+            """
+            import static java.util.Collections.emptyList;
+            import java.util.List;
+
+            class Test {
+                List<String> list = java.util.Collections.emptyList();
+
+                void method() {
+                    // emptyList should be fully qualified
+                    List<Integer> empty = java.util.Collections.emptyList();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyStaticVariable() {
+        // Create a variable type for java.lang.System.out
+        JavaType.Variable outVariable = createVariableType(
+            "java.lang.System", "out", "java.io.PrintStream"
+        );
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyMemberReference<>(outVariable))),
+          java(
+            """
+            import static java.lang.System.out;
+
+            class Test {
+                void method() {
+                    // out should be fully qualified
+                    out.println("Hello, world!");
+                }
+            }
+            """,
+            """
+            import static java.lang.System.out;
+
+            class Test {
+                void method() {
+                    // out should be fully qualified
+                    java.lang.System.out.println("Hello, world!");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void doNotQualifyNonStaticMethods() {
+        // Create a method type for java.util.Collections.emptyList()
+        JavaType.Method emptyListMethod = createMethodType(
+            "java.util.Collections", "emptyList", "java.util.List"
+        );
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyMemberReference<>(emptyListMethod))),
+          java(
+            """
+            import java.util.ArrayList;
+            import java.util.List;
+
+            class Test {
+                void method() {
+                    // add is not a static method, should not be qualified
+                    List<String> list = new ArrayList<>();
+                    list.add("test");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void doNotQualifyNonStaticVariables() {
+        // Create a variable type for java.lang.System.out
+        JavaType.Variable outVariable = createVariableType(
+            "java.lang.System", "out", "java.io.PrintStream"
+        );
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyMemberReference<>(outVariable))),
+          java(
+            """
+            class Test {
+                private String name;
+
+                void method() {
+                    // name is not a static variable, should not be qualified
+                    this.name = "test";
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyMultipleStaticMethods() {
+        // Create a method type for java.lang.Math.max(int, int)
+        JavaType.Method maxMethod = createMethodType(
+            "java.lang.Math", "max", "int", "int", "int"
+        );
+
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyMemberReference<>(maxMethod))),
+          java(
+            """
+            import static java.lang.Math.max;
+            import static java.lang.Math.min;
+
+            class Test {
+                void method() {
+                    // max should be fully qualified, min should remain as is
+                    int maximum = max(5, 10);
+                    int minimum = min(5, 10);
+                }
+            }
+            """,
+            """
+            import static java.lang.Math.max;
+            import static java.lang.Math.min;
+
+            class Test {
+                void method() {
+                    // max should be fully qualified, min should remain as is
+                    int maximum = java.lang.Math.max(5, 10);
+                    int minimum = min(5, 10);
+                }
+            }
+            """
+          )
+        );
+    }
+
+    /**
+     * Helper method to create a JavaType.Method instance for testing
+     */
+    private JavaType.Method createMethodType(String declaringType, String methodName, String returnType, String... parameterTypes) {
+        JavaType.FullyQualified declaringClass = JavaType.ShallowClass.build(declaringType);
+
+        JavaType returnTypeObj = JavaType.buildType(returnType);
+
+        JavaType[] paramTypes = new JavaType[parameterTypes.length];
+        for (int i = 0; i < parameterTypes.length; i++) {
+            paramTypes[i] = JavaType.buildType(parameterTypes[i]);
+        }
+
+        return new JavaType.Method(
+            null,
+            Flag.Public.getBitMask() | Flag.Static.getBitMask(),
+            declaringClass,
+            methodName,
+            returnTypeObj,
+            Collections.emptyList(),
+            Arrays.asList(paramTypes),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            Collections.emptyList()
+        );
+    }
+
+    /**
+     * Helper method to create a JavaType.Variable instance for testing
+     */
+    private JavaType.Variable createVariableType(String ownerType, String variableName, String variableType) {
+        JavaType.FullyQualified ownerClass = JavaType.ShallowClass.build(ownerType);
+
+        JavaType type = JavaType.buildType(variableType);
+
+        return new JavaType.Variable(
+            null,
+            Flag.Public.getBitMask() | Flag.Static.getBitMask(),
+            variableName,
+            ownerClass,
+            type,
+            Collections.emptyList()
+        );
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/FullyQualifyTypeReferenceTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/FullyQualifyTypeReferenceTest.java
@@ -1,0 +1,322 @@
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class FullyQualifyTypeReferenceTest implements RewriteTest {
+
+    @Test
+    void fullyQualify() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.List"))
+          ))),
+          java(
+            """
+            import java.util.*;
+
+            class Test {
+                List<String> list = new ArrayList<>();
+
+                void method(List<Integer> param) {
+                    // List should be fully qualified
+                }
+            }
+            """,
+            """
+            import java.util.*;
+
+            class Test {
+                java.util.List<String> list = new ArrayList<>();
+
+                void method(java.util.List<Integer> param) {
+                    // List should be fully qualified
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyFieldAccess() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.Collections"))
+          ))),
+          java(
+            """
+            import java.util.Collections;
+            import java.util.List;
+
+            class Test {
+                List<String> list = Collections.emptyList();
+
+                void method(Collections foo) {
+                    // Collections should be fully qualified
+                    List<Integer> empty = Collections.emptyList();
+                }
+            }
+            """,
+            """
+            import java.util.Collections;
+            import java.util.List;
+
+            class Test {
+                List<String> list = java.util.Collections.emptyList();
+
+                void method(java.util.Collections foo) {
+                    // Collections should be fully qualified
+                    List<Integer> empty = java.util.Collections.emptyList();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyTypeCast() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.List"))
+          ))),
+          java(
+            """
+            import java.util.*;
+
+            class Test {
+                Object getObject() {
+                    return new ArrayList<String>();
+                }
+
+                void method() {
+                    // List should be fully qualified in the cast
+                    List<String> list = (List<String>) getObject();
+                }
+            }
+            """,
+            """
+            import java.util.*;
+
+            class Test {
+                Object getObject() {
+                    return new ArrayList<String>();
+                }
+
+                void method() {
+                    // List should be fully qualified in the cast
+                    java.util.List<String> list = (java.util.List<String>) getObject();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyMethodReturnType() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.List"))
+          ))),
+          java(
+            """
+            import java.util.*;
+
+            class Test {
+                // List should be fully qualified in the return type
+                List<String> getList() {
+                    return new ArrayList<>();
+                }
+            }
+            """,
+            """
+            import java.util.*;
+
+            class Test {
+                // List should be fully qualified in the return type
+                java.util.List<String> getList() {
+                    return new ArrayList<>();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyExceptionType() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.io.IOException"))
+          ))),
+          java(
+            """
+            import java.io.IOException;
+
+            class Test {
+                void method() {
+                    try {
+                        throw new IOException("Error");
+                    } catch (IOException e) {
+                        // IOException should be fully qualified
+                        e.printStackTrace();
+                    }
+                }
+            }
+            """,
+            """
+            import java.io.IOException;
+
+            class Test {
+                void method() {
+                    try {
+                        throw new java.io.IOException("Error");
+                    } catch (java.io.IOException e) {
+                        // IOException should be fully qualified
+                        e.printStackTrace();
+                    }
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyGenericTypeParameter() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.Map"))
+          ))),
+          java(
+            """
+            import java.util.*;
+
+            class Test {
+                // Map should be fully qualified in the generic type parameter
+                void processEntries(List<Map<String, Integer>> maps) {
+                    for (Map<String, Integer> map : maps) {
+                        // process map
+                    }
+                }
+
+                // Map should be fully qualified in the type parameter of the class
+                class Container<T extends Map<String, Integer>> {
+                    T value;
+                }
+            }
+            """,
+            """
+            import java.util.*;
+
+            class Test {
+                // Map should be fully qualified in the generic type parameter
+                void processEntries(List<java.util.Map<String, Integer>> maps) {
+                    for (java.util.Map<String, Integer> map : maps) {
+                        // process map
+                    }
+                }
+
+                // Map should be fully qualified in the type parameter of the class
+                class Container<T extends java.util.Map<String, Integer>> {
+                    T value;
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyArrayType() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.Date"))
+          ))),
+          java(
+            """
+            import java.util.Date;
+
+            class Test {
+                // Date should be fully qualified in the array type
+                Date[] getDates() {
+                    return new Date[0];
+                }
+
+                void processDateArray(Date[] dates) {
+                    // process dates
+                }
+
+                void createMultiDimensionalArray() {
+                    // Date should be fully qualified in multi-dimensional array
+                    Date[][] dateMatrix = new Date[3][3];
+                }
+            }
+            """,
+            """
+            import java.util.Date;
+
+            class Test {
+                // Date should be fully qualified in the array type
+                java.util.Date[] getDates() {
+                    return new java.util.Date[0];
+                }
+
+                void processDateArray(java.util.Date[] dates) {
+                    // process dates
+                }
+
+                void createMultiDimensionalArray() {
+                    // Date should be fully qualified in multi-dimensional array
+                    java.util.Date[][] dateMatrix = new java.util.Date[3][3];
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualifyInstanceOf() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new FullyQualifyTypeReference<>(
+              TypeUtils.asFullyQualified(JavaType.buildType("java.util.List"))
+          ))),
+          java(
+            """
+            import java.util.*;
+
+            class Test {
+                void method(Object obj) {
+                    // List should be fully qualified in instanceof check
+                    if (obj instanceof List) {
+                        List<String> list = (List<String>) obj;
+                        // process list
+                    }
+                }
+            }
+            """,
+            """
+            import java.util.*;
+
+            class Test {
+                void method(Object obj) {
+                    // List should be fully qualified in instanceof check
+                    if (obj instanceof java.util.List) {
+                        java.util.List<String> list = (java.util.List<String>) obj;
+                        // process list
+                    }
+                }
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Previously, the AddImport logic did not account for import ambiguity, leading to compilation errors when ambiguous imports were added. This update introduces a check for ambiguity before adding an import. If ambiguity is detected, the code now fully qualifies the relevant identifiers instead of adding the import


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
