### PR TITLE
Only allow gradle dependency locking for already locked configurations/artifacts

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateDependencyLock.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateDependencyLock.java
@@ -31,10 +31,8 @@ import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySortedSet;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -152,17 +150,5 @@ public class UpdateDependencyLock extends PlainTextVisitor<ExecutionContext> {
             return;
         }
         lockedArtifacts.add(new GroupArtifact(gavParts[0], gavParts[1]));
-    }
-
-    private SortedSet<String> parseEmptyConfigurations(String lock) {
-        String[] parts = lock.split("=");
-        if (parts.length != 2) {
-            return emptySortedSet();
-        }
-        String[] configurations = parts[1].split(",");
-        return Arrays.stream(configurations)
-                .map(String::trim)
-                .filter(conf -> !conf.isEmpty())
-                .collect(Collectors.toCollection(TreeSet::new));
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/LockDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/LockDependencyVersionsTest.java
@@ -159,44 +159,6 @@ class LockDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
-    void onlyUpdateExistingLockedArtifacts() {
-        rewriteRun(spec ->
-            spec.beforeRecipe(withToolingApi()),
-          buildGradleKts(
-            """
-              plugins {
-                  java
-              }
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  implementation("org.apache.tomcat.embed:tomcat-embed-core:10.0.27")
-                  implementation("org.apache.tomcat:tomcat-annotations-api:10.0.27")
-              }
-              """
-          ),
-          lockfile(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              """,
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              org.apache.tomcat.embed:tomcat-embed-core:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              """
-          )
-        );
-    }
-
-    @Test
     void multimodule() {
         rewriteRun(spec ->
             spec.beforeRecipe(withToolingApi()),

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/LockDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/LockDependencyVersionsTest.java
@@ -15,36 +15,43 @@
  */
 package org.openrewrite.gradle;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.*;
-import org.openrewrite.gradle.marker.GradleProject;
-import org.openrewrite.groovy.tree.G;
-import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.text.PlainText;
-import org.openrewrite.text.PlainTextParser;
-
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.openrewrite.gradle.Assertions.*;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class LockDependencyVersionsTest implements RewriteTest {
 
+    private static String EMPTY_LOCK_FILE = """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              empty=
+              """;
+    private static String JACKSON_LOCKFILE = """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              com.fasterxml.jackson.core:jackson-annotations:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-core:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson.core:jackson-databind:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              com.fasterxml.jackson:jackson-bom:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """;
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(RewriteTest.toRecipe(UpdateDependencyLock::new));
+    }
+
     @Test
     @DocumentExample
-    void createGradleLockFile() {
+    void updateGradleLock() {
         rewriteRun(spec ->
-            spec.beforeRecipe(withToolingApi())
-              .recipe(new LockDependencyVersions()),
+            spec.beforeRecipe(withToolingApi()),
           buildGradle(
             """
               plugins {
@@ -61,7 +68,7 @@ class LockDependencyVersionsTest implements RewriteTest {
               """
           ),
           lockfile(
-            null,
+            JACKSON_LOCKFILE,
             """
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
@@ -79,8 +86,7 @@ class LockDependencyVersionsTest implements RewriteTest {
     @Test
     void preserveNewLineEOFIfPresent() {
         rewriteRun(spec ->
-            spec.beforeRecipe(withToolingApi())
-              .recipe(new LockDependencyVersions()),
+            spec.beforeRecipe(withToolingApi()),
           buildGradle(
             """
               plugins {
@@ -110,22 +116,24 @@ class LockDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
-    void updateGradleLock() {
+    void onlyUpdateExistingConfigurations() {
         rewriteRun(spec ->
-            spec.beforeRecipe(withToolingApi())
-              .recipe(new LockDependencyVersions()),
-          buildGradle(
+            spec.beforeRecipe(withToolingApi()),
+          buildGradleKts(
             """
               plugins {
-                  id 'java'
+                  java
               }
               repositories {
                   mavenCentral()
               }
+              
+              val asciidoclet by configurations.creating
+              
               dependencies {
-                  implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-                  implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.4'
-                  implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
+                  implementation("org.apache.tomcat.embed:tomcat-embed-core:10.0.27")
+                  implementation("org.apache.tomcat:tomcat-annotations-api:10.0.27")
+                  asciidoclet("org.asciidoctor:asciidoclet:1.+")
               }
               """
           ),
@@ -134,20 +142,54 @@ class LockDependencyVersionsTest implements RewriteTest {
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
               # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat:tomcat-annotations-api:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
               empty=annotationProcessor,testAnnotationProcessor
               """,
             """
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
               # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              org.apache.tomcat:tomcat-annotations-api:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyUpdateExistingLockedArtifacts() {
+        rewriteRun(spec ->
+            spec.beforeRecipe(withToolingApi()),
+          buildGradleKts(
+            """
+              plugins {
+                  java
+              }
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  implementation("org.apache.tomcat.embed:tomcat-embed-core:10.0.27")
+                  implementation("org.apache.tomcat:tomcat-annotations-api:10.0.27")
+              }
+              """
+          ),
+          lockfile(
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+              empty=annotationProcessor,testAnnotationProcessor
+              """,
+            """
+              # This is a Gradle generated file for dependency locking.
+              # Manual edits can break the build and are not advised.
+              # This file is expected to be part of source control.
+              org.apache.tomcat.embed:tomcat-embed-core:10.0.27=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
               empty=annotationProcessor,testAnnotationProcessor
               """
           )
@@ -157,8 +199,7 @@ class LockDependencyVersionsTest implements RewriteTest {
     @Test
     void multimodule() {
         rewriteRun(spec ->
-            spec.beforeRecipe(withToolingApi())
-              .recipe(new LockDependencyVersions()),
+            spec.beforeRecipe(withToolingApi()),
           settingsGradle(
             """
               rootProject.name = 'test'
@@ -197,24 +238,10 @@ class LockDependencyVersionsTest implements RewriteTest {
             spec -> spec.path("module2/build.gradle")
           ),
           lockfile(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              empty=
-              """
+            EMPTY_LOCK_FILE
           ),
           lockfile(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              """,
+            JACKSON_LOCKFILE,
             """
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
@@ -228,16 +255,7 @@ class LockDependencyVersionsTest implements RewriteTest {
             spec -> spec.path("module1/gradle.lockfile")
           ),
           lockfile(
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              com.fasterxml.jackson.core:jackson-annotations:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-core:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson.core:jackson-databind:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              com.fasterxml.jackson:jackson-bom:2.15.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-              empty=annotationProcessor,testAnnotationProcessor
-              """,
+            JACKSON_LOCKFILE,
             """
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
@@ -256,8 +274,7 @@ class LockDependencyVersionsTest implements RewriteTest {
     @Test
     void createMultiModuleLockFile() {
         rewriteRun(spec ->
-            spec.beforeRecipe(withToolingApi())
-              .recipe(new LockDependencyVersions()),
+            spec.beforeRecipe(withToolingApi()),
           settingsGradle(
             """
               rootProject.name = 'test'
@@ -296,16 +313,10 @@ class LockDependencyVersionsTest implements RewriteTest {
             spec -> spec.path("module2/build.gradle")
           ),
           lockfile(
-            null,
-            """
-              # This is a Gradle generated file for dependency locking.
-              # Manual edits can break the build and are not advised.
-              # This file is expected to be part of source control.
-              empty=
-              """
+            EMPTY_LOCK_FILE
           ),
           lockfile(
-            null,
+            JACKSON_LOCKFILE,
             """
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
@@ -319,7 +330,7 @@ class LockDependencyVersionsTest implements RewriteTest {
             spec -> spec.path("module1/gradle.lockfile")
           ),
           lockfile(
-            null,
+            JACKSON_LOCKFILE,
             """
               # This is a Gradle generated file for dependency locking.
               # Manual edits can break the build and are not advised.
@@ -333,94 +344,5 @@ class LockDependencyVersionsTest implements RewriteTest {
             spec -> spec.path("module2/gradle.lockfile")
           )
         );
-    }
-
-    //TODO for now I have this recipe here to test the calculation of the lockfile is correct.
-    //     I will later move it to production recipes when it also generates the  necessary build.gradle and build.gradle.kts changes.
-    @Value
-    @EqualsAndHashCode(callSuper = false)
-    public static class LockDependencyVersions extends ScanningRecipe<LockDependencyVersions.Accumulator> {
-        private static final String[] EMPTY = new String[0];
-
-        @Override
-        public String getDisplayName() {
-            return "Create or update a gradle.lockfile";
-        }
-
-        @Override
-        public String getDescription() {
-            //language=markdown
-            return "Using dynamic dependency versions (e.g., 1.+ or [1.0,2.0)) can cause builds to break unexpectedly because the exact version of a dependency that gets resolved can change over time.\n" +
-              "To ensure reproducible builds, it’s necessary to lock versions of dependencies and their transitive dependencies. " +
-              "This guarantees that a build with the same inputs will always resolve to the same module versions, a process known as dependency locking.\n" +
-              "This recipe creates a `gradle.lockfile` in the root of every gradle module in the project.\n" +
-              "The `gradle.lockfile` contains the resolved versions of all dependencies and their transitive dependencies, ensuring that the same versions are used across different builds.\n" +
-              "The dependencies used for locking are the ones that are resolved during the BUILD time of your LST. \n" +
-              "If you want to update the lockfile after impacting dependencies using a recipe, either you first need to build a new LST or use the `UpdateDependencyLockFileVisitor`.";
-        }
-
-        @Value
-        static class Accumulator {
-            Set<String> lockfiles = new HashSet<>();
-            Set<GradleProject> gradleProjects = new HashSet<>();
-        }
-
-        @Override
-        public Accumulator getInitialValue(ExecutionContext ctx) {
-            return new Accumulator();
-        }
-
-        @Override
-        public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
-            return new TreeVisitor<Tree, ExecutionContext>() {
-                @Override
-                public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-                    return (sourceFile instanceof G.CompilationUnit && sourceFile.getSourcePath().toString().endsWith(".gradle")) ||
-                      (sourceFile instanceof K.CompilationUnit && sourceFile.getSourcePath().toString().endsWith(".gradle.kts")) ||
-                      (sourceFile instanceof PlainText && sourceFile.getSourcePath().endsWith("gradle.lockfile"));
-                }
-
-                @Override
-                public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                    if (tree instanceof PlainText && ((PlainText) tree).getSourcePath().endsWith("gradle.lockfile")) {
-                        acc.getLockfiles().add(((PlainText) tree).getSourcePath().toString());
-                    } else if (tree instanceof JavaSourceFile) {
-                        tree.getMarkers().findFirst(GradleProject.class).ifPresent(acc.gradleProjects::add);
-                    }
-                    return super.visit(tree, ctx);
-                }
-            };
-        }
-
-        @Override
-        public Collection<? extends SourceFile> generate(Accumulator acc, ExecutionContext ctx) {
-            return acc.gradleProjects.stream()
-              .flatMap(project -> {
-                  String path = project.getPath();
-                  if (path.startsWith(":")) {
-                      path = path.substring(1);
-                  }
-                  if (!path.isEmpty()) {
-                      path += "/";
-                  }
-                  path = path.replaceAll(":", "/") + "gradle.lockfile";
-                  String finalPath = path;
-                  return PlainTextParser.builder().build()
-                    .parse("# This is a Gradle generated file for dependency locking.\n" +
-                      "# Manual edits can break the build and are not advised.\n" +
-                      "# This file is expected to be part of source control.\n" +
-                      "empty=")
-                    .map(brandNewFile -> (SourceFile) brandNewFile
-                      .withSourcePath(Paths.get(finalPath))
-                      .withMarkers(brandNewFile.getMarkers().add(project))
-                    )
-                    .filter(brandNewFile -> !acc.lockfiles.contains(brandNewFile.getSourcePath().toString()));
-              }).collect(Collectors.toList());
-        }
-
-        @Override
-        public UpdateDependencyLock getVisitor(Accumulator acc) {
-            return new UpdateDependencyLock();
-        }
     }
 }


### PR DESCRIPTION
## What's changed?
I used to completely write the lockfile based on the marker, but did miss that configurations can be ignored for locking. Even artifacts themselves can be ignored. 
This fix addresses to make sure we only put the lock if:
- The configuration was in the lockfile before
- The GroupArtifact was locked before

This way we will address issues like [this repo's lockfile](https://github.com/atlassian/aws-infrastructure/blob/master/gradle.lockfile) not being wrongfully updated to contain locks [for excluded configurations](https://github.com/atlassian/aws-infrastructure/blob/master/build.gradle.kts#L21-L23).

## Anyone you would like to review specifically?
@shanman190 I think this is one quick-win yet big improvement to the "wrongfully updating the lockfile"
@sambsnyd Shannon reached out to mention we might have been to fast. Rather than rolling back, I hope we can fix-forward instead

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
