### PR TITLE
Enhance AddImport to shorten fully qualified names

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -1031,7 +1031,7 @@ class AddImportTest implements RewriteTest {
                   Map<String, String> map = new HashMap<>();
                   Set<String> set = new HashSet<>();
                   List<String> test = Collections.singletonList("test");
-                  List<String> test2 = new java.util.ArrayList<>();
+                  List<String> test2 = new ArrayList<>();
               }
               """
           )
@@ -1546,7 +1546,7 @@ class AddImportTest implements RewriteTest {
               import static com.example.CustomColor.RED;
 
               class Ambiguous {
-                  Color color = java.awt.Color.RED;
+                  Color color = Color.RED;
                   void method() {
                       // RED is from com.example.CustomColor
                       System.out.println(RED);


### PR DESCRIPTION
## What's changed?
PR #5439 introduced logic to handle import ambiguity by using fully qualified names when conflicting usages are present. However, this led to regressions in cases where such conflicts only existed temporarily during multi-step recipe transformations.
### Issue
When multiple recipes are applied, intermediate steps may introduce conflicting usages. But at the end might all such usage can be safely replaced to shortend names.

To handle this, updated AddImport to shorten existing fullyqualified names for the type or member for which import is being added.

### Testing
Validated the fix by running all tests in the rewrite-testing-frameworks.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
