### PR TITLE
Fixed the scanner being executed in a loop that then causes all scans to be updated in a single run.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -902,6 +902,9 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     private static org.openrewrite.maven.tree.Dependency maybeUpdateDependency(
             org.openrewrite.maven.tree.Dependency dep,
             org.openrewrite.maven.tree.Dependency newDep) {
+        if (Objects.equals(dep.getGroupId(), newDep.getGroupId()) && Objects.equals(dep.getArtifactId(), newDep.getArtifactId()) && Objects.equals(dep.getVersion(), newDep.getVersion())) {
+            return dep;
+        }
         if (Objects.equals(dep.getGroupId(), newDep.getGroupId()) && Objects.equals(dep.getArtifactId(), newDep.getArtifactId())) {
             return newDep;
         }
@@ -924,6 +927,9 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             ResolvedDependency newDep,
             Set<ResolvedDependency> traversalHistory) {
         if (traversalHistory.contains(dep)) {
+            return dep;
+        }
+        if (Objects.equals(dep.getGroupId(), newDep.getGroupId()) && Objects.equals(dep.getArtifactId(), newDep.getArtifactId()) && Objects.equals(dep.getVersion(), newDep.getVersion())) {
             return dep;
         }
         if (Objects.equals(dep.getGroupId(), newDep.getGroupId()) && Objects.equals(dep.getArtifactId(), newDep.getArtifactId())) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -443,6 +443,9 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                     ).visitNonNull(cu, ctx);
 
                     for (Map.Entry<GroupArtifact, Map<GradleDependencyConfiguration, String>> update : projectRequiredUpdates.entrySet()) {
+                        if (!dependencyMatcher.matches(update.getKey().getGroupId(), update.getKey().getArtifactId())) {
+                            continue;
+                        }
                         Map<GradleDependencyConfiguration, String> configs = update.getValue();
                         for (Map.Entry<GradleDependencyConfiguration, String> config : configs.entrySet()) {
                             cu = (JavaSourceFile) new AddConstraint(cu instanceof K.CompilationUnit, config.getKey().getName(), new GroupArtifactVersion(update.getKey().getGroupId(),

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -56,6 +56,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Preconditions.not;
@@ -412,7 +413,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                 JavaSourceFile cu = (JavaSourceFile) tree;
                 gradleProject = cu.getMarkers().findFirst(GradleProject.class).orElseThrow(() -> new IllegalStateException("Unable to find GradleProject marker."));
 
-                if (!updatesPerProject.get(getGradleProjectKey(gradleProject)).isEmpty()) {
+                if (!updatesPerProject.getOrDefault(getGradleProjectKey(gradleProject), emptyMap()).isEmpty()) {
                     cu = (JavaSourceFile) Preconditions.check(
                             not(new JavaIsoVisitor<ExecutionContext>() {
                                 @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -1440,7 +1440,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Test
     void lockFileGetsUpdated() {
         rewriteRun(
-          spec -> spec.recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "latest.patch", null)),
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "10.0.27", null)),
           //language=groovy
           buildGradle(
             """
@@ -1483,7 +1483,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Test
     void multimoduleProjectLockFile() {
         rewriteRun(spec ->
-            spec.recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "latest.patch", null)),
+            spec.recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "10.0.27", null)),
           settingsGradle(
             """
             rootProject.name = 'my-project'
@@ -1716,7 +1716,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Test
     void multiProject() {
         rewriteRun(
-            spec -> spec.recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "latest.patch", null)),
+            spec -> spec.recipe(new UpgradeDependencyVersion("org.apache.tomcat.embed", "*", "10.0.27", null)),
           buildGradle(
             """
               plugins { id 'java' }


### PR DESCRIPTION
## What's changed?
Fixed some regression introduced by moving the `updatesPerProject` to an accumulatro -> 1 run of visitor would upgrade all of the scanned newVersions resulting in the because being the same. 
We only update if the recipe is for the provided group/artifact BUT we keep adding the new version in scanner so that other recipes can use 1 grouped accumulator.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
