### PR TITLE
Continue type attribution in a case of exception

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -240,11 +240,16 @@ public class ReloadableJava11Parser implements JavaParser {
                 if (!annotationProcessors.isEmpty()) {
                     compiler.processAnnotations(jcCompilationUnits, emptyList());
                 }
-                compiler.attribute(compiler.todo);
             } catch (Throwable t) {
-                // when symbol entering fails on problems like missing types, attribution can often times proceed
-                // unhindered, but it sometimes cannot (so attribution is always best-effort in the presence of errors)
-                ctx.getOnError().accept(new JavaParsingException("Failed symbol entering or attribution", t));
+                handleParsingException(ctx, t);
+            }
+
+            while (!compiler.todo.isEmpty()) {
+                try {
+                    compiler.attribute(compiler.todo);
+                } catch (Throwable t) {
+                    handleParsingException(ctx, t);
+                }
             }
         } catch (IllegalStateException e) {
             if ("endPosTable already set".equals(e.getMessage())) {
@@ -255,6 +260,12 @@ public class ReloadableJava11Parser implements JavaParser {
             throw e;
         }
         return cus;
+    }
+
+    private void handleParsingException(ExecutionContext ctx, Throwable t) {
+        // when symbol entering fails on problems like missing types, attribution can often times proceed
+        // unhindered, but it sometimes cannot (so attribution is always best-effort in the presence of errors)
+        ctx.getOnError().accept(new JavaParsingException("Failed symbol entering or attribution", t));
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -237,11 +237,16 @@ public class ReloadableJava17Parser implements JavaParser {
                 if (!annotationProcessors.isEmpty()) {
                     compiler.processAnnotations(jcCompilationUnits, emptyList());
                 }
-                compiler.attribute(compiler.todo);
             } catch (Throwable t) {
-                // when symbol entering fails on problems like missing types, attribution can often times proceed
-                // unhindered, but it sometimes cannot (so attribution is always best-effort in the presence of errors)
-                ctx.getOnError().accept(new JavaParsingException("Failed symbol entering or attribution", t));
+                handleParsingException(ctx, t);
+            }
+
+            while (!compiler.todo.isEmpty()) {
+                try {
+                    compiler.attribute(compiler.todo);
+                } catch (Throwable t) {
+                    handleParsingException(ctx, t);
+                }
             }
         } catch (IllegalStateException e) {
             if ("endPosTable already set".equals(e.getMessage())) {
@@ -253,6 +258,12 @@ public class ReloadableJava17Parser implements JavaParser {
         }
 
         return cus;
+    }
+
+    private void handleParsingException(ExecutionContext ctx, Throwable t) {
+        // when symbol entering fails on problems like missing types, attribution can often times proceed
+        // unhindered, but it sometimes cannot (so attribution is always best-effort in the presence of errors)
+        ctx.getOnError().accept(new JavaParsingException("Failed symbol entering or attribution", t));
     }
 
     @Override


### PR DESCRIPTION
Since type attribution is a best-effort, we continue it even in the presence of errors. But in a current implementation for `JavaCompiler#attribute(Queue)`, it will be stopped in case of error, and not all entries in a queue will be processed.

In the fix, the attribution will be continued for the rest entries in `compiler.todo`

- Fix https://github.com/openrewrite/rewrite/issues/5227

Kudos [@Knut-Ove](https://github.com/Knut-Ove) for the finding and a fix