### PR TITLE
Added Gradle caching for npm test

### DIFF
--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -62,6 +62,7 @@ npmTest.configure {
         include("jest.config.js")
     })
     inputs.files(fileTree("rewrite/src"))
+    inputs.files(fileTree("rewrite/test"))
     outputs.files("rewrite/README.md") // A fake output entry; without it Gradle build caching doesn't work
 }
 tasks.check {

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -56,6 +56,14 @@ extensions.configure<NodeExtension> {
 }
 
 val npmTest = tasks.named("npm_test")
+npmTest.configure {
+    inputs.files(fileTree("rewrite") {
+        include("*.json")
+        include("jest.config.js")
+    })
+    inputs.files(fileTree("rewrite/src"))
+    outputs.files("rewrite/README.md") // A fake output entry; without it Gradle build caching doesn't work
+}
 tasks.check {
     dependsOn(
         tasks.named("npmInstall"),

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -64,6 +64,8 @@ npmTest.configure {
     inputs.files(fileTree("rewrite/src"))
     inputs.files(fileTree("rewrite/test"))
     outputs.files("rewrite/README.md") // A fake output entry; without it Gradle build caching doesn't work
+
+    dependsOn(tasks.named("npmInstall"))
 }
 tasks.check {
     dependsOn(


### PR DESCRIPTION
## What's changed?

Adding Gradle bulld caching for NPM tests in `rewrite-javascript`.

Note - this is coarse-grained caching - i.e. any change in `rewrite-javascript` makes the cache invalid. No fine-grained caching for specific files, etc. I don't think this matters for now.

Another note - this assumes the tests are deterministic. I.e. the same code in specified input files gives the same result.

## What's your motivation?
- To prevent Gradle from running these tests for unrelated PRs - i.e. these with no Javascript changes at all

## Testing performed

- First run: https://ge.openrewrite.org/s/idawlbmqy6qbw
- Then the second with no changes: https://ge.openrewrite.org/s/q2dow5pyppqrk (retrieved from cache 👍 )
- Then applying some to some of the source files: https://ge.openrewrite.org/s/omxettigqfpos (all tests were run again 👍 )
- Then re-running with no further change: https://ge.openrewrite.org/s/ihuosa6dbzcbc (retrievd from cache 👍 )
- etc.
- Then make one of the tests fail: https://ge.openrewrite.org/s/4e5cmfj2myiiw (all tests were run 👍 )
- Then re-run with no further change: https://ge.openrewrite.org/s/t3rbgbinchhie (all tests were run again and failed too 👍 )