### PR TITLE
Steps to prevent harmful mid-recipe instantiation of InMemoryExecutionContext

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
+++ b/rewrite-core/src/main/java/org/openrewrite/TreeVisitor.java
@@ -26,9 +26,7 @@ import org.openrewrite.marker.Markers;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -186,7 +184,7 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
     public static <U extends Tree, R, C extends Collection<R>> C collect(TreeVisitor<?, ExecutionContext> visitor,
                                                                          Tree tree, C initial, Class<U> matchOn,
                                                                          Function<U, R> map) {
-        InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+        ExecutionContext ctx = InMemoryExecutionContext.unsafeExecutionContext();
         ctx.addObserver(new TreeObserver.Subscription(new TreeObserver() {
             @Override
             public Tree treeChanged(Cursor cursor, Tree newTree) {
@@ -224,10 +222,7 @@ public abstract class TreeVisitor<T extends @Nullable Tree, P> {
             return defaultValue(null, p);
         }
 
-        boolean topLevel = false;
-        if (visitCount == 0) {
-            topLevel = true;
-        }
+        boolean topLevel = visitCount == 0;
 
         visitCount++;
         setCursor(new Cursor(cursor, tree));

--- a/rewrite-core/src/main/java/org/openrewrite/quark/QuarkParser.java
+++ b/rewrite-core/src/main/java/org/openrewrite/quark/QuarkParser.java
@@ -17,7 +17,6 @@ package org.openrewrite.quark;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.internal.StringUtils;
@@ -34,7 +33,7 @@ import static org.openrewrite.Tree.randomId;
 
 public class QuarkParser implements Parser {
 
-    public static Stream<SourceFile> parseAllOtherFiles(Path rootDir, List<SourceFile> sourceFiles) throws IOException {
+    public static Stream<SourceFile> parseAllOtherFiles(Path rootDir, List<SourceFile> sourceFiles, ExecutionContext ctx) throws IOException {
         Stack<List<PathMatcher>> gitignores = new Stack<>();
         parseGitignore(new File(System.getProperty("user.home") + "/.gitignore"), gitignores);
 
@@ -84,7 +83,7 @@ public class QuarkParser implements Parser {
             }
         });
 
-        return new QuarkParser().parse(quarks, rootDir, new InMemoryExecutionContext());
+        return new QuarkParser().parse(quarks, rootDir, ctx);
     }
 
     private static void parseGitignore(File gitignore, Stack<List<PathMatcher>> gitignores) throws IOException {

--- a/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
+++ b/rewrite-core/src/main/java/org/openrewrite/text/CreateTextFile.java
@@ -72,7 +72,7 @@ public class CreateTextFile extends ScanningRecipe<AtomicBoolean> {
     @Override
     public Collection<SourceFile> generate(AtomicBoolean shouldCreate, ExecutionContext ctx) {
         if (shouldCreate.get()) {
-            return PlainTextParser.builder().build().parse(fileContents)
+            return PlainTextParser.builder().build().parse(ctx, fileContents)
                     .map(brandNewFile -> (SourceFile) brandNewFile.withSourcePath(Paths.get(relativeFileName)))
                     .collect(Collectors.toList());
         }

--- a/rewrite-core/src/test/java/org/openrewrite/quark/QuarkParserTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/quark/QuarkParserTest.java
@@ -41,10 +41,11 @@ class QuarkParserTest implements RewriteTest {
 
     @Test
     void allOthers() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
         rewriteRun(
           spec -> spec.beforeRecipe(sources -> {
               try {
-                  List<SourceFile> quarks = QuarkParser.parseAllOtherFiles(Paths.get("../"), sources).toList();
+                  List<SourceFile> quarks = QuarkParser.parseAllOtherFiles(Paths.get("../"), sources, ctx).toList();
                   assertThat(quarks).isNotEmpty();
                   assertThat(quarks.stream().map(SourceFile::getSourcePath))
                     .doesNotContain(Paths.get("build.gradle.kts"));

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -309,7 +309,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
             }
 
             //noinspection UnusedProperty
-            Properties.File gradleWrapperProperties = new PropertiesParser().parse(
+            Properties.File gradleWrapperProperties = new PropertiesParser().parse(ctx,
                             "distributionBase=GRADLE_USER_HOME\n" +
                             "distributionPath=wrapper/dists\n" +
                             "distributionUrl=" + gradleWrapper.getPropertiesFormattedUrl() + "\n" +

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/MoveContentToFile.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/MoveContentToFile.java
@@ -102,7 +102,7 @@ public class MoveContentToFile extends ScanningRecipe<MoveContentToFile.Scanned>
         if (acc.destinationExists || acc.toMove == null) {
             return Collections.emptyList();
         }
-        Hcl.ConfigFile configFile = HclParser.builder().build().parse("")
+        Hcl.ConfigFile configFile = HclParser.builder().build().parse(ctx,"")
                 .findFirst()
                 .map(Hcl.ConfigFile.class::cast)
                 .orElseThrow(() -> new IllegalArgumentException("Could not parse as HCL"));

--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/template/HclTemplateParser.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/internal/template/HclTemplateParser.java
@@ -16,6 +16,7 @@
 package org.openrewrite.hcl.internal.template;
 
 import lombok.RequiredArgsConstructor;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.hcl.HclParser;
 import org.openrewrite.hcl.RandomizeIdVisitor;
 import org.openrewrite.hcl.tree.BodyContent;
@@ -70,7 +71,7 @@ public class HclTemplateParser {
     }
 
     private Hcl.ConfigFile compileTemplate(String stub) {
-        return parser.parse(stub)
+        return parser.parse(InMemoryExecutionContext.unsafeExecutionContext(), stub)
                 .findFirst()
                 .map(Hcl.ConfigFile.class::cast)
                 .orElseThrow(() -> new IllegalArgumentException("Could not parse as HCL"));

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclAttributeTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/tree/HclAttributeTest.java
@@ -31,7 +31,7 @@ class HclAttributeTest implements RewriteTest {
     void attributeValue() {
         rewriteRun(
           spec -> spec
-            .recipe(RewriteTest.toRecipe(() -> new HclVisitor<ExecutionContext>() {
+            .recipe(RewriteTest.toRecipe(() -> new HclVisitor<>() {
                   @Override
                   public Hcl visitBlock(Hcl.Block block, ExecutionContext executionContext) {
                       assertThat(block.<String>getAttributeValue("key"))

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11Parser.java
@@ -301,7 +301,7 @@ public class ReloadableJava11Parser implements JavaParser {
 
     private void compileDependencies() {
         if (dependsOn != null) {
-            InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+            InMemoryExecutionContext ctx = InMemoryExecutionContext.unsafeExecutionContext();
             ctx.putMessage("org.openrewrite.java.skipSourceSetMarker", true);
             parseInputs(dependsOn, null, ctx);
         }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java
@@ -299,7 +299,7 @@ public class ReloadableJava17Parser implements JavaParser {
 
     private void compileDependencies() {
         if (dependsOn != null) {
-            InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+            InMemoryExecutionContext ctx = InMemoryExecutionContext.unsafeExecutionContext();
             ctx.putMessage("org.openrewrite.java.skipSourceSetMarker", true);
             parseInputs(dependsOn, null, ctx);
         }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21Parser.java
@@ -299,7 +299,7 @@ public class ReloadableJava21Parser implements JavaParser {
 
     private void compileDependencies() {
         if (dependsOn != null) {
-            InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+            InMemoryExecutionContext ctx = InMemoryExecutionContext.unsafeExecutionContext();
             ctx.putMessage("org.openrewrite.java.skipSourceSetMarker", true);
             parseInputs(dependsOn, null, ctx);
         }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8Parser.java
@@ -271,7 +271,7 @@ class ReloadableJava8Parser implements JavaParser {
 
     private void compileDependencies() {
         if (dependsOn != null) {
-            InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+            InMemoryExecutionContext ctx = InMemoryExecutionContext.unsafeExecutionContext();
             ctx.putMessage("org.openrewrite.java.skipSourceSetMarker", true);
             parseInputs(dependsOn, null, ctx);
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -266,7 +266,7 @@ public class JavaTemplateParser {
     }
 
     private JavaSourceFile compileTemplate(@Language("java") String stub) {
-        ExecutionContext ctx = new InMemoryExecutionContext();
+        ExecutionContext ctx = InMemoryExecutionContext.unsafeExecutionContext();
         ctx.putMessage(JavaParser.SKIP_SOURCE_SET_TYPE_GENERATION, true);
         ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
         Parser jp = parser.build();

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMissingTypes.java
@@ -61,7 +61,11 @@ public class FindMissingTypes extends Recipe {
     }
 
     public static List<MissingTypeResult> findMissingTypes(J j, boolean checkDocumentation) {
-        J j1 = new FindMissingTypesVisitor(checkDocumentation).visit(j, new InMemoryExecutionContext());
+        return findMissingTypes(j, checkDocumentation, InMemoryExecutionContext.unsafeExecutionContext());
+    }
+
+    public static List<MissingTypeResult> findMissingTypes(J j, boolean checkDocumentation, ExecutionContext ctx) {
+        J j1 = new FindMissingTypesVisitor(checkDocumentation).visit(j, ctx);
         List<MissingTypeResult> results = new ArrayList<>();
         if (j1 != j) {
             new JavaIsoVisitor<List<MissingTypeResult>>() {
@@ -77,7 +81,7 @@ public class FindMissingTypes extends Recipe {
                         if (j != null) {
                             String printedTree;
                             if (getCursor().firstEnclosing(JavaSourceFile.class) != null) {
-                                printedTree = j.printTrimmed(new InMemoryExecutionContext(), getCursor().getParentOrThrow());
+                                printedTree = j.printTrimmed(ctx, getCursor().getParentOrThrow());
                             } else {
                                 printedTree = String.valueOf(j);
                             }

--- a/rewrite-json/src/main/java/org/openrewrite/json/AddKeyValue.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/AddKeyValue.java
@@ -83,7 +83,7 @@ public class AddKeyValue extends Recipe {
                     boolean jsonIsEmpty = originalMembers.isEmpty() || originalMembers.get(0) instanceof Json.Empty;
                     Space space = jsonIsEmpty || prepend ? originalMembers.get(0).getPrefix() : Space.build("\n", emptyList());
 
-                    Json newMember = new Json.Member(randomId(), space, Markers.EMPTY, rightPaddedKey(), parsedValue());
+                    Json newMember = new Json.Member(randomId(), space, Markers.EMPTY, rightPaddedKey(), parsedValue(ctx));
 
                     if (jsonIsEmpty) {
                         return autoFormat(obj.withMembers(Collections.singletonList(newMember)), ctx, getCursor().getParent());
@@ -97,9 +97,9 @@ public class AddKeyValue extends Recipe {
                 return obj;
             }
 
-            private JsonValue parsedValue() {
+            private JsonValue parsedValue(ExecutionContext ctx) {
                 Json.Document parsedDoc = (Json.Document) JsonParser.builder().build()
-                        .parse(value.trim()).findFirst().get();
+                        .parse(ctx, value.trim()).findFirst().get();
                 JsonValue value = parsedDoc.getValue();
                 return value.withPrefix(value.getPrefix().withWhitespace(" "));
             }

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/CreatePropertiesFile.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/CreatePropertiesFile.java
@@ -78,7 +78,7 @@ public class CreatePropertiesFile extends ScanningRecipe<AtomicBoolean> {
     @Override
     public Collection<SourceFile> generate(AtomicBoolean shouldCreate, ExecutionContext ctx) {
         if (shouldCreate.get()) {
-            return PropertiesParser.builder().build().parse(fileContents == null ? "" : fileContents)
+            return PropertiesParser.builder().build().parse(ctx, fileContents == null ? "" : fileContents)
                     .map(brandNewFile -> (SourceFile) brandNewFile.withSourcePath(Paths.get(relativeFileName)))
                     .collect(Collectors.toList());
         }

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -134,6 +134,7 @@ public interface RewriteTest extends SourceSpecs {
     }
 
     default void rewriteRun(Consumer<RecipeSpec> spec, SourceSpec<?>... sourceSpecs) {
+        InMemoryExecutionContext.unsafeSetInTest(false);
         RecipeSpec testClassSpec = RecipeSpec.defaults();
         defaults(testClassSpec);
 
@@ -160,6 +161,7 @@ public interface RewriteTest extends SourceSpecs {
 
         PrintOutputCapture<ExecutionContext> out = new PrintOutputCapture<>(ctx, markerPrinter);
 
+        InMemoryExecutionContext.unsafeSetInTest(true);
         Recipe recipe = testMethodSpec.recipe == null ?
                 testClassSpec.recipe == null ? Recipe.noop() : testClassSpec.recipe :
                 testMethodSpec.recipe;
@@ -380,7 +382,7 @@ public interface RewriteTest extends SourceSpecs {
                 cycles,
                 expectedCyclesThatMakeChanges + 1
         );
-
+        InMemoryExecutionContext.unsafeSetInTest(false);
         for (Consumer<RecipeRun> afterRecipe : testClassSpec.afterRecipes) {
             afterRecipe.accept(recipeRun);
         }

--- a/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
@@ -97,6 +97,14 @@ class RewriteTestTest implements RewriteTest {
         );
     }
 
+    @Test
+    void noExecutionContextInstantiation() {
+        assertThrows(AssertionError.class, () ->
+          rewriteRun(
+            spec -> spec.recipe(new InstantiateExecutionContext()),
+            text("irrelevant")
+          ));
+    }
 
     @Test
     void rejectRecipeValidationFailure() {
@@ -196,6 +204,30 @@ class MutateExecutionContext extends Recipe {
                 ctx.putMessage("mutated", true);
                 return tree;
             }
+        };
+    }
+}
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+@NullMarked
+class InstantiateExecutionContext extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Instantiate execution context";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Instantiates an InMemoryExecutionContext to trigger a validation failure.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        //noinspection unused
+        return new TreeVisitor<>() {
+            final ExecutionContext ctx = new InMemoryExecutionContext();
         };
     }
 }


### PR DESCRIPTION
This has always been a bad thing to do. Recently it was part of why a recipe was timing out. With these changes RewriteTest will warn recipe authors before they can make this mistake.