### PR TITLE
Making sure visitStatement is also called for methodInvocations and methodDeclarations

### DIFF
--- a/rewrite-javascript/rewrite/src/java/visitor.ts
+++ b/rewrite-javascript/rewrite/src/java/visitor.ts
@@ -566,6 +566,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
     }
 
     protected async visitMethodDeclaration(methodDecl: J.MethodDeclaration, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(methodDecl, p);
+        if (!statement?.kind || statement.kind !== J.Kind.MethodDeclaration) {
+            return statement;
+        }
+        methodDecl = statement as J.MethodDeclaration;
+
         return this.produceJava<J.MethodDeclaration>(methodDecl, p, async draft => {
             draft.leadingAnnotations = await mapAsync(methodDecl.leadingAnnotations, a => this.visitDefined<J.Annotation>(a, p));
             draft.modifiers = await mapAsync(methodDecl.modifiers, m => this.visitDefined<J.Modifier>(m, p));
@@ -594,6 +600,12 @@ export class JavaVisitor<P> extends TreeVisitor<J, P> {
             return expression;
         }
         methodInv = expression as J.MethodInvocation;
+
+        const statement = await this.visitStatement(methodInv, p);
+        if (!statement?.kind || statement.kind !== J.Kind.MethodInvocation) {
+            return statement;
+        }
+        methodInv = statement as J.MethodInvocation;
 
         return this.produceJava<J.MethodInvocation>(methodInv, p, async draft => {
             draft.select = await this.visitOptionalRightPadded(methodInv.select, p);

--- a/rewrite-javascript/rewrite/test/java/visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/java/visitor.test.ts
@@ -22,10 +22,10 @@ import {JavaScriptVisitor, typescript} from "../../src/javascript";
 describe('visitor', () => {
     test('call visitStatement for subclasses', async () => {
         // given
-        let global = "not visited yet";
+        let global = "";
         const CustomVisitor = class extends JavaScriptVisitor<ExecutionContext> {
             protected async visitStatement(statement: Statement, p: ExecutionContext): Promise<J | undefined> {
-                global = "visited " + statement.kind;
+                global = global + "/" + statement.kind;
                 return await super.visitStatement(statement, p);
             }
         }
@@ -35,11 +35,12 @@ describe('visitor', () => {
         // when
         await spec.rewriteRun(
             //language=typescript
-            typescript('class A {}')
+            typescript('class A {};"a".includes("b")')
         );
 
         // test
-        expect(global).toEqual("visited org.openrewrite.java.tree.J$ClassDeclaration");
+        // TODO I am not sure about the FieldAccess - what is it doing here?
+        expect(global).toEqual("/org.openrewrite.java.tree.J$ClassDeclaration/org.openrewrite.java.tree.J$Empty/org.openrewrite.java.tree.J$MethodInvocation/org.openrewrite.java.tree.J$FieldAccess");
     });
 
     test('call visitExpression for subclasses', async () => {


### PR DESCRIPTION
## What's changed?

Amending the Javascript visitor to call `visitStatement` also for method invocations and method declarations.

## What's your motivation?

Otherwise, a visitor implementing `visitStatement` might miss them.
