### PR TITLE
Fix XPathMatcher: correctly handle spaces around '=' in predicates with conjunctions

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/XPathMatcher.java
@@ -42,7 +42,7 @@ public class XPathMatcher {
     // Regular expression to support conditional tags like `plugin[artifactId='maven-compiler-plugin']` or foo[@bar='baz']
     private static final Pattern ELEMENT_WITH_CONDITION_PATTERN = Pattern.compile("(@)?([-:\\w]+|\\*)(\\[.+])");
     private static final Pattern CONDITION_PATTERN = Pattern.compile("(\\[.*?])+?");
-    private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))=[\"'](.*?)[\"'](\\h?(or|and)\\h?)?)+?");
+    private static final Pattern CONDITION_CONJUNCTION_PATTERN = Pattern.compile("(((local-name|namespace-uri)\\(\\)|(@)?([-\\w:]+|\\*))\\h*=\\h*[\"'](.*?)[\"'](\\h?(or|and)\\h?)?)+?");
 
     private final String expression;
     private final boolean startsWithSlash;

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/ChangeTagAttributeTest.java
@@ -124,4 +124,22 @@ class ChangeTagAttributeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeTagAttributeAndXSDProblem() {
+        rewriteRun(
+            spec -> spec.recipe(new ChangeTagAttribute("//*[namespace-uri() = 'http://java.sun.com/xml/ns/jaxb' and local-name() = 'bindings']",
+                    "version", "3.0", "1.0", false)).expectedCyclesThatMakeChanges(0),
+
+            xml(
+                    """
+                            <schema xmlns="http://www.w3.org/2001/XMLSchema"
+                            xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            targetNamespace="http://www.w3.org/2001/04/xmlenc#"
+                            elementFormDefault="qualified" version="1.0"/>
+                            """
+            )
+        );
+    }
 }


### PR DESCRIPTION
ensuring EE10 migration recipes (e.g. JavaxXmlToJakartaXmlXJCBinding) reliably match intended elements, regardless of whitespace.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
 * Updated the regular expression logic in XPathMatcher to correctly handle whitespace before and after the = sign in XPath predicate conjunctions.
 * Added a regression test for ChangeTagAttribute to ensure correct behavior when spaces are present around = in XPath predicates.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
The previous implementation of XPathMatcher failed to match such predicates, which made the official recipe
org.openrewrite.java.migrate.jakarta.JavaxXmlToJakartaXmlXJCBinding unusable in certain scenarios (e.g., when targeting attributes like version="1.0").

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Please verify that the regular expression change in XPathMatcher does not cause regressions for other XPath patterns.

## Anyone you would like to review specifically?
<!-- @mention them here -->
No specific reviewers.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
As a temporary workaround, the affected recipes could be adjusted to avoid whitespace in XPath expressions.
However, this is not practical for real-world XML, so a generic fix in the matcher was preferred.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
This change will improve the robustness of OpenRewrite's XML recipes for migration and transformation tasks in the presence of varied XML formatting.

### Checklist
- [x] I've added unit tests to cover both positive case
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [-] I've used the IntelliJ IDEA auto-formatter on affected files
