### PR TITLE
SpacesVisitor - make sure there's a space after `throw`

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -704,6 +704,13 @@ export class MinimumViableSpacingVisitor extends JavaScriptVisitor<ExecutionCont
         });
     }
 
+    protected async visitThrow(thrown: J.Throw, p: ExecutionContext): Promise<J | undefined> {
+        const ret = await super.visitThrow(thrown, p) as J.Throw;
+        return ret && produce(ret, draft => {
+           draft.exception.prefix.whitespace = " ";
+        });
+    }
+
     protected async visitVariableDeclarations(v: J.VariableDeclarations, p: ExecutionContext): Promise<J | undefined> {
         let ret = await super.visitVariableDeclarations(v, p) as J.VariableDeclarations;
         let first = ret.leadingAnnotations.length === 0;

--- a/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
@@ -51,5 +51,15 @@ describe('MinimumViableSpacingVisitor', () => {
                 // @formatter:on
         ))
     });
+
+    test('throw new', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`throw new Error("things went south");`,
+                `throw new Error("things went south");`
+                // @formatter:on
+            ))
+    });
 });
 


### PR DESCRIPTION
## What's changed?

Minor amendment to `SpacesVisitor` in Javascript.
Adding a mandatory space after `throw`.

## What's your motivation?

Otherwise the following code change is observed:
```diff
-     throw new Error("test");
+     thrownew Error("test");
```
