### PR TITLE
Handling undefined prefix in TabsAndIndentsVisitor

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -959,6 +959,9 @@ export class TabsAndIndentsVisitor extends JavaScriptVisitor<ExecutionContext> {
         const relativeIndent = this.currentIndent;
 
         return produce(ret, draft => {
+            if (draft.prefix == undefined) {
+                draft.prefix = {kind: J.Kind.Space, comments: [], whitespace: ""};
+            }
             if (draft.prefix.whitespace.includes("\n")) {
                 draft.prefix.whitespace = this.combineIndent(draft.prefix.whitespace, relativeIndent);
             }

--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -182,4 +182,16 @@ describe('TabsAndIndentsVisitor', () => {
             // @formatter:on
         )
     });
+
+    test('lambda', () => {
+        const spec = new RecipeSpec()
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents(draft => {
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`console.log(() => "a");`)
+            // @formatter:on
+        )
+    });
 });


### PR DESCRIPTION
## What's changed?

Amending `TabsAndIndentsVisitor` in Javascript - not to crash on undefined prefixes.

## What's your motivation?

Otherwise it crashes for some real-life files with:
```
Error: TypeError: Cannot read properties of undefined (reading 'whitespace')
    at /Users/greg/git/rewrite/rewrite-javascript/rewrite/src/javascript/format.ts:965:30
    at Immer2.produce (/Users/greg/git/rewrite/rewrite-javascript/rewrite/node_modules/immer/src/core/immerClass.ts:97:14)
    at TabsAndIndentsVisitor.<anonymous> (/Users/greg/git/rewrite/rewrite-javascript/rewrite/src/javascript/format.ts:961:23)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/greg/git/rewrite/rewrite-javascript/rewrite/src/javascript/format.ts:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)

    at TabsAndIndentsVisitor.<anonymous> (/Users/greg/git/rewrite/rewrite-javascript/rewrite/src/visitor.ts:98:19)
    at Generator.throw (<anonymous>)
    at rejected (/Users/greg/git/rewrite/rewrite-javascript/rewrite/src/visitor.ts:6:65)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
```