### PR TITLE
Fixing handling of spaces in Import and Export declarations in Javascript

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -232,6 +232,12 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     }
 
     protected async visitImportDeclaration(jsImport: JS.Import, p: P): Promise<J | undefined> {
+        const statement = await this.visitStatement(jsImport, p);
+        if (!statement?.kind || statement.kind !== JS.Kind.Import) {
+            return statement;
+        }
+        jsImport = statement as JS.Import;
+
         return this.produceJavaScript<JS.Import>(jsImport, p, async draft => {
             draft.importClause = jsImport.importClause && await this.visitDefined<JS.ImportClause>(jsImport.importClause, p);
             draft.moduleSpecifier = await this.visitLeftPadded(jsImport.moduleSpecifier, p);

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -48,4 +48,34 @@ describe('SpacesVisitor', () => {
             // @formatter:on
         )
     });
+
+    test('spaces after export or import', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+                export{MyPreciousClass} from'./my-precious-class';
+                export type{MyOtherClass} from'./my-other-class';
+                import{delta,gamma,zeta}from'delta.js';
+                import{b}from'qux.js';
+                import*as foo from'foo.js';
+                import a from'baz.js';
+                import'module-without-export.js';
+                import type{Models} from'../models';
+                `,
+                `
+                export {MyPreciousClass} from './my-precious-class';
+                export type {MyOtherClass} from './my-other-class';
+                import {delta, gamma, zeta} from 'delta.js';
+                import {b} from 'qux.js';
+                import * as foo from 'foo.js';
+                import a from 'baz.js';
+                import 'module-without-export.js';
+                import type {Models} from '../models';
+                `
+                // @formatter:on
+        ));
+    });
 });


### PR DESCRIPTION
## What's changed?

Fixing Autoformatting in Javascript not to collapse mandatory spaces in `import` and `export` declarations.

## What's your motivation?

Otherwise invalid code is produced, e.g.
```
importbazfrom'baz.js'
```
