### PR TITLE
Honoring es6ImportExportBraces style setting in Javascript

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -155,6 +155,13 @@ export class SpacesVisitor extends JavaScriptVisitor<ExecutionContext> {
         return produce(ret, draft => {
             if (draft.exportClause) {
                 draft.exportClause.prefix.whitespace = " ";
+                if (draft.exportClause.kind == JS.Kind.NamedExports) {
+                    const ne = (draft.exportClause as Draft<JS.NamedExports>);
+                    if (ne.elements.elements.length > 0) {
+                        ne.elements.elements[0].element.prefix.whitespace = this.style.within.es6ImportExportBraces ? " " : "";
+                        ne.elements.elements[ne.elements.elements.length - 1].after.whitespace = this.style.within.es6ImportExportBraces ? " " : "";
+                    }
+                }
             }
             draft.typeOnly.before.whitespace = draft.typeOnly.element ? " " : "";
             if (draft.moduleSpecifier) {
@@ -212,6 +219,11 @@ export class SpacesVisitor extends JavaScriptVisitor<ExecutionContext> {
                 }
                 if (draft.importClause.namedBindings) {
                     draft.importClause.namedBindings.prefix.whitespace = " ";
+                    if (draft.importClause.namedBindings.kind == JS.Kind.NamedImports) {
+                        const ni = draft.importClause.namedBindings as Draft<JS.NamedImports>;
+                        ni.elements.elements[0].element.prefix.whitespace = this.style.within.es6ImportExportBraces ? " " : "";
+                        ni.elements.elements[ni.elements.elements.length - 1].after.whitespace = this.style.within.es6ImportExportBraces ? " " : "";
+                    }
                 }
             }
             if (draft.moduleSpecifier) {

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -76,6 +76,27 @@ describe('SpacesVisitor', () => {
                 import type {Models} from '../models';
                 `
                 // @formatter:on
-        ));
+            ));
+    });
+
+    test('ES6 Import Export braces', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+            draft.within.es6ImportExportBraces = true;
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+                export{MyPreciousClass} from'./my-precious-class';
+                import{delta,gamma,zeta}from'delta.js';
+                import no from 'change.js';
+                `,
+                `
+                export { MyPreciousClass } from './my-precious-class';
+                import { delta, gamma, zeta } from 'delta.js';
+                import no from 'change.js';
+                `
+                // @formatter:on
+            ));
     });
 });


### PR DESCRIPTION
## What's changed?

Adding support for handling the `SpacesStyle.within.es6ImportExportBraces` setting.

## What's your motivation?

- Fuller support for autoformatting.
- Although it's not the default in IntelliJ, the settings seems popularly enabled in TS open source code.