### PR TITLE
The onlyForConfigurations can also be an empty list

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -316,7 +316,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         break;
                 }
 
-                if (onlyForConfigurations != null) {
+                if (onlyForConfigurations != null && !onlyForConfigurations.isEmpty()) {
                     if (!onlyForConfigurations.contains(constraintConfigName)) {
                         return null;
                     }


### PR DESCRIPTION
## What's changed?
It seems that when I launch (with cli, but same beahviour in platform) the recipe without the onlyForConfigurations option set it takes it as an empty list.
Did anything change with the way arguments are passed? We do not see this issue with FindAndFixVuln as that one uses code to set that value to null. With a null value present, the constraintConfiguration is being returned and we can successfully run the recipe.
Running the recipe directly, triggers the recipe with an empty list causing [this line](https://github.com/openrewrite/rewrite/blob/v8.52.0/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java#L208) to return null. I could very easily adapt [this line](https://github.com/openrewrite/rewrite/blob/v8.52.0/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java#L367) to be an emptyOrNull check which will fix this, but it looks like this should have been working before rendering null as the list iso empty list.
Did something change in the jackson behaviour or anything else? I will for now just fix this one recipe.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
