### PR TITLE
Javascript - space around extends

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -135,7 +135,11 @@ export class SpacesVisitor extends JavaScriptVisitor<ExecutionContext> {
 
         return produce(ret, draft => {
             draft.body.prefix.whitespace = this.style.beforeLeftBrace.catchLeftBrace ? " " : "";
-            // TODO if (classDecl.body.statements.length === 0) {
+
+            if (draft.extends) {
+                draft.extends.before.whitespace = " ";
+                draft.extends.element.prefix.whitespace = " ";
+            }
         }) as J.ClassDeclaration;
     }
 

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -27,8 +27,10 @@ describe('AutoformatVisitor', () => {
             // @formatter:off
             //language=typescript
             typescript(`
-                    class K{
+                    class L {}
+                    class K extends L{
                         constructor  ( ){
+                            super();
                         }
                         m ( x :number  ,  y  :  number[] ) :number{
                             this.m( x, [1] );
@@ -63,8 +65,12 @@ describe('AutoformatVisitor', () => {
                     }
                 `,
                 `
-                    class K {
+                    class L {
+                    }
+
+                    class K extends L {
                         constructor() {
+                            super();
                         }
 
 


### PR DESCRIPTION
## What's changed?

Fix for Javascript's SpacesVisitor wrt `extends` in class declaration.

## What's your motivation?
Invalid code is produced.