### PR TITLE
Fixing spaces for type declarations in Javascript Autoformatting

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -342,6 +342,18 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         });
     }
 
+    protected async visitTypeDeclaration(typeDeclaration: JS.TypeDeclaration, p: P): Promise<J | undefined> {
+        const ret = await super.visitTypeDeclaration(typeDeclaration, p) as JS.TypeDeclaration;
+        return produce(ret, draft => {
+            if (draft.modifiers.length > 0) {
+                draft.name.before.whitespace = " ";
+            }
+            draft.name.element.prefix.whitespace = " ";
+            draft.initializer.before.whitespace = this.style.aroundOperators.assignment ? " " : "";
+            draft.initializer.element.prefix.whitespace = this.style.aroundOperators.assignment ? " " : "";
+        });
+    }
+
     protected async visitTypeInfo(typeInfo: JS.TypeInfo, p: P): Promise<J | undefined> {
         const ret = await super.visitTypeInfo(typeInfo, p) as JS.TypeInfo;
         return produceAsync(ret, async draft => {

--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -806,6 +806,16 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
         });
     }
 
+    protected async visitTypeDeclaration(typeDeclaration: JS.TypeDeclaration, p: P): Promise<J | undefined> {
+        const ret = await super.visitTypeDeclaration(typeDeclaration, p) as JS.TypeDeclaration;
+        return produce(ret, draft => {
+            if (draft.modifiers.length > 0) {
+                draft.name.before.whitespace = " ";
+            }
+            draft.name.element.prefix.whitespace = " ";
+        });
+    }
+
     protected async visitVariableDeclarations(v: J.VariableDeclarations, p: P): Promise<J | undefined> {
         let ret = await super.visitVariableDeclarations(v, p) as J.VariableDeclarations;
         let first = ret.leadingAnnotations.length === 0;

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -27,6 +27,8 @@ describe('AutoformatVisitor', () => {
             // @formatter:off
             //language=typescript
             typescript(`
+                     type T1=string;
+                     export   type   T2   =   string;
                     class L {}
                     class K extends L{
                         constructor  ( ){
@@ -65,6 +67,9 @@ describe('AutoformatVisitor', () => {
                     }
                 `,
                 `
+                    type T1 = string;
+                    export type T2 = string;
+
                     class L {
                     }
 

--- a/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
@@ -61,5 +61,16 @@ describe('MinimumViableSpacingVisitor', () => {
                 // @formatter:on
             ))
     });
+
+    test('type', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `type T1 = string;`,
+                `type T1=string;`
+                // @formatter:on
+            ))
+    });
 });
 


### PR DESCRIPTION
## What's changed?

Fixing Javascript Autoformatting wrt type declarations.

## What's your motivation?

Broken code is produced.
