### PR TITLE
Fixing formatting around assignment operators in Javascript

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -27,7 +27,6 @@ import {
     WrappingAndBracesStyle
 } from "./style";
 import {produceAsync} from "../visitor";
-import {MarkersKind} from "../markers";
 
 export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
     async visit<R extends J>(tree: Tree, p: P, cursor?: Cursor): Promise<R | undefined> {
@@ -64,6 +63,14 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         return produce(ret, draft => {
             draft.dimension.index.element.prefix.whitespace = this.style.within.arrayBrackets ? " " : "";
             draft.dimension.index.after.whitespace = this.style.within.arrayBrackets ? " " : "";
+        });
+    }
+
+    protected async visitAssignment(assignment: J.Assignment, p: P): Promise<J | undefined> {
+        const ret = await super.visitAssignment(assignment, p) as J.Assignment;
+        return produce(ret, draft => {
+            draft.assignment.before.whitespace = this.style.aroundOperators.assignment ? " " : "";
+            draft.assignment.element.prefix.whitespace = this.style.aroundOperators.assignment ? " " : "";
         });
     }
 
@@ -237,6 +244,14 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         })
     }
 
+    protected async visitIndexSignatureDeclaration(indexSignatureDeclaration: JS.IndexSignatureDeclaration, p: P): Promise<J | undefined> {
+        const ret = await super.visitIndexSignatureDeclaration(indexSignatureDeclaration, p) as JS.IndexSignatureDeclaration;
+        return produce(ret, draft => {
+            draft.typeExpression.before.whitespace = this.style.other.beforeTypeReferenceColon ? " " : "";
+            draft.typeExpression.element.prefix.whitespace = this.style.other.afterTypeReferenceColon ? " " : "";
+        });
+    }
+
     protected async visitMethodDeclaration(methodDecl: J.MethodDeclaration, p: P): Promise<J | undefined> {
         const ret = await super.visitMethodDeclaration(methodDecl, p) as J.MethodDeclaration;
         return produceAsync(ret, async draft => {
@@ -278,7 +293,6 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
             } else if (ret.arguments.elements.length == 1) {
                 draft.arguments.elements[0] = await this.spaceAfterRightPadded(await this.spaceBeforeRightPaddedElement(draft.arguments.elements[0], this.style.within.functionCallParentheses), false);
             }
-
             // TODO typeParameters handling - see visitClassDeclaration
 
             // TODO
@@ -286,19 +300,6 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
             // if (m.getArguments().isEmpty() || m.getArguments()[0] instanceof J.Empty) {
             //   ...
         });
-    }
-
-    protected async visitRightPadded<T extends J | boolean>(right: J.RightPadded<T>, p: P): Promise<J.RightPadded<T>> {
-        const ret = await super.visitRightPadded(right, p);
-        if (isTree(ret.element)) {
-            switch (ret.element.kind) {
-                case J.Kind.NamedVariable:
-                    return produce(ret, draft => {
-                        draft.after.whitespace = this.style.aroundOperators.assignment ? " " : "";
-                    });
-            }
-        }
-        return ret;
     }
 
     protected async visitSwitch(switchNode: J.Switch, p: P): Promise<J | undefined> {
@@ -389,7 +390,8 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         const ret = await super.visitVariable(variable, p) as J.VariableDeclarations.NamedVariable;
         return produceAsync(ret, async draft => {
             if (draft.initializer) {
-                draft.initializer = await this.spaceBeforeLeftPaddedElement(draft.initializer, false, this.style.aroundOperators.assignment);
+                draft.initializer.before.whitespace = this.style.aroundOperators.assignment ? " " : "";
+                draft.initializer.element.prefix.whitespace = this.style.aroundOperators.assignment ? " " : "";
             }
         });
     }

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -116,4 +116,19 @@ describe('AutoformatVisitor', () => {
             // @formatter:on
         )
     });
+
+    test('types', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+            type Values={[key:string]:string;}
+            `,
+            `
+            type Values = {
+                [key: string]: string;
+            }
+            `)
+            // @formatter:on
+        )});
 });

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -115,4 +115,47 @@ describe('SpacesVisitor', () => {
                 // @formatter:on
             ));
     });
+
+    test('types', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+            type Values={
+                [key:string]:string;
+            }
+            `,
+                `
+            type Values = {
+                [key: string]: string;
+            }
+            `)
+            // @formatter:on
+        )});
+
+    test('space around assignment operator: true', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+            draft.aroundOperators.assignment = true;
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`const x=3; class A {m() { this.x=4; }}`,
+                `const x = 3; class A {m() { this.x = 4; }}`)
+            // @formatter:on
+        )});
+
+    test('space around assignment operator: false', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+            draft.aroundOperators.assignment = false;
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`const x = 3; class A {m() { this.x = 4; }}`,
+                `const x=3; class A {m() { this.x=4; }}`)
+            // @formatter:on
+        )});
 });


### PR DESCRIPTION
## What's changed?

Amending the AutoformatVisitor in Javascript wrt spaces around assignment operators and alikes.

## What's your motivation?

To honor the desired formatting style closer.
