### PR TITLE
Support classifier when downloading Maven artifacts

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/MavenArtifactDownloader.java
@@ -98,6 +98,7 @@ public class MavenArtifactDownloader {
                           dependency.getVersion() + '/' +
                           dependency.getArtifactId() + '-' +
                           (dependency.getDatedSnapshotVersion() == null ? dependency.getVersion() : dependency.getDatedSnapshotVersion()) +
+                          (dependency.getClassifier() == null ? "" : "-" + dependency.getClassifier()) +
                           ".jar";
             String uri = baseUri + (baseUri.endsWith("/") ? "" : "/") + path;
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/MavenArtifactDownloaderTest.java
@@ -71,18 +71,63 @@ class MavenArtifactDownloaderTest {
         MavenResolutionResult mavenModel = parsed.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
         assertThat(mavenModel.getDependencies()).isNotEmpty();
 
-    List<ResolvedDependency> runtimeDependencies = mavenModel.getDependencies().get(Scope.Runtime);
-    for (ResolvedDependency runtimeDependency : runtimeDependencies) {
-        if (!("bom".equals(runtimeDependency.getType()))) {
-            assertNotNull(
-              downloader.downloadArtifact(runtimeDependency),
-              String.format(
-                "%s:%s:%s:%s failed to download",
-                runtimeDependency.getGroupId(),
-                runtimeDependency.getArtifactId(),
-                runtimeDependency.getVersion(),
-                runtimeDependency.getType()));
+        List<ResolvedDependency> runtimeDependencies = mavenModel.getDependencies().get(Scope.Runtime);
+        for (ResolvedDependency runtimeDependency : runtimeDependencies) {
+            if (!("bom".equals(runtimeDependency.getType()))) {
+                assertNotNull(
+                  downloader.downloadArtifact(runtimeDependency),
+                  String.format(
+                    "%s:%s:%s:%s failed to download",
+                    runtimeDependency.getGroupId(),
+                    runtimeDependency.getArtifactId(),
+                    runtimeDependency.getVersion(),
+                    runtimeDependency.getType()));
+            }
         }
     }
-  }
+
+    @Test
+    void downloadDependenciesWithClassifier(@TempDir Path tempDir) {
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        MavenArtifactCache artifactCache = new LocalMavenArtifactCache(tempDir);
+        MavenArtifactDownloader downloader = new MavenArtifactDownloader(
+          artifactCache, null, t -> ctx.getOnError().accept(t));
+
+        MavenParser mavenParser = MavenParser.builder().build();
+        SourceFile parsed = mavenParser.parse(ctx,
+          //language=xml
+          """
+            <project>
+                <groupId>org.openrewrite</groupId>
+                <artifactId>maven-downloader-test</artifactId>
+                <version>1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.sf.json-lib</groupId>
+                        <artifactId>json-lib</artifactId>
+                        <version>2.4</version>
+                        <classifier>jdk15</classifier>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+        ).findFirst().orElseThrow(() -> new IllegalArgumentException("Could not parse as XML"));
+
+        MavenResolutionResult mavenModel = parsed.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+        assertThat(mavenModel.getDependencies()).isNotEmpty();
+
+        List<ResolvedDependency> runtimeDependencies = mavenModel.getDependencies().get(Scope.Runtime);
+        for (ResolvedDependency runtimeDependency : runtimeDependencies) {
+            if (!("bom".equals(runtimeDependency.getType()))) {
+                assertNotNull(
+                  downloader.downloadArtifact(runtimeDependency),
+                  String.format(
+                    "%s:%s:%s:%s failed to download",
+                    runtimeDependency.getGroupId(),
+                    runtimeDependency.getArtifactId(),
+                    runtimeDependency.getVersion(),
+                    runtimeDependency.getType()));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What's changed?

Giving fllowing pom.xml, the depdency chould be download normally.
```xml
<dependency>
    <groupId>net.sf.json-lib</groupId>
    <artifactId>json-lib</artifactId>
    <version>2.4</version>
    <classifier>jdk15</classifier>
</dependency>
```

## What's your motivation?

In pom.xml, dependency with classifier will cause `MavenDownloadingException(Unable to download dependency xxx. Response was 404)`

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
