### PR TITLE
Add ChangeTaskToTasksRegister recipe

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeTaskToTasksRegister.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeTaskToTasksRegister.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeTaskToTasksRegister extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Change `task` to `tasks.register`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Changes eager task creation `task myTask(...)` to lazy registration `tasks.register(\"myTask\", ...)` in Gradle build scripts. " +
+                "This aligns with modern Gradle best practices for improved build performance.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new IsBuildGradle<>(), new GroovyIsoVisitor<ExecutionContext>() {
+            private final JavaTemplate registerNoClosureTemplate = JavaTemplate
+                    .builder("tasks.register(#{any(java.lang.String)}, #{any(org.openrewrite.java.tree.Expression)})")
+                    .build();
+
+            private final JavaTemplate registerWithClosureTemplate = JavaTemplate
+                    .builder("tasks.register(#{any(java.lang.String)}, #{any(org.openrewrite.java.tree.Expression)}, #{any(org.openrewrite.java.tree.J.Lambda)})")
+                    .build();
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                if (!"task".equals(m.getSimpleName())) {
+                    return m;
+                }
+                List<Expression> taskCallArgs = m.getArguments();
+                if (taskCallArgs.size() != 1 || !(taskCallArgs.get(0) instanceof J.MethodInvocation)) {
+                    return m;
+                }
+
+                J.MethodInvocation taskDefinitionInvocation = (J.MethodInvocation) taskCallArgs.get(0);
+                List<Expression> taskDefArgs = taskDefinitionInvocation.getArguments();
+                Expression taskTypeExpression = null;
+                J.Lambda taskConfigurationLambda = null;
+                for (Expression arg : taskDefArgs) {
+                    if (arg instanceof G.MapEntry) {
+                        G.MapEntry mapEntry = (G.MapEntry) arg;
+                        if (mapEntry.getKey() instanceof J.Literal && "type".equals(((J.Literal) mapEntry.getKey()).getValue())) {
+                            taskTypeExpression = mapEntry.getValue();
+                        }
+                    } else if (arg instanceof J.Lambda) {
+                        taskConfigurationLambda = (J.Lambda) arg;
+                    }
+                }
+                if (taskTypeExpression == null) {
+                    return m;
+                }
+
+                J.Literal literalTaskName = getLiteralTaskName(taskDefinitionInvocation);
+                if (taskConfigurationLambda == null) {
+                    m = registerNoClosureTemplate.apply(
+                            getCursor(),
+                            m.getCoordinates().replace(),
+                            literalTaskName,
+                            taskTypeExpression
+                    );
+                } else {
+                    m = registerWithClosureTemplate.apply(
+                            getCursor(),
+                            m.getCoordinates().replace(),
+                            literalTaskName,
+                            taskTypeExpression,
+                            taskConfigurationLambda
+                    );
+                }
+
+                return m;
+            }
+        });
+    }
+
+    private J.Literal getLiteralTaskName(J.MethodInvocation taskDefinitionInvocation) {
+        String taskName = taskDefinitionInvocation.getSimpleName();
+        if (taskName.startsWith("\"") && taskName.endsWith("\"") && taskName.length() > 1) {
+            taskName = taskName.substring(1, taskName.length() - 1);
+        }
+        return new J.Literal(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                taskName,
+                "\"" + taskName + "\"",
+                null,
+                JavaType.Primitive.String
+        );
+    }
+}

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeTaskToTasksRegisterTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeTaskToTasksRegisterTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+
+class ChangeTaskToTasksRegisterTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ChangeTaskToTasksRegister());
+    }
+
+    @DocumentExample
+    @Test
+    void basicTaskToTasksRegister() {
+        rewriteRun(
+          buildGradle(
+            """
+            task myCopyTask(type: Copy)
+            """,
+            """
+            tasks.register("myCopyTask", Copy)
+            """
+          )
+        );
+    }
+
+    @Test
+    void taskNameAsLiteralString() {
+        rewriteRun(
+          buildGradle(
+            """
+            task "literalTask"(type: Jar) {
+                archiveFileName = "my-app.jar"
+            }
+            """,
+            """
+            tasks.register("literalTask", Jar) {
+                archiveFileName = "my-app.jar"
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotChangeExistingTasksRegister() {
+        rewriteRun(
+          buildGradle(
+            """
+            tasks.register("alreadyLazy", Copy) {
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotChangeTaskWithoutType() {
+        rewriteRun(
+          buildGradle(
+            """
+            task "simpleStringArgument"
+            """
+          )
+        );
+    }
+
+    @Test
+    void taskWithConfigurationClosure() {
+        rewriteRun(
+          buildGradle(
+            """
+            import org.gradle.api.tasks.Delete
+            
+            task closureTask(type: Delete) {
+                description = 'Deletes the build directory.'
+                delete rootProject.buildDir
+            }
+            """,
+            """
+            import org.gradle.api.tasks.Delete
+            
+            tasks.register("closureTask", Delete) {
+                description = 'Deletes the build directory.'
+                delete rootProject.buildDir
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void taskTypeIsFullyQualified() {
+        rewriteRun(
+          buildGradle(
+            """
+            task fullQualifiedTask(type: org.gradle.api.tasks.Copy) {
+                from 'src/main/resources'
+                into 'build/generated-resources'
+            }
+            """,
+            """
+            tasks.register("fullQualifiedTask", org.gradle.api.tasks.Copy) {
+                from 'src/main/resources'
+                into 'build/generated-resources'
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void taskTypeIsSimpleNameWithLocalClass() {
+        rewriteRun(
+          buildGradle(
+            """
+            class MyCustomTaskType extends DefaultTask {
+            }
+            
+            task custom(type: MyCustomTaskType) {
+                group = 'custom'
+            }
+            """,
+            """
+            class MyCustomTaskType extends DefaultTask {
+            }
+            
+            tasks.register("custom", MyCustomTaskType) {
+                group = 'custom'
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotChangeOtherMethodsNamedTask() {
+        rewriteRun(
+          buildGradle(
+            """
+            class TaskHelper {
+                void task(Map params, Closure cl) { /* ... */ }
+            }
+            def helper = new TaskHelper()
+            helper.task(type: Copy) {
+                // This is not a standard Gradle task definition
+            }
+            
+            task realGradleTask(type: Delete)
+            """,
+            """
+            class TaskHelper {
+                void task(Map params, Closure cl) { /* ... */ }
+            }
+            def helper = new TaskHelper()
+            helper.task(type: Copy) {
+                // This is not a standard Gradle task definition
+            }
+            
+            tasks.register("realGradleTask", Delete)
+            """
+          )
+        );
+    }
+
+    @Test
+    void preserveFormatting() {
+        rewriteRun(
+          buildGradle(
+            """
+            task "format preservation"(type: Exec) {
+                group = "verification"
+                description = "Runs tests and checks."
+            
+                // comments
+                commandLine 'echo', "Formatted"
+            }
+            """,
+            """
+            tasks.register("format preservation", Exec) {
+                group = "verification"
+                description = "Runs tests and checks."
+            
+                // comments
+                commandLine 'echo', "Formatted"
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
This PR introduces a new Gradle recipe, `ChangeTaskToTasksRegister`, which changes eager task creations 
`task exampleTask(type: ExampleType)` to lazy registrations `tasks.register("exampleTask", ExampleType)`.

## What's your motivation?
Closes #5333. This change aligns with modern Gradle best practices for improved build performance by utilizing lazy task registration.

## Anything in particular you'd like reviewers to focus on?
* The handling of task names (both identifiers and string literals).
* The preservation of task type expressions and configuration closures.
* Whether any logic in the recipe could be further simplified or if any defensive checks are redundant.
* The test suite for any duplicated test cases or any missing edge cases that should be covered.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
