### PR TITLE
Check if XML file uses NS URI

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/search/HasNotNamespaceUri.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/search/HasNotNamespaceUri.java
@@ -1,0 +1,43 @@
+package org.openrewrite.xml.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class HasNotNamespaceUri extends Recipe {
+
+    @Option(displayName = "Namespace URI",
+            description = "The Namespace URI to check.",
+            example = "http://www.w3.org/2001/XMLSchema-instance")
+    String namespaceUri;
+
+    @Override
+    public String getDisplayName() {
+        return "Find tags without Namespace URI";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find XML that do not have a specific Namespace URI, optionally restricting the search by an XPath expression.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
+                boolean notInUse = HasNamespaceUri.find(document, namespaceUri, null).isEmpty();
+
+                if (notInUse) {
+                    return document.withRoot(SearchResult.found(document.getRoot()));
+                }
+                return document;
+            }
+        };
+    }
+}

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/search/HasNotNamespaceUriTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/search/HasNotNamespaceUriTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.xml.search;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class HasNotNamespaceUriTest implements RewriteTest {
+    @DocumentExample
+    @Test
+    void doesNotContain() {
+        rewriteRun(
+          spec -> spec.recipe(new HasNotNamespaceUri("http://example.com/dummy")),
+          xml(
+            source,
+            """
+              <!--~~>--><beans xmlns="http://www.springframework.org/schema/beans"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="
+                      http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
+                      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+              
+                  <jaxws:client name="{http://cxf.apache.org/hello_world_soap_http}SoapPort" createdFromAPI="true" xmlns:jaxws="http://cxf.apache.org/jaxws">
+                      <jaxws:conduitSelector>
+                          <bean class="org.apache.cxf.endpoint.DeferredConduitSelector"/>
+                      </jaxws:conduitSelector>
+                  </jaxws:client>
+              </beans>
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void containedInRoot() {
+        rewriteRun(
+          spec -> spec.recipe(new HasNotNamespaceUri("http://www.w3.org/2001/XMLSchema-instance")),
+          xml(source)
+        );
+    }
+
+
+    @Test
+    void containedInChild() {
+        rewriteRun(
+          spec -> spec.recipe(new HasNotNamespaceUri("http://cxf.apache.org/jaxws")),
+          xml(source)
+        );
+    }
+
+    @Language("xml")
+    private final String source = """
+      <beans xmlns="http://www.springframework.org/schema/beans"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="
+              http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
+              http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+      
+          <jaxws:client name="{http://cxf.apache.org/hello_world_soap_http}SoapPort" createdFromAPI="true" xmlns:jaxws="http://cxf.apache.org/jaxws">
+              <jaxws:conduitSelector>
+                  <bean class="org.apache.cxf.endpoint.DeferredConduitSelector"/>
+              </jaxws:conduitSelector>
+          </jaxws:client>
+      </beans>
+      """;
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Add a search recipe that finds XML root nodes that (or a child) use a namespace uri.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
enable https://github.com/openrewrite/rewrite-migrate-java/pull/741

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
