### PR TITLE
Fixing multiline html comment

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11JavadocVisitor.java
@@ -289,6 +289,8 @@ public class ReloadableJava11JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             }
             if (docTree instanceof DCTree.DCText) {
                 body.addAll(visitText(((DCTree.DCText) docTree).getBody()));
+            } else if (docTree instanceof DCTree.DCComment) {
+                body.addAll(visitText(((DCTree.DCComment) docTree).getBody()));
             } else {
                 body.add((Javadoc) scan(docTree, body));
             }

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17JavadocVisitor.java
@@ -290,8 +290,10 @@ public class ReloadableJava17JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             if (!(docTree instanceof DCTree.DCText && i > 0)) {
                 body.addAll(whitespaceBefore());
             }
-            if (docTree instanceof DCTree.DCText) {
-                body.addAll(visitText(((DCTree.DCText) docTree).getBody()));
+            if (docTree instanceof DCTree.DCText textNode) {
+                body.addAll(visitText(textNode.getBody()));
+            } else if (docTree instanceof DCTree.DCComment commentNode) {
+                body.addAll(visitText(commentNode.getBody()));
             } else {
                 body.add((Javadoc) scan(docTree, body));
             }

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21JavadocVisitor.java
@@ -290,8 +290,10 @@ public class ReloadableJava21JavadocVisitor extends DocTreeScanner<Tree, List<Ja
             if (!(docTree instanceof DCTree.DCText && i > 0)) {
                 body.addAll(whitespaceBefore());
             }
-            if (docTree instanceof DCTree.DCText) {
-                body.addAll(visitText(((DCTree.DCText) docTree).getBody()));
+            if (docTree instanceof DCTree.DCText textNode) {
+                body.addAll(visitText(textNode.getBody()));
+            } else if (docTree instanceof DCTree.DCComment commentNode) {
+                body.addAll(visitText(commentNode.getBody()));
             } else {
                 body.add((Javadoc) scan(docTree, body));
             }

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8JavadocVisitor.java
@@ -289,6 +289,8 @@ public class ReloadableJava8JavadocVisitor extends DocTreeScanner<Tree, List<Jav
             }
             if (docTree instanceof DCTree.DCText) {
                 body.addAll(visitText(((DCTree.DCText) docTree).getBody()));
+            } else if (docTree instanceof DCTree.DCComment) {
+                body.addAll(visitText(((DCTree.DCComment) docTree).getBody()));
             } else {
                 body.add((Javadoc) scan(docTree, body));
             }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -2052,4 +2052,25 @@ class JavadocTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5411")
+    void multilineHtmlCommentInJavadoc() {
+        rewriteRun(
+          java(
+            """
+              /** 
+              * First line of comment
+              * <!-- comment 
+              *   Second line of comment
+              * -->
+              * <!-- another comment -->
+              * Final comment line
+              */
+              class Test {
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Updated the `DocCommentTree` parser to handle both one-line (`<!-- oneline -->`) and multiline (`<!-- line 1 \n line 2 \n -->`) comments by reusing the existing visitText() logic when processing `DCComment` nodes.


## What's your motivation?
Fixing https://github.com/openrewrite/rewrite/issues/5411 

## Anyone you would like to review specifically?
@MBoegers as reporter

## Any additional context
In the Javadoc parser, both one-line (`<!-- oneline -->`) and multiline (`<!-- line 1 \n line 2 \n -->`) HTML comments are represented as `DCComment`.

Currently,  `Tree visitComment(CommentTree node, List<Javadoc> body)`  handles these nodes but converts them into `Javadoc.Text` anyway.

As fix, I propose to reuse the existing `List<Javadoc> visitText(String node)` logic when processing `DCComment` within the `DocCommentTree`. It handles the multiline text well.

## Have you considered any alternatives or workarounds?
As an alternative, the Javadoc model could be extended to introduce a dedicated node type, like Javadoc.HtmlComment and handle HTML comments separately.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
