### PR TITLE
Add an `applyTo` option to the UnfoldProperties recipe

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
@@ -42,12 +42,19 @@ public class UnfoldProperties extends Recipe {
     private static final Pattern LINE_BREAK = Pattern.compile("\\R");
 
     @Option(displayName = "Exclusions",
-            description = "A list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions to specify keys that should not be unfolded.",
+            description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions to specify keys that should not be unfolded.",
             example = "$..[org.springframework.security]")
     List<String> exclusions;
 
-    public UnfoldProperties(@Nullable final List<String> exclusions) {
+    @Option(displayName = "Apply to",
+            description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions that specify which keys the recipe should target only. " +
+                    "Only the properties matching these expressions will be unfolded.",
+            example = "$..[org.springframework.security]")
+    List<String> applyTo;
+
+    public UnfoldProperties(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
         this.exclusions = exclusions == null ? emptyList() : exclusions;
+        this.applyTo = applyTo == null ? emptyList() : applyTo;
     }
 
     @Override
@@ -62,7 +69,8 @@ public class UnfoldProperties extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        List<JsonPathMatcher> matchers = exclusions.stream().map(JsonPathMatcher::new).collect(toList());
+        List<JsonPathMatcher> exclusionMatchers = exclusions.stream().map(JsonPathMatcher::new).collect(toList());
+        List<JsonPathMatcher> applyToMatchers = applyTo.stream().map(JsonPathMatcher::new).collect(toList());
         return new YamlIsoVisitor<ExecutionContext>() {
             @Override
             public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
@@ -79,10 +87,10 @@ public class UnfoldProperties extends Recipe {
                 if (key.contains(".")) {
                     boolean foundMatch = false;
                     Cursor c = getCursor();
-                    while (!foundMatch && c.getValue() != Cursor.ROOT_VALUE) {
+                    while (!foundMatch && !c.isRoot()) {
                         Cursor current = c;
-                        foundMatch = matchers.stream().anyMatch(matcher -> matcher.matches(current));
-                        if(foundMatch) {
+                        foundMatch = exclusionMatchers.stream().anyMatch(matcher -> matcher.matches(current));
+                        if (foundMatch) {
                             break;
                         } else {
                             c = c.getParent();
@@ -113,6 +121,7 @@ public class UnfoldProperties extends Recipe {
             /**
              * Splits a key into parts while respecting certain exclusion rules.
              * The method ensures certain segments of the key are kept together as defined in the exclusion list.
+             * It does also take the applyOnlyOn list into account.
              *
              * @param key the full key to be split into parts
              * @return a list of strings representing the split parts of the key
@@ -141,6 +150,15 @@ public class UnfoldProperties extends Recipe {
                     }
                     result.add(parts.get(i));
                     i++;
+                }
+
+                if (!applyToMatchers.isEmpty()) {
+                    for (String in : applyTo) {
+                        if (!matches(key, in, parentKey).isEmpty()) {
+                            return result;
+                        }
+                    }
+                    return emptyList();
                 }
 
                 return result;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
@@ -70,7 +70,6 @@ public class UnfoldProperties extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         List<JsonPathMatcher> exclusionMatchers = exclusions.stream().map(JsonPathMatcher::new).collect(toList());
-        List<JsonPathMatcher> applyToMatchers = applyTo.stream().map(JsonPathMatcher::new).collect(toList());
         return new YamlIsoVisitor<ExecutionContext>() {
             @Override
             public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
@@ -152,13 +151,10 @@ public class UnfoldProperties extends Recipe {
                     i++;
                 }
 
-                if (!applyToMatchers.isEmpty()) {
-                    for (String in : applyTo) {
-                        if (!matches(key, in, parentKey).isEmpty()) {
-                            return result;
-                        }
+                if (!applyTo.isEmpty()) {
+                    if (applyTo.stream().allMatch(in -> matches(key, in, parentKey).isEmpty())) {
+                        return emptyList();
                     }
-                    return emptyList();
                 }
 
                 return result;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
@@ -121,7 +121,7 @@ public class UnfoldProperties extends Recipe {
             /**
              * Splits a key into parts while respecting certain exclusion rules.
              * The method ensures certain segments of the key are kept together as defined in the exclusion list.
-             * It does also take the applyOnlyOn list into account.
+             * It also considers the applyTo list during the split process.
              *
              * @param key the full key to be split into parts
              * @return a list of strings representing the split parts of the key

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
@@ -88,7 +88,7 @@ public class UnfoldProperties extends Recipe {
                     Cursor c = getCursor();
                     while (!foundMatch && !c.isRoot()) {
                         Cursor current = c;
-                        foundMatch = exclusionMatchers.stream().anyMatch(matcher -> matcher.matches(current));
+                        foundMatch = exclusionMatchers.stream().anyMatch(it -> it.matches(current));
                         if (foundMatch) {
                             break;
                         } else {
@@ -152,7 +152,7 @@ public class UnfoldProperties extends Recipe {
                 }
 
                 if (!applyTo.isEmpty()) {
-                    if (applyTo.stream().allMatch(in -> matches(key, in, parentKey).isEmpty())) {
+                    if (applyTo.stream().allMatch(it -> matches(key, it, parentKey).isEmpty())) {
                         return emptyList();
                     }
                 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -28,14 +28,14 @@ import static org.openrewrite.yaml.Assertions.yaml;
 class UnfoldPropertiesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UnfoldProperties(null));
+        spec.recipe(new UnfoldProperties(null, null));
     }
 
     @DocumentExample
     @Test
     void unfold() {
         rewriteRun(
-          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/.*/))]", "$..[enable.process.files]"))),
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/.*/))]", "$..[enable.process.files]"), null)),
           yaml(
             """
               spring.application.name: my-app
@@ -145,7 +145,7 @@ class UnfoldPropertiesTest implements RewriteTest {
             "$..[show.details]",
             "$.management.endpoint.health[show.controllers]",
             "$.management.endpoint.health.show.views"
-          ))),
+          ), null)),
           yaml(
             """
               management:
@@ -163,7 +163,7 @@ class UnfoldPropertiesTest implements RewriteTest {
     @Test
     void exclusionWithSubSetOfKey() {
         rewriteRun(
-          spec -> spec.recipe(new UnfoldProperties(List.of("$..['com.service']"))),
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..['com.service']"), null)),
           yaml(
             """
               logging.level.com.service.A: DEBUG
@@ -183,7 +183,7 @@ class UnfoldPropertiesTest implements RewriteTest {
     @Test
     void exclusionWithRegex() {
         rewriteRun(
-          spec -> spec.recipe(new UnfoldProperties(List.of("$..[?(@property.match(/some.*/))]"))),
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[?(@property.match(/some.*/))]"), null)),
           yaml(
             """
               A.B:
@@ -202,7 +202,7 @@ class UnfoldPropertiesTest implements RewriteTest {
     @Test
     void exclusionWithParentAndRegex() {
         rewriteRun(
-          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/^com.*/))]"))),
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/^com.*/))]"), null)),
           yaml(
             """
               first:
@@ -228,7 +228,7 @@ class UnfoldPropertiesTest implements RewriteTest {
     @Test
     void exclusionWithSingleLineAndMatchAll() {
         rewriteRun(
-          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/.*/))]"))),
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[logging.level][?(@property.match(/.*/))]"), null)),
           yaml(
             """
               logging.level.com.company.extern.service: DEBUG
@@ -251,7 +251,7 @@ class UnfoldPropertiesTest implements RewriteTest {
      */
     void exclusionWithSingleLineAndGroupMatcherAndMatchAll() {
         rewriteRun(
-          spec -> spec.recipe(new UnfoldProperties(List.of("$..[root.group][?(@property.match(/^sub.*group\\./))][?(@property.match(/.*/))]"))),
+          spec -> spec.recipe(new UnfoldProperties(List.of("$..[root.group][?(@property.match(/^sub.*group\\./))][?(@property.match(/.*/))]"), null)),
           yaml(
             """
               root.group.sub1.group.org.key1: value1
@@ -388,4 +388,62 @@ class UnfoldPropertiesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void applyTo() {
+        rewriteRun(
+          spec -> spec.recipe(new UnfoldProperties(
+            null,
+            List.of("$..[?(@property.match(/logging.*/))]", "$..[logging.level][?(@property.match(/.*/))]")
+          )),
+          yaml(
+            """
+              spring.application:
+                name: my-app
+              logging.level:
+                root: INFO
+                org.springframework.web: DEBUG
+              """,
+            """
+              spring.application:
+                name: my-app
+              logging:
+                level:
+                  root: INFO
+                  org:
+                    springframework:
+                      web: DEBUG
+              """
+          )
+        );
+    }
+
+    @Test
+    void applyToWithExclusion() {
+        rewriteRun(
+          spec -> spec.recipe(new UnfoldProperties(
+            List.of("$..[logging.level][?(@property.match(/springframework.*/))]"),
+            List.of("$..[?(@property.match(/logging.*/))]", "$..[logging.level][?(@property.match(/.*/))]")
+          )),
+          yaml(
+            """
+              spring.application:
+                name: my-app
+              logging.level:
+                root: INFO
+                org.springframework.web: DEBUG
+              """,
+            """
+              spring.application:
+                name: my-app
+              logging:
+                level:
+                  root: INFO
+                  org:
+                    springframework.web: DEBUG
+              """
+          )
+        );
+    }
 }
+

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -422,7 +422,7 @@ class UnfoldPropertiesTest implements RewriteTest {
     void applyToWithExclusion() {
         rewriteRun(
           spec -> spec.recipe(new UnfoldProperties(
-            List.of("$..[logging.level][?(@property.match(/springframework.*/))]"),
+            List.of("$..[logging.level][?(@property.match(/.*springframework.*/))]"),
             List.of("$..[?(@property.match(/logging.*/))]", "$..[logging.level][?(@property.match(/.*/))]")
           )),
           yaml(

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -446,4 +446,3 @@ class UnfoldPropertiesTest implements RewriteTest {
         );
     }
 }
-


### PR DESCRIPTION
## What's changed?
The UnfoldProperties recipe has a new option where you can define JsonPath selectors to which properties you only want to apply the changes.

## What's your motivation?
Customer request.

## Any additional context
I implemented this feature at the final stage of processing: once it’s determined which parts should have a nested entry, I check whether those parts exist in the `applyTo` list.

This approach offers a small bonus—you can now combine `exclusions` with `applyTo`. While I doubt many users will take advantage of that, it's a nice extra.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
