### PR TITLE
Not adding newline in TabsAndIndents block end handling in Javascript

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -1098,7 +1098,7 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
             }
             if (draft.kind === J.Kind.Block) {
                 const block = draft as Draft<J> as Draft<J.Block>;
-                block.end.whitespace = this.newline + relativeIndent;
+                block.end.whitespace = this.combineIndent(block.end.whitespace, relativeIndent);
             }
         });
     }

--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -155,7 +155,6 @@ describe('TabsAndIndentsVisitor', () => {
                             switch( s  ){
                                 case "apple"  :
                                     return 1;
-                   
                             }
                             return 0;
                         }
@@ -236,6 +235,52 @@ describe('TabsAndIndentsVisitor', () => {
                     [key: string]: any;
                 }
                 `)
+            // @formatter:on
+        )
+    })
+
+    test("multi-line callback", () => {
+        const spec = new RecipeSpec()
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents(draft => {
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `
+                [1, 2, 3].forEach( x => {
+                console.log(x);
+                });
+                `,
+                `
+                [1, 2, 3].forEach( x => {
+                    console.log(x);
+                });
+                `)
+            // @formatter:on
+        )
+    })
+
+    test("single-line callback with braces", () => {
+        const spec = new RecipeSpec()
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents(draft => {
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`[1, 2, 3].forEach(x => {console.log(x)});`)
+            // @formatter:on
+        )
+    })
+
+    test("single-line callback without braces", () => {
+        const spec = new RecipeSpec()
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents(draft => {
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`[1, 2, 3].forEach(x => console.log(x));`)
             // @formatter:on
         )
     })


### PR DESCRIPTION
## What's changed?

Simplifying the logic of handling block end whitespace in `TabsAndIndents` JavaScript visitor.

## What's your motivation?
- Not to add extra newline.