### PR TITLE
Generalize changing of properties in Maven recipes

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactId.java
@@ -25,7 +25,6 @@ import org.openrewrite.maven.tree.*;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.xml.AddToTagVisitor;
-import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
@@ -239,16 +238,7 @@ public class ChangeDependencyGroupIdAndArtifactId extends Recipe {
                         .anyMatch(rd -> (version == null) || version.equals(rd.getVersion()));
             }
 
-            private Xml.Tag changeChildTagValue(Xml.Tag tag, String childTagName, String newValue, ExecutionContext ctx) {
-                Optional<Xml.Tag> childTag = tag.getChild(childTagName);
-                if (childTag.isPresent() && !newValue.equals(childTag.get().getValue().orElse(null))) {
-                    tag = (Xml.Tag) new ChangeTagValueVisitor<>(childTag.get(), newValue).visitNonNull(tag, ctx);
-                }
-                return tag;
-            }
-
             private boolean isDependencyManaged(Scope scope, String groupId, String artifactId) {
-
                 MavenResolutionResult result = getResolutionResult();
                 for (ResolvedManagedDependency managedDependency : result.getPom().getDependencyManagement()) {
                     if (groupId.equals(managedDependency.getGroupId()) && artifactId.equals(managedDependency.getArtifactId())) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactId.java
@@ -26,7 +26,6 @@ import org.openrewrite.maven.tree.ResolvedManagedDependency;
 import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
-import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
 
@@ -40,11 +39,6 @@ import static org.openrewrite.internal.StringUtils.isBlank;
 public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
     @EqualsAndHashCode.Exclude
     MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
-
-    // there are several implicitly defined version properties that we should never attempt to update
-    private static final Set<String> implicitlyDefinedVersionProperties = new HashSet<>(Arrays.asList(
-            "${version}", "${project.version}", "${pom.version}", "${project.parent.version}"
-    ));
 
     @Option(displayName = "Old groupId",
             description = "The old groupId to replace. The groupId is the first part of a managed dependency coordinate `com.google.guava:guava:VERSION`.",
@@ -146,24 +140,17 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
 
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
-
                 Xml.Tag t = super.visitTag(tag, ctx);
                 if (isManagedDependencyTag(oldGroupId, oldArtifactId)) {
-                    Optional<Xml.Tag> groupIdTag = t.getChild("groupId");
-                    boolean changed = false;
-                    if (groupIdTag.isPresent() && !newGroupId.equals(groupIdTag.get().getValue().orElse(null))) {
-                        doAfterVisit(new ChangeTagValueVisitor<>(groupIdTag.get(), newGroupId));
-                        changed = true;
+                    if (t.getChild("groupId").isPresent()) {
+                        t = changeChildTagValue(t, "groupId", newGroupId, ctx);
                     }
-                    Optional<Xml.Tag> artifactIdTag = t.getChild("artifactId");
-                    if (artifactIdTag.isPresent() && !newArtifactId.equals(artifactIdTag.get().getValue().orElse(null))) {
-                        doAfterVisit(new ChangeTagValueVisitor<>(artifactIdTag.get(), newArtifactId));
-                        changed = true;
+                    if (t.getChild("artifactId").isPresent()) {
+                        t = changeChildTagValue(t, "artifactId", newArtifactId, ctx);
                     }
                     if (newVersion != null) {
                         try {
                             Optional<Xml.Tag> versionTag = t.getChild("version");
-
                             if (versionTag.isPresent()) {
                                 String resolvedArtifactId = newArtifactId;
                                 if (resolvedArtifactId.contains("${")) {
@@ -172,14 +159,13 @@ public class ChangeManagedDependencyGroupIdAndArtifactId extends Recipe {
                                     resolvedArtifactId = ResolvedPom.placeholderHelper.replacePlaceholders(newArtifactId, properties::get);
                                 }
                                 String resolvedNewVersion = resolveSemverVersion(ctx, newGroupId, resolvedArtifactId, getResolutionResult().getPom().getValue(versionTag.get().getValue().orElse(null)));
-                                t = (Xml.Tag) new ChangeTagValueVisitor<>(versionTag.get(), resolvedNewVersion).visitNonNull(t, 0, getCursor().getParentOrThrow());
+                                t = changeChildTagValue(t, "version", resolvedNewVersion, ctx);
                             }
-                            changed = true;
                         } catch (MavenDownloadingException e) {
                             return e.warn(t);
                         }
                     }
-                    if (changed) {
+                    if (t != tag) {
                         maybeUpdateModel();
                         doAfterVisit(new RemoveRedundantDependencyVersions(null, null, null, null).getVisitor());
                         if (isNewDependencyPresent) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangePluginGroupIdAndArtifactId.java
@@ -23,10 +23,7 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.maven.table.MavenMetadataFailures;
-import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
-
-import java.util.Optional;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -104,14 +101,6 @@ public class ChangePluginGroupIdAndArtifactId extends Recipe {
                 }
                 //noinspection ConstantConditions
                 return t;
-            }
-
-            private Xml.Tag changeChildTagValue(Xml.Tag tag, String childTagName, String newValue, ExecutionContext ctx) {
-                Optional<Xml.Tag> childTag = tag.getChild(childTagName);
-                if (childTag.isPresent() && !newValue.equals(childTag.get().getValue().orElse(null))) {
-                    tag = (Xml.Tag) new ChangeTagValueVisitor<>(childTag.get(), newValue).visitNonNull(tag, ctx);
-                }
-                return tag;
             }
         };
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenVisitor.java
@@ -21,6 +21,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.tree.*;
+import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
@@ -46,6 +47,11 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     static final XPathMatcher MANAGED_PLUGIN_MATCHER = new XPathMatcher("//pluginManagement/plugins/plugin");
     static final XPathMatcher PARENT_MATCHER = new XPathMatcher("/project/parent");
     static final XPathMatcher PROJECT_MATCHER = new XPathMatcher("/project");
+
+    // there are several implicitly defined version properties that we should never attempt to update
+    private static final Set<String> IMPLICITLY_DEFINED_VERSION_PROPERTIES = new HashSet<>(Arrays.asList(
+            "${version}", "${project.version}", "${pom.version}", "${project.parent.version}"
+    ));
 
     private transient Xml.@Nullable Document document;
 
@@ -267,6 +273,32 @@ public class MavenVisitor<P> extends XmlVisitor<P> {
     private boolean isTag(String name) {
         // `XPathMatcher` is still a bit expensive
         return getCursor().getValue() instanceof Xml.Tag && name.equals(getCursor().<Xml.Tag>getValue().getName());
+    }
+
+    protected Xml.Tag changeChildTagValue(Xml.Tag tag, String childTagName, @Nullable String newValue, P p) {
+        return changeChildTagValue(tag, childTagName, newValue, false, p);
+    }
+
+    protected Xml.Tag changeChildTagValue(Xml.Tag tag, String childTagName, @Nullable String newValue, @Nullable Boolean addPropertyIfMissing, P p) {
+        Optional<Xml.Tag> childTag = tag.getChild(childTagName);
+        if (childTag.isPresent()) {
+            String oldValue = childTag.get().getValue().orElse(null);
+            if (newValue != null && !newValue.equals(oldValue)) {
+                if (isProperty(oldValue)) {
+                    String propertyName = oldValue.substring(2, oldValue.length() - 1);
+                    if (getResolutionResult().getPom().getRequested().getProperties().containsKey(propertyName)) {
+                        doAfterVisit((TreeVisitor<?, P>) new ChangePropertyValue(propertyName, newValue, addPropertyIfMissing, false).getVisitor());
+                    }
+                } else {
+                    tag = (Xml.Tag) new ChangeTagValueVisitor<>(childTag.get(), newValue).visitNonNull(tag, p);
+                }
+            }
+        }
+        return tag;
+    }
+
+    protected boolean isProperty(@Nullable String value) {
+        return value != null && value.startsWith("${") && !IMPLICITLY_DEFINED_VERSION_PROPERTIES.contains(value);
     }
 
     public @Nullable ResolvedDependency findDependency(Xml.Tag tag) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -52,11 +52,6 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     @EqualsAndHashCode.Exclude
     transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
 
-    // there are several implicitly defined version properties that we should never attempt to update
-    private static final Collection<String> implicitlyDefinedVersionProperties = Arrays.asList(
-            "${version}", "${project.version}", "${pom.version}", "${project.parent.version}"
-    );
-
     @Option(displayName = "Group",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
             example = "com.fasterxml.jackson*")
@@ -156,8 +151,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 Optional<Xml.Tag> version = tag.getChild("version");
                                 if (version.isPresent()) {
                                     String requestedVersion = d.getRequested().getVersion();
-                                    if (requestedVersion != null && requestedVersion.startsWith("${") &&
-                                        !implicitlyDefinedVersionProperties.contains(requestedVersion)) {
+                                    if (isProperty(requestedVersion)) {
                                         String propertyName = requestedVersion.substring(2, requestedVersion.length() - 1);
                                         if (!getResolutionResult().getPom().getRequested().getProperties().containsKey(propertyName)) {
                                             storeParentPomProperty(getResolutionResult().getParent(), propertyName, newerVersion);
@@ -180,8 +174,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
              * @param propertyName the name of the property to update, if found in any the parent pom source file
              * @param newerVersion the resolved newer version that any matching parent pom property should be updated to
              */
-            private void storeParentPomProperty(
-                    @Nullable MavenResolutionResult currentMavenResolutionResult, String propertyName, String newerVersion) {
+            private void storeParentPomProperty(@Nullable MavenResolutionResult currentMavenResolutionResult, String propertyName, String newerVersion) {
                 if (currentMavenResolutionResult == null) {
                     return; // No parent contained the property; might then be in the same source file, or an import BOM
                 }
@@ -270,10 +263,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 }
 
                 private void retainVersions() {
-                    for (Recipe retainVersionRecipe : RetainVersions.plan(this, retainVersions == null ?
-                            emptyList() : retainVersions)) {
-                        doAfterVisit(retainVersionRecipe.getVisitor());
-                    }
+                    RetainVersions.plan(this, retainVersions == null ? emptyList() : retainVersions)
+                            .forEach(it -> doAfterVisit(it.getVisitor()));
                 }
             }
 
@@ -284,26 +275,13 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     // as a source file, attempt to find a new version.
                     String newerVersion = findNewerVersion(d.getGroupId(), d.getArtifactId(), d.getVersion(), ctx);
                     if (newerVersion != null) {
-                        Optional<Xml.Tag> version = t.getChild("version");
-                        if (version.isPresent()) {
-                            String requestedVersion = d.getRequested().getVersion();
-                            if (requestedVersion != null && requestedVersion.startsWith("${") && !implicitlyDefinedVersionProperties.contains(requestedVersion)) {
-                                String propertyName = requestedVersion.substring(2, requestedVersion.length() - 1);
-                                if (getResolutionResult().getPom().getRequested().getProperties().containsKey(propertyName)) {
-                                    doAfterVisit(new ChangePropertyValue(propertyName, newerVersion, overrideManagedVersion, false).getVisitor());
-                                }
-                            } else {
-                                t = (Xml.Tag) new ChangeTagValueVisitor<>(version.get(), newerVersion).visitNonNull(t, 0, getCursor().getParentOrThrow());
-                            }
+                        if (t.getChild("version").isPresent()) {
+                            t = changeChildTagValue(t, "version", newerVersion, overrideManagedVersion, ctx);
                         } else if (Boolean.TRUE.equals(overrideManagedVersion)) {
                             ResolvedManagedDependency dm = findManagedDependency(t);
                             // if a managed dependency is expressed as a property, change the property value
                             // do this only when a requested bom is absent, otherwise changing property has no effect
-                            if (dm != null &&
-                                dm.getRequested().getVersion() != null &&
-                                dm.getRequested().getVersion().startsWith("${") &&
-                                !implicitlyDefinedVersionProperties.contains(dm.getRequested().getVersion()) &&
-                                dm.getRequestedBom() == null) {
+                            if (dm != null && isProperty(dm.getRequested().getVersion()) && dm.getRequestedBom() == null) {
                                 doAfterVisit(new ChangePropertyValue(dm.getRequested().getVersion().substring(2,
                                         dm.getRequested().getVersion().length() - 1),
                                         newerVersion, overrideManagedVersion, false).getVisitor());
@@ -359,20 +337,14 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 if (groupId != null && artifactId != null && version != null) {
                     String newerVersion = findNewerVersion(groupId, artifactId, resolveVersion(version), ctx);
                     if (newerVersion != null) {
-                        if (version.startsWith("${") && !implicitlyDefinedVersionProperties.contains(version)) {
-                            doAfterVisit(new ChangePropertyValue(version.substring(2, version.length() - 1), newerVersion, overrideManagedVersion, false).getVisitor());
-                        } else {
-                            Optional<Xml.Tag> versionTag = t.getChild("version");
-                            assert versionTag.isPresent();
-                            t = (Xml.Tag) new ChangeTagValueVisitor<>(versionTag.get(), newerVersion).visitNonNull(t, 0, getCursor().getParentOrThrow());
-                        }
+                        t = changeChildTagValue(t, "version", newerVersion, overrideManagedVersion, ctx);
                     }
                 }
                 return t;
             }
 
             private String resolveVersion(String version) {
-                if (version.startsWith("${") && !implicitlyDefinedVersionProperties.contains(version)) {
+                if (isProperty(version)) {
                     Map<String, String> properties = getResolutionResult().getPom().getProperties();
                     String property = version.substring(2, version.length() - 1);
                     return properties.getOrDefault(property, version);
@@ -384,7 +356,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 String newerVersion = findNewerVersion(groupId, artifactId, version2, ctx);
                 if (newerVersion == null) {
                     return null;
-                } else if (requestedVersion != null && requestedVersion.startsWith("${")) {
+                } else if (isProperty(requestedVersion)) {
                     //noinspection unchecked
                     return (TreeVisitor<Xml, ExecutionContext>) new ChangePropertyValue(requestedVersion.substring(2, requestedVersion.length() - 1), newerVersion, overrideManagedVersion, false)
                             .getVisitor();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -1624,4 +1624,56 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void changeDependencyGroupIdAndArtifactIdWithVersionProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "javax.activation",
+            "javax.activation-api",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "1.2.x",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <properties>
+                      <activation.api>1.2.0</activation.api>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>javax.activation</groupId>
+                          <artifactId>javax.activation-api</artifactId>
+                          <version>${activation.api}</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <properties>
+                      <activation.api>1.2.2</activation.api>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.activation</groupId>
+                          <artifactId>jakarta.activation-api</artifactId>
+                          <version>${activation.api}</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeManagedDependencyGroupIdAndArtifactIdTest.java
@@ -329,14 +329,14 @@ class ChangeManagedDependencyGroupIdAndArtifactIdTest implements RewriteTest {
                   <artifactId>my-app</artifactId>
                   <version>1</version>
                   <properties>
-                      <version.property>1.2.0</version.property>
+                      <version.property>1.2.2</version.property>
                   </properties>
                   <dependencyManagement>
                       <dependencies>
                           <dependency>
                               <groupId>jakarta.activation</groupId>
                               <artifactId>jakarta.activation-api</artifactId>
-                              <version>1.2.2</version>
+                              <version>${version.property}</version>
                           </dependency>
                       </dependencies>
                   </dependencyManagement>


### PR DESCRIPTION
## What's changed?
The "ChangeDependencyGroupIdAndArtifactId" and "ChangeManagedDependencyGroupIdAndArtifactId" recipes now handle a value change for the version tag including cases where a property is used.

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4527

## Anything in particular you'd like reviewers to focus on?
I moved the logic of the property resolvent out of the "UpgradeDependencyVersion" and into the "MavenVisitor" (and used it in the other recipes). Is this a good solution?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
