### PR TITLE
Deprecated ChangePluginVersion in favor of UpgradePluginVersion as that one is Kotlin aware.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePluginVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/ChangePluginVersion.java
@@ -40,8 +40,12 @@ import org.openrewrite.semver.Semver;
 
 import java.util.List;
 
+/**
+ * @deprecated in favor of {@link org.openrewrite.gradle.plugins.UpgradePluginVersion}.
+ */
 @Value
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class ChangePluginVersion extends Recipe {
     private static final String GRADLE_PROPERTIES_FILE_NAME = "gradle.properties";
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -97,7 +97,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
                         G.CompilationUnit g = cu;
                         g = (G.CompilationUnit) new ChangePlugin("com.gradle.enterprise", "com.gradle.develocity", version).getVisitor()
                                 .visitNonNull(g, ctx);
-                        g = (G.CompilationUnit) new ChangePluginVersion("com.gradle.common-custom-user-data-gradle-plugin", "2.x", null).getVisitor()
+                        g = (G.CompilationUnit) new UpgradePluginVersion("com.gradle.common-custom-user-data-gradle-plugin", "2.x", null).getVisitor()
                                 .visitNonNull(g, ctx);
                         g = (G.CompilationUnit) new MigrateConfigurationVisitor().visitNonNull(g, ctx);
                         return g;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -59,6 +59,31 @@ class UpgradePluginVersionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void change() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.x", null)),
+          settingsGradle(
+            """
+              pluginManagement {
+                  plugins {
+                      String v = '5.40.0'
+                      id 'org.openrewrite.rewrite' version v
+                  }
+              }
+              """,
+            """
+              pluginManagement {
+                  plugins {
+                      String v = '5.40.6'
+                      id 'org.openrewrite.rewrite' version v
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample("Upgrading a settings plugin")
     @Test
     void upgradeGradleSettingsPlugin() {


### PR DESCRIPTION
As described here: 
- https://github.com/openrewrite/rewrite/issues/5361

>AFAICS there are 2 recipes to change the version of a plugin. We have ChangePluginVersion which is only a GroovyVisitor and UpgradePluginVersion which uses a JavaVisitor. Can we deprecate ChangePluginVersion so that we support kotlin and groovy with 1 UpgradePluginVersion recipe?

> ChangePluginVersion and UpgradePluginVersion both are only impacting the version, have the same amount/type of parameters.UpgradePluginVersion goes further in the way that if the version is a variable, it will update the variable value and not overwrite the variable usage with the updated version.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
