### PR TITLE
Javascript - removing RightPadded wrapper from JsxTag.children

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -358,7 +358,7 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
 
             // Visit children in lock step
             for (let i = 0; i < element.children.length; i++) {
-                await this.visit(element.children[i].element, otherElement.children![i].element);
+                await this.visit(element.children[i], otherElement.children![i]);
                 if (!this.match) return element;
             }
         }

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3434,12 +3434,7 @@ export class JavaScriptParserVisitor {
                     this.prefix(this.findChildNode(node.openingElement, ts.SyntaxKind.GreaterThanToken)!),
                     () => emptyMarkers
                 ),
-            children:
-                this.mapJsxChildren<JSX.EmbeddedExpression | JSX.Tag | J.Identifier | J.Literal>(
-                    node.children,
-                    this.prefix(this.findChildNode(node.closingElement, ts.SyntaxKind.LessThanToken)!),
-                    () => emptyMarkers
-                ),
+            children: this.mapJsxChildren<JSX.EmbeddedExpression | JSX.Tag | J.Identifier | J.Literal>(node.children),
             closingName: this.leftPadded(this.prefix(node.closingElement.tagName), this.visit(node.closingElement.tagName)),
             afterClosingName: this.suffix(node.closingElement.tagName)
         };
@@ -3475,12 +3470,7 @@ export class JavaScriptParserVisitor {
             openName: this.leftPadded(this.prefix(node.openingFragment), this.newEmpty()),
             afterName: this.prefix(this.findChildNode(node.openingFragment, ts.SyntaxKind.GreaterThanToken)!),
             attributes: [],
-            children:
-                this.mapJsxChildren<JSX.EmbeddedExpression | JSX.Tag | J.Identifier | J.Literal>(
-                    node.children,
-                    this.prefix(this.findChildNode(node.closingFragment, ts.SyntaxKind.LessThanToken)!),
-                    () => emptyMarkers
-                ),
+            children: this.mapJsxChildren<JSX.EmbeddedExpression | JSX.Tag | J.Identifier | J.Literal>(node.children),
             closingName: this.leftPadded(emptySpace, this.newEmpty()),
             afterClosingName: emptySpace
         };
@@ -4046,25 +4036,15 @@ export class JavaScriptParserVisitor {
         return args;
     }
 
-    private mapJsxChildren<T extends J>(elementList: readonly ts.Node[], lastAfter: J.Space, markers?: (ns: readonly ts.Node[], i: number) => Markers): J.RightPadded<T>[] {
+    private mapJsxChildren<T extends J>(elementList: readonly ts.Node[]): T[] {
         let childCount = elementList.length;
 
-        const args: J.RightPadded<T>[] = [];
+        const args: T[] = [];
         if (childCount === 0) {
-            args.push(this.rightPadded(
-                this.newEmpty() as T,
-                lastAfter,
-                emptyMarkers
-            ));
+            args.push(this.newEmpty() as T);
         } else {
             for (let i = 0; i < childCount; i++) {
-                const node = elementList[i];
-                const isLast = i === childCount - 1;
-                args.push(this.rightPadded(
-                    this.visit(node),
-                    isLast ? lastAfter : emptySpace,
-                    markers ? markers(elementList, i) : emptyMarkers
-                ));
+                args.push(this.visit(elementList[i]));
             }
         }
         return args;

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3435,18 +3435,12 @@ export class JavaScriptParserVisitor {
                     this.prefix(this.findChildNode(node.openingElement, ts.SyntaxKind.GreaterThanToken)!),
                     () => emptyMarkers
                 ),
-            children: node.children.length > 0 ?
+            children:
                 this.mapJsxChildren<JSX.EmbeddedExpression | JSX.Tag | J.Identifier | J.Literal>(
                     node.children,
                     this.prefix(this.findChildNode(node.closingElement, ts.SyntaxKind.LessThanToken)!),
                     () => emptyMarkers
-                ) :
-                [
-                    this.rightPadded(
-                        this.newEmpty(),
-                        this.prefix(this.findChildNode(node.closingElement, ts.SyntaxKind.LessThanToken)!)
-                    )
-                ],
+                ),
             closingName: this.leftPadded(this.prefix(node.closingElement.tagName), this.visit(node.closingElement.tagName)),
             afterClosingName: this.suffix(node.closingElement.tagName)
         };
@@ -3483,18 +3477,12 @@ export class JavaScriptParserVisitor {
             openName: this.leftPadded(this.prefix(node.openingFragment), this.newEmpty()),
             afterName: this.prefix(this.findChildNode(node.openingFragment, ts.SyntaxKind.GreaterThanToken)!),
             attributes: [],
-            children: node.children.length > 0 ?
+            children:
                 this.mapJsxChildren<JSX.EmbeddedExpression | JSX.Tag | J.Identifier | J.Literal>(
                     node.children,
                     this.prefix(this.findChildNode(node.closingFragment, ts.SyntaxKind.LessThanToken)!),
                     () => emptyMarkers
-                ) :
-                [
-                    this.rightPadded(
-                        this.newEmpty(),
-                        this.prefix(this.findChildNode(node.closingFragment, ts.SyntaxKind.LessThanToken)!)
-                    )
-                ],
+                ),
             closingName: this.leftPadded(emptySpace, this.newEmpty()),
             afterClosingName: emptySpace
         };

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3428,9 +3428,8 @@ export class JavaScriptParserVisitor {
             afterName: attrs.length === 0 ?
                 this.prefix(this.findChildNode(node.openingElement, ts.SyntaxKind.GreaterThanToken)!) :
                 emptySpace,
-            attributes: attrs.length === 0 ?
-                [] :
-                this.mapJsxChildren<Attribute | SpreadAttribute>(
+            attributes:
+                this.mapJsxAttributes<Attribute | SpreadAttribute>(
                     attrs,
                     this.prefix(this.findChildNode(node.openingElement, ts.SyntaxKind.GreaterThanToken)!),
                     () => emptyMarkers
@@ -3457,9 +3456,8 @@ export class JavaScriptParserVisitor {
             afterName: attrs.length === 0 ?
                 this.prefix(this.findChildNode(node, ts.SyntaxKind.GreaterThanToken)!) :
                 emptySpace,
-            attributes: attrs.length === 0 ?
-                [] :
-                this.mapJsxChildren<Attribute | SpreadAttribute>(
+            attributes:
+                this.mapJsxAttributes<Attribute | SpreadAttribute>(
                     attrs,
                     this.prefix(this.findChildNode(node, ts.SyntaxKind.GreaterThanToken)!),
                     () => emptyMarkers
@@ -4070,6 +4068,25 @@ export class JavaScriptParserVisitor {
             }
         }
         return args;
+    }
+
+    private mapJsxAttributes<T extends J>(elementList: readonly ts.Node[], lastAfter: J.Space, markers?: (ns: readonly ts.Node[], i: number) => Markers): J.RightPadded<T>[] {
+        let childCount = elementList.length;
+        if (childCount === 0) {
+            return [];
+        } else {
+            const args: J.RightPadded<T>[] = [];
+            for (let i = 0; i < childCount; i++) {
+                const node = elementList[i];
+                const isLast = i === childCount - 1;
+                args.push(this.rightPadded(
+                    this.visit(node),
+                    isLast ? lastAfter : emptySpace,
+                    markers ? markers(elementList, i) : emptyMarkers
+                ));
+            }
+            return args;
+        }
     }
 
     private mapDecorators(node: ts.ClassDeclaration | ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration | ts.ParameterDeclaration | ts.PropertyDeclaration | ts.SetAccessorDeclaration | ts.GetAccessorDeclaration | ts.ClassExpression): J.Annotation[] {

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -100,7 +100,9 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         } else {
             p.append(">");
             if (element.children) {
-                await this.visitRightPaddedLocal(element.children, "", p);
+                for (let i = 0; i < element.children.length; i++) {
+                    await this.visit(element.children[i], p)
+                }
                 await this.visitLeftPaddedLocal("</", element.closingName, p);
                 await this.visitSpace(element.afterClosingName, p);
                 p.append(">");

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -377,7 +377,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         await q.getAndSendList(tag, el => el.attributes, attr => attr.element.id, attr => this.visitRightPadded(attr, q));
 
         await q.getAndSend(tag, el => el.selfClosing, space => this.visitSpace(space, q));
-        await q.getAndSendList(tag, el => el.children!, child => child.element.id, child => this.visitRightPadded(child, q));
+        await q.getAndSendList(tag, el => el.children!, child => child.id, child => this.visit(child, q));
         await q.getAndSend(tag, el => el.closingName, el => this.visitLeftPadded(el, q));
         await q.getAndSend(tag, el => el.afterClosingName, el => this.visitSpace(el, q));
 
@@ -943,7 +943,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         draft.attributes = await q.receiveListDefined(draft.attributes, attr => this.visitRightPadded(attr, q));
 
         draft.selfClosing = await q.receive(draft.selfClosing, space => this.visitSpace(space, q));
-        draft.children = await q.receiveListDefined(draft.children, child => this.visitRightPadded(child, q));
+        draft.children = await q.receiveListDefined(draft.children, child => this.visit(child, q));
         draft.closingName = await q.receive(draft.closingName, el => this.visitLeftPadded(el, q));
         draft.afterClosingName = await q.receive(draft.afterClosingName, el => this.visitSpace(el, q));
 

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -841,7 +841,7 @@ export namespace JSX {
         }) |
         (BaseTag & {
             readonly selfClosing?: undefined;
-            readonly children: J.RightPadded<EmbeddedExpression | Tag | J.Identifier | J.Literal | J.Empty>[];
+            readonly children: (EmbeddedExpression | Tag | J.Identifier | J.Literal | J.Empty)[];
             readonly closingName: J.LeftPadded<J.Identifier | J.FieldAccess | NamespacedName | J.Empty>;
             readonly afterClosingName: J.Space;
         });

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -122,7 +122,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
             draft.afterName = await this.visitSpace(element.afterName, p);
             draft.attributes = await mapAsync(element.attributes, attr => this.visitRightPadded(attr, p));
             draft.selfClosing = element.selfClosing && await this.visitSpace(element.selfClosing, p);
-            draft.children = element.children && await mapAsync(element.children, child => this.visitRightPadded(child, p));
+            draft.children = element.children && await mapAsync(element.children, child => this.visit(child, p));
             draft.closingName = element.closingName && await this.visitLeftPadded(element.closingName, p);
             draft.afterClosingName = element.afterClosingName && await this.visitSpace(element.afterClosingName, p);
         });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -1065,7 +1065,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         if (t.isSelfClosing()) {
             t = t.withSelfClosing(visitSpace(requireNonNull(t.getSelfClosing()), Space.Location.LANGUAGE_EXTENSION, p));
         } else if (t.hasChildren()) {
-            t = t.getPadding().withChildren(requireNonNull(ListUtils.map(t.getPadding().getChildren(), child -> visitRightPadded(child, JRightPadded.Location.LANGUAGE_EXTENSION, p))));
+            t = t.withChildren(ListUtils.map(t.getChildren(), child -> visitAndCast(child, p)));
             t = t.getPadding().withClosingName(requireNonNull(visitLeftPadded(t.getPadding().getClosingName(), JLeftPadded.Location.LANGUAGE_EXTENSION, p)));
             t = t.withAfterClosingName(visitSpace(requireNonNull(t.getAfterClosingName()), Space.Location.LANGUAGE_EXTENSION, p));
         }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -436,7 +436,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
                 .withAfterName(q.receive(tag.getAfterName(), space2 -> visitSpace(space2, q)))
                 .getPadding().withAttributes(q.receiveList(tag.getPadding().getAttributes(), attr -> visitRightPadded(attr, q)))
                 .withSelfClosing(q.receive(tag.getSelfClosing(), space1 -> visitSpace(space1, q)))
-                .getPadding().withChildren(q.receiveList(tag.getPadding().getChildren(), child -> visitRightPadded(child, q)))
+                .withChildren(q.receiveList(tag.getChildren(), child -> (Expression) visitNonNull(child, q)))
                 .getPadding().withClosingName(q.receive(tag.getPadding().getClosingName(), name -> visitLeftPadded(name, q)))
                 .withAfterClosingName(q.receive(tag.getAfterClosingName(), space -> visitSpace(space, q)));
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -435,7 +435,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         q.getAndSendList(tag, el -> el.getPadding().getAttributes(), attr -> attr.getElement().getId(), attr -> visitRightPadded(attr, q));
 
         q.getAndSend(tag, JSX.Tag::getSelfClosing, space -> visitSpace(space, q));
-        q.getAndSendList(tag, el -> el.getPadding().getChildren(), child -> child.getElement().getId(), child -> visitRightPadded(child, q));
+        q.getAndSendList(tag, JSX.Tag::getChildren, Tree::getId, child -> visit(child, q));
         q.getAndSend(tag, el -> el.getPadding().getClosingName(), el -> visitLeftPadded(el, q));
         q.getAndSend(tag, JSX.Tag::getAfterClosingName, space -> visitSpace(space, q));
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JSX.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JSX.java
@@ -93,21 +93,10 @@ public interface JSX extends JS {
         @Nullable
         Space selfClosing;
 
+        @Getter
+        @With
         @Nullable
-        List<JRightPadded<Expression>> children;
-
-        public @Nullable List<Expression> getChildren() {
-            return children == null ? null : JRightPadded.getElements(children);
-        }
-
-        public Tag withChildren(@Nullable List<Expression> children) {
-            if (this.children == null && children == null) {
-                return this;
-            } else if (this.children == null) {
-                return getPadding().withChildren(JRightPadded.withElements(new ArrayList<>(), children));
-            }
-            return getPadding().withChildren(children == null ? null : JRightPadded.withElements(this.children, children));
-        }
+        List<Expression> children;
 
         @Nullable
         JLeftPadded<String> closingName;
@@ -185,14 +174,6 @@ public interface JSX extends JS {
 
             public Tag withAttributes(List<JRightPadded<JSX>> attributes) {
                 return t.attributes == attributes ? t : new Tag(t.id, t.prefix, t.markers, t.openName, t.afterName, attributes, t.selfClosing, t.children, t.closingName, t.afterClosingName);
-            }
-
-            public @Nullable List<JRightPadded<Expression>> getChildren() {
-                return t.children;
-            }
-
-            public Tag withChildren(@Nullable List<JRightPadded<Expression>> children) {
-                return t.children == children ? t : new Tag(t.id, t.prefix, t.markers, t.openName, t.afterName, t.attributes, t.selfClosing, children, t.closingName, t.afterClosingName);
             }
 
             public @Nullable JLeftPadded<String> getClosingName() {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
