### PR TITLE
Made DependencyUseStringNotation kotlin-aware

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/DependencyUseStringNotationTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.buildGradleKts;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 
 class DependencyUseStringNotationTest implements RewriteTest {
@@ -62,6 +63,47 @@ class DependencyUseStringNotationTest implements RewriteTest {
               dependencies {
                   api("org.openrewrite:rewrite-core:latest.release")
                   implementation "org.openrewrite:rewrite-core:latest.release"
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void kotlinSupport() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins {
+                  `java-library`
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              val version = "latest.release"
+              
+              dependencies {
+                  api(group = "org.openrewrite", name = "rewrite-core", version = "latest.release")
+                  implementation(group = "org.openrewrite", name = "rewrite-core", version = version, classifier = "sources")
+              }
+              """,
+            """
+              plugins {
+                  `java-library`
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              val version = "latest.release"
+              
+              dependencies {
+                  api("org.openrewrite:rewrite-core:latest.release")
+                  implementation("org.openrewrite:rewrite-core:$version:sources")
               }
               """
           )


### PR DESCRIPTION
As described here:

- https://github.com/openrewrite/rewrite/issues/5361

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
