### PR TITLE
Removing parentheses following annotation if they are empty and you try to change the annotation attribute name.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeAnnotationAttributeNameTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeAnnotationAttributeNameTest.java
@@ -102,7 +102,7 @@ class ChangeAnnotationAttributeNameTest implements RewriteTest {
     }
 
     @Test
-    void collapseImplicitValueAttributeWithEmpty() {
+    void doNotChangeWhenImplicitValueAttributeWithEmpty() {
         rewriteRun(
           spec -> spec.recipe(new ChangeAnnotationAttributeName("java.lang.SuppressWarnings", "value", "description")),
           //language=java

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeAnnotationAttributeName.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeAnnotationAttributeName.java
@@ -20,12 +20,9 @@ import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JLeftPadded;
 import org.openrewrite.marker.Markers;
-
-import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;


### PR DESCRIPTION
There was a bit of an incorrect modification of annotation attributes when using `ChangeAnnotationAttributeName`, specifically when you have an annotation that was written like this: `@Schema()`. To the user, obviously the presence or absence of the parentheses doesn't make a difference in how it behaves, but to openrewrite, it could end up performing operations resulting in an inability to compile.

When written as `@Schema()`, calling `ChangeAnnotationAttributeName` to change `"value"` to `"somethingelse"` would result in openrewrite changing the annotation to `@Schema(somethingelse = )`, breaking the code.

This PR will filter the arguments on the annotation to remove those that are instances of `J.Empty` (there should only ever be at most one of these, and in that situation it would be the only argument anyway) before performing the iterating through the arguments to try to rename the correct one, meaning it should result in `@Schema` instead.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
