### PR TITLE
Fixing the case when catch has no binding parameter in Javascript autoformatting

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -355,7 +355,9 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                 catch_ = await this.spaceBefore(catch_, this.style.beforeKeywords.catchKeyword);
                 catch_.parameter.prefix.whitespace = this.style.beforeParentheses.catchParentheses ? " " : "";
                 catch_.parameter.tree = await this.spaceAfterRightPadded(await this.spaceBeforeRightPaddedElement(catch_.parameter.tree, this.style.within.catchParentheses), this.style.within.catchParentheses);
-                catch_.parameter.tree.element.variables[catch_.parameter.tree.element.variables.length - 1].after.whitespace = "";
+                if (catch_.parameter.tree.element.variables.length > 0) {
+                    catch_.parameter.tree.element.variables[catch_.parameter.tree.element.variables.length - 1].after.whitespace = "";
+                }
                 catch_.body.prefix.whitespace = this.style.beforeLeftBrace.catchLeftBrace ? " " : "";
                 return catch_;
             }));

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -150,4 +150,25 @@ describe('AutoformatVisitor', () => {
             `)
             // @formatter:on
         )});
+
+    test('try catch-all', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+            try {
+                m();
+            } catch {
+                console.log("It failed", e);
+            }
+            `,
+                `
+            try {
+                m();
+            } catch {
+                console.log("It failed", e);
+            }
+            `)
+            // @formatter:on
+        )});
 });


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
