### PR TITLE
Javascript TreePrinters not to re-use printers

### DIFF
--- a/rewrite-javascript/rewrite/src/java/print.ts
+++ b/rewrite-javascript/rewrite/src/java/print.ts
@@ -8,4 +8,4 @@ class JavaPrinter extends JavaVisitor<PrintOutputCapture> {
     }
 }
 
-TreePrinters.register(J.Kind.CompilationUnit, new JavaPrinter());
+TreePrinters.register(J.Kind.CompilationUnit, () => new JavaPrinter());

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -1923,4 +1923,4 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
     }
 }
 
-TreePrinters.register(JS.Kind.CompilationUnit, new JavaScriptPrinter());
+TreePrinters.register(JS.Kind.CompilationUnit, () => new JavaScriptPrinter());

--- a/rewrite-javascript/rewrite/src/json/print.ts
+++ b/rewrite-javascript/rewrite/src/json/print.ts
@@ -128,4 +128,4 @@ class JsonPrinter extends JsonVisitor<PrintOutputCapture> {
     private jsonMarkerWrapper = (out: string): string => `/*~~${out}${out ? "~~" : ""}*/`;
 }
 
-TreePrinters.register(Json.Kind.Document, new JsonPrinter());
+TreePrinters.register(Json.Kind.Document, () => new JsonPrinter());

--- a/rewrite-javascript/rewrite/src/parse-error.ts
+++ b/rewrite-javascript/rewrite/src/parse-error.ts
@@ -46,7 +46,7 @@ export class ParseErrorVisitor<P> extends TreeVisitor<Tree, P> {
     }
 }
 
-TreePrinters.register(ParseErrorKind, new class extends ParseErrorVisitor<PrintOutputCapture> {
+TreePrinters.register(ParseErrorKind, () => new class extends ParseErrorVisitor<PrintOutputCapture> {
     protected async visitParseError(e: ParseError, p: PrintOutputCapture): Promise<ParseError | undefined> {
         for (let marker of e.markers.markers) {
             p.append(p.markerPrinter.beforePrefix(marker, new Cursor(marker, this.cursor), it => it))

--- a/rewrite-javascript/rewrite/src/print.ts
+++ b/rewrite-javascript/rewrite/src/print.ts
@@ -71,10 +71,10 @@ interface TreePrinter {
 
 export class TreePrinters {
     private static _registry =
-        new Map<string, () => TreePrinter>();
+        new Map<string, TreePrinter>();
 
     static register(kind: string, printer: () => TreeVisitor<any, PrintOutputCapture>): void {
-        this._registry.set(kind, () => new class implements TreePrinter {
+        this._registry.set(kind, {
             async print(tree: Tree, out?: PrintOutputCapture): Promise<string> {
                 const p = out || new PrintOutputCapture();
                 await printer().visit(tree, p);
@@ -97,7 +97,7 @@ export class TreePrinters {
         if (!this._registry.has(sourceFileKind)) {
             throw new Error(`No printer registered for ${sourceFileKind}`)
         }
-        return this._registry.get(sourceFileKind)!();
+        return this._registry.get(sourceFileKind)!;
     }
 
     static print(sourceFile: SourceFile): Promise<string> {

--- a/rewrite-javascript/rewrite/src/print.ts
+++ b/rewrite-javascript/rewrite/src/print.ts
@@ -71,16 +71,15 @@ interface TreePrinter {
 
 export class TreePrinters {
     private static _registry =
-        new Map<string, TreePrinter>();
+        new Map<string, () => TreePrinter>();
 
-    static register(kind: string, printer: TreeVisitor<any, PrintOutputCapture>): void {
-        this._registry.set(kind, {
+    static register(kind: string, printer: () => TreeVisitor<any, PrintOutputCapture>): void {
+        this._registry.set(kind, () => new class implements TreePrinter {
             async print(tree: Tree, out?: PrintOutputCapture): Promise<string> {
                 const p = out || new PrintOutputCapture();
-                await printer.visit(tree, p);
+                await printer().visit(tree, p);
                 return p.out;
-            }
-        });
+            }})
     }
 
     /**
@@ -98,7 +97,7 @@ export class TreePrinters {
         if (!this._registry.has(sourceFileKind)) {
             throw new Error(`No printer registered for ${sourceFileKind}`)
         }
-        return this._registry.get(sourceFileKind)!;
+        return this._registry.get(sourceFileKind)!();
     }
 
     static print(sourceFile: SourceFile): Promise<string> {

--- a/rewrite-javascript/rewrite/src/text/print.ts
+++ b/rewrite-javascript/rewrite/src/text/print.ts
@@ -52,4 +52,4 @@ class PlainTextPrinter extends PlainTextVisitor<PrintOutputCapture> {
     }
 }
 
-TreePrinters.register(PlainText.Kind.PlainText, new PlainTextPrinter());
+TreePrinters.register(PlainText.Kind.PlainText, () => new PlainTextPrinter());


### PR DESCRIPTION
## What's changed?

Javascript TreePrinters not to re-use printers. Instead it requests a new instance every time.

## What's your motivation?

Fix a concurrency bug.
LST Visitors in Javascript are not thread-safe. A single tree printer instance cannot be safely used to print multiple source files in parallel. When running several in parallel, they give unexpected errors (what's even more peculiar they mostly work, but blunder in some specific cases).

## Testing performed

A spontaneous test-case of parsing and printing multiple source files in parallel.