### PR TITLE
Narrow down types in import tree elements in Javascript

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3316,7 +3316,7 @@ export class JavaScriptParserVisitor {
                     propertyName: this.rightPadded(this.convert(node.propertyName), this.suffix(node.propertyName)),
                     alias: this.convert(node.name)
                 } as JS.Alias
-                : this.convert(node.name),
+                : this.convert(node.name) as J.Identifier,
             type: this.mapType(node),
         };
     }

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -679,7 +679,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     override async visitImportSpecifier(jsImportSpecifier: JS.ImportSpecifier, q: RpcReceiveQueue): Promise<J | undefined> {
         const draft = createDraft(jsImportSpecifier);
         draft.importType = await q.receive(draft.importType, el => this.visitLeftPadded(el, q));
-        draft.specifier = await q.receive(draft.specifier, el => this.visitDefined<Expression>(el, q));
+        draft.specifier = await q.receive(draft.specifier, el => this.visitDefined<JS.Alias | J.Identifier>(el, q));
         draft.type = await q.receive(draft.type, el => this.visitType(el, q));
         return finishDraft(draft);
     }

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -244,7 +244,7 @@ export namespace JS {
      */
     export interface NamedImports extends JS, Expression {
         readonly kind: typeof Kind.NamedImports;
-        readonly elements: J.Container<Expression>;
+        readonly elements: J.Container<ImportSpecifier>;
         readonly type?: JavaType;
     }
 
@@ -255,7 +255,7 @@ export namespace JS {
     export interface ImportSpecifier extends JS, Expression, TypedTree {
         readonly kind: typeof Kind.ImportSpecifier;
         readonly importType: J.LeftPadded<boolean>;
-        readonly specifier: Expression;
+        readonly specifier: J.Identifier | Alias;
         readonly type?: JavaType;
     }
 

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -313,7 +313,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
         return this.produceJavaScript<JS.ImportSpecifier>(importSpecifier, p, async draft => {
             draft.importType = await this.visitLeftPadded(importSpecifier.importType, p);
-            draft.specifier = await this.visitDefined<Expression>(importSpecifier.specifier, p);
+            draft.specifier = await this.visitDefined<JS.Alias | J.Identifier>(importSpecifier.specifier, p);
             draft.type = importSpecifier.type && await this.visitType(importSpecifier.type, p);
         });
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -1317,13 +1317,13 @@ public interface JS extends J {
         @Getter
         Markers markers;
 
-        JContainer<Expression> elements;
+        JContainer<ImportSpecifier> elements;
 
-        public List<Expression> getElements() {
+        public List<ImportSpecifier> getElements() {
             return elements.getElements();
         }
 
-        public NamedImports withElements(List<Expression> elements) {
+        public NamedImports withElements(List<ImportSpecifier> elements) {
             return getPadding().withElements(JContainer.withElements(this.elements, elements));
         }
 
@@ -1361,11 +1361,11 @@ public interface JS extends J {
         public static class Padding {
             private final NamedImports t;
 
-            public JContainer<Expression> getElements() {
+            public JContainer<ImportSpecifier> getElements() {
                 return t.elements;
             }
 
-            public NamedImports withElements(JContainer<Expression> elements) {
+            public NamedImports withElements(JContainer<ImportSpecifier> elements) {
                 return t.elements == elements ? t : new NamedImports(t.id, t.prefix, t.markers, elements, t.type);
             }
         }


### PR DESCRIPTION
## What's changed?

Narrowing down types in the LST elements in Javascript around imports:
- `NamedImports.elements` are always `ImportSpecifiers`
- `ImportSpecifier.specifier` is always either an `Identifier` or an `Alias`
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Be more strong-typed.