### PR TITLE
Allow to more easily check for a null literal value

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LiteralTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LiteralTest.java
@@ -16,10 +16,15 @@
 package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class LiteralTest implements RewriteTest {
 
@@ -232,19 +237,6 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
-    void escapedString() {
-        rewriteRun(
-          java(
-            """
-              class Test {
-                  String s = "\\t	\\n";
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void escapedCharacter() {
         rewriteRun(
           java(
@@ -252,6 +244,31 @@ class LiteralTest implements RewriteTest {
               class Test {
                   char c = '\\'';
                   char tab = '	';
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nullableStringIsNull() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
+                  assertThat(J.Literal.isLiteralValue(literal, null)).isTrue();
+                  return SearchResult.found(literal);
+              }
+          })),
+          java(
+            """
+              class Test {
+                  String s = null;
+              }
+              """,
+            """
+              class Test {
+                  String s = /*~~>*/null;
               }
               """
           )

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LiteralTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LiteralTest.java
@@ -237,6 +237,19 @@ class LiteralTest implements RewriteTest {
     }
 
     @Test
+    void escapedString() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  String s = "\\t	\\n";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void escapedCharacter() {
         rewriteRun(
           java(

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3718,10 +3718,10 @@ public interface J extends Tree, RpcCodec<J> {
          * @return {@code true} if the given {@link Expression} is a {@link Literal} with the given value.
          */
         @Incubating(since = "7.25.0")
-        public static boolean isLiteralValue(@Nullable Expression maybeLiteral, Object value) {
+        public static boolean isLiteralValue(@Nullable Expression maybeLiteral, @Nullable Object value) {
             if (maybeLiteral instanceof Literal) {
                 Literal literal = (Literal) maybeLiteral;
-                return literal.getValue() != null && literal.getValue().equals(value);
+                return literal.getValue() == null ? value == null : literal.getValue().equals(value);
             }
             return false;
         }


### PR DESCRIPTION
Saw a pattern on https://github.com/openrewrite/rewrite-migrate-java/pull/714 that had bugged me previously, where it's cumbersome to check if a literal contains null. This small change makes that easier, as demonstrated in the test.