### PR TITLE
In Javascript - allow for beforeRecipe or afterRecipe to be async with void return type

### DIFF
--- a/rewrite-javascript/rewrite/src/test/rewrite-test.ts
+++ b/rewrite-javascript/rewrite/src/test/rewrite-test.ts
@@ -32,8 +32,8 @@ export interface SourceSpec<T extends SourceFile> {
     after?: AfterRecipeText
     path?: string,
     parser: (ctx: ExecutionContext) => Parser,
-    beforeRecipe?: (sourceFile: T) => T | void | Promise<T>,
-    afterRecipe?: (sourceFile: T) => T | void | Promise<T>,
+    beforeRecipe?: (sourceFile: T) => T | void | Promise<T> | Promise<void>,
+    afterRecipe?: (sourceFile: T) => T | void | Promise<T> | Promise<void>,
     ext: string
 }
 
@@ -121,7 +121,7 @@ export class RecipeSpec {
                     // fail("Expected after to be undefined.");
                 }
                 if (spec.afterRecipe) {
-                    spec.afterRecipe(matchingSpec![1]);
+                    await spec.afterRecipe(matchingSpec![1]);
                 }
             } else {
                 await this.expectAfter(spec, after);
@@ -149,7 +149,7 @@ export class RecipeSpec {
             (spec.after as (actual: string) => string)(actualAfter) : spec.after as string;
         expect(actualAfter).toEqual(afterSource);
         if (spec.afterRecipe) {
-            spec.afterRecipe(actualAfter);
+            await spec.afterRecipe(actualAfter);
         }
     }
 


### PR DESCRIPTION
## What's changed?

In Javascript recipe test harness, allowing for `beforeRecipe` and `afterRecipe` mixins to be async functions returning void.
Currently it allows for async returning `T` or non-async void, but the other combination is not allowed.

## What's your motivation?

I needed it for my local tests.
