### PR TITLE
Handle non-literal arguments in AddOrUpdateAnnotationAttribute

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -18,6 +18,8 @@ package org.openrewrite.java;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
@@ -25,6 +27,7 @@ import static org.openrewrite.java.Assertions.java;
 
 class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
 
+    @DocumentExample
     @Test
     void addValueAttribute() {
         rewriteRun(
@@ -1326,5 +1329,91 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
               )
             );
         }
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/5526")
+    @Test
+    void fieldAccessArgumentDefaultAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+            "org.example.Foo", null, "hello", null, false, false)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String[] value() default {};
+              }
+              """
+          ),
+          java(
+            """
+              package org.example;
+              public interface Bar {
+                  String BAR = "bar";
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.Bar;
+              import org.example.Foo;
+              
+              @Foo({Bar.BAR})
+              public class A {
+              }
+              """,
+            """
+              import org.example.Bar;
+              import org.example.Foo;
+              
+              @Foo({"hello"})
+              public class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/5526")
+    @Test
+    void fieldAccessArgumentNamedAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateAnnotationAttribute(
+            "org.example.Foo", "foo", "hello", null, false, false)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String[] foo() default {};
+              }
+              """
+          ),
+          java(
+            """
+              package org.example;
+              public interface Bar {
+                  String BAR = "bar";
+              }
+              """
+          ),
+          java(
+            """
+              import org.example.Bar;
+              import org.example.Foo;
+              
+              @Foo(foo = {Bar.BAR})
+              public class A {
+              }
+              """,
+            """
+              import org.example.Bar;
+              import org.example.Foo;
+              
+              @Foo(foo = {"hello"})
+              public class A {
+              }
+              """
+          )
+        );
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -152,7 +152,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                             }
 
                             if (as.getAssignment() instanceof J.NewArray) {
-                                List<Expression> jLiteralList = requireNonNull(((J.NewArray) as.getAssignment()).getInitializer());
+                                List<Expression> initializerList = requireNonNull(((J.NewArray) as.getAssignment()).getInitializer());
                                 String attributeValueCleanedUp = attributeValue.replaceAll("\\s+", "").replaceAll("[\\s+{}\"]", "");
                                 List<String> attributeList = Arrays.asList(attributeValueCleanedUp.contains(",") ? attributeValueCleanedUp.split(",") : new String[]{attributeValueCleanedUp});
 
@@ -164,7 +164,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                     boolean changed = false;
                                     for (String attrListValues : attributeList) {
                                         String newAttributeListValue = maybeQuoteStringArgument(attributeName, attrListValues, finalA);
-                                        if (Boolean.FALSE.equals(addOnly) && attributeValIsAlreadyPresent(jLiteralList, newAttributeListValue)) {
+                                        if (Boolean.FALSE.equals(addOnly) && attributeValIsAlreadyPresent(initializerList, newAttributeListValue)) {
                                             continue;
                                         }
                                         if (oldAttributeValue != null && !oldAttributeValue.equals(attrListValues)) {
@@ -176,44 +176,45 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                                 .build()
                                                 .apply(getCursor(), finalA.getCoordinates().replaceArguments()))
                                                 .getArguments()).get(0);
-                                        jLiteralList.add(e);
+                                        initializerList.add(e);
                                     }
-                                    return changed ? as.withAssignment(((J.NewArray) as.getAssignment()).withInitializer(jLiteralList))
+                                    return changed ? as.withAssignment(((J.NewArray) as.getAssignment()).withInitializer(initializerList))
                                             .withMarkers(as.getMarkers().add(new AlreadyAppended(randomId(), newAttributeValue))) : as;
                                 }
                                 int m = 0;
-                                for (int i = 0; i < requireNonNull(jLiteralList).size(); i++) {
+                                for (int i = 0; i < requireNonNull(initializerList).size(); i++) {
                                     if (i >= attributeList.size()) {
-                                        jLiteralList.remove(i);
+                                        initializerList.remove(i);
                                         i--;
                                         continue;
                                     }
 
                                     String newAttributeListValue = maybeQuoteStringArgument(attributeName, attributeList.get(i), finalA);
-                                    if (jLiteralList.size() == i + 1) {
+                                    if (initializerList.size() == i + 1) {
                                         m = i + 1;
                                     }
 
-                                    if (newAttributeListValue.equals(((J.Literal) jLiteralList.get(i)).getValueSource()) || Boolean.TRUE.equals(addOnly)) {
+                                    if (initializerList.get(i) instanceof J.Literal && newAttributeListValue.equals(((J.Literal) initializerList.get(i)).getValueSource()) || Boolean.TRUE.equals(addOnly)) {
                                         continue;
                                     }
                                     if (oldAttributeValue != null && !oldAttributeValue.equals(attributeList.get(i))) {
                                         continue;
                                     }
 
-                                    jLiteralList.set(i, ((J.Literal) jLiteralList.get(i)).withValue(newAttributeListValue).withValueSource(newAttributeListValue).withPrefix(jLiteralList.get(i).getPrefix()));
+                                    J.Literal newLiteral = new J.Literal(randomId(), initializerList.get(i).getPrefix(), Markers.EMPTY, newAttributeListValue, newAttributeListValue, null, JavaType.Primitive.String);
+                                    initializerList.set(i, newLiteral);
                                 }
-                                if (jLiteralList.size() < attributeList.size() || Boolean.TRUE.equals(addOnly)) {
+                                if (initializerList.size() < attributeList.size() || Boolean.TRUE.equals(addOnly)) {
                                     if (Boolean.TRUE.equals(addOnly)) {
                                         m = 0;
                                     }
                                     for (int j = m; j < attributeList.size(); j++) {
                                         String newAttributeListValue = maybeQuoteStringArgument(attributeName, attributeList.get(j), finalA);
-                                        jLiteralList.add(j, new J.Literal(randomId(), jLiteralList.get(j - 1).getPrefix(), Markers.EMPTY, newAttributeListValue, newAttributeListValue, null, JavaType.Primitive.String));
+                                        initializerList.add(j, new J.Literal(randomId(), initializerList.get(j - 1).getPrefix(), Markers.EMPTY, newAttributeListValue, newAttributeListValue, null, JavaType.Primitive.String));
                                     }
                                 }
 
-                                return as.withAssignment(((J.NewArray) as.getAssignment()).withInitializer(jLiteralList));
+                                return as.withAssignment(((J.NewArray) as.getAssignment()).withInitializer(initializerList));
                             } else {
                                 Expression exp = as.getAssignment();
                                 if (exp instanceof J.Literal) {
@@ -294,7 +295,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                             }
 
                             J.NewArray arrayValue = (J.NewArray) it;
-                            List<Expression> jLiteralList = requireNonNull(arrayValue.getInitializer());
+                            List<Expression> initializerList = requireNonNull(arrayValue.getInitializer());
                             String attributeValueCleanedUp = attributeValue.replaceAll("\\s+", "").replaceAll("[\\s+{}\"]", "");
                             List<String> attributeList = Arrays.asList(attributeValueCleanedUp.contains(",") ? attributeValueCleanedUp.split(",") : new String[]{attributeValueCleanedUp});
 
@@ -302,7 +303,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                 boolean changed = false;
                                 for (String attrListValues : attributeList) {
                                     String newAttributeListValue = maybeQuoteStringArgument(attributeName, attrListValues, finalA);
-                                    if (Boolean.FALSE.equals(addOnly) && attributeValIsAlreadyPresent(jLiteralList, newAttributeListValue)) {
+                                    if (Boolean.FALSE.equals(addOnly) && attributeValIsAlreadyPresent(initializerList, newAttributeListValue)) {
                                         continue;
                                     }
                                     changed = true;
@@ -312,38 +313,39 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                             .build()
                                             .apply(getCursor(), finalA.getCoordinates().replaceArguments()))
                                             .getArguments()).get(0);
-                                    jLiteralList.add(e);
+                                    initializerList.add(e);
                                 }
                                 if (oldAttributeValue != null) { // remove old value from array
-                                    jLiteralList = ListUtils.map(jLiteralList, val -> valueMatches(val, oldAttributeValue) ? null : val);
+                                    initializerList = ListUtils.map(initializerList, val -> valueMatches(val, oldAttributeValue) ? null : val);
                                 }
 
-                                return changed ? arrayValue.withInitializer(jLiteralList)
+                                return changed ? arrayValue.withInitializer(initializerList)
                                         .withMarkers(it.getMarkers().add(new AlreadyAppended(randomId(), newAttributeValue))) : it;
                             }
                             int m = 0;
-                            for (int i = 0; i < requireNonNull(jLiteralList).size(); i++) {
+                            for (int i = 0; i < requireNonNull(initializerList).size(); i++) {
                                 if (i >= attributeList.size()) {
-                                    jLiteralList.remove(i);
+                                    initializerList.remove(i);
                                     i--;
                                     continue;
                                 }
 
                                 String newAttributeListValue = maybeQuoteStringArgument(attributeName, attributeList.get(i), finalA);
-                                if (jLiteralList.size() == i + 1) {
+                                if (initializerList.size() == i + 1) {
                                     m = i + 1;
                                 }
 
-                                if (newAttributeListValue.equals(((J.Literal) jLiteralList.get(i)).getValueSource()) || Boolean.TRUE.equals(addOnly)) {
+                                if (initializerList.get(i) instanceof J.Literal && newAttributeListValue.equals(((J.Literal) initializerList.get(i)).getValueSource()) || Boolean.TRUE.equals(addOnly)) {
                                     continue;
                                 }
                                 if (oldAttributeValue != null && !oldAttributeValue.equals(newAttributeListValue)) {
                                     continue;
                                 }
 
-                                jLiteralList.set(i, ((J.Literal) jLiteralList.get(i)).withValue(newAttributeListValue).withValueSource(newAttributeListValue).withPrefix(jLiteralList.get(i).getPrefix()));
+                                J.Literal newLiteral = new J.Literal(randomId(), initializerList.get(i).getPrefix(), Markers.EMPTY, newAttributeListValue, newAttributeListValue, null, JavaType.Primitive.String);
+                                initializerList.set(i, newLiteral);
                             }
-                            if (jLiteralList.size() < attributeList.size() || Boolean.TRUE.equals(addOnly)) {
+                            if (initializerList.size() < attributeList.size() || Boolean.TRUE.equals(addOnly)) {
                                 if (Boolean.TRUE.equals(addOnly)) {
                                     m = 0;
                                 }
@@ -355,11 +357,11 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                             .build()
                                             .apply(getCursor(), finalA.getCoordinates().replaceArguments()))
                                             .getArguments()).get(0);
-                                    jLiteralList.add(j, e);
+                                    initializerList.add(j, e);
                                 }
                             }
 
-                            return arrayValue.withInitializer(jLiteralList);
+                            return arrayValue.withInitializer(initializerList);
                         }
                         return it;
                     });


### PR DESCRIPTION
Not a perfect solution just yet, as I saw some more shortcomings when
1. Array attribute initialized not with an array but with a single value, which then fails to append new items
2. duplication between named and value attributes

- Fixes #5526 
