### PR TITLE
Fix: Import handling where types for some of expressions are missing

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java
@@ -1655,4 +1655,90 @@ class AddImportTest implements RewriteTest {
         );
     }
 
+    @Test
+    void codeSanityCheck() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(
+            """
+              package com.ex.app.config;
+              public class OldA {}
+              """,
+            """
+              package com.ex.app.task;
+              public class OldB {}
+              """,
+            """
+              package com.ex.app.task;
+              public class OldC {}
+              """,
+            """
+              package com.ex.app.task;
+              public class OldD {}
+              """,
+            """
+              package com.ex.app.task;
+              public class OldE {}
+              """
+          )).recipes(
+            new ChangeType("com.ex.app.config.OldA", "com.ex.app.config.NewA", null),
+            new ChangeType("com.ex.app.task.OldB", "com.ex.app.task.NewB", null),
+            new ChangeType("com.ex.app.task.OldC", "com.ex.app.task.NewC", null),
+            new ChangeType("com.ex.app.task.OldD", "com.ex.app.task.NewD", null),
+            new ChangeType("com.ex.app.task.OldE", "com.ex.app.task.NewE", null)
+          ),
+          java(
+            """
+              package sample;
+              
+              import com.ex.app.config.OldA;
+              import com.ex.app.task.OldB;
+              import com.ex.app.task.OldC;
+              import com.ex.app.task.OldD;
+              import com.ex.app.task.OldE;
+              
+              public class A {
+                  private final OldA a;
+                  private final OldB b;
+                  private final OldC c;
+                  private final OldD d;
+                  private final OldE e;
+              
+                  public A(OldA a, OldB b, OldC c, OldD d, OldE e) {
+                      this.a = a;
+                      this.b = b;
+                      this.c = c;
+                      this.d = d;
+                      this.e = e;
+                  }
+              }
+              """,
+            """
+          package sample;
+          
+          import com.ex.app.config.NewA;
+          import com.ex.app.task.NewB;
+          import com.ex.app.task.NewC;
+          import com.ex.app.task.NewD;
+          import com.ex.app.task.NewE;
+          
+          public class A {
+              private final NewA a;
+              private final NewB b;
+              private final NewC c;
+              private final NewD d;
+              private final NewE e;
+          
+              public A(NewA a, NewB b, NewC c, NewD d, NewE e) {
+                  this.a = a;
+                  this.b = b;
+                  this.c = c;
+                  this.d = d;
+                  this.e = e;
+              }
+          }
+          """
+          )
+        );
+    }
+
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -269,7 +269,10 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
             //Non-static imports, we just look for field accesses.
             for (NameTree t : FindTypes.find(compilationUnit, fullyQualifiedName)) {
                 if (!(t instanceof J.FieldAccess) || !((J.FieldAccess) t).isFullyQualifiedClassReference(fullyQualifiedName)) {
-                    return getTypeReference(t);
+                    Optional<JavaType> mayBeTypeReference = getTypeReference(t);
+                    if (mayBeTypeReference.isPresent()) {
+                        return mayBeTypeReference;
+                    }
                 }
             }
             return Optional.empty();


### PR DESCRIPTION
Fix: #5542 

### Why it was random (flaky)?
`FindTypes.find returns` a HashSet of expressions for a given type name. The previous logic only inspected the first expression in the set and returned empty if that expression had missing types. Since the hash of expression objects can vary between runs, the iteration order of the HashSet is not consistent. As a result, the test would fail or pass depending on whether an expression with missing types happened to appear first in the set.