### PR TITLE
Javascript - Remove duplicate Primitive interface

### DIFF
--- a/rewrite-javascript/rewrite/src/java/type.ts
+++ b/rewrite-javascript/rewrite/src/java/type.ts
@@ -146,11 +146,6 @@ export namespace JavaType {
         }
     }
 
-    export interface Primitive extends JavaType {
-        readonly kind: typeof Kind.Primitive;
-        readonly keyword: string;
-    }
-
     export interface Union extends JavaType {
         readonly kind: typeof Kind.Union;
         readonly bounds: JavaType[];


### PR DESCRIPTION
## What's changed?

Removing duplicate definition of `Primitive` interface in `JavaType`.

## What's your motivation?

Cleaning up. It's likely a mistake as far as I can tell.
