### PR TITLE
Fixed that the YAML DeleteKey does not remove unused parent keys in all situations

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/DeleteKey.java
@@ -58,7 +58,7 @@ public class DeleteKey extends Recipe {
             @Override
             public  Yaml.Sequence.@Nullable Entry visitSequenceEntry(Yaml.Sequence.Entry entry, ExecutionContext ctx) {
                 if (matcher.matches(getCursor()) || matcher.matches(new Cursor(getCursor(), entry.getBlock()))) {
-                    //noinspection ConstantConditions
+                    removeUnused(getCursor().getParent());
                     return null;
                 }
                 return super.visitSequenceEntry(entry, ctx);

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeleteKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeleteKeyTest.java
@@ -224,4 +224,46 @@ class DeleteKeyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void deleteSequenceEntryUsingChildRegexMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new DeleteKey("$.b.c[?(@.name =~ 'b1-.*')]", null)),
+          yaml(
+            """
+                  a: a-value
+                  b:
+                    c:
+                      - name: b1-value
+                      - name: b2-value
+              """,
+            """
+                  a: a-value
+                  b:
+                    c:
+                      - name: b2-value
+              """
+          )
+        );
+    }
+
+    @Test
+    void deleteSequenceEntriesUsingChildRegexMatchRemovingUnusedKeysRecursively() {
+        rewriteRun(
+          spec -> spec.recipe(new DeleteKey("$.b.c[?(@.name =~ '.*-value')]", null)),
+          yaml(
+            """
+                  a: a-value
+                  b:
+                    c:
+                      - name: b1-value
+                      - name: b2-value
+              """,
+            """
+                  a: a-value
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeleteKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeleteKeyTest.java
@@ -260,7 +260,7 @@ class DeleteKeyTest implements RewriteTest {
                       - name: b2-value
               """,
             """
-                  a: a-value
+              a: a-value
               """
           )
         );

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeleteKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/DeleteKeyTest.java
@@ -253,15 +253,15 @@ class DeleteKeyTest implements RewriteTest {
           spec -> spec.recipe(new DeleteKey("$.b.c[?(@.name =~ '.*-value')]", null)),
           yaml(
             """
-                  a: a-value
-                  b:
-                    c:
-                      - name: b1-value
-                      - name: b2-value
-              """,
+            a: a-value
+            b:
+              c:
+                - name: b1-value
+                - name: b2-value
+            """,
             """
-              a: a-value
-              """
+            a: a-value
+            """
           )
         );
     }


### PR DESCRIPTION
## What's changed?
This solves that the YAML `DeleteKey` recipe doesn't always remove unused parent keys, specifically in combination with a regex match and sequence entries. 

I encountered the issue in the following scenario:

**When** the `DeleteKey` recipe is used with  a JSON path that matches using a regex on a child value of a YAML sequence entry
**And** this results in the sequence becoming empty
**Then** the sequence key and any empty parent keys are not removed
**However** I expected them to be removed, because this does happen when you use an exact match on the child value

The added `deleteSequenceEntriesUsingChildRegexMatchRemovingUnusedKeysRecursively` unit test method shows the expected behavior. Without this fix the `after` looks like this:

```yaml
a: a-value
b:
  c:
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
