### PR TITLE
Javascript - type mapping for Unique Symbols

### DIFF
--- a/rewrite-javascript/rewrite/src/java/type.ts
+++ b/rewrite-javascript/rewrite/src/java/type.ts
@@ -15,6 +15,7 @@ export namespace JavaType {
         Primitive: "org.openrewrite.java.tree.JavaType$Primitive",
         ShallowClass: "org.openrewrite.java.tree.JavaType$ShallowClass",
         Union: "org.openrewrite.java.tree.JavaType$MultiCatch",
+        UniqueSymbol: "org.openrewrite.java.tree.JavaType$UniqueSymbol",
         Unknown: "org.openrewrite.java.tree.JavaType$Unknown",
         Variable: "org.openrewrite.java.tree.JavaType$Variable",
     }
@@ -158,6 +159,10 @@ export namespace JavaType {
 
     export interface ShallowClass extends JavaType.Class {
         readonly kind: typeof Kind.ShallowClass;
+    }
+
+    export interface UniqueSymbol extends JavaType {
+        readonly kind: typeof Kind.UniqueSymbol;
     }
 
     export const unknownType: JavaType = {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -131,6 +131,12 @@ export class JavaScriptTypeMapping {
             this.typeCache.set(signature, result);
             // FIXME unsafeSet
             return result;
+        } else if (type.flags & ts.TypeFlags.UniqueESSymbol) {
+            let result = {
+                kind: JavaType.Kind.UniqueSymbol,
+            } as JavaType.UniqueSymbol;
+            this.typeCache.set(signature, result);
+            return result;
         }
 
         // if (ts.isRegularExpressionLiteral(node)) {

--- a/rewrite-javascript/rewrite/test/javascript/parser/unique-symbol.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/unique-symbol.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../../src/test";
+import {JS, typescript} from "../../../src/javascript";
+import {J, JavaType} from "../../../src/java";
+
+describe('unique symbol mapping', () => {
+    test('basic', async () => {
+        const spec = new RecipeSpec();
+        //language=typescript
+        const source = typescript('const favorite = Symbol("anwil");')
+        source.afterRecipe = tree => {
+            const scopedVarDecl = tree.statements[0].element as JS.ScopedVariableDeclarations;
+            const varDecl = scopedVarDecl.variables[0].element as J.VariableDeclarations;
+            const ident = varDecl.variables[0].element.name as J.Identifier;
+            expect(ident.simpleName).toEqual("favorite");
+            expect(ident.type!.kind).toEqual(JavaType.Kind.UniqueSymbol);
+        }
+        await spec.rewriteRun(source);
+    })
+});


### PR DESCRIPTION
## What's changed?

An amendment to Javascript type attribution/mapping. Adding support for [Unique Symbols](https://www.typescriptlang.org/docs/handbook/symbols.html)

## What's your motivation?

Fewer gaps in type attribution.
