### PR TITLE
Move accepting licenses to Environment$Builder / Environment

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
+++ b/rewrite-core/src/main/java/org/openrewrite/InMemoryExecutionContext.java
@@ -16,6 +16,7 @@
 package org.openrewrite;
 
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.config.LicenseKey;
 
 import java.time.Duration;
 import java.util.Map;
@@ -48,6 +49,7 @@ public class InMemoryExecutionContext implements ExecutionContext, Cloneable {
         this.onError = onError;
         this.onTimeout = onTimeout;
         putMessage(ExecutionContext.RUN_TIMEOUT, runTimeout);
+        LicenseKey.ofModerneCli().ifPresent(key -> ModerneLicenseKeyExecutionContextView.view(this).setLicenseKey(key));
     }
 
     @Override

--- a/rewrite-core/src/main/java/org/openrewrite/ModerneLicenseKeyExecutionContextView.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ModerneLicenseKeyExecutionContextView.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.config.LicenseKey;
+
+public class ModerneLicenseKeyExecutionContextView extends DelegatingExecutionContext {
+    private static final String LICENSE_KEY = "moderne.io.licenseKey";
+
+    public ModerneLicenseKeyExecutionContextView(ExecutionContext delegate) {
+        super(delegate);
+    }
+
+    public static ModerneLicenseKeyExecutionContextView view(ExecutionContext ctx) {
+        if (ctx instanceof ModerneLicenseKeyExecutionContextView) {
+            return (ModerneLicenseKeyExecutionContextView) ctx;
+        }
+        return new ModerneLicenseKeyExecutionContextView(ctx);
+    }
+
+    public ModerneLicenseKeyExecutionContextView setLicenseKey(LicenseKey key) {
+        putMessage(LICENSE_KEY, key);
+        return this;
+    }
+
+    public @Nullable LicenseKey getLicenseKey() {
+        return getMessage(LICENSE_KEY);
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -308,14 +308,20 @@ public class Environment {
     }
 
     public Environment(Collection<? extends ResourceLoader> resourceLoaders) {
-        this.resourceLoaders = resourceLoaders;
-        this.dependencyResourceLoaders = emptyList();
+        this(resourceLoaders, emptyList(), emptyList());
     }
 
     public Environment(Collection<? extends ResourceLoader> resourceLoaders,
                        Collection<? extends ResourceLoader> dependencyResourceLoaders) {
+        this(resourceLoaders, dependencyResourceLoaders, emptyList());
+    }
+
+    public Environment(Collection<? extends ResourceLoader> resourceLoaders,
+                       Collection<? extends ResourceLoader> dependencyResourceLoaders,
+                       Collection<String> acceptedLicenses) {
         this.resourceLoaders = resourceLoaders;
         this.dependencyResourceLoaders = dependencyResourceLoaders;
+        LicenseVerifier.verifyAllLicensesAccepted(this, acceptedLicenses);
     }
 
     public static Builder builder(Properties properties) {
@@ -330,6 +336,7 @@ public class Environment {
         private final Properties properties;
         private final Collection<ResourceLoader> resourceLoaders = new ArrayList<>();
         private final Collection<ResourceLoader> dependencyResourceLoaders = new ArrayList<>();
+        private final List<String> additionallyAcceptedLicenses = new ArrayList<>();
 
         public Builder(Properties properties) {
             this.properties = properties;
@@ -392,6 +399,23 @@ public class Environment {
             return this;
         }
 
+        @SuppressWarnings("unused")
+        public Builder acceptLicense(String license) {
+            additionallyAcceptedLicenses.add(license);
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        public Builder acceptLicenses(String... licenses) {
+            return acceptLicenses(Arrays.asList(licenses));
+        }
+
+        public Builder acceptLicenses(Collection<String> licenses) {
+            additionallyAcceptedLicenses.clear();
+            additionallyAcceptedLicenses.addAll(licenses);
+            return this;
+        }
+
         public Builder load(ResourceLoader resourceLoader, Collection<? extends ResourceLoader> dependencyResourceLoaders) {
             resourceLoaders.add(resourceLoader);
             this.dependencyResourceLoaders.addAll(dependencyResourceLoaders);
@@ -399,7 +423,7 @@ public class Environment {
         }
 
         public Environment build() {
-            return new Environment(resourceLoaders, dependencyResourceLoaders);
+            return new Environment(resourceLoaders, dependencyResourceLoaders, additionallyAcceptedLicenses);
         }
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/Environment.java
@@ -308,16 +308,23 @@ public class Environment {
     }
 
     public Environment(Collection<? extends ResourceLoader> resourceLoaders) {
-        this(resourceLoaders, emptyList(), emptyList());
+        this(resourceLoaders, emptyList(), false);
     }
 
     public Environment(Collection<? extends ResourceLoader> resourceLoaders,
                        Collection<? extends ResourceLoader> dependencyResourceLoaders) {
-        this(resourceLoaders, dependencyResourceLoaders, emptyList());
+        this(resourceLoaders, dependencyResourceLoaders, false);
     }
 
-    public Environment(Collection<? extends ResourceLoader> resourceLoaders,
+    private Environment(Collection<? extends ResourceLoader> resourceLoaders,
                        Collection<? extends ResourceLoader> dependencyResourceLoaders,
+                       boolean acceptLicenses) {
+        this(resourceLoaders, dependencyResourceLoaders, acceptLicenses, emptyList());
+    }
+
+    private Environment(Collection<? extends ResourceLoader> resourceLoaders,
+                       Collection<? extends ResourceLoader> dependencyResourceLoaders,
+                       boolean acceptLicenses,
                        Collection<String> acceptedLicenses) {
         this.resourceLoaders = resourceLoaders;
         this.dependencyResourceLoaders = dependencyResourceLoaders;
@@ -337,6 +344,7 @@ public class Environment {
         private final Collection<ResourceLoader> resourceLoaders = new ArrayList<>();
         private final Collection<ResourceLoader> dependencyResourceLoaders = new ArrayList<>();
         private final List<String> additionallyAcceptedLicenses = new ArrayList<>();
+        private boolean acceptAllLicenses = false;
 
         public Builder(Properties properties) {
             this.properties = properties;
@@ -410,6 +418,11 @@ public class Environment {
             return acceptLicenses(Arrays.asList(licenses));
         }
 
+        public Builder acceptLicenses() {
+            acceptAllLicenses = true;
+            return this;
+        }
+
         public Builder acceptLicenses(Collection<String> licenses) {
             additionallyAcceptedLicenses.clear();
             additionallyAcceptedLicenses.addAll(licenses);
@@ -423,7 +436,7 @@ public class Environment {
         }
 
         public Environment build() {
-            return new Environment(resourceLoaders, dependencyResourceLoaders, additionallyAcceptedLicenses);
+            return new Environment(resourceLoaders, dependencyResourceLoaders, acceptAllLicenses, acceptAllLicenses ? emptyList() : additionallyAcceptedLicenses);
         }
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/License.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/License.java
@@ -15,10 +15,30 @@
  */
 package org.openrewrite.config;
 
+import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 @Value
+@EqualsAndHashCode
 public class License {
     String name;
+
+    @Nullable
     String url;
+
+    @EqualsAndHashCode.Exclude
+    Set<String> modules = new HashSet<>();
+
+    void addModule(String module) {
+        this.modules.add(module);
+    }
+
+    public Set<String> getModules() {
+        return Collections.unmodifiableSet(modules);
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/config/LicenseKey.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/LicenseKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.config;
+
+import lombok.Getter;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.io.*;
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+public class LicenseKey {
+    private static final String MODERNE_CLI_CONFIG_PATH = System.getProperty("user.home") + "/.moderne/cli/moderne.yml";
+
+    private final String key;
+
+    private LicenseKey(String key){
+        this.key = key;
+    }
+
+    public static LicenseKey of(String key){
+        return new LicenseKey(key);
+    }
+
+    public static Optional<LicenseKey> ofModerneCli() {
+        File cliConfig = new File(MODERNE_CLI_CONFIG_PATH);
+        if (cliConfig.exists()) {
+            try (BufferedReader config = new BufferedReader(new FileReader(cliConfig))) {
+                Object loaded = new Yaml(new SafeConstructor(new LoaderOptions())).load(config);
+                if (loaded instanceof Map) {
+                    Object license = ((Map<?, ?>) loaded).get("license");
+                    if (license instanceof Map) {
+                        Object licenseKey = ((Map<?, ?>) license).get("key");
+                        if (licenseKey instanceof String) {
+                            return Optional.of(LicenseKey.of((String) licenseKey));
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/LicenseNotAcceptedException.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/LicenseNotAcceptedException.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.config;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+public final class LicenseNotAcceptedException extends RuntimeException {
+    private static final StackTraceElement[] DISABLE_STACKTRACE = new StackTraceElement[]{};
+
+    private final Collection<License> unacceptedLicenses;
+
+    LicenseNotAcceptedException(Collection<License> unacceptedLicenses) {
+        super(buildMessage(unacceptedLicenses));
+        this.unacceptedLicenses = unacceptedLicenses;
+
+    }
+
+    @SuppressWarnings("unused")
+    public Collection<License> getUnacceptedLicenses() {
+        return Collections.unmodifiableCollection(unacceptedLicenses);
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+        return DISABLE_STACKTRACE;
+    }
+
+    private static String buildMessage(Collection<License> unacceptedLicenses) {
+        StringBuilder sb = new StringBuilder("Unaccepted licenses detected on the classpath:");
+        for (License unacceptedLicense : unacceptedLicenses) {
+            sb.append("\n    - ").append(unacceptedLicense.getName());
+            if (unacceptedLicense.getUrl() != null) {
+                sb.append("(")
+                        .append(unacceptedLicense.getUrl())
+                        .append(")");
+            }
+            if (!unacceptedLicense.getModules().isEmpty()) {
+                sb.append(" is detected in:");
+                for (String module : unacceptedLicense.getModules()) {
+                    sb.append("\n        - ")
+                            .append(module);
+                }
+            }
+        }
+        sb.append("\nEither add command line arguments \"")
+                .append(unacceptedLicenses.stream().map(License::getName).map(LicenseVerifier::asOption).map(option -> "-Drewrite.acceptedLicense." + option.replaceAll(" ", "_")).collect(Collectors.joining(" ")))
+                .append("\" to accept licenses or look at plugin specific solutions.\n")
+                .append("This only needs to be done once. Previously accepted licenses can be revoked again by removing the corresponding lines from ")
+                .append(System.getProperty("user.home"))
+                .append("/.rewrite/licenses.properties");
+
+        return sb.toString();
+    }
+}

--- a/rewrite-core/src/main/java/org/openrewrite/config/LicenseVerifier.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/LicenseVerifier.java
@@ -95,6 +95,9 @@ public class LicenseVerifier {
         if (APACHE_LICENSE.equals(licenseName)) {
             return true;
         }
+        if ((MSAL_LICENSE.equals(licenseName) || MPL_LICENSE.equals(licenseName)) && LicenseKey.ofModerneCli().isPresent()) {
+            return true;
+        }
         return acceptedLicenses.containsKey(licenseName);
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/config/LicenseVerifier.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/LicenseVerifier.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.config;
+
+import lombok.Getter;
+import org.openrewrite.internal.StringUtils;
+
+import java.io.*;
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class LicenseVerifier {
+
+    private static final String APACHE_LICENSE = "Apache License Version 2.0";
+    private static final String MSAL_LICENSE = "Moderne Source Available License";
+    private static final String MSAL_LICENSE_SHORT = "MSAL";
+    private static final String MSAL_LICENSE_LOWERCASE = "moderne source available license";
+    private static final String MPL_LICENSE = "Moderne Proprietary License";
+    private static final String MPL_LICENSE_SHORT = "MPL";
+    private static final String MPL_LICENSE_LOWERCASE = "moderne proprietary license";
+
+    private static final String LICENSES_PATH = System.getProperty("user.home") + "/.rewrite/licenses.properties";
+
+    private final Map<String, LicenseAcceptation> acceptedLicenses = new HashMap<>();
+    private final Map<String, License> requiredLicenses;
+
+    public static void verifyAllLicensesAccepted(Environment environment, Collection<String> additionallyAcceptedLicense) {
+        new LicenseVerifier(environment.listLicenses(), additionallyAcceptedLicense).verify();
+    }
+
+    private LicenseVerifier(Set<License> requiredLicenses, Collection<String> additionallyAcceptedLicenses) {
+        File userHomeRewriteLicenseConfig = new File(LICENSES_PATH);
+        if (userHomeRewriteLicenseConfig.exists()) {
+            try (BufferedReader licenses = new BufferedReader(new FileReader(userHomeRewriteLicenseConfig))) {
+                licenses.lines().filter(Objects::nonNull).filter(s -> !s.trim().isEmpty()).map(LicenseAcceptation::ofProperty).forEach(license -> acceptedLicenses.put(license.getLicense(), license));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        this.requiredLicenses = requiredLicenses.stream()
+                .filter(license -> !isAccepted(license.getName()))
+                .collect(Collectors.toMap(License::getName, Function.identity()));
+
+        acceptSystemPropertyLicenses();
+        if (!this.requiredLicenses.isEmpty()) {
+            additionallyAcceptedLicenses.forEach(this::acceptLicenseIfRequired);
+        }
+    }
+
+    private void acceptLicenseIfRequired(String license) {
+        String licenseName = asLicenseName(license);
+        License requiredLicense = requiredLicenses.values().stream().filter(name -> name.getName().equalsIgnoreCase(licenseName)).findFirst().orElse(null);
+        if (requiredLicense == null) {
+            return;
+        }
+        acceptedLicenses.put(requiredLicense.getName(), new LicenseAcceptation(requiredLicense.getName(), Instant.now())); //renew acceptation timestamp
+        requiredLicenses.remove(requiredLicense.getName());
+    }
+
+    private void verify() {
+        if (!acceptedLicenses.isEmpty()) {
+            File userHomeRewriteLicenseConfig = new File(LICENSES_PATH);
+            userHomeRewriteLicenseConfig.getParentFile().mkdirs();
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(userHomeRewriteLicenseConfig))) {
+                for (LicenseAcceptation license : acceptedLicenses.values()) {
+                    writer.write(license.getLicense() + "=" + license.getAcceptedAt().getEpochSecond());
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        if (!requiredLicenses.isEmpty()) {
+            throw new LicenseNotAcceptedException(requiredLicenses.values());
+        }
+    }
+
+    private boolean isAccepted(String license) {
+        String licenseName = asLicenseName(license);
+        if (APACHE_LICENSE.equals(licenseName)) {
+            return true;
+        }
+        return acceptedLicenses.containsKey(licenseName);
+    }
+
+    private void acceptSystemPropertyLicenses() {
+        if (!requiredLicenses.isEmpty()) {
+            for (Object systemProp : System.getProperties().keySet()) {
+                if (systemProp instanceof String) {
+                    String key = (String) systemProp;
+                    if (key.toLowerCase().startsWith("rewrite.acceptedlicense.")) {
+                        String license = System.getProperty(key);
+                        if (license != null) {
+                            acceptLicenseIfRequired(key.substring("rewrite.acceptedlicense.".length()).replaceAll("_", " "));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Getter
+    private static class LicenseAcceptation {
+        private final String license;
+        private final Instant acceptedAt;
+
+        private LicenseAcceptation(String license, Instant acceptedAt) {
+            this.license = asLicenseName(license);
+            this.acceptedAt = acceptedAt;
+        }
+
+        private static LicenseAcceptation ofProperty(String property) {
+            int splitOn = property.lastIndexOf("=");
+            if (splitOn == -1) {
+                throw new IllegalArgumentException("Invalid license property: " + property + "(does not contain a '=')");
+            }
+            String licenseName = property.substring(0, splitOn);
+            String acceptedAt = property.substring(splitOn + 1);
+            if (licenseName.trim().isEmpty()) {
+                throw new IllegalArgumentException("Invalid license property: " + property + "(license name empty)");
+            }
+            if (acceptedAt.trim().isEmpty() || !StringUtils.isNumeric(acceptedAt)) {
+                throw new IllegalArgumentException("Invalid license property: " + property + "(not an epoch-second/numeric value)");
+            }
+
+            return new LicenseAcceptation(licenseName, Instant.ofEpochSecond(Long.parseLong(acceptedAt)));
+        }
+
+    }
+
+    public static String asLicenseName(String license) {
+        switch (license.toUpperCase()) {
+            case MSAL_LICENSE_SHORT: return MSAL_LICENSE;
+            case MPL_LICENSE_SHORT: return MPL_LICENSE;
+            default: return license;
+        }
+    }
+
+    public static String asOption(String license) {
+        switch (license.toLowerCase()) {
+            case MSAL_LICENSE_LOWERCASE: return MSAL_LICENSE_SHORT;
+            case MPL_LICENSE_LOWERCASE: return MPL_LICENSE_SHORT;
+            default: return license;
+        }
+    }
+}

--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -64,6 +64,7 @@ public interface RewriteTest extends SourceSpecs {
 
     static Recipe fromRuntimeClasspath(String recipe) {
         return Environment.builder()
+                .acceptLicenses()
                 .scanRuntimeClasspath()
                 .build()
                 .activateRecipes(recipe);
@@ -80,6 +81,7 @@ public interface RewriteTest extends SourceSpecs {
         // recipe that fails to configure
         SoftAssertions softly = new SoftAssertions();
         for (Recipe recipe : Environment.builder()
+                .acceptLicenses()
                 .scanRuntimeClasspath(packageName)
                 .build()
                 .listRecipes()) {


### PR DESCRIPTION
A first swing at moving license acceptations as close enough to core so that all the tooling modules can make use of it.

The empty stacktrace is debatable if this is a practice we want to do, but in this case it does result in cleaner error message AND the class name is printed -> should not be very hard to figure out where it is thrown. 

<img width="1199" alt="Screenshot 2025-06-05 at 09 52 41" src="https://github.com/user-attachments/assets/3d505d1a-2643-43af-9120-6474e4dc0e9f" />

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
