### PR TITLE
Fixed some detection logic for DependencyInsight in gradle.

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -23,12 +23,11 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
-import org.openrewrite.groovy.tree.G;
+import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.marker.JavaSourceSet;
-import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.marker.SearchResult;
@@ -36,10 +35,12 @@ import org.openrewrite.maven.table.DependenciesInUse;
 import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -51,6 +52,7 @@ public class DependencyInsight extends Recipe {
 
     private static final MethodMatcher DEPENDENCY_CONFIGURATION_MATCHER = new MethodMatcher("DependencyHandlerSpec *(..)");
     private static final MethodMatcher DEPENDENCY_CLOSURE_MATCHER = new MethodMatcher("RewriteGradleProject dependencies(..)");
+    private static final Function<Object, Set<GroupArtifactVersion>> EMPTY = gav -> new HashSet<>();
 
     @Option(displayName = "Group pattern",
             description = "Group glob pattern used to match dependencies.",
@@ -64,8 +66,8 @@ public class DependencyInsight extends Recipe {
 
     @Option(displayName = "Version",
             description = "Match only dependencies with the specified version. " +
-                          "Node-style [version selectors](https://docs.openrewrite.org/reference/dependency-version-selectors) may be used." +
-                          "All versions are searched by default.",
+                    "Node-style [version selectors](https://docs.openrewrite.org/reference/dependency-version-selectors) may be used." +
+                    "All versions are searched by default.",
             example = "1.x",
             required = false)
     @Nullable
@@ -86,7 +88,7 @@ public class DependencyInsight extends Recipe {
     @Override
     public String getDescription() {
         return "Find direct and transitive dependencies matching a group, artifact, and optionally a configuration name. " +
-               "Results include dependencies that either directly match or transitively include a matching dependency.";
+                "Results include dependencies that either directly match or transitively include a matching dependency.";
     }
 
     @Override
@@ -129,47 +131,38 @@ public class DependencyInsight extends Recipe {
                     if (!(configuration == null || configuration.isEmpty() || c.getName().equals(configuration))) {
                         continue;
                     }
-                    for (ResolvedDependency resolvedDependency : c.getResolved()) {
-                        ResolvedDependency dep = resolvedDependency.findDependency(groupIdPattern, artifactIdPattern);
-                        if (dep == null) {
+                    for (ResolvedDependency resolvedDependency : c.getDirectResolved()) {
+                        if (!resolvedDependency.isDirect()) { // for some reason the direct resolved ones are also containing depth ones.
                             continue;
                         }
-                        if (version != null) {
-                            VersionComparator versionComparator = Semver.validate(version, null).getValue();
-                            if (versionComparator == null) {
-                                sourceFile = Markup.warn(sourceFile, new IllegalArgumentException("Could not construct a valid version comparator from " + version + "."));
-                            } else {
-                                if (!versionComparator.isValid(null, dep.getVersion())) {
-                                    continue;
+                        List<ResolvedDependency> nestedMatchingDependencies = resolvedDependency.findDependencies(groupIdPattern, artifactIdPattern);
+                        for (ResolvedDependency dep : nestedMatchingDependencies) {
+                            if (version != null) {
+                                VersionComparator versionComparator = Semver.validate(version, null).getValue();
+                                if (versionComparator == null) {
+                                    sourceFile = Markup.warn(sourceFile, new IllegalArgumentException("Could not construct a valid version comparator from " + version + "."));
+                                } else {
+                                    if (!versionComparator.isValid(null, dep.getVersion())) {
+                                        continue;
+                                    }
                                 }
                             }
+                            GroupArtifactVersion requestedGav = new GroupArtifactVersion(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId(), resolvedDependency.getVersion());
+                            GroupArtifactVersion targetGav = new GroupArtifactVersion(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
+                            configurationToDirectDependency.computeIfAbsent(c.getName(), EMPTY).add(requestedGav);
+                            directDependencyToTargetDependency.computeIfAbsent(requestedGav, EMPTY).add(targetGav);
+                            dependenciesInUse.insertRow(ctx, new DependenciesInUse.Row(
+                                    projectName,
+                                    sourceSetName,
+                                    dep.getGroupId(),
+                                    dep.getArtifactId(),
+                                    dep.getVersion(),
+                                    dep.getDatedSnapshotVersion(),
+                                    dep.getRequested().getScope(),
+                                    dep.getDepth(),
+                                    resolvedDependency.getGav().asGroupArtifactVersion()
+                            ));
                         }
-                        GroupArtifactVersion requestedGav = new GroupArtifactVersion(resolvedDependency.getGroupId(), resolvedDependency.getArtifactId(), resolvedDependency.getVersion());
-                        GroupArtifactVersion targetGav = new GroupArtifactVersion(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
-                        configurationToDirectDependency.compute(c.getName(), (k, v) -> {
-                            if (v == null) {
-                                v = new LinkedHashSet<>();
-                            }
-                            v.add(requestedGav);
-                            return v;
-                        });
-                        directDependencyToTargetDependency.compute(requestedGav, (k, v) -> {
-                            if (v == null) {
-                                v = new LinkedHashSet<>();
-                            }
-                            v.add(targetGav);
-                            return v;
-                        });
-                        dependenciesInUse.insertRow(ctx, new DependenciesInUse.Row(
-                                projectName,
-                                sourceSetName,
-                                dep.getGroupId(),
-                                dep.getArtifactId(),
-                                dep.getVersion(),
-                                dep.getDatedSnapshotVersion(),
-                                dep.getRequested().getScope(),
-                                dep.getDepth()
-                        ));
                     }
                 }
                 if (directDependencyToTargetDependency.isEmpty()) {
@@ -181,19 +174,17 @@ public class DependencyInsight extends Recipe {
                         continue;
                     }
                     for (Dependency dependency : c.getRequested()) {
-                        if (directDependencyToTargetDependency.containsKey(new GroupArtifactVersion(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()))) {
-                            configurationToDirectDependency.compute(c.getName(), (k, v) -> {
-                                if (v == null) {
-                                    v = new LinkedHashSet<>();
-                                }
-                                v.add(new GroupArtifactVersion(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
-                                return v;
-                            });
+                        GroupArtifactVersion gav = dependency.getGav();
+                        Optional<GroupArtifactVersion> matchingGroupArtifact = directDependencyToTargetDependency.keySet().stream().filter(key -> key.equals(gav)).findFirst();
+                        if (!matchingGroupArtifact.isPresent()) {
+                            matchingGroupArtifact = directDependencyToTargetDependency.keySet().stream().filter(key -> key.asGroupArtifact().equals(gav.asGroupArtifact())).findFirst();
                         }
+
+                        matchingGroupArtifact.ifPresent(version ->
+                                configurationToDirectDependency.computeIfAbsent(c.getName(), EMPTY).add(version));
                     }
                 }
-                return new MarkIndividualDependency(configurationToDirectDependency, directDependencyToTargetDependency)
-                        .attachMarkers(sourceFile, ctx);
+                return new MarkIndividualDependency(configurationToDirectDependency, directDependencyToTargetDependency).attachMarkers(sourceFile, ctx);
             }
         };
     }
@@ -204,22 +195,16 @@ public class DependencyInsight extends Recipe {
     private static class MarkIndividualDependency extends JavaIsoVisitor<ExecutionContext> {
         private final Map<String, Set<GroupArtifactVersion>> configurationToDirectDependency;
         private final Map<GroupArtifactVersion, Set<GroupArtifactVersion>> directDependencyToTargetDependency;
-        private boolean attachToDependencyClosure = false;
-        private boolean hasMarker = false;
 
         public Tree attachMarkers(Tree before, ExecutionContext ctx) {
             Tree after = super.visitNonNull(before, ctx);
-            if (!hasMarker) {
-                if (after == before) {
-                    attachToDependencyClosure = true;
-                    after = super.visitNonNull(before, ctx);
-                }
-                if (after == before) {
-                    String resultText = directDependencyToTargetDependency.values().stream()
-                            .flatMap(Set::stream)
-                            .distinct()
-                            .map(target -> target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion())
-                            .collect(Collectors.joining(","));
+            if (after == before) {
+                String resultText = directDependencyToTargetDependency.values().stream()
+                        .flatMap(Set::stream)
+                        .distinct()
+                        .map(target -> target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion())
+                        .collect(Collectors.joining(","));
+                if (!resultText.isEmpty()) {
                     return SearchResult.found(after, resultText);
                 }
             }
@@ -235,87 +220,29 @@ public class DependencyInsight extends Recipe {
                         .distinct()
                         .map(target -> target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion())
                         .collect(Collectors.joining(","));
-                J.MethodInvocation after = SearchResult.found(m, resultText);
-                if (after == m) {
-                    hasMarker = true;
-                }
-                if (attachToDependencyClosure) {
-                    return after;
+                if (!resultText.isEmpty()) {
+                    directDependencyToTargetDependency.clear();
+                    return SearchResult.found(m, resultText);
                 }
             }
-            if (!DEPENDENCY_CONFIGURATION_MATCHER.matches(m) || !configurationToDirectDependency.containsKey(m.getSimpleName()) ||
-                m.getArguments().isEmpty()) {
-                return m;
-            }
 
-            Expression arg = m.getArguments().get(0);
-            if (arg instanceof J.Literal && ((J.Literal) arg).getValue() instanceof String) {
-                String[] gav = ((String) ((J.Literal) arg).getValue()).split(":");
-                if (gav.length < 2) {
-                    return m;
-                }
-                String groupId = gav[0];
-                String artifactId = gav[1];
-                //noinspection DuplicatedCode
-                Optional<GroupArtifactVersion> maybeMatch = configurationToDirectDependency.get(m.getSimpleName()).stream()
-                        .filter(dep -> Objects.equals(dep.getGroupId(), groupId) && Objects.equals(dep.getArtifactId(), artifactId))
-                        .findAny();
-                if (!maybeMatch.isPresent()) {
-                    return m;
-                }
-                GroupArtifactVersion direct = maybeMatch.get();
-                if (groupId.equals(direct.getGroupId()) && artifactId.equals(direct.getArtifactId())) {
-                    String resultText = directDependencyToTargetDependency.get(direct).stream()
-                            .map(target -> target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion())
-                            .collect(Collectors.joining(","));
-                    J.MethodInvocation result = SearchResult.found(m, resultText);
-                    if (m == result) {
-                        hasMarker = true;
+            if (configurationToDirectDependency.containsKey(m.getSimpleName())) {
+                return Traits.gradleDependency().get(getCursor()).map(dependency -> {
+                    ResolvedGroupArtifactVersion gav = dependency.getResolvedDependency().getGav();
+                    Optional<GroupArtifactVersion> configurationGav = configurationToDirectDependency.get(m.getSimpleName()).stream()
+                            .filter(dep -> dep.asGroupArtifact().equals(gav.asGroupArtifact()))
+                            .findAny();
+                    if (configurationGav.isPresent()) {
+                        configurationToDirectDependency.get(m.getSimpleName());
+                        String resultText = directDependencyToTargetDependency.remove(configurationGav.get()).stream()
+                                .map(target -> target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion())
+                                .collect(Collectors.joining(","));
+                        if (!resultText.isEmpty()) {
+                            return SearchResult.found(m, resultText);
+                        }
                     }
-                    return result;
-                }
-            } else if (arg instanceof G.MapEntry) {
-                String groupId = null;
-                String artifactId = null;
-                for (Expression argExp : m.getArguments()) {
-                    if (!(argExp instanceof G.MapEntry)) {
-                        continue;
-                    }
-                    G.MapEntry gavPart = (G.MapEntry) argExp;
-                    if (!(gavPart.getKey() instanceof J.Literal)) {
-                        continue;
-                    }
-                    String key = (String) ((J.Literal) gavPart.getKey()).getValue();
-                    if ("group".equals(key)) {
-                        groupId = (String) ((J.Literal) gavPart.getValue()).getValue();
-                    } else if ("name".equals(key)) {
-                        artifactId = (String) ((J.Literal) gavPart.getValue()).getValue();
-                    }
-                    if (groupId != null && artifactId != null) {
-                        break;
-                    }
-                }
-
-                String finalGroupId = groupId;
-                String finalArtifactId = artifactId;
-                //noinspection DuplicatedCode
-                Optional<GroupArtifactVersion> maybeMatch = configurationToDirectDependency.get(m.getSimpleName()).stream()
-                        .filter(dep -> Objects.equals(dep.getGroupId(), finalGroupId) && Objects.equals(dep.getArtifactId(), finalArtifactId))
-                        .findAny();
-                if (!maybeMatch.isPresent()) {
-                    return m;
-                }
-                GroupArtifactVersion direct = maybeMatch.get();
-                if (groupId.equals(direct.getGroupId()) && artifactId.equals(direct.getArtifactId())) {
-                    String resultText = directDependencyToTargetDependency.get(direct).stream()
-                            .map(target -> target.getGroupId() + ":" + target.getArtifactId() + ":" + target.getVersion())
-                            .collect(Collectors.joining(","));
-                    J.MethodInvocation result = SearchResult.found(m, resultText);
-                    if (m == result) {
-                        hasMarker = true;
-                    }
-                    return result;
-                }
+                    return null;
+                }).orElse(m);
             }
             return m;
         }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -249,4 +249,166 @@ class DependencyInsightTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void nestedDependenciesAreTransitivelySearchedForMatchingDependencies() {
+        rewriteRun(
+          spec -> spec.recipe(new DependencyInsight("org.springframework.boot", "*", null, null))
+            .dataTable(DependenciesInUse.Row.class, rows -> {
+              assertThat(rows).isNotEmpty();
+              DependenciesInUse.Row row = rows.getFirst();
+              assertThat(row.getArtifactId()).isEqualTo("spring-boot-starter-web");
+              assertThat(row.getDepth()).isEqualTo(0);
+              assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
+              row = rows.get(4);
+              assertThat(row.getArtifactId()).isEqualTo("spring-boot");
+              assertThat(row.getDepth()).isEqualTo(4);
+              assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
+          }),
+          buildGradle(
+            """
+              buildscript {
+              	    ext {
+              	    	springBootVersion = '2.6.6'
+              	    }
+              	    dependencies {
+              	        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.6.6")
+              	    }
+              	    repositories {
+              	        mavenCentral()
+              	    }
+              }
+              repositories {
+                  mavenCentral()
+              }
+    
+              apply plugin: 'org.springframework.boot'
+              apply plugin: 'io.spring.dependency-management'
+              apply plugin: 'java'
+
+              java {
+                  sourceCompatibility = '11'
+              }
+              
+              dependencies {
+                  implementation 'org.springframework.boot:spring-boot-starter-web'
+                  implementation 'org.springframework.boot:spring-boot-starter-actuator:2.6.4'
+                  implementation 'io.pivotal.cfenv:java-cfenv-boot:2.5.0'
+              }
+              """,
+            """
+              buildscript {
+              	    ext {
+              	    	springBootVersion = '2.6.6'
+              	    }
+              	    dependencies {
+              	        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.6.6")
+              	    }
+              	    repositories {
+              	        mavenCentral()
+              	    }
+              }
+              repositories {
+                  mavenCentral()
+              }
+    
+              apply plugin: 'org.springframework.boot'
+              apply plugin: 'io.spring.dependency-management'
+              apply plugin: 'java'
+
+              java {
+                  sourceCompatibility = '11'
+              }
+              
+              dependencies {
+                  /*~~(org.springframework.boot:spring-boot-starter-web:2.6.6,org.springframework.boot:spring-boot-starter:2.6.6,org.springframework.boot:spring-boot-autoconfigure:2.6.6,org.springframework.boot:spring-boot-starter-json:2.6.6,org.springframework.boot:spring-boot:2.6.6,org.springframework.boot:spring-boot-starter-tomcat:2.6.6,org.springframework.boot:spring-boot-starter-logging:2.6.6)~~>*/implementation 'org.springframework.boot:spring-boot-starter-web'
+                  /*~~(org.springframework.boot:spring-boot-starter-actuator:2.6.4,org.springframework.boot:spring-boot-starter:2.6.6,org.springframework.boot:spring-boot-autoconfigure:2.6.6,org.springframework.boot:spring-boot:2.6.6,org.springframework.boot:spring-boot-actuator-autoconfigure:2.6.6,org.springframework.boot:spring-boot-starter-logging:2.6.6,org.springframework.boot:spring-boot-actuator:2.6.6)~~>*/implementation 'org.springframework.boot:spring-boot-starter-actuator:2.6.4'
+                  /*~~(org.springframework.boot:spring-boot-dependencies:2.6.15,org.springframework.boot:spring-boot:2.6.6)~~>*/implementation 'io.pivotal.cfenv:java-cfenv-boot:2.5.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jacksonIsFoundInternally() {
+        rewriteRun(
+          spec -> spec.recipe(new DependencyInsight("com.fasterxml.jackson.*", "*", null, null))
+            .dataTable(DependenciesInUse.Row.class, rows -> {
+                assertThat(rows).isNotEmpty();
+                DependenciesInUse.Row row = rows.getFirst();
+                assertThat(row.getGroupId()).isEqualTo("com.fasterxml.jackson.datatype");
+                assertThat(row.getArtifactId()).isEqualTo("jackson-datatype-jsr310");
+                assertThat(row.getDepth()).isEqualTo(2);
+                assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
+                row = rows.get(4);
+                assertThat(row.getGroupId()).isEqualTo("com.fasterxml.jackson.core");
+                assertThat(row.getArtifactId()).isEqualTo("jackson-core");
+                assertThat(row.getDepth()).isEqualTo(3);
+                assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
+            }),
+          buildGradle(
+            """
+              buildscript {
+              	    ext {
+              	    	springBootVersion = '2.6.6'
+              	    }
+              	    dependencies {
+              	        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.6.6")
+              	    }
+              	    repositories {
+              	        mavenCentral()
+              	    }
+              }
+              repositories {
+                  mavenCentral()
+              }
+    
+              apply plugin: 'org.springframework.boot'
+              apply plugin: 'io.spring.dependency-management'
+              apply plugin: 'java'
+
+              java {
+                  sourceCompatibility = '11'
+              }
+              
+              dependencies {
+                  implementation 'org.springframework.boot:spring-boot-starter-web'
+                  implementation 'org.springframework.boot:spring-boot-starter-actuator:2.6.4'
+                  implementation 'io.pivotal.cfenv:java-cfenv-boot:2.5.0'
+              }
+              """,
+            """
+              buildscript {
+              	    ext {
+              	    	springBootVersion = '2.6.6'
+              	    }
+              	    dependencies {
+              	        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.6.6")
+              	    }
+              	    repositories {
+              	        mavenCentral()
+              	    }
+              }
+              repositories {
+                  mavenCentral()
+              }
+    
+              apply plugin: 'org.springframework.boot'
+              apply plugin: 'io.spring.dependency-management'
+              apply plugin: 'java'
+
+              java {
+                  sourceCompatibility = '11'
+              }
+              
+              dependencies {
+                  /*~~(com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.2,com.fasterxml.jackson.core:jackson-core:2.13.2,com.fasterxml.jackson.core:jackson-annotations:2.13.2,com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2,com.fasterxml.jackson.core:jackson-databind:2.13.2.2,com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.2)~~>*/implementation 'org.springframework.boot:spring-boot-starter-web'
+                  /*~~(com.fasterxml.jackson.core:jackson-core:2.13.2,com.fasterxml.jackson.core:jackson-annotations:2.13.2,com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2,com.fasterxml.jackson.core:jackson-databind:2.13.2.2)~~>*/implementation 'org.springframework.boot:spring-boot-starter-actuator:2.6.4'
+                  /*~~(com.fasterxml.jackson.core:jackson-core:2.13.2,com.fasterxml.jackson.core:jackson-annotations:2.13.2,com.fasterxml.jackson.core:jackson-databind:2.13.2.2)~~>*/implementation 'io.pivotal.cfenv:java-cfenv-boot:2.5.0'
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
@@ -156,7 +156,8 @@ public class DependencyInsight extends Recipe {
                         match.getDatedSnapshotVersion(),
                         StringUtils.isBlank(match.getRequested().getScope()) ? "compile" :
                                 match.getRequested().getScope(),
-                        match.getDepth()
+                        match.getDepth(),
+                        null
                 ));
 
                 return t;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.Recipe;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
 
 @JsonIgnoreType
 public class DependenciesInUse extends DataTable<DependenciesInUse.Row> {
@@ -64,5 +65,11 @@ public class DependenciesInUse extends DataTable<DependenciesInUse.Row> {
         @Column(displayName = "Depth",
                 description = "How many levels removed from a direct dependency. This will be 0 for direct dependencies.")
         Integer depth;
+
+        @Column(displayName = "Direct dependency",
+                description = "What dependency brings this dependency to the project. If depth is 0, this will be the same as the detected dependency. " +
+                              "Only for gradle dependencies")
+        @Nullable
+        GroupArtifactVersion direct;
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -23,10 +23,7 @@ import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.internal.StringUtils.matchesGlob;
@@ -118,6 +115,34 @@ public class ResolvedDependency implements Serializable {
         return gav.getDatedSnapshotVersion();
     }
 
+    public List<ResolvedDependency> findDependencies(String groupId, String artifactId) {
+        return findDependencies0(groupId, artifactId, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    public List<ResolvedDependency> findDependencies0(String groupId, String artifactId, Set<ResolvedDependency> visited) {
+        List<ResolvedDependency> dependencies = new ArrayList<>();
+        if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
+            dependencies.add(this);
+        } else if (!visited.add(this)) {
+            return emptyList();
+        }
+        for (ResolvedDependency dependency : this.dependencies) {
+            dependency.findDependencies0(groupId, artifactId, visited).stream()
+                    .filter(found -> {
+                        if (getRequested().getExclusions() != null) {
+                            for (GroupArtifact exclusion : getRequested().getExclusions()) {
+                                if (matchesGlob(found.getGroupId(), exclusion.getGroupId()) &&
+                                        matchesGlob(found.getArtifactId(), exclusion.getArtifactId())) {
+                                    return false;
+                                }
+                            }
+                        }
+                        return true;
+                    }).forEach(dependencies::add);
+        }
+        return dependencies;
+    }
+
     public @Nullable ResolvedDependency findDependency(String groupId, String artifactId) {
         return findDependency0(groupId, artifactId, Collections.newSetFromMap(new IdentityHashMap<>()));
     }
@@ -129,7 +154,7 @@ public class ResolvedDependency implements Serializable {
             return null;
         }
         outer:
-        for (ResolvedDependency dependency : dependencies) {
+        for (ResolvedDependency dependency : this.dependencies) {
             ResolvedDependency found = dependency.findDependency0(groupId, artifactId, visited);
             if (found != null) {
                 if (getRequested().getExclusions() != null) {


### PR DESCRIPTION
## What's changed?
Improved the logic of Gradle `DependencyInsight`, added the parent/direct dependency which cause the row to show up and wrote 2 tests that show the issue. 

## What's your motivation?
EG. 
When `ResolvedDependency dep = resolvedDependency.findDependency(groupIdPattern, artifactIdPattern);`
would run using a searchPattern for `spring-boot` group and artifact `*` pattern and the dependency declared matched this pattern, transitive dependencies of that one would not be in the insight result list as 
```java
        if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
            return this;
        }
```
would just return `this`. That dependency would then be added to the insights report, but all nested ones (which might also match the search would not be searched. 
Similarly: if you have a dependency for multiple parents that all match the criteria, this implementation in ResolvedDependendency would only return the first matching element and not all matching elements. 
As the datatable for insights need to be correct we need to do a more costly traversal of all dependencies that match. 

## Anything in particular you'd like reviewers to focus on?
@knutwannheden I think I did not make the mistake of using new Set all the time here, but just want to be sure that I am not causing any other outages by the same coding mistake. 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
