### PR TITLE
Bump plugin version for gradle in buildscript classpath dependency scope

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -105,7 +105,7 @@ class UpgradePluginVersionTest implements RewriteTest {
     }
 
     @Test
-    void change() {
+    void changePluginManagementPlugins() {
         rewriteRun(
           spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.x", null)),
           settingsGradle(
@@ -295,6 +295,43 @@ class UpgradePluginVersionTest implements RewriteTest {
               plugins {
                   id 'org.openrewrite.rewrite' version "5.40.7"
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradePluginVersionInBuildScript() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.40.7", null)),
+          buildGradle(
+            """
+              buildscript {
+                  ext {
+                      rewriteVersion = '5.40.0'
+                  }
+                  repositories {
+                      gradlePluginPortal()
+                  }
+                  dependencies {
+                      classpath "org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:$rewriteVersion"
+                  }
+              }
+              apply plugin: "org.openrewrite.rewrite"
+              """,
+            """
+              buildscript {
+                  ext {
+                      rewriteVersion = '5.40.7'
+                  }
+                  repositories {
+                      gradlePluginPortal()
+                  }
+                  dependencies {
+                      classpath "org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:$rewriteVersion"
+                  }
+              }
+              apply plugin: "org.openrewrite.rewrite"
               """
           )
         );

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/plugins/UpgradePluginVersionTest.java
@@ -307,6 +307,37 @@ class UpgradePluginVersionTest implements RewriteTest {
           buildGradle(
             """
               buildscript {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+                  dependencies {
+                      classpath "org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:5.40.0"
+                  }
+              }
+              apply plugin: "org.openrewrite.rewrite"
+              """,
+            """
+              buildscript {
+                  repositories {
+                      gradlePluginPortal()
+                  }
+                  dependencies {
+                      classpath "org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:5.40.7"
+                  }
+              }
+              apply plugin: "org.openrewrite.rewrite"
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradePluginVersionInBuildScriptWithExtVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion("org.openrewrite.rewrite", "5.40.7", null)),
+          buildGradle(
+            """
+              buildscript {
                   ext {
                       rewriteVersion = '5.40.0'
                   }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependencyTest.java
@@ -30,8 +30,12 @@ class GradleDependencyTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .beforeRecipe(withToolingApi())
-          .recipe(RewriteTest.toRecipe(() -> gradleDependency().asVisitor(dep ->
-            SearchResult.found(dep.getTree(), dep.getResolvedDependency().getGav().toString()))));
+          .recipe(RewriteTest.toRecipe(() -> gradleDependency().asVisitor(dep -> {
+            if (dep.getRequestedDependency().getVersion().contains("-jre")) {
+                return dep.withVersion("32.0.0-jre");
+            }
+            return SearchResult.found(dep.getTree(), dep.getResolvedDependency().getGav().toString());
+          })));
     }
 
     @DocumentExample
@@ -62,7 +66,7 @@ class GradleDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  /*~~(com.google.guava:guava:28.2-jre)~~>*/implementation "com.google.guava:guava:28.2-jre"
+                  implementation "com.google.guava:guava:32.0.0-jre"
               }
               """
           )
@@ -132,7 +136,7 @@ class GradleDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  /*~~(com.google.guava:guava:28.2-jre)~~>*/implementation group: "com.google.guava", name: "guava", version: "28.2-jre"
+                  implementation group: "com.google.guava", name: "guava", version: "32.0.0-jre"
               }
               """
           )
@@ -166,7 +170,7 @@ class GradleDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  /*~~(com.google.guava:guava:28.2-jre)~~>*/implementation(platform("com.google.guava:guava:28.2-jre"))
+                  implementation(platform("com.google.guava:guava:32.0.0-jre"))
               }
               """
           )
@@ -200,7 +204,7 @@ class GradleDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  /*~~(com.google.guava:guava:28.2-jre)~~>*/implementation(enforcedPlatform("com.google.guava:guava:28.2-jre"))
+                  implementation(enforcedPlatform("com.google.guava:guava:32.0.0-jre"))
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Dependency Trait now allows for `withVersion` to easily bump the version of a Dependency J.MethodInvocation and return the resulting J.MethodInvocation
Plugins can now be updated by the buildscript dependencies also. 

## What's your motivation?
The plugin dependencies in buildscript are methodinvocations. Rather than copying/gathering stuff from elsewhere I think this approach would allow other recipes to bump a version rather easily. (later perhaps also groups/artifactids?

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
