### PR TITLE
Include specifics when non-downloading failures occur during pom resolution

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -195,6 +195,8 @@ public class MavenResolutionResult implements Marker {
                         exceptions = MavenDownloadingExceptions.append(exceptions, exception);
                     }
                 }
+            } catch (IllegalStateException e) {
+                throw new IllegalStateException("Unable to resolve dependencies of " + pom.getGav(), e);
             }
         }
         if (exceptions != null) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -1150,44 +1150,48 @@ public class ResolvedPom {
     }
 
     private Dependency getValues(Dependency dep, int depth) {
-        Dependency d = dep.withGav(getValues(dep.getGav()))
-                .withScope(getValue(dep.getScope()));
+        Dependency d = dep;
+        try {
+            d = dep.withGav(getValues(dep.getGav()))
+                    .withScope(getValue(dep.getScope()));
 
-        if (d.getGroupId() == null) {
-            return d;
-        }
-
-        String scope;
-        if (d.getScope() == null) {
-            Scope parsedScope = getManagedScope(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
-            scope = parsedScope == null ? null : parsedScope.toString().toLowerCase();
-        } else {
-            scope = getValue(d.getScope());
-        }
-
-        List<GroupArtifact> managedExclusions = getManagedExclusions(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
-        if (!managedExclusions.isEmpty()) {
-            d = d.withExclusions(ListUtils.concatAll(d.getExclusions(), managedExclusions));
-        }
-
-        if (d.getClassifier() != null) {
-            d = d.withClassifier(getValue(d.getClassifier()));
-        }
-        if (d.getType() != null) {
-            d = d.withType(getValue(d.getType()));
-        }
-        String version = d.getVersion();
-        if (d.getVersion() == null || depth > 0) {
-            // dependency management overrides transitive dependency versions
-            version = getManagedVersion(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
-            if (version == null) {
-                version = d.getVersion();
+            if (d.getGroupId() == null) {
+                return d;
             }
-        }
 
-        return d
-                .withGav(d.getGav().withVersion(version))
-                .withScope(scope);
+            String scope;
+            if (d.getScope() == null) {
+                Scope parsedScope = getManagedScope(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
+                scope = parsedScope == null ? null : parsedScope.toString().toLowerCase();
+            } else {
+                scope = getValue(d.getScope());
+            }
+
+            List<GroupArtifact> managedExclusions = getManagedExclusions(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
+            if (!managedExclusions.isEmpty()) {
+                d = d.withExclusions(ListUtils.concatAll(d.getExclusions(), managedExclusions));
+            }
+
+            if (d.getClassifier() != null) {
+                d = d.withClassifier(getValue(d.getClassifier()));
+            }
+            if (d.getType() != null) {
+                d = d.withType(getValue(d.getType()));
+            }
+            String version = d.getVersion();
+            if (d.getVersion() == null || depth > 0) {
+                // dependency management overrides transitive dependency versions
+                version = getManagedVersion(d.getGroupId(), d.getArtifactId(), d.getType(), d.getClassifier());
+                if (version == null) {
+                    version = d.getVersion();
+                }
+            }
+
+            return d.withGav(d.getGav().withVersion(version))
+                    .withScope(scope);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to get values of " + d, e);
+        }
     }
 
     @Value


### PR DESCRIPTION
When we get back a stack trace like this one it can be really hard, without a lot of debugging, to figure out exactly where the problem actually originates:

```
Caused by: java.lang.IllegalArgumentException: Circular placeholder reference 'project.version' in property definitions
    at org.openrewrite.internal.PropertyPlaceholderHelper.parseStringValue (PropertyPlaceholderHelper.java:94)
    at org.openrewrite.internal.PropertyPlaceholderHelper.parseStringValue (PropertyPlaceholderHelper.java:115)
    at org.openrewrite.internal.PropertyPlaceholderHelper.replacePlaceholders (PropertyPlaceholderHelper.java:74)
    at org.openrewrite.maven.tree.ResolvedPom.getValue (ResolvedPom.java:285)
    at org.openrewrite.maven.tree.ResolvedPom.getValues (ResolvedPom.java:362)
    at org.openrewrite.maven.tree.ResolvedPom.getValues (ResolvedPom.java:1125)
    at org.openrewrite.maven.tree.ResolvedPom.resolveDependencies (ResolvedPom.java:949)
    at org.openrewrite.maven.tree.ResolvedPom.resolveDependencies (ResolvedPom.java:925)
    at org.openrewrite.maven.tree.MavenResolutionResult.resolveDependencies (MavenResolutionResult.java:189)
    at org.openrewrite.maven.MavenParser.parseInputs (MavenParser.java:121)
    at org.openrewrite.Parser.parse (Parser.java:59)
```

This change ensures that the dependency being resolved will be called out in the stack trace.