### PR TITLE
Circular Maven `${project.version}` resolution

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
@@ -90,12 +90,10 @@ public class PropertyPlaceholderHelper {
                 if (visitedPlaceholders == null) {
                     visitedPlaceholders = new HashSet<>(4);
                 }
-                if (!visitedPlaceholders.add(originalPlaceholder)) {
-                    throw new IllegalArgumentException(
-                            "Circular placeholder reference '" + originalPlaceholder + "' in property definitions");
+                if (visitedPlaceholders.add(originalPlaceholder)) {
+                    placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
                 }
                 // Recursive invocation, parsing placeholders contained in the placeholder key.
-                placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
                 // Now obtain the value for the fully resolved key...
                 String propVal = placeholderResolver.apply(placeholder);
                 if (propVal == null && valueSeparator != null) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -316,7 +316,11 @@ public class ResolvedPom {
             case "version":
             case "project.version":
             case "pom.version":
-                return requested.getVersion();
+                String version = requested.getVersion();
+                if (version.contains(property) && requested.getParent() != null) {
+                    return requested.getParent().getVersion();
+                }
+                return version;
             case "project.parent.version":
             case "parent.version":
                 return requested.getParent() != null ? requested.getParent().getVersion() : null;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class ResolvedPomTest implements RewriteTest {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class ResolvedPomTest implements RewriteTest {
@@ -102,6 +103,53 @@ class ResolvedPomTest implements RewriteTest {
               </project>
               """,
             spec -> spec.path("bar/pom.xml")
+          )
+        );
+    }
+
+    @Test
+    void projectVersion() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>3.17.0</version>
+              </project>
+              """
+          ),
+          mavenProject(
+            "app",
+            pomXml(
+              """
+                <project>
+                    <groupId>org.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>${project.version}</version>
+                    <parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>3.17.0</version>
+                        <relativeParent>../pom.xml</relativeParent>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec
+                .afterRecipe(doc -> {
+                    List<ResolvedDependency> deps = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getDependencies()
+                      .get(Scope.Compile);
+                    assertThat(deps).hasSize(1);
+                    assertThat(deps.getFirst().getVersion()).isEqualTo("3.17.0");
+                })
+            )
           )
         );
     }
@@ -226,7 +274,7 @@ class ResolvedPomTest implements RewriteTest {
           pomXml(father, spec -> spec.path("father/pom.xml")),
           pomXml(child, spec -> spec.path("father/child/pom.xml").afterRecipe(doc -> {
                 List<Plugin> pluginManagement = doc.getMarkers().findFirst(MavenResolutionResult.class)
-                  .get().getPom().getPluginManagement();
+                  .orElseThrow().getPom().getPluginManagement();
                 assertThat(pluginManagement).hasSize(1);
                 Plugin plugin = pluginManagement.getFirst();
                 assertThat(plugin).extracting(Plugin::getArtifactId).isEqualTo("maven-enforcer-plugin");
@@ -469,7 +517,7 @@ class ResolvedPomTest implements RewriteTest {
               pomXml(father, spec -> spec.path("pom.xml")),
               pomXml(childA, spec -> spec.path("childA/pom.xml")),
               pomXml(childB, spec -> spec.path("childB/pom.xml").afterRecipe(doc -> {
-                    ResolvedPom pom = doc.getMarkers().findFirst(MavenResolutionResult.class).get().getPom();
+                    ResolvedPom pom = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom();
                     String version = pom.getManagedVersion("com.some", "some-artifact", null, null);
                     // Assert that version is not null!
                     assertThat(version).isEqualTo("1");
@@ -540,7 +588,7 @@ class ResolvedPomTest implements RewriteTest {
               """,
             spec -> spec.path("child/pom.xml")
               .afterRecipe(doc -> {
-                  ResolvedPom pom = doc.getMarkers().findFirst(MavenResolutionResult.class).get().getPom();
+                  ResolvedPom pom = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom();
                   assertThat(pom.getDependencyManagement()).hasSize(1);
               })
           )
@@ -586,7 +634,7 @@ class ResolvedPomTest implements RewriteTest {
               """,
             spec -> spec
               .afterRecipe(doc -> {
-                  ResolvedPom pom = doc.getMarkers().findFirst(MavenResolutionResult.class).get().getPom();
+                  ResolvedPom pom = doc.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom();
                   assertThat(pom.getManagedVersion("com.fasterxml.jackson.core", "jackson-core", null, null)).isEqualTo("2.16.1");
               })
           )


### PR DESCRIPTION
## What's changed?

Solving problems recursively resolving `${project.version}`.