### PR TITLE
`AddOrUpdateAnnotationAttribute` mistakenly matches named attribute with field reference

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -1416,4 +1416,37 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotMisMatchWhenUsingFieldReferenceOnNamedAttribute() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new AddOrUpdateAnnotationAttribute(
+              "org.example.Foo",
+              "name",
+              "newValue",
+              "oldValue",
+              null,
+              null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String name() default "";
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import org.example.Foo;
+              
+              @Foo(name = A.OTHER_VALUE)
+              public class A {
+                  public static final String OTHER_VALUE = "otherValue";
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
As reported.