### PR TITLE
Javascript - removing the notion of scope in variable declarations

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -757,8 +757,10 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
         }
 
         // Visit module specifier
-        await this.visit(jsImport.moduleSpecifier.element, otherImport.moduleSpecifier.element);
-        if (!this.match) return jsImport;
+        if (jsImport.moduleSpecifier) {
+            await this.visit(jsImport.moduleSpecifier.element, otherImport.moduleSpecifier!.element);
+            if (!this.match) return jsImport;
+        }
 
         // Compare attributes
         if (!!jsImport.attributes !== !!otherImport.attributes) {
@@ -768,6 +770,12 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
 
         if (jsImport.attributes) {
             await this.visit(jsImport.attributes, otherImport.attributes!);
+        }
+
+        // Compare initializer
+        if (jsImport.initializer) {
+            await this.visit(jsImport.initializer.element, otherImport.initializer!.element);
+            if (!this.match) return jsImport;
         }
 
         return jsImport;
@@ -1300,19 +1308,6 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
         for (let i = 0; i < scopedVariableDeclarations.modifiers.length; i++) {
             await this.visit(scopedVariableDeclarations.modifiers[i], otherScopedVariableDeclarations.modifiers[i]);
             if (!this.match) return scopedVariableDeclarations;
-        }
-
-        // Compare scope
-        if (!!scopedVariableDeclarations.scope !== !!otherScopedVariableDeclarations.scope) {
-            this.abort();
-            return scopedVariableDeclarations;
-        }
-
-        if (scopedVariableDeclarations.scope) {
-            if (!otherScopedVariableDeclarations.scope || scopedVariableDeclarations.scope.element !== otherScopedVariableDeclarations.scope!.element) {
-                this.abort();
-                return scopedVariableDeclarations;
-            }
         }
 
         // Compare variables

--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -53,16 +53,6 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
 export class NormalizeWhitespaceVisitor<P> extends JavaScriptVisitor<P> {
     // called NormalizeFormat in Java
 
-    protected async visitScopedVariableDeclarations(scopedVariableDeclarations: JS.ScopedVariableDeclarations, p: P): Promise<J | undefined> {
-        const ret = await super.visitScopedVariableDeclarations(scopedVariableDeclarations, p) as JS.ScopedVariableDeclarations;
-        return produce(ret, draft => {
-            if (draft.scope) {
-                this.concatenatePrefix(draft, draft.scope!.before);
-                draft.scope!.before = emptySpace;
-            }
-        });
-    }
-
     private concatenatePrefix(node: Draft<J>, right: J.Space) {
         // TODO look at https://github.com/openrewrite/rewrite/commit/990a366fab9e5656812d81d0eb15ecb6bfd2fde0#diff-ec2e977fe8f1e189735e71b817f8f1ebaf79c1490c0210652e8a559f7f7877de
         // and possibly incorporate it here - some special logic needed to merge comments better (?)
@@ -207,11 +197,7 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
             draft.control.prefix.whitespace = this.style.beforeParentheses.forParentheses ? " " : "";
             draft.control.init = await Promise.all(draft.control.init.map(async (oneInit, index) => {
                 if (oneInit.element.kind === JS.Kind.ScopedVariableDeclarations) {
-                    const scopedVD = oneInit.element as Draft<JS.ScopedVariableDeclarations>;
-                    if (scopedVD.scope != undefined) {
-                        scopedVD.scope.before.whitespace = "";
-                        scopedVD.variables[scopedVD.variables.length - 1].after.whitespace = "";
-                    }
+                    // TODO remove?
                 } else if (oneInit.element.kind === J.Kind.VariableDeclarations) {
                     const vd = oneInit.element as Draft<J.VariableDeclarations>;
                     if (vd.modifiers && vd.modifiers.length > 0) {
@@ -813,16 +799,6 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
             });
         }
         return r;
-    }
-
-    protected async visitScopedVariableDeclarations(scopedVariableDeclarations: JS.ScopedVariableDeclarations, p: P): Promise<J | undefined> {
-        const ret = await super.visitScopedVariableDeclarations(scopedVariableDeclarations, p) as JS.ScopedVariableDeclarations;
-        return ret.scope && produce(ret, draft => {
-            if (draft.scope && draft.modifiers.length > 0) {
-                this.ensureSpace(draft.scope.before);
-            }
-            this.ensureSpace(draft.variables[0].element.prefix);
-        });
     }
 
     protected async visitThrow(thrown: J.Throw, p: P): Promise<J | undefined> {

--- a/rewrite-javascript/rewrite/src/javascript/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format.ts
@@ -196,9 +196,7 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         return produceAsync(ret, async draft => {
             draft.control.prefix.whitespace = this.style.beforeParentheses.forParentheses ? " " : "";
             draft.control.init = await Promise.all(draft.control.init.map(async (oneInit, index) => {
-                if (oneInit.element.kind === JS.Kind.ScopedVariableDeclarations) {
-                    // TODO remove?
-                } else if (oneInit.element.kind === J.Kind.VariableDeclarations) {
+                if (oneInit.element.kind === J.Kind.VariableDeclarations) {
                     const vd = oneInit.element as Draft<J.VariableDeclarations>;
                     if (vd.modifiers && vd.modifiers.length > 0) {
                         vd.modifiers[0].prefix.whitespace = "";

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3252,8 +3252,6 @@ export class JavaScriptParserVisitor {
     }
 
     visitImportEqualsDeclaration(node: ts.ImportEqualsDeclaration): JS.Import {
-        const kind = this.findChildNode(node, ts.SyntaxKind.ImportKeyword)!;
-
         return {
             kind: JS.Kind.Import,
             id: randomId(),
@@ -3271,7 +3269,7 @@ export class JavaScriptParserVisitor {
             moduleSpecifier: undefined,
             attributes: undefined,
             initializer: this.leftPadded(this.suffix(node.name), this.visit(node.moduleReference))
-        }; // TODO as JS.Import;
+        } as JS.Import;
     }
 
     visitImportKeyword(node: ts.ImportExpression): J.Identifier {

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3251,48 +3251,27 @@ export class JavaScriptParserVisitor {
         };
     }
 
-    visitImportEqualsDeclaration(node: ts.ImportEqualsDeclaration): JS.ScopedVariableDeclarations {
+    visitImportEqualsDeclaration(node: ts.ImportEqualsDeclaration): JS.Import {
         const kind = this.findChildNode(node, ts.SyntaxKind.ImportKeyword)!;
 
         return {
-            kind: JS.Kind.ScopedVariableDeclarations,
+            kind: JS.Kind.Import,
             id: randomId(),
             prefix: this.prefix(node),
+            importClause: {
+                kind: JS.Kind.ImportClause,
+                id: randomId(),
+                prefix: this.prefix(node),
+                markers: emptyMarkers,
+                typeOnly: node.isTypeOnly,
+                name: node.name && this.rightPadded(this.visit(node.name), this.suffix(node.name)),
+                namedBindings: undefined
+            },
             markers: emptyMarkers,
-            modifiers: this.mapModifiers(node),
-            scope: this.leftPadded(
-                this.prefix(kind),
-                JS.ScopedVariableDeclarations.Scope.Import
-            ),
-            variables: [
-                this.rightPadded({
-                    kind: J.Kind.VariableDeclarations,
-                    id: randomId(),
-                    prefix: emptySpace,
-                    markers: emptyMarkers,
-                    leadingAnnotations: [],
-                    modifiers: node.isTypeOnly ? [{
-                        kind: J.Kind.Modifier,
-                        id: randomId(),
-                        prefix: this.prefix(this.findChildNode(node, ts.SyntaxKind.TypeKeyword)!),
-                        markers: emptyMarkers,
-                        keyword: "type",
-                        type: J.ModifierType.LanguageExtension,
-                        annotations: []
-                    }] : [],
-                    variables: [this.rightPadded({
-                        kind: J.Kind.NamedVariable,
-                        id: randomId(),
-                        prefix: emptySpace,
-                        markers: emptyMarkers,
-                        name: this.visit(node.name),
-                        dimensionsAfterName: [],
-                        initializer: this.leftPadded(this.suffix(node.name), this.visit(node.moduleReference)),
-                        variableType: this.mapVariableType(node)
-                    }, emptySpace)]
-                }, emptySpace)
-            ]
-        }
+            moduleSpecifier: undefined,
+            attributes: undefined,
+            initializer: this.leftPadded(this.suffix(node.name), this.visit(node.moduleReference))
+        }; // TODO as JS.Import;
     }
 
     visitImportKeyword(node: ts.ImportExpression): J.Identifier {

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -164,6 +164,11 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
 
         jsImport.attributes && await this.visit(jsImport.attributes, p);
 
+        if (jsImport.initializer) {
+            p.append("=");
+            await this.visitLeftPadded(jsImport.initializer, p);
+        }
+
         await this.afterSyntax(jsImport, p);
         return jsImport;
     }
@@ -430,29 +435,6 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
 
         for (const m of variableDeclarations.modifiers) {
             await this.visitModifier(m, p);
-        }
-
-        const scope = variableDeclarations.scope;
-        if (scope) {
-            await this.visitSpace(scope.before, p);
-
-            switch (scope.element) {
-                case JS.ScopedVariableDeclarations.Scope.Let:
-                    p.append("let");
-                    break;
-                case JS.ScopedVariableDeclarations.Scope.Const:
-                    p.append("const");
-                    break;
-                case JS.ScopedVariableDeclarations.Scope.Var:
-                    p.append("var");
-                    break;
-                case JS.ScopedVariableDeclarations.Scope.Using:
-                    p.append("using");
-                    break;
-                case JS.ScopedVariableDeclarations.Scope.Import:
-                    p.append("import");
-                    break;
-            }
         }
 
         await this.visitRightPaddedLocal(variableDeclarations.variables, ",", p);

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -236,7 +236,6 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
 
     override async visitScopedVariableDeclarations(scopedVariableDeclarations: JS.ScopedVariableDeclarations, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSendList(scopedVariableDeclarations, el => el.modifiers, el => el.id, el => this.visit(el, q));
-        await q.getAndSend(scopedVariableDeclarations, el => el.scope, el => this.visitLeftPadded(el, q));
         await q.getAndSendList(scopedVariableDeclarations, el => el.variables, el => el.element.id, el => this.visitRightPadded(el, q));
         return scopedVariableDeclarations;
     }
@@ -783,7 +782,6 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     override async visitScopedVariableDeclarations(scopedVariableDeclarations: JS.ScopedVariableDeclarations, q: RpcReceiveQueue): Promise<J | undefined> {
         const draft = createDraft(scopedVariableDeclarations);
         draft.modifiers = await q.receiveListDefined(draft.modifiers, el => this.visitDefined<J.Modifier>(el, q));
-        draft.scope = await q.receive(draft.scope, el => this.visitLeftPadded(el, q));
         draft.variables = await q.receiveListDefined(draft.variables, el => this.visitRightPadded(el, q));
         return finishDraft(draft);
     }

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -132,6 +132,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         await q.getAndSend(jsImport, el => el.importClause, el => this.visit(el, q));
         await q.getAndSend(jsImport, el => el.moduleSpecifier, el => this.visitLeftPadded(el, q));
         await q.getAndSend(jsImport, el => el.attributes, el => this.visit(el, q));
+        await q.getAndSend(jsImport, el => el.initializer, el => this.visitLeftPadded(el, q));
         return jsImport;
     }
 
@@ -663,6 +664,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         draft.importClause = await q.receive(draft.importClause, el => this.visitDefined<JS.ImportClause>(el, q));
         draft.moduleSpecifier = await q.receive(draft.moduleSpecifier, el => this.visitLeftPadded(el, q));
         draft.attributes = await q.receive(draft.attributes, el => this.visitDefined<JS.ImportAttributes>(el, q));
+        draft.initializer = await q.receive(draft.initializer, el => this.visitLeftPadded(el, q));
         return finishDraft(draft);
     }
 

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -223,8 +223,9 @@ export namespace JS {
     export interface Import extends JS, Statement {
         readonly kind: typeof Kind.Import;
         readonly importClause?: ImportClause;
-        readonly moduleSpecifier: J.LeftPadded<Expression>;
+        readonly moduleSpecifier?: J.LeftPadded<Expression>;
         readonly attributes?: ImportAttributes;
+        readonly initializer?: J.LeftPadded<Expression>;
     }
 
     /**
@@ -418,18 +419,7 @@ export namespace JS {
     export interface ScopedVariableDeclarations extends JS, Statement {
         readonly kind: typeof Kind.ScopedVariableDeclarations;
         readonly modifiers: J.Modifier[];
-        readonly scope?: J.LeftPadded<ScopedVariableDeclarations.Scope>;
         readonly variables: J.RightPadded<J>[];
-    }
-
-    export namespace ScopedVariableDeclarations {
-        export const enum Scope {
-            Const = "Const",
-            Let = "Let",
-            Var = "Var",
-            Using = "Using",
-            Import = "Import"
-        }
     }
 
     /**

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -279,8 +279,9 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
         return this.produceJavaScript<JS.Import>(jsImport, p, async draft => {
             draft.importClause = jsImport.importClause && await this.visitDefined<JS.ImportClause>(jsImport.importClause, p);
-            draft.moduleSpecifier = await this.visitLeftPadded(jsImport.moduleSpecifier, p);
+            draft.moduleSpecifier = jsImport.moduleSpecifier && await this.visitLeftPadded(jsImport.moduleSpecifier, p);
             draft.attributes = jsImport.attributes && await this.visitDefined<JS.ImportAttributes>(jsImport.attributes, p);
+            draft.initializer = jsImport.initializer && await this.visitLeftPadded(jsImport.initializer, p);
         });
     }
 
@@ -451,7 +452,6 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
 
         return this.produceJavaScript<JS.ScopedVariableDeclarations>(scopedVariableDeclarations, p, async draft => {
             draft.modifiers = await mapAsync(scopedVariableDeclarations.modifiers, item => this.visitDefined<J.Modifier>(item, p));
-            draft.scope = scopedVariableDeclarations.scope && await this.visitLeftPadded(scopedVariableDeclarations.scope, p);
             draft.variables = await mapAsync(scopedVariableDeclarations.variables, item => this.visitRightPadded(item, p));
         });
     }

--- a/rewrite-javascript/rewrite/test/javascript/parser/import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/import.test.ts
@@ -121,11 +121,22 @@ describe('import mapping', () => {
             `)
         ));
 
-    test('external module import', () =>
+    test('import equals with require', () =>
         spec.rewriteRun(
             //language=typescript
             typescript(`
                 import mongodb = /*a*/require/*b*/(/*c*/'mongodb'/*d*/)/*e*/;
+            `)
+        ));
+
+    test('import equals with qualified name', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                namespace MyLib {
+                    export function hello() {}
+                }
+                import my = MyLib.hello;
             `)
         ));
 });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -256,9 +256,9 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
             i = (JS.Import) temp;
         }
         i = i.withImportClause(visitAndCast(i.getImportClause(), p));
-        i = i.getPadding().withModuleSpecifier(requireNonNull(visitLeftPadded(i.getPadding().getModuleSpecifier(), JsLeftPadded.Location.IMPORT_MODULE_SPECIFIER, p)));
+        i = i.getPadding().withModuleSpecifier(visitLeftPadded(i.getPadding().getModuleSpecifier(), JsLeftPadded.Location.IMPORT_MODULE_SPECIFIER, p));
         i = i.withAttributes(visitAndCast(i.getAttributes(), p));
-        i = i.getPadding().withInitializer(requireNonNull(visitLeftPadded(i.getPadding().getInitializer(), JsLeftPadded.Location.IMPORT_INITIALIZER, p)));
+        i = i.getPadding().withInitializer(visitLeftPadded(i.getPadding().getInitializer(), JsLeftPadded.Location.IMPORT_INITIALIZER, p));
         return i;
     }
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -258,6 +258,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         i = i.withImportClause(visitAndCast(i.getImportClause(), p));
         i = i.getPadding().withModuleSpecifier(requireNonNull(visitLeftPadded(i.getPadding().getModuleSpecifier(), JsLeftPadded.Location.IMPORT_MODULE_SPECIFIER, p)));
         i = i.withAttributes(visitAndCast(i.getAttributes(), p));
+        i = i.getPadding().withInitializer(requireNonNull(visitLeftPadded(i.getPadding().getInitializer(), JsLeftPadded.Location.IMPORT_INITIALIZER, p)));
         return i;
     }
 
@@ -452,7 +453,6 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
             vd = (JS.ScopedVariableDeclarations) temp;
         }
         vd = vd.withModifiers(requireNonNull(ListUtils.map(vd.getModifiers(), e -> visitAndCast(e, p))));
-        vd = vd.getPadding().withScope(visitLeftPadded(vd.getPadding().getScope(), JsLeftPadded.Location.SCOPED_VARIABLE_DECLARATIONS_SCOPE, p));
         vd = vd.getPadding().withVariables(requireNonNull(ListUtils.map(vd.getPadding().getVariables(), e -> visitRightPadded(e, JsRightPadded.Location.SCOPED_VARIABLE_DECLARATIONS_VARIABLE, p))));
         return vd;
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -274,7 +274,6 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     public J visitScopedVariableDeclarations(JS.ScopedVariableDeclarations scopedVariableDeclarations, RpcReceiveQueue q) {
         return scopedVariableDeclarations
                 .withModifiers(q.receiveList(scopedVariableDeclarations.getModifiers(), mod -> (J.Modifier) visitNonNull(mod, q)))
-                .getPadding().withScope(q.receive(scopedVariableDeclarations.getPadding().getScope(), el -> visitLeftPadded(el, q, toEnum(JS.ScopedVariableDeclarations.Scope.class))))
                 .getPadding().withVariables(q.receiveList(scopedVariableDeclarations.getPadding().getVariables(), el -> visitRightPadded(el, q)));
     }
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -154,7 +154,8 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         return anImport
                 .withImportClause(q.receive(anImport.getImportClause(), el -> (JS.ImportClause) visitNonNull(el, q)))
                 .getPadding().withModuleSpecifier(q.receive(anImport.getPadding().getModuleSpecifier(), el -> visitLeftPadded(el, q)))
-                .withAttributes(q.receive(anImport.getAttributes(), el -> (JS.ImportAttributes) visitNonNull(el, q)));
+                .withAttributes(q.receive(anImport.getAttributes(), el -> (JS.ImportAttributes) visitNonNull(el, q)))
+                .getPadding().withInitializer(q.receive(anImport.getPadding().getInitializer(), el -> visitLeftPadded(el, q)));
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -272,7 +272,6 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     @Override
     public J visitScopedVariableDeclarations(JS.ScopedVariableDeclarations scopedVariableDeclarations, RpcSendQueue q) {
         q.getAndSendList(scopedVariableDeclarations, JS.ScopedVariableDeclarations::getModifiers, J.Modifier::getId, el -> visit(el, q));
-        q.getAndSend(scopedVariableDeclarations, el -> el.getPadding().getScope(), el -> visitLeftPadded(el, q));
         q.getAndSendList(scopedVariableDeclarations, el -> el.getPadding().getVariables(), el -> el.getElement().getId(), el -> visitRightPadded(el, q));
         return scopedVariableDeclarations;
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -153,6 +153,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         q.getAndSend(jsImport, JS.Import::getImportClause, el -> visit(el, q));
         q.getAndSend(jsImport, el -> el.getPadding().getModuleSpecifier(), el -> visitLeftPadded(el, q));
         q.getAndSend(jsImport, JS.Import::getAttributes, el -> visit(el, q));
+        q.getAndSend(jsImport, el -> el.getPadding().getInitializer(), el -> visitLeftPadded(el, q));
         return jsImport;
     }
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -1179,6 +1179,17 @@ public interface JS extends J {
         @Nullable
         ImportAttributes attributes;
 
+        @Nullable
+        JLeftPadded<Expression> initializer;
+        public Expression getInitializer() {
+            return initializer.getElement();
+        }
+
+        public JS.Import withInitializer(Expression initializer) {
+            return getPadding().withInitializer(JLeftPadded.withElement(this.initializer, initializer));
+        }
+
+
         @Override
         public <P> J acceptJavaScript(JavaScriptVisitor<P> v, P p) {
             return v.visitImport(this, p);
@@ -1213,8 +1224,17 @@ public interface JS extends J {
             }
 
             public JS.Import withModuleSpecifier(JLeftPadded<Expression> moduleSpecifier) {
-                return t.moduleSpecifier == moduleSpecifier ? t : new JS.Import(t.id, t.prefix, t.markers, t.importClause, moduleSpecifier, t.attributes);
+                return t.moduleSpecifier == moduleSpecifier ? t : new JS.Import(t.id, t.prefix, t.markers, t.importClause, moduleSpecifier, t.attributes, t.initializer);
             }
+
+            public JLeftPadded<Expression> getInitializer() {
+                return t.initializer;
+            }
+
+            public JS.Import withInitializer(@Nullable JLeftPadded<Expression> initializer) {
+                return t.initializer == initializer ? t : new JS.Import(t.id, t.prefix, t.markers, t.importClause, t.moduleSpecifier, t.attributes, initializer);
+            }
+
         }
     }
 
@@ -2479,17 +2499,6 @@ public interface JS extends J {
         @Getter
         List<J.Modifier> modifiers;
 
-        @Nullable
-        JLeftPadded<Scope> scope;
-
-        public @Nullable Scope getScope() {
-            return scope != null ? scope.getElement() : null;
-        }
-
-        public ScopedVariableDeclarations withScope(@Nullable Scope scope) {
-            return getPadding().withScope(JLeftPadded.withElement(this.scope, scope));
-        }
-
         List<JRightPadded<J>> variables;
 
         public List<J> getVariables() {
@@ -2525,14 +2534,6 @@ public interface JS extends J {
             return p;
         }
 
-        public enum Scope {
-            Const,
-            Let,
-            Var,
-            Using,
-            Import
-        }
-
         @RequiredArgsConstructor
         public static class Padding {
             private final ScopedVariableDeclarations t;
@@ -2542,15 +2543,7 @@ public interface JS extends J {
             }
 
             public ScopedVariableDeclarations withVariables(List<JRightPadded<J>> variables) {
-                return t.variables == variables ? t : new ScopedVariableDeclarations(t.id, t.prefix, t.markers, t.modifiers, t.scope, variables);
-            }
-
-            public @Nullable JLeftPadded<Scope> getScope() {
-                return t.scope;
-            }
-
-            public ScopedVariableDeclarations withScope(@Nullable JLeftPadded<Scope> scope) {
-                return t.scope == scope ? t : new ScopedVariableDeclarations(t.id, t.prefix, t.markers, t.modifiers, scope, t.variables);
+                return t.variables == variables ? t : new ScopedVariableDeclarations(t.id, t.prefix, t.markers, t.modifiers, variables);
             }
         }
     }


### PR DESCRIPTION
## What's changed?

Following #5569:
- removing the notion of `ScopedVariableDeclarations.scope` as let/const/var was already moved to VariableDeclarations.modifier
- now adopting a new LST model for what used to be called Import scope

## What's your motivation?

To meet the design decision of "remove that import scope and instead update the model of JS.Import to cover that case".