### PR TITLE
Javascript - avoiding const length in one of the tests

### DIFF
--- a/rewrite-javascript/rewrite/test/javascript/parser/expression-statement.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/expression-statement.test.ts
@@ -97,7 +97,7 @@ describe('expression statement mapping', () => {
             }
 
             const user = getUser(1);
-            const length = user  !.profile?.username  !.length /*test*/;
+            const length2 = user  !.profile?.username  !.length /*test*/;
             const username2 = getUser(1) !.profile?.username; // test;
             const username = user!.profile?.username ?? 'Guest';
         `)


### PR DESCRIPTION
## What's changed?

Minor change in one of the tests.

## What's your motivation?

This is not valid TS code as per:
```
../../opt/homebrew/lib/node_modules/typescript/lib/lib.dom.d.ts:28594:13 - error TS2451: Cannot redeclare block-scoped variable 'length'.

28594 declare var length: number;
```

https://www.typescriptlang.org/play/?#code/MYewdgzgLgBANgUzAcygCxgXhgZgNxA

