### PR TITLE
Correctly parse comments in doctype declarations

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -740,7 +740,7 @@ public interface Xml extends Tree {
             }
 
             Markers markers;
-            List<Element> elements;
+            List<Content> elements;
 
             @Override
             public <P> Xml acceptXml(XmlVisitor<P> v, P p) {


### PR DESCRIPTION
## What's changed?
This change updates the logic in `visitDoctypedecl` to correctly create `Xml.Comment` objects for comments found within a doctype's internal subset. All other markup, such as entity declarations, is parsed as `Xml.CharData` to preserve its raw text.

## What's your motivation?
Closes #4930

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
