### PR TITLE
Prevent NPE in FindAndReplaceLiteral when literal value is null

### DIFF
--- a/rewrite-hcl/src/main/java/org/openrewrite/hcl/search/FindAndReplaceLiteral.java
+++ b/rewrite-hcl/src/main/java/org/openrewrite/hcl/search/FindAndReplaceLiteral.java
@@ -89,6 +89,9 @@ public class FindAndReplaceLiteral extends Recipe {
                     patternOptions |= Pattern.CASE_INSENSITIVE;
                 }
                 Pattern pattern = Pattern.compile(searchStr, patternOptions);
+                if (literal.getValue() == null) {
+                    return literal;
+                }
                 Matcher matcher = pattern.matcher(literal.getValue().toString());
                 if (!matcher.find()) {
                     return literal;

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/search/FindAndReplaceLiteralTest.java
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/search/FindAndReplaceLiteralTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.hcl.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.hcl.Assertions.hcl;
@@ -268,6 +269,22 @@ class FindAndReplaceLiteralTest implements RewriteTest {
                   cluster_name = "cluster-4"
                 }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5579")
+    void handleNullLiteral() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new FindAndReplaceLiteral("foo", "bar", null, null)
+          ),
+          //language=hcl
+          hcl(
+            """
+              myVar = null
               """
           )
         );


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This PR fixes `NullPointerException` in the `FindAndReplaceLiteral` recipe when `literal.getValue()` is `null`

## What's your motivation?
Fixes #5579


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
