### PR TITLE
Fail to resolve property values if they can't be resolved

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/PropertyPlaceholderHelper.java
@@ -90,7 +90,8 @@ public class PropertyPlaceholderHelper {
                 if (visitedPlaceholders == null) {
                     visitedPlaceholders = new HashSet<>(4);
                 }
-                if (visitedPlaceholders.add(originalPlaceholder)) {
+                boolean visited = visitedPlaceholders.add(originalPlaceholder);
+                if (visited) {
                     placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
                 }
                 // Recursive invocation, parsing placeholders contained in the placeholder key.
@@ -110,7 +111,11 @@ public class PropertyPlaceholderHelper {
                 if (propVal != null) {
                     // Recursive invocation, parsing placeholders contained in the
                     // previously resolved placeholder value.
-                    propVal = parseStringValue(propVal, placeholderResolver, visitedPlaceholders);
+                    if (propVal.equals(placeholder) && !visited) {
+                        // if the value is the same as the placeholder, only try to parse if we haven't
+                        // already visited it.
+                        propVal = parseStringValue(propVal, placeholderResolver, visitedPlaceholders);
+                    }
                     result.replace(startIndex, endIndex + placeholderSuffix.length(), propVal);
 
                     if (propVal.length() < endIndex - startIndex + 1) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -1032,7 +1032,7 @@ public class ResolvedPom {
                     if ((d.getGav().getGroupId() != null && d.getGav().getGroupId().startsWith("${") && d.getGav().getGroupId().endsWith("}")) ||
                         (d.getGav().getArtifactId().startsWith("${") && d.getGav().getArtifactId().endsWith("}")) ||
                         (d.getGav().getVersion() != null && d.getGav().getVersion().startsWith("${") && d.getGav().getVersion().endsWith("}"))) {
-                        throw new MavenDownloadingException("Could not resolve property", null, d.getGav());
+                        throw new MavenDownloadingException("Could not determine values for all properties in " + d.getGav(), null, d.getGav());
                     }
 
                     Pom dPom = downloader.download(d.getGav(), null, dd.definedIn, getRepositories());

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/tree/ResolvedPomTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.test.RewriteTest;
 
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -105,6 +107,49 @@ class ResolvedPomTest implements RewriteTest {
             spec -> spec.path("bar/pom.xml")
           )
         );
+    }
+
+    @Test
+    void dependencyWithExplicitParent() {
+        assertThatThrownBy(() -> rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>${project.version}</version>
+              </project>
+              """
+          ),
+          mavenProject(
+            "app",
+            pomXml(
+              """
+                <project>
+                    <groupId>org.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>${project.version}</version>
+                    <parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>${project.version}</version>
+                        <relativeParent>../pom.xml</relativeParent>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        ))
+          .cause()
+          .isInstanceOf(MavenDownloadingException.class)
+          .hasMessageContaining("org.apache.commons:commons-lang3:${project.version}");
     }
 
     @Test


### PR DESCRIPTION

## What's changed?

Prevent `StackOverflowError` when a property cannot be resolved.