### PR TITLE
Don't throw SOE on circular `${project.version}` reference

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -317,8 +317,12 @@ public class ResolvedPom {
             case "project.version":
             case "pom.version":
                 String version = requested.getVersion();
-                if (version.contains(property) && requested.getParent() != null) {
-                    return requested.getParent().getVersion();
+                if (version.contains(property)) {
+                    if (requested.getParent() != null) {
+                        return requested.getParent().getVersion();
+                    } else {
+                        return "error.circular.project.version";
+                    }
                 }
                 return version;
             case "project.parent.version":

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -319,8 +319,9 @@ public class ResolvedPom {
                 String version = requested.getVersion();
                 if (version.contains(property)) {
                     if (requested.getParent() != null) {
-                        return requested.getParent().getVersion();
-                    } else {
+                        version = requested.getParent().getVersion();
+                    }
+                    if (version.contains(property)) {
                         return "error.circular.project.version";
                     }
                 }


### PR DESCRIPTION
## What's changed?

We're struggling to identify how a Maven circular `${project.version}` reference can exist in a dependency version. By returning a version we know can't resolve, we'll pinpoint the dependency that starts this chain reaction.

