### PR TITLE
Maven self-referential property resolution

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(./gradlew:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(grep:*)"
     ],
     "deny": []
   }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -296,7 +296,14 @@ public class ResolvedPom {
         // This facilitates the usage of "-D" arguments on the command line to customize builds
         String propVal = System.getProperty(property, properties.get(property));
         if (propVal != null) {
-            return propVal;
+            // Check if this would create a circular reference
+            // e.g., <project.version>${project.version}</project.version>
+            if (propVal.equals("${" + property + "}")) {
+                // Skip the user-defined property and fall through to built-in resolution
+                propVal = null;
+            } else {
+                return propVal;
+            }
         }
         switch (property) {
             case "groupId":


### PR DESCRIPTION
## What's changed?

We're trying to address a StackOverflowError in Maven resolution for dependencies that use ${project.version} as their version.

The StackOverflowError occurred when a POM defines a property that shadows the built-in project.version with a
  self-referential value:

```
  <properties>
    <project.version>${project.version}</project.version>
  </properties>
```

  This is a valid Maven scenario (though unusual) where someone inadvertently creates a circular reference by
  defining a user property with the same name as a built-in property.

  When resolving `${project.version}`:
  1. ResolvedPom.getProperty() checks user-defined properties first
  2. It finds project.version=${project.version}
  3. Returns "${project.version}" which needs resolution
  4. This creates infinite recursion

  When a property references itself, we skip the user-defined value and fall through to the built-in property
  resolution, which correctly returns the actual project version.

