### PR TITLE
private internal findDependencies for ResolvedDependency

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedDependency.java
@@ -119,7 +119,7 @@ public class ResolvedDependency implements Serializable {
         return findDependencies0(groupId, artifactId, Collections.newSetFromMap(new IdentityHashMap<>()));
     }
 
-    public List<ResolvedDependency> findDependencies0(String groupId, String artifactId, Set<ResolvedDependency> visited) {
+    private List<ResolvedDependency> findDependencies0(String groupId, String artifactId, Set<ResolvedDependency> visited) {
         List<ResolvedDependency> dependencies = new ArrayList<>();
         if (matchesGlob(getGroupId(), groupId) && matchesGlob(getArtifactId(), artifactId)) {
             dependencies.add(this);


### PR DESCRIPTION
## What's changed?
Made a previously introduced method private as it was originally intended not to be exposed. 

## What's your motivation?
People should not be calling this one directly but the public 2-args one.
