### PR TITLE
Annotation wrapping: Leave comments in tact

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest5Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest5Test.java
@@ -439,7 +439,8 @@ class JavaTemplateTest5Test implements RewriteTest {
                       // comment n
                       @SuppressWarnings("ALL") @Deprecated int n;
                       @SuppressWarnings("ALL") @Deprecated final Boolean b;
-                      @SuppressWarnings("ALL") @Deprecated // comment x, y
+                      @SuppressWarnings("ALL") @Deprecated
+                      // comment x, y
                       private Boolean x, y;
                   }
               }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
@@ -822,4 +822,102 @@ class WrappingAndBracesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void annotationWrappingWithComments() {
+        rewriteRun(
+          java(
+            """
+              import java.lang.annotation.Repeatable;
+              
+              @Repeatable(Foo.Foos.class)
+              @interface Foo {
+                  @interface Foos {
+                      Foo[] value();
+                  }
+              }
+              """,
+            SourceSpec::skip),
+          java(
+            """
+              class Test {
+                  @Foo //comment
+                  String method1(){
+                      return "test";
+                  }
+              
+                  @Foo /* comment
+                  on multiple
+                  lines */
+                  String method2(){
+                      return "test";
+                  }
+              
+                  @Foo
+                  //comment
+                  String method3(){
+                      return "test";
+                  }
+              
+                  @Foo
+                  /* comment
+                  on multiple
+                  lines */
+                  String method4(){
+                      return "test";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void annotationWrappingWithCommentsWithModifiers() {
+        rewriteRun(
+          java(
+            """
+              import java.lang.annotation.Repeatable;
+              
+              @Repeatable(Foo.Foos.class)
+              @interface Foo {
+                  @interface Foos {
+                      Foo[] value();
+                  }
+              }
+              """,
+            SourceSpec::skip),
+          java(
+            """
+              class Test {
+                  @Foo //comment
+                  final String method1(){
+                      return "test";
+                  }
+              
+                  @Foo /* comment
+                  on multiple
+                  lines */
+                  final String method2(){
+                      return "test";
+                  }
+              
+                  @Foo
+                  //comment
+                  final String method3(){
+                      return "test";
+                  }
+              
+                  @Foo
+                  /* comment
+                  on multiple
+                  lines */
+                  final String method4(){
+                      return "test";
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
@@ -205,10 +205,12 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private Space wrapElement(Space prefix, String whitespace, WrappingAndBracesStyle.Annotations annotationsStyle) {
-        if (annotationsStyle.getWrap() == DoNotWrap && (hasLineBreak(prefix.getWhitespace()) || prefix.isEmpty())) {
-            return prefix.withWhitespace(Space.SINGLE_SPACE.getWhitespace());
-        } else if (annotationsStyle.getWrap() == WrapAlways) {
-            return prefix.withWhitespace((whitespace.startsWith("\n") ? "" : "\n") + whitespace);
+        if (prefix.getComments().isEmpty()) {
+            if (annotationsStyle.getWrap() == DoNotWrap && (hasLineBreak(prefix.getWhitespace()) || prefix.isEmpty())) {
+                return prefix.withWhitespace(Space.SINGLE_SPACE.getWhitespace());
+            } else if (annotationsStyle.getWrap() == WrapAlways) {
+                return prefix.withWhitespace((whitespace.startsWith("\n") ? "" : "\n") + whitespace);
+            }
         }
         return prefix;
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Comment wrapping should be left intact as part of annotation wrapping

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
[Failing CI on rewrite-spring](https://ge.openrewrite.org/s/rbreyz3vrjt4i/tests/task/:testWithSpringBoot_2_1/details/org.openrewrite.java.spring.framework.BeanMethodsNotPublicTest/removePublicModifierFromBeanMethods()?top-execution=1)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
