### PR TITLE
Revert "Correctly parse comments in doctype declarations"

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -31,6 +31,7 @@ import org.openrewrite.xml.tree.Xml;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -328,45 +329,27 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                 String subsetPrefix = prefix(c.DTD_SUBSET_OPEN());
                 cursor = c.DTD_SUBSET_OPEN().getSymbol().getStopIndex() + 1;
 
-                List<Content> elements = new ArrayList<>();
-                for (ParseTree child : c.intsubset().children) {
-                    ParserRuleContext element = (ParserRuleContext) child;
+                List<Xml.Element> elements = new ArrayList<>();
+                List<ParseTree> children = c.intsubset().children;
+                for (int i = 0; i < children.size(); i++) {
+                    ParserRuleContext element = (ParserRuleContext) children.get(i);
                     // Markup declarations are not fully implemented.
                     // n.getText() includes element subsets.
-                    Content content;
-                    if (element instanceof XMLParser.MarkupdeclContext && ((XMLParser.MarkupdeclContext) element).COMMENT() != null) {
-                        TerminalNode commentNode = ((XMLParser.MarkupdeclContext) element).COMMENT();
-                        content = convert(commentNode, (n, p) -> new Xml.Comment(
-                                randomId(),
-                                p,
-                                Markers.EMPTY,
-                                n.getText().substring("<!--".length(), n.getText().length() - "-->".length())
-                        ));
-                    } else {
-                        content = convert(element, (n, p) -> new Xml.CharData(
-                                randomId(),
-                                p,
-                                Markers.EMPTY,
-                                false,
-                                n.getText(),
-                                ""
-                        ));
-                    }
-                    elements.add(content);
-                }
+                    Xml.Ident ident = convert(element, (n, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, n.getText()));
 
-                if (!elements.isEmpty()) {
-                    String beforeElementTag = prefix(c.DTD_SUBSET_CLOSE());
-                    cursor = c.DTD_SUBSET_CLOSE().getSymbol().getStopIndex() + 1;
-
-                    Content lastElement = elements.get(elements.size() - 1);
-                    if (lastElement instanceof Xml.Comment) {
-                        elements.add(new Xml.CharData(randomId(), "", Markers.EMPTY, false, beforeElementTag, ""));
-                    } else if (lastElement instanceof Xml.CharData) {
-                        Xml.CharData lastCharData = (Xml.CharData) lastElement;
-                        String afterText = (lastCharData.getAfterText() == null ? "" : lastCharData.getAfterText()) + beforeElementTag;
-                        elements.set(elements.size() - 1, lastCharData.withAfterText(afterText));
+                    String beforeElementTag = "";
+                    if (i == children.size() - 1) {
+                        beforeElementTag = prefix(c.DTD_SUBSET_CLOSE());
+                        cursor = c.DTD_SUBSET_CLOSE().getSymbol().getStopIndex() + 1;
                     }
+
+                    elements.add(
+                            new Xml.Element(
+                                    randomId(),
+                                    prefix(element),
+                                    Markers.EMPTY,
+                                    Collections.singletonList(ident),
+                                    beforeElementTag));
                 }
                 externalSubsets = new Xml.DocTypeDecl.ExternalSubsets(randomId(), subsetPrefix, Markers.EMPTY, elements);
             }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -740,7 +740,7 @@ public interface Xml extends Tree {
             }
 
             Markers markers;
-            List<Content> elements;
+            List<Element> elements;
 
             @Override
             public <P> Xml acceptXml(XmlVisitor<P> v, P p) {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -25,11 +25,9 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.trait.Reference;
-import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Paths;
-import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -462,46 +460,6 @@ class XmlParserTest implements RewriteTest {
         rewriteRun(
           xml(
             "<?xml version=\"1.0\"?>CR<a>CR</a>".replace("CR", "\r")
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/4930")
-    @Test
-    void commentIsParsedAsXmlComment() {
-        rewriteRun(
-          xml(
-            """
-            <?xml version="1.0" encoding="iso-8859-1" standalone="no"?>
-            <!DOCTYPE xsl:stylesheet [
-                <!-- EXSLT-Math -->
-                <!ENTITY foons "https://www.foo.org/bar">
-            ]>
-            <xsl:stylesheet version="1.0"/>
-            """,
-            spec -> spec.afterRecipe(doc -> {
-                Xml.DocTypeDecl docTypeDecl = doc.getProlog().getMisc().stream()
-                  .filter(Xml.DocTypeDecl.class::isInstance)
-                  .map(Xml.DocTypeDecl.class::cast)
-                  .findFirst()
-                  .orElse(null);
-
-                assertNotNull(docTypeDecl, "DocTypeDecl should be present");
-                assertNotNull(docTypeDecl.getExternalSubsets(), "ExternalSubsets should be present");
-
-                List<Content> elements = docTypeDecl.getExternalSubsets().getElements();
-                assertThat(elements.size()).isEqualTo(2);
-
-                assertThat(elements.get(0))
-                  .as("Comment should be Xml.Comment")
-                  .isInstanceOf(Xml.Comment.class);
-                assertThat(((Xml.Comment) elements.get(0)).getText().trim())
-                  .isEqualTo("EXSLT-Math");
-
-                assertThat(elements.get(1))
-                  .as("Non-comment should be Xml.CharData")
-                  .isInstanceOf(Xml.CharData.class);
-            })
           )
         );
     }


### PR DESCRIPTION
Reverts openrewrite/rewrite#5581
as it's causing downstream problems, e.g.
```
/home/runner/work/rewrite-java-security/rewrite-java-security/src/main/java/org/openrewrite/java/security/xml/ExternalDTDAccumulator.java:32: error: incompatible types: Content cannot be converted to Element
                    for (Xml.Element element : docTypeDecl.getExternalSubsets().getElements()) {
```
Also this comment:
https://github.com/openrewrite/rewrite/pull/5581#issuecomment-2957716271
needs to be addressed.