### PR TITLE
Do not expect after to be non null in handleError

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -290,9 +290,9 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                                              Throwable t) {
         ctx.getOnError().accept(t);
 
-        if (t instanceof RecipeRunException) {
+        if (t instanceof RecipeRunException && after != null) {
             RecipeRunException vt = (RecipeRunException) t;
-            after = (SourceFile) new FindRecipeRunException(vt).visitNonNull(requireNonNull(after, "after is null"), 0);
+            after = (SourceFile) new FindRecipeRunException(vt).visitNonNull(after, 0);
         }
 
         // Use the original source file to record the error, not the one that may have been modified by the visitor.


### PR DESCRIPTION
Actual error is being swallowed in case of a failure during generate:

```
java.lang.NullPointerException: after is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:235)
	at org.openrewrite.scheduling.RecipeRunCycle.handleError(RecipeRunCycle.java:295)
	at org.openrewrite.scheduling.RecipeRunCycle.lambda$generateSources$6(RecipeRunCycle.java:159)
	at org.openrewrite.scheduling.RecipeStack.reduce(RecipeStack.java:60)
	at org.openrewrite.scheduling.RecipeRunCycle.generateSources(RecipeRunCycle.java:127)
	```
