### PR TITLE
Fix `NullPointerException` on `WrappingAndBracesStyle`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/WrappingAndBracesTest.java
@@ -23,7 +23,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.style.SpacesStyle;
 import org.openrewrite.java.style.WrappingAndBracesStyle;
-import org.openrewrite.style.LineWrapSetting;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -345,7 +344,7 @@ class WrappingAndBracesTest implements RewriteTest {
                   }
               }
               """,
-              """
+            """
               public class Test {
                   public void doSomething() {
                       @SuppressWarnings("ALL") int foo;
@@ -875,6 +874,63 @@ class WrappingAndBracesTest implements RewriteTest {
     @Test
     void annotationWrappingWithCommentsWithModifiers() {
         rewriteRun(
+          java(
+            """
+              import java.lang.annotation.Repeatable;
+              
+              @Repeatable(Foo.Foos.class)
+              @interface Foo {
+                  @interface Foos {
+                      Foo[] value();
+                  }
+              }
+              """,
+            SourceSpec::skip),
+          java(
+            """
+              class Test {
+                  @Foo //comment
+                  final String method1(){
+                      return "test";
+                  }
+              
+                  @Foo /* comment
+                  on multiple
+                  lines */
+                  final String method2(){
+                      return "test";
+                  }
+              
+                  @Foo
+                  //comment
+                  final String method3(){
+                      return "test";
+                  }
+              
+                  @Foo
+                  /* comment
+                  on multiple
+                  lines */
+                  final String method4(){
+                      return "test";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void annotationWrappingWithNulls() {
+        rewriteRun(spec ->
+            spec.recipe(toRecipe(() -> new WrappingAndBracesVisitor<>(new WrappingAndBracesStyle(
+              new WrappingAndBracesStyle.IfStatement(false),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null)))),
           java(
             """
               import java.lang.annotation.Repeatable;

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/WrappingAndBracesVisitor.java
@@ -25,10 +25,10 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
-import org.openrewrite.style.LineWrapSetting;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static org.openrewrite.internal.StringUtils.hasLineBreak;
 import static org.openrewrite.style.LineWrapSetting.DoNotWrap;
 import static org.openrewrite.style.LineWrapSetting.WrapAlways;
@@ -205,7 +205,7 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private Space wrapElement(Space prefix, String whitespace, WrappingAndBracesStyle.Annotations annotationsStyle) {
-        if (annotationsStyle != null && prefix.getComments().isEmpty()) {
+        if (prefix.getComments().isEmpty()) {
             if (annotationsStyle.getWrap() == DoNotWrap && (hasLineBreak(prefix.getWhitespace()) || prefix.isEmpty())) {
                 return prefix.withWhitespace(Space.SINGLE_SPACE.getWhitespace());
             } else if (annotationsStyle.getWrap() == WrapAlways) {
@@ -219,12 +219,12 @@ public class WrappingAndBracesVisitor<P> extends JavaIsoVisitor<P> {
         if (prefix.getComments().isEmpty()) {
             return prefix.withWhitespace((hasLineBreak(prefix.getWhitespace()) ? "" : "\n") + prefix.getWhitespace());
         } else if (prefix.getComments().get(prefix.getComments().size() - 1).isMultiline()) {
-            return prefix.withComments(ListUtils.mapLast(prefix.getComments(), c -> c.withSuffix("\n")));
+            return prefix.withComments(ListUtils.mapLast(prefix.getComments(), c -> requireNonNull(c).withSuffix("\n")));
         }
         return prefix;
     }
 
     private List<J.Modifier> withNewline(List<J.Modifier> modifiers, String whitespace, WrappingAndBracesStyle.Annotations annotationsStyle) {
-        return ListUtils.mapFirst(modifiers, mod -> mod.withPrefix(wrapElement(mod.getPrefix(), whitespace, annotationsStyle)));
+        return ListUtils.mapFirst(modifiers, mod -> requireNonNull(mod).withPrefix(wrapElement(mod.getPrefix(), whitespace, annotationsStyle)));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/WrappingAndBracesStyle.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/WrappingAndBracesStyle.java
@@ -15,11 +15,15 @@
  */
 package org.openrewrite.java.style;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Value;
 import lombok.With;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.java.JavaStyle;
 import org.openrewrite.style.LineWrapSetting;
+
+import static org.openrewrite.style.LineWrapSetting.DoNotWrap;
+import static org.openrewrite.style.LineWrapSetting.WrapAlways;
 
 @Value
 @With
@@ -32,6 +36,23 @@ public class WrappingAndBracesStyle implements JavaStyle {
     Annotations parameterAnnotations;
     Annotations localVariableAnnotations;
     Annotations enumFieldAnnotations;
+
+    @JsonCreator
+    public WrappingAndBracesStyle(IfStatement ifStatement,
+                                  @Nullable Annotations classAnnotations,
+                                  @Nullable Annotations methodAnnotations,
+                                  @Nullable Annotations fieldAnnotations,
+                                  @Nullable Annotations parameterAnnotations,
+                                  @Nullable Annotations localVariableAnnotations,
+                                  @Nullable Annotations enumFieldAnnotations) {
+        this.ifStatement = ifStatement;
+        this.classAnnotations = classAnnotations == null ? new WrappingAndBracesStyle.Annotations(WrapAlways) : classAnnotations;
+        this.methodAnnotations = methodAnnotations == null ? new WrappingAndBracesStyle.Annotations(WrapAlways) : methodAnnotations;
+        this.fieldAnnotations = fieldAnnotations == null ? new WrappingAndBracesStyle.Annotations(WrapAlways) : fieldAnnotations;
+        this.parameterAnnotations = parameterAnnotations == null ? new WrappingAndBracesStyle.Annotations(DoNotWrap) : parameterAnnotations;
+        this.localVariableAnnotations = localVariableAnnotations == null ? new WrappingAndBracesStyle.Annotations(DoNotWrap) : localVariableAnnotations;
+        this.enumFieldAnnotations = enumFieldAnnotations == null ? new WrappingAndBracesStyle.Annotations(DoNotWrap) : enumFieldAnnotations;
+    }
 
     public IfStatement getIfStatement() {
         //noinspection ConstantConditions


### PR DESCRIPTION
Instead of checking for null on non-nullable fields we set them to sensible defaults (based on the defaults from `Intellij`

## What's changed?
Since the added fields to `WrappingAndBracesStyle` are not available in older LSTs these are going to be null. By setting sensible defaults we allow this version to run on those LSTs.

## What's your motivation?
This causes NullPointerExceptions

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Have you considered any alternatives or workarounds?
We could make the fields `Nullable` and handle this.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
