### PR TITLE
Remove redundant Gradle dependencies if exact transient dep exists

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
@@ -537,6 +537,85 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
+    void removeUnmanagedDependencyIfDependencyIsLoadedTransitivelyIsExactlyTheSame() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  implementation('org.flywaydb:flyway-sqlserver:10.10.0')
+                  runtimeOnly('org.flywaydb:flyway-core:10.10.0')
+              }
+              """,
+            """
+              plugins {
+                  id "java"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  implementation('org.flywaydb:flyway-sqlserver:10.10.0')
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepUnmanagedDependencyIfDependencyIsLoadedTransitivelyIsDifferentVersion() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  implementation('org.flywaydb:flyway-sqlserver:10.10.0')
+                  runtimeOnly('org.flywaydb:flyway-core:10.11.0')
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepUnmanagedDirectDependencyIfDependencyIsLoadedTransitivelyHasNoVersion() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  implementation('org.flywaydb:flyway-sqlserver')
+                  runtimeOnly('org.flywaydb:flyway-core')
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void kotlin() {
         rewriteRun(
           buildGradleKts(


### PR DESCRIPTION
## What's changed?
More redundant dependencies are cleanup up.

## Anything in particular you'd like reviewers to focus on?
I wonder if this can even be improved. Does this PR really make any sense? How often would someone list their dependencies like this?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
