### PR TITLE
add reproducer showing `gradle.FindDependency` finds gradle dependency constraints

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -207,4 +207,22 @@ class FindDependencyTest implements RewriteTest {
         }
 
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5599")
+    void ignoreConstraints() {
+        rewriteRun(spec -> spec.recipe(new FindDependency("com.fasterxml.jackson.core", "jackson-databind", "implementation")),
+          buildGradle(
+            //language=gradle
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  constraints {
+                      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.1') 
+                  }
+              }
+              """));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
