### PR TITLE
Enhance MavenSettings to handle password decryption

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSecuritySettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenSecuritySettings.java
@@ -201,7 +201,8 @@ public class MavenSecuritySettings {
             System.arraycopy(clearBytes, 0, decryptedBytes, 0, decryptedBytes.length);
             return new String(decryptedBytes, StandardCharsets.UTF_8);
         } catch (NoSuchPaddingException | NoSuchAlgorithmException | BadPaddingException | IllegalBlockSizeException |
-                 InvalidKeyException | InvalidAlgorithmParameterException | IllegalArgumentException e) {
+                 InvalidKeyException | InvalidAlgorithmParameterException | NegativeArraySizeException |
+                 ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
             return null;
         }
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
fixes https://github.com/moderneinc/customer-requests/issues/1155

We decrypt the passwords if we are loading the Maven files from disk but we don't decrypt the settings if loaded from parsing.

## What's your motivation?

- consistent behaviour when loading the Maven `settings.xml`
- fix customer issue where they are using a `security-setting.xml` to encrypt their passwords

## Anything in particular you'd like reviewers to focus on?
approach?

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
