### PR TITLE
Datatable should not have the direct column

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -159,8 +159,7 @@ public class DependencyInsight extends Recipe {
                                     dep.getVersion(),
                                     dep.getDatedSnapshotVersion(),
                                     dep.getRequested().getScope(),
-                                    dep.getDepth(),
-                                    resolvedDependency.getGav().asGroupArtifactVersion().toString()
+                                    dep.getDepth()
                             ));
                         }
                     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -160,7 +160,7 @@ public class DependencyInsight extends Recipe {
                                     dep.getDatedSnapshotVersion(),
                                     dep.getRequested().getScope(),
                                     dep.getDepth(),
-                                    resolvedDependency.getGav().asGroupArtifactVersion()
+                                    resolvedDependency.getGav().asGroupArtifactVersion().toString()
                             ));
                         }
                     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/DependencyInsightTest.java
@@ -259,11 +259,9 @@ class DependencyInsightTest implements RewriteTest {
               DependenciesInUse.Row row = rows.getFirst();
               assertThat(row.getArtifactId()).isEqualTo("spring-boot-starter-web");
               assertThat(row.getDepth()).isEqualTo(0);
-              assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
               row = rows.get(4);
               assertThat(row.getArtifactId()).isEqualTo("spring-boot");
               assertThat(row.getDepth()).isEqualTo(4);
-              assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
           }),
           buildGradle(
             """
@@ -340,12 +338,10 @@ class DependencyInsightTest implements RewriteTest {
                 assertThat(row.getGroupId()).isEqualTo("com.fasterxml.jackson.datatype");
                 assertThat(row.getArtifactId()).isEqualTo("jackson-datatype-jsr310");
                 assertThat(row.getDepth()).isEqualTo(2);
-                assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
                 row = rows.get(4);
                 assertThat(row.getGroupId()).isEqualTo("com.fasterxml.jackson.core");
                 assertThat(row.getArtifactId()).isEqualTo("jackson-core");
                 assertThat(row.getDepth()).isEqualTo(3);
-                assertThat(row.getDirect()).isNotNull().hasToString("org.springframework.boot:spring-boot-starter-web:2.6.6");
             }),
           buildGradle(
             """

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/DependencyInsight.java
@@ -156,8 +156,7 @@ public class DependencyInsight extends Recipe {
                         match.getDatedSnapshotVersion(),
                         StringUtils.isBlank(match.getRequested().getScope()) ? "compile" :
                                 match.getRequested().getScope(),
-                        match.getDepth(),
-                        null
+                        match.getDepth()
                 ));
 
                 return t;

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
@@ -21,7 +21,6 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.Recipe;
-import org.openrewrite.maven.tree.GroupArtifactVersion;
 
 @JsonIgnoreType
 public class DependenciesInUse extends DataTable<DependenciesInUse.Row> {
@@ -70,6 +69,6 @@ public class DependenciesInUse extends DataTable<DependenciesInUse.Row> {
                 description = "What dependency brings this dependency to the project. If depth is 0, this will be the same as the detected dependency. " +
                               "Only for gradle dependencies")
         @Nullable
-        GroupArtifactVersion direct;
+        String direct;
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/table/DependenciesInUse.java
@@ -64,11 +64,5 @@ public class DependenciesInUse extends DataTable<DependenciesInUse.Row> {
         @Column(displayName = "Depth",
                 description = "How many levels removed from a direct dependency. This will be 0 for direct dependencies.")
         Integer depth;
-
-        @Column(displayName = "Direct dependency",
-                description = "What dependency brings this dependency to the project. If depth is 0, this will be the same as the detected dependency. " +
-                              "Only for gradle dependencies")
-        @Nullable
-        String direct;
     }
 }


### PR DESCRIPTION
## What's changed?
Datatable should not have the direct column

**AFAICT, I will also need to followup release in rewrite-java-dependencies as that one also uses the constructor [here](https://github.com/openrewrite/rewrite-java-dependencies/blob/f6d1cff5be4c865fa3ef4b09ff612394655d482b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java#L176)**

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
