### PR TITLE
Polish the Gradle build's configuration phase

### DIFF
--- a/rewrite-gradle/build.gradle.kts
+++ b/rewrite-gradle/build.gradle.kts
@@ -78,14 +78,14 @@ dependencies {
 
 // This seems to be the only way to get the groovy compiler to emit java-8 compatible bytecode
 // No option to explicitly target java-8 in the groovy compiler
-tasks.withType<GroovyCompile> {
+tasks.withType<GroovyCompile>().configureEach {
     this.javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(8))
     })
 }
 
 //Javadoc compiler will complain about the use of the internal types.
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     exclude(
         "**/GradleProject**",
         "**/GradleDependencyConfiguration**",

--- a/rewrite-java-11/build.gradle.kts
+++ b/rewrite-java-11/build.gradle.kts
@@ -38,7 +38,7 @@ java {
     }
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     // allows --add-exports to in spite of the JDK's restrictions on this
     sourceCompatibility = JavaVersion.VERSION_11.toString()
     targetCompatibility = JavaVersion.VERSION_11.toString()
@@ -57,7 +57,7 @@ tasks.withType<JavaCompile> {
 }
 
 //Javadoc compiler will complain about the use of the internal types.
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     exclude(
         "**/ReloadableJava11JavadocVisitor**",
         "**/ReloadableJava11Parser**",

--- a/rewrite-java-17/build.gradle.kts
+++ b/rewrite-java-17/build.gradle.kts
@@ -30,7 +30,7 @@ java {
     }
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     // allows --add-exports to in spite of the JDK's restrictions on this
     sourceCompatibility = JavaVersion.VERSION_17.toString()
     targetCompatibility = JavaVersion.VERSION_17.toString()
@@ -49,7 +49,7 @@ tasks.withType<JavaCompile> {
 }
 
 //Javadoc compiler will complain about the use of the internal types.
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     exclude(
         "**/ReloadableJava17JavadocVisitor**",
         "**/ReloadableJava17Parser**",

--- a/rewrite-java-21/build.gradle.kts
+++ b/rewrite-java-21/build.gradle.kts
@@ -31,7 +31,7 @@ java {
     }
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     // allows --add-exports to in spite of the JDK's restrictions on this
     sourceCompatibility = JavaVersion.VERSION_21.toString()
     targetCompatibility = JavaVersion.VERSION_21.toString()
@@ -50,7 +50,7 @@ tasks.withType<JavaCompile> {
 }
 
 //Javadoc compiler will complain about the use of the internal types.
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     exclude(
         "**/ReloadableJava21JavadocVisitor**",
         "**/ReloadableJava21Parser**",

--- a/rewrite-java-tck/build.gradle.kts
+++ b/rewrite-java-tck/build.gradle.kts
@@ -36,12 +36,12 @@ infoBroker {
     )
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     isFailOnError = false
     exclude("org/openrewrite/java/**")
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.release.set(null as? Int?) // remove `--release 8` set in `org.openrewrite.java-base`
 }
 

--- a/rewrite-java-test/build.gradle.kts
+++ b/rewrite-java-test/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     testImplementation(project(":rewrite-xml"))
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     isFailOnError = false
     exclude("org/openrewrite/java/**")
 }
@@ -31,7 +31,7 @@ tasks.named<JavaCompile>("compileTestJava") {
     options.release.set(null as Int?) // remove `--release 8` set in `org.openrewrite.java-base`
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     systemProperty("junit.jupiter.extensions.autodetection.enabled", true)
 }
 

--- a/rewrite-java/build.gradle.kts
+++ b/rewrite-java/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     testRuntimeOnly("org.slf4j:jul-to-slf4j:1.7.+")
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     // generated ANTLR sources violate doclint
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
 

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -57,7 +57,7 @@ extensions.configure<NodeExtension> {
 }
 
 val datedSnapshotVersion by extra {
-    if (System.getenv("CI")?.toBoolean() ?: false) {
+    if (System.getenv("CI") != null) {
         project.version.toString().replace(
             "SNAPSHOT",
             LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -199,7 +199,7 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     dependsOn(setupNpmrc)
 
-    args = listOf("publish", "--dry-run")
+    args = listOf("publish", npmPack.get().archiveFile.get().asFile.absolutePath, "--dry-run")
     if (!project.hasProperty("releasing")) {
         args.addAll("--tag", "next")
     }

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -199,7 +199,7 @@ val npmPublish = tasks.register<NpmTask>("npmPublish") {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     dependsOn(setupNpmrc)
 
-    args = listOf("publish", npmPack.get().archiveFile.get().asFile.absolutePath, "--dry-run")
+    args = provider { listOf("publish", npmPack.get().archiveFile.get().asFile.absolutePath, "--dry-run") }
     if (!project.hasProperty("releasing")) {
         args.addAll("--tag", "next")
     }

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("org.openrewrite.build.moderne-source-available-license")
     id("com.netflix.nebula.integtest-standalone")
     id("com.github.node-gradle.node") version "latest.release"
+    id("publishing")
 }
 
 dependencies {
@@ -34,7 +35,7 @@ dependencies {
     integTestRuntimeOnly("org.junit.platform:junit-platform-suite-engine:latest.release")
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     // generated ANTLR sources violate doclint
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
 
@@ -55,80 +56,91 @@ extensions.configure<NodeExtension> {
     nodeProjectDir.set(projectDir.resolve("rewrite"))
 }
 
-val npmTest = tasks.named("npm_test")
-npmTest.configure {
+val datedSnapshotVersion by extra {
+    if (System.getenv("CI")?.toBoolean() ?: false) {
+        project.version.toString().replace(
+            "SNAPSHOT",
+            LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+        )
+    } else {
+        project.version.toString()
+    }
+}
+
+val npmInstall = tasks.named("npmInstall")
+
+val npmTest = tasks.register<NpmTask>("npmTest") {
+    inputs.files(npmInstall)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files(fileTree("rewrite") {
         include("*.json")
         include("jest.config.js")
-    })
+    }).withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files(fileTree("rewrite/src"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files(fileTree("rewrite/test"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.files("rewrite/build/test-results/jest/junit.xml")
 
-    dependsOn(tasks.named("npmInstall"))
+    args = listOf("run", "ci:test")
 }
 
-tasks.register<Test>("npmTestReporting") {
-    description = "Makes Jest test results visible to Develocity"
-
-    // Don't run any JVM tests
-    enabled = true
-    testClassesDirs = files()
-    classpath = files()
-
-    // Configure where to find the Jest test results
-    reports.junitXml.outputLocation.set(file("rewrite/build/test-results/jest"))
-
-    // Always run
-    outputs.upToDateWhen { false }
-
-    // This runs after npmTest completes
+tasks.named("check") {
     dependsOn(npmTest)
 }
 
-tasks.check {
-    dependsOn(
-        tasks.named("npmInstall"),
-        tasks.named("npmTestReporting"),
-    )
+
+val npmRunBuild = tasks.register<NpmTask>("npmBuild") {
+    inputs.files(npmInstall)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(file("rewrite/package.json"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(fileTree("rewrite/src"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(file("rewrite/dist/src/"))
+
+    args = listOf("run", "build")
 }
-
-
-val npmRunBuild = tasks.named("npm_run_build")
-tasks.named("build") {
+tasks.named("assemble") {
     dependsOn(npmRunBuild)
 }
 
-val npmPack = tasks.register<NpmTask>("npmPack") {
-    dependsOn(npmRunBuild, npmVersion)
-    finalizedBy(npmResetVersion)
+val npmVersion = tasks.register<NpmTask>("npmVersion") {
+    val versionDir = layout.buildDirectory.file("tmp/npmVersion")
+    inputs.file("rewrite/package.json")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir(versionDir)
 
-    val tempPackDir = layout.buildDirectory.dir("tmp/npm-pack").get().asFile
-
-    // Delete existing tgz files before packing
     doFirst {
-        if (tempPackDir.exists()) {
-            tempPackDir.listFiles { _, name -> name.endsWith(".tgz") }?.forEach { file ->
-                file.delete()
-            }
+        copy {
+            from("rewrite/package.json")
+            into(versionDir)
         }
-        tempPackDir.mkdirs()
     }
 
-    args.set(listOf(
-        "pack",
-        "--pack-destination=${tempPackDir.absolutePath}"
-    ))
-    workingDir.set(file("rewrite"))
-
-    inputs.files(fileTree("rewrite/dist"))
-    inputs.files("rewrite/package.json", "rewrite/package-lock.json")
-    outputs.files(fileTree(tempPackDir) {
-        include("*.tgz")
-    })
+    args = listOf("version", "--no-git-tag-version", datedSnapshotVersion)
+    workingDir = versionDir
 }
 
-val npmInitTemp by tasks.registering(NpmTask::class) {
+val npmPack = tasks.register<Tar>("npmPack") {
+    from(npmRunBuild) {
+        into("package/dist/src/")
+    }
+    from(npmVersion) {
+        into("package")
+    }
+    from("rewrite/README.md") {
+        into("package")
+    }
+
+    archiveBaseName = "openrewrite-rewrite"
+    archiveVersion = datedSnapshotVersion
+    compression = Compression.GZIP
+    archiveExtension = "tgz"
+    destinationDirectory = layout.buildDirectory.dir("distributions")
+}
+
+val npmInitTemp = tasks.register<NpmTask>("npmInitTemp") {
     val tempInstallDir = layout.buildDirectory.dir("tmp/npmInstall").get().asFile
     args.set(listOf("init", "-y"))
     workingDir.set(tempInstallDir)
@@ -141,90 +153,38 @@ val npmInitTemp by tasks.registering(NpmTask::class) {
     }
 }
 
-val npmInstallTemp by tasks.registering(NpmTask::class) {
-    dependsOn(npmInitTemp, npmPack)
-    val tempInstallDir = layout.buildDirectory.dir("tmp/npmInstall").get().asFile
-    workingDir.set(tempInstallDir)
+val npmInstallTemp = tasks.register<NpmTask>("npmInstallTemp") {
+    val tempInstallDir = layout.buildDirectory.file("tmp/npmInstall")
+    inputs.files(npmPack)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    dependsOn(npmInitTemp)
 
     // Use a provider to defer evaluation until execution time
-    args.set(provider {
-        val tgzFile = npmPack.get().outputs.files.singleFile
-        listOf("install", tgzFile.absolutePath, "--omit=dev")
-    })
-}
-
-sourceSets {
-    main {
-        resources {
-            srcDir("src/main/generated-resources")
-        }
-    }
-}
-
-afterEvaluate {
-    tasks.named("licenseMain") {
-        dependsOn(createProductionPackage)
-    }
-}
-
-tasks.named<Jar>("sourcesJar") {
-    dependsOn("createProductionPackage")
-    exclude("production-package.zip")
+    args = provider { listOf("install", npmPack.get().archiveFile.get().asFile.absolutePath, "--omit=dev") }
+    workingDir.set(tempInstallDir)
 }
 
 // Creates a production-ready package; writing it to `src/main/generated-resources` so that it will be included by IDEA
 val createProductionPackage by tasks.register<Zip>("createProductionPackage") {
-    dependsOn(npmInstallTemp)
-
     // Configure the tar output
     archiveFileName.set("production-package.zip")
-    destinationDirectory.set(layout.projectDirectory.dir("src/main/generated-resources"))
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
 
-    from(layout.buildDirectory.dir("tmp/npmInstall")) {
-        // Include everything from the temp install directory
-        include("**/*")
-    }
+    from(npmInstallTemp)
 }
 
-// Update processResources to depend on the new task instead
-tasks.named("processResources") {
-    dependsOn(createProductionPackage)
+// Include production-ready package into jar
+tasks.named<Jar>("jar") {
+    from(createProductionPackage)
 }
 
 tasks.named("integrationTest") {
     dependsOn(npmRunBuild)
 }
 
-val npmVersion = tasks.register("npmVersion", NpmTask::class) {
-    val versionProperty = "npmVersionGenerated"
-
-    args.set(provider {
-        // Check if we already generated a version for this build
-        val existingVersion = project.extensions.findByName(versionProperty) as String?
-        if (existingVersion != null) {
-            listOf("version", "--no-git-tag-version", existingVersion)
-        } else {
-            val generatedVersion = project.version.toString().replace(
-                "SNAPSHOT",
-                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
-            )
-            // Store the generated version for reuse
-            project.extensions.add(versionProperty, generatedVersion)
-            listOf("version", "--no-git-tag-version", generatedVersion)
-        }
-    })
-
-    workingDir.set(file("rewrite"))
-}
-
-val npmResetVersion = tasks.register<NpmTask>("npmResetVersion") {
-    args.set(listOf("version", "0.0.0", "--no-git-tag-version"))
-    workingDir.set(file("rewrite"))
-}
-
 // This task creates a `.npmrc` file with the given token, so that the `npm publish` succeeds
 // For local development the user would typically have a `~/.npmrc` file with the token in it
-tasks.register("setupNpmrc") {
+val setupNpmrc = tasks.register("setupNpmrc") {
     doLast {
         if (project.hasProperty("nodeAuthToken")) {
             val npmrcFile = file("rewrite/.npmrc")
@@ -234,54 +194,21 @@ tasks.register("setupNpmrc") {
 }
 
 // Implicitly `--tag latest` if not specified
-val npmPublish = tasks.named<NpmTask>("npm_publish") {
-    dependsOn(tasks.named("setupNpmrc"), npmRunBuild, npmVersion)
-    finalizedBy(npmResetVersion)
+val npmPublish = tasks.register<NpmTask>("npmPublish") {
+    inputs.files(npmPack)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    dependsOn(setupNpmrc)
 
-    args.set(provider {
-        buildList {
-            add("--dry-run")
-            if (!project.hasProperty("releasing")) {
-                add("--tag")
-                add("next")
-            }
-        }
-    })
+    args = listOf("publish", "--dry-run")
+    if (!project.hasProperty("releasing")) {
+        args.addAll("--tag", "next")
+    }
 
     workingDir.set(file("rewrite"))
 }
 
-open class RestorePackageJson : DefaultTask() {
-    override fun dependsOn(vararg paths: Any?): Task {
-        return super.dependsOn(*paths)
-    }
-
-    @TaskAction
-    fun restore() {
-        val git = Git.open(project.rootDir)
-        git.checkout()
-            .addPath("${project.projectDir.relativeTo(project.rootDir).path}/rewrite/package.json")
-            .addPath("${project.projectDir.relativeTo(project.rootDir).path}/rewrite/package-lock.json")
-            .call()
-    }
-}
-
-val restorePackageJson = tasks.register("restorePackageJson", RestorePackageJson::class)
-
-// To later install a snapshot: npm install @openrewrite/rewrite@next
-val npmPublishProcess = tasks.register("npmPublish") {
-    dependsOn(
-        tasks.named("build"),
-        npmVersion,
-        npmPublish,
-        restorePackageJson
-    )
-}
-
-listOf("final", "snapshot").forEach { phase ->
-    project.rootProject.tasks.named(phase) {
-        dependsOn(npmPublishProcess)
-    }
+tasks.named("publish") {
+    dependsOn(npmPublish)
 }
 
 extensions.configure<LicenseExtension> {

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -7,8 +7,7 @@
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [
-    "dist/src/**",
-    "src/**"
+    "dist/src/**"
   ],
   "exports": {
     ".": "./dist/src/index.js",
@@ -22,6 +21,7 @@
     "build": "rm -rf ./dist && tsc --build tsconfig.build.json",
     "dev": "tsc --watch -p tsconfig.json",
     "test": "npm run build && jest",
+    "ci:test": "jest",
     "start": "npm run build && node ./dist/src/rpc/server.js"
   },
   "dependencies": {

--- a/rewrite-javascript/rewrite/tsconfig.build.json
+++ b/rewrite-javascript/rewrite/tsconfig.build.json
@@ -8,7 +8,6 @@
     "removeComments": true
   },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ]
 }

--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -59,7 +59,7 @@ tasks.register<JavaExec>("generateAntlrSources") {
     classpath = sourceSets["main"].runtimeClasspath
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     // generated ANTLR sources violate doclint
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
 

--- a/rewrite-xml/build.gradle.kts
+++ b/rewrite-xml/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 }
 
 //Javadoc compiler will complain about the use of the internal types.
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
     exclude(
         "**/Xml**"
     )


### PR DESCRIPTION
## What's changed?
Gradle build cleanup.

Before: 1m 58s
After: 18s

## What's your motivation?
Get to actually having Gradle do work sooner

## Anything in particular you'd like reviewers to focus on?
rewrite-javascript had a bit of restructuring, but is fundamentally the same. It should be reviewed carefully though.

Several of the previous rewrite-javascript tasks were using the node-gradle plugin's internal Gradle rule (ie. `npm_*` which resulted in eager task creation).

## Anyone you would like to review specifically?
Anybody

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
There are additional pieces that can be cleaned up. There are several plugins -- the license plugin being the worst offender -- that still eagerly create tasks and we could investigate next enabling configuration cache as well.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
