### PR TITLE
Guard against NPE in `JavadocPrinter#visitMemberReference()`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavadocPrinter.java
@@ -397,9 +397,11 @@ public class JavadocPrinter<P> extends JavadocVisitor<PrintOutputCapture<P>> {
         @Override
         public J visitMemberReference(J.MemberReference memberRef, PrintOutputCapture<P> p) {
             beforeSyntax(memberRef, Space.Location.MEMBER_REFERENCE_PREFIX, p);
-            Expression containing = memberRef.getContaining();
-            if (containing != null) { // Invalid references will have a null containing
-                visit(containing, p);
+            JRightPadded<Expression> containing = memberRef.getPadding().getContaining();
+            // TO-BE-REMOVED(2025-09-01) For LSTs ingested before commit 117414b7 the entire `JRightPadded<Expression>` is `null`
+            //noinspection ConstantValue
+            if (containing != null && containing.getElement() != null) { // Invalid references will have a null containing
+                visit(containing.getElement(), p);
                 visitLeftPadded("#", memberRef.getPadding().getReference(), JLeftPadded.Location.MEMBER_REFERENCE_NAME, p);
             } else {
                 visitLeftPadded(null, memberRef.getPadding().getReference(), JLeftPadded.Location.MEMBER_REFERENCE_NAME, p);


### PR DESCRIPTION
LSTs produced prior to commit 117414b7 would end up producing `J.MemberReference` objects with a `null` `containing` field and thus causing an NPE in `JavadocPrinter`. Guarding against this.

This is just a partial solution, because a `JRightPadded` with a null `element` is problematic, as `visitRightPadded()` will always coalesce it to `null`, so after running a recipe / visitor over a source file with Javadoc like this, then we are back to a `J.MemberReference` with a null `containing`.