### PR TITLE
Fix parsing of import type =

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3262,7 +3262,14 @@ export class JavaScriptParserVisitor {
             importClause: {
                 kind: JS.Kind.ImportClause,
                 id: randomId(),
-                prefix: this.prefix(node),
+                prefix: (() => {
+                    if (node.isTypeOnly) {
+                        const typeKeyword = node.getChildren().find(n => n.kind === ts.SyntaxKind.TypeKeyword);
+                        return this.prefix(typeKeyword!);
+                    } else {
+                        return emptySpace;
+                    }
+                })(),
                 markers: emptyMarkers,
                 typeOnly: node.isTypeOnly,
                 name: node.name && this.rightPadded(this.visit(node.name), this.suffix(node.name)),

--- a/rewrite-javascript/rewrite/test/javascript/parser/import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/import.test.ts
@@ -139,4 +139,12 @@ describe('import mapping', () => {
                 import my = MyLib.hello;
             `)
         ));
+
+    test('import type equals', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                import   type my = require('my-library');
+            `)
+        ));
 });


### PR DESCRIPTION
## What's changed?

Fix parsing of `import type something = require('something')`.

## What's your motivation?

Without the fix, there's no space before `type`:
```
Expected: "import   type my = require('my-library');"
Received: "importtype my = require('my-library');"
```

## OSS repro
https://github.com/microsoft/vscode/blob/74430769757679c680f4679b617a3e428ac8fe1d/extensions/markdown-language-features/src/markdownEngine.ts#L6
