### PR TITLE
Migrate Traits class usage to constructor calls

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -27,7 +27,6 @@ import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.search.FindGradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -183,7 +182,7 @@ public class ChangeDependency extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                         .groupId(oldGroupId)
                         .artifactId(oldArtifactId);
 

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyArtifactId.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -113,7 +112,7 @@ public class ChangeDependencyArtifactId extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                         .configuration(configuration)
                         .groupId(groupId)
                         .artifactId(artifactId);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -111,7 +110,7 @@ public class ChangeDependencyClassifier extends Recipe {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                         .configuration(configuration)
                         .groupId(groupId)
                         .artifactId(artifactId);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyConfiguration.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyConfiguration.java
@@ -22,7 +22,6 @@ import org.openrewrite.*;
 import org.openrewrite.gradle.internal.Dependency;
 import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.StringUtils;
@@ -95,7 +94,7 @@ public class ChangeDependencyConfiguration extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                         .configuration(configuration);
 
                 if (!gradleDependencyMatcher.get(getCursor()).isPresent() && !matchesOtherDependency(m)) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyExtension.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyExtension.java
@@ -23,7 +23,6 @@ import org.openrewrite.gradle.internal.ChangeStringLiteral;
 import org.openrewrite.gradle.internal.Dependency;
 import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -85,7 +84,7 @@ public class ChangeDependencyExtension extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                         .configuration(configuration)
                         .groupId(groupId)
                         .artifactId(artifactId);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyGroupId.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -113,7 +112,7 @@ public class ChangeDependencyGroupId extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                         .configuration(configuration)
                         .groupId(groupId)
                         .artifactId(artifactId);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseMapNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseMapNotation.java
@@ -19,7 +19,6 @@ import org.openrewrite.*;
 import org.openrewrite.gradle.internal.Dependency;
 import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -62,7 +61,7 @@ public class DependencyUseMapNotation extends Recipe {
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
-            GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency();
+            GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher();
 
             if (!gradleDependencyMatcher.get(getCursor()).isPresent()) {
                 return m;
@@ -94,7 +93,7 @@ public class DependencyUseMapNotation extends Recipe {
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
-            GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency();
+            GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher();
 
             if (!gradleDependencyMatcher.get(getCursor()).isPresent()) {
                 return m;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyUseStringNotation.java
@@ -21,7 +21,6 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.Expression;
@@ -54,7 +53,7 @@ public class DependencyUseStringNotation extends Recipe {
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency();
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher();
 
                 if (!gradleDependencyMatcher.get(getCursor()).isPresent()) {
                     return m;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
@@ -22,7 +22,6 @@ import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -77,7 +76,7 @@ public class RemoveDependency extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new IsBuildGradle<>(), new JavaIsoVisitor<ExecutionContext>() {
-            final GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency()
+            final GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
                     .configuration(configuration)
                     .groupId(groupId)
                     .artifactId(artifactId);

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -329,7 +328,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                        Optional<GradleDependency> maybeGradleDependency = Traits.gradleDependency()
+                        Optional<GradleDependency> maybeGradleDependency = new GradleDependency.Matcher()
                                 .groupId(groupPattern)
                                 .artifactId(artifactPattern)
                                 .get(getCursor());

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -27,7 +27,6 @@ import org.openrewrite.gradle.internal.DependencyStringNotationConverter;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.GradleDependency;
-import org.openrewrite.gradle.trait.Traits;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
@@ -170,7 +169,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency();
+                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher();
 
                 if (gradleDependencyMatcher.get(getCursor()).isPresent()) {
                     if (m.getArguments().get(0) instanceof G.MapEntry) {
@@ -532,7 +531,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         @Override
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-            GradleDependency.Matcher gradleDependencyMatcher = Traits.gradleDependency();
+            GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher();
 
             if (gradleDependencyMatcher.get(getCursor()).isPresent()) {
                 List<Expression> depArgs = m.getArguments();

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
@@ -54,7 +54,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.gradle.AddDependencyVisitor.DependencyModifier.ENFORCED_PLATFORM;
 import static org.openrewrite.gradle.AddDependencyVisitor.DependencyModifier.PLATFORM;
-import static org.openrewrite.gradle.trait.Traits.gradleDependency;
 
 @RequiredArgsConstructor
 public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
@@ -135,7 +134,7 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                 return m;
             }
 
-            Optional<GradleDependency> maybeDependency = gradleDependency()
+            Optional<GradleDependency> maybeDependency = new GradleDependency.Matcher()
                     .configuration(configuration)
                     .groupId(groupId)
                     .artifactId(artifactId)

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/DependencyInsight.java
@@ -23,7 +23,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
-import org.openrewrite.gradle.trait.Traits;
+import org.openrewrite.gradle.trait.GradleDependency;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.marker.JavaProject;
@@ -231,7 +231,7 @@ public class DependencyInsight extends Recipe {
             }
 
             if (configurationToDirectDependency.containsKey(m.getSimpleName())) {
-                return Traits.gradleDependency().get(getCursor()).map(dependency -> {
+                return new GradleDependency.Matcher().get(getCursor()).map(dependency -> {
                     ResolvedGroupArtifactVersion gav = dependency.getResolvedDependency().getGav();
                     Optional<GroupArtifactVersion> configurationGav = configurationToDirectDependency.get(m.getSimpleName()).stream()
                             .filter(dep -> dep.asGroupArtifact().equals(gav.asGroupArtifact()))

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindJVMTestSuites.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindJVMTestSuites.java
@@ -28,8 +28,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.openrewrite.gradle.trait.Traits.jvmTestSuite;
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class FindJVMTestSuites extends Recipe {
@@ -54,7 +52,7 @@ public class FindJVMTestSuites extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         boolean tableAvailable = this.insertRows == null || this.insertRows;
-        return Preconditions.check(new IsBuildGradle<>(), jvmTestSuite().asVisitor((suite, ctx) -> {
+        return Preconditions.check(new IsBuildGradle<>(), new JvmTestSuite.Matcher().asVisitor((suite, ctx) -> {
             if (tableAvailable) {
                 jvmTestSuitesDefined.insertRow(ctx, new JVMTestSuitesDefined.Row(suite.getName()));
             }
@@ -67,7 +65,7 @@ public class FindJVMTestSuites extends Recipe {
             return Collections.emptySet();
         }
 
-        return jvmTestSuite().lower(sourceFile)
+        return new JvmTestSuite.Matcher().lower(sourceFile)
                 .collect(Collectors.toSet());
     }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/GradleDependencyTest.java
@@ -23,14 +23,13 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
-import static org.openrewrite.gradle.trait.Traits.gradleDependency;
 
 class GradleDependencyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
           .beforeRecipe(withToolingApi())
-          .recipe(RewriteTest.toRecipe(() -> gradleDependency().asVisitor(dep ->
+          .recipe(RewriteTest.toRecipe(() -> new GradleDependency.Matcher().asVisitor(dep ->
             SearchResult.found(dep.getTree(), dep.getResolvedDependency().getGav().toString()))));
     }
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/JvmTestSuiteTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/JvmTestSuiteTest.java
@@ -26,13 +26,12 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.buildGradleKts;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
-import static org.openrewrite.gradle.trait.Traits.jvmTestSuite;
 
 class JvmTestSuiteTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.beforeRecipe(withToolingApi())
-          .recipe(RewriteTest.toRecipe(() -> jvmTestSuite().asVisitor(suite ->
+          .recipe(RewriteTest.toRecipe(() -> new JvmTestSuite.Matcher().asVisitor(suite ->
             SearchResult.found(suite.getTree()))));
     }
 
@@ -98,7 +97,7 @@ class JvmTestSuiteTest implements RewriteTest {
         @Test
         void findByName() {
             rewriteRun(
-              spec -> spec.recipe(RewriteTest.toRecipe(() -> jvmTestSuite().name("integrationTest").asVisitor(suite ->
+              spec -> spec.recipe(RewriteTest.toRecipe(() -> new JvmTestSuite.Matcher().name("integrationTest").asVisitor(suite ->
                 SearchResult.found(suite.getTree())))),
               buildGradle(
                 """
@@ -156,7 +155,7 @@ class JvmTestSuiteTest implements RewriteTest {
         @Test
         void addDependency() {
             rewriteRun(
-              spec -> spec.recipe(RewriteTest.toRecipe((recipe) -> jvmTestSuite().asVisitor((suite, ctx) ->
+              spec -> spec.recipe(RewriteTest.toRecipe((recipe) -> new JvmTestSuite.Matcher().asVisitor((suite, ctx) ->
                 suite.addDependency("implementation", "com.google.guava", "guava", "29.0-jre", null, null, null, new MavenMetadataFailures(recipe), null, ctx).visitNonNull(suite.getTree(), ctx, suite.getCursor().getParentOrThrow())))),
               buildGradle(
                 """
@@ -291,7 +290,7 @@ class JvmTestSuiteTest implements RewriteTest {
         @Test
         void findByName() {
             rewriteRun(
-              spec -> spec.recipe(RewriteTest.toRecipe(() -> jvmTestSuite().name("integrationTest").asVisitor(suite ->
+              spec -> spec.recipe(RewriteTest.toRecipe(() -> new JvmTestSuite.Matcher().name("integrationTest").asVisitor(suite ->
                 SearchResult.found(suite.getTree())))),
               buildGradleKts(
                 """
@@ -349,7 +348,7 @@ class JvmTestSuiteTest implements RewriteTest {
         @Test
         void addDependency() {
             rewriteRun(
-              spec -> spec.recipe(RewriteTest.toRecipe((recipe) -> jvmTestSuite().asVisitor((suite, ctx) ->
+              spec -> spec.recipe(RewriteTest.toRecipe((recipe) -> new JvmTestSuite.Matcher().asVisitor((suite, ctx) ->
                 suite.addDependency("implementation", "com.google.guava", "guava", "29.0-jre", null, null, null, new MavenMetadataFailures(recipe), null, ctx).visitNonNull(suite.getTree(), ctx, suite.getCursor().getParentOrThrow())))),
               buildGradleKts(
                 """

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/AnnotatedTest.java
@@ -20,7 +20,6 @@ import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.trait.Traits.annotated;
 
 class AnnotatedTest implements RewriteTest {
 
@@ -28,7 +27,7 @@ class AnnotatedTest implements RewriteTest {
     void attributes() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
-            annotated("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
+            new Annotated.Matcher("@Example").asVisitor(a -> SearchResult.found(a.getTree(),
               a.getDefaultAttribute("name")
                 .map(lit -> lit.getValue(String.class))
                 .orElse("unknown"))
@@ -68,7 +67,7 @@ class AnnotatedTest implements RewriteTest {
         rewriteRun(
           spec ->
             spec.recipe(RewriteTest.toRecipe(() ->
-              annotated("@Example(other=\"World\")")
+              new Annotated.Matcher("@Example(other=\"World\")")
                 .asVisitor(a -> SearchResult.found(a.getTree()))
             )),
           java(

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/LiteralTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/LiteralTest.java
@@ -23,7 +23,6 @@ import org.openrewrite.test.RewriteTest;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.trait.Traits.literal;
 
 class LiteralTest implements RewriteTest {
 
@@ -32,7 +31,7 @@ class LiteralTest implements RewriteTest {
     void numericLiteral() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
-              literal().asVisitor(lit -> {
+              new Literal.Matcher().asVisitor(lit -> {
                   assertThat(lit.isNotNull()).isTrue();
                   // NOTE: Jackson's coercion config allows us to
                   // coerce various numeric literal types to an Integer
@@ -63,7 +62,7 @@ class LiteralTest implements RewriteTest {
     void arrayLiteral() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->
-              literal().asVisitor(lit -> {
+              new Literal.Matcher().asVisitor(lit -> {
                   assertThat(lit.isNotNull()).isTrue();
                   return SearchResult.found(lit.getTree(),
                     String.join(",", lit.getStrings()));

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/MethodAccessTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/MethodAccessTest.java
@@ -24,7 +24,6 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.trait.Traits.methodAccess;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @SuppressWarnings("ALL")
@@ -32,8 +31,7 @@ class MethodAccessTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(markMethodAccesses(methodAccess(
-          new MethodMatcher("java.util.List add(..)", true))));
+        spec.recipe(markMethodAccesses(new MethodAccess.Matcher(new MethodMatcher("java.util.List add(..)", true))));
     }
 
     @DocumentExample

--- a/rewrite-java/src/test/java/org/openrewrite/java/trait/VariableAccessTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/trait/VariableAccessTest.java
@@ -24,7 +24,6 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.trait.Traits.variableAccess;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @SuppressWarnings("ALL")
@@ -32,7 +31,7 @@ class VariableAccessTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(markVariableAccesses(variableAccess()));
+        spec.recipe(markVariableAccesses(new VariableAccess.Matcher()));
     }
 
     @DocumentExample

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
@@ -22,6 +22,7 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.maven.trait.MavenPlugin;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
@@ -30,8 +31,6 @@ import org.openrewrite.xml.tree.Xml;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.openrewrite.maven.trait.Traits.mavenPlugin;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -73,7 +72,7 @@ public class AddAnnotationProcessor extends Recipe {
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
                 Xml.Tag plugins = (Xml.Tag) super.visitTag(tag, ctx);
-                plugins = (Xml.Tag) mavenPlugin().asVisitor(plugin -> {
+                plugins = (Xml.Tag) new MavenPlugin.Matcher().asVisitor(plugin -> {
                     if (MAVEN_COMPILER_PLUGIN_GROUP_ID.equals(plugin.getGroupId()) &&
                             MAVEN_COMPILER_PLUGIN_ARTIFACT_ID.equals(plugin.getArtifactId())) {
                         MavenResolutionResult mrr = getResolutionResult();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/trait/MavenPluginTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/trait/MavenPluginTest.java
@@ -22,13 +22,12 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.maven.trait.Traits.mavenPlugin;
 
 class MavenPluginTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(RewriteTest.toRecipe(() -> mavenPlugin().asVisitor(plugin ->
+        spec.recipe(RewriteTest.toRecipe(() -> new MavenPlugin.Matcher().asVisitor(plugin ->
           SearchResult.found(plugin.getTree(), plugin.getGroupId() + ":" + plugin.getArtifactId()))));
     }
 


### PR DESCRIPTION
## What's changed?
remove `Traits` factory method usage.

## What's your motivation?
See https://github.com/openrewrite/rewrite-rewrite/pull/16
