### PR TITLE
Don't send type for enums

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -197,7 +197,7 @@ public class RpcSendQueue {
         }
         Class<?> type = after.getClass();
         if (type.isPrimitive() || type.getPackage().getName().startsWith("java.lang") ||
-            type.equals(UUID.class) || Iterable.class.isAssignableFrom(type)) {
+            type.equals(UUID.class) || Iterable.class.isAssignableFrom(type) || Enum.class.isAssignableFrom(type)) {
             return null;
         }
         return type.getName();


### PR DESCRIPTION
Languages like JS cannot get the type for an enum at runtime, and we have decided to serialize enums using their name.
