### PR TITLE
Fix: handle nested type annotations on array

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1266,6 +1266,12 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
                 new HashMap<>(node.getAnnotations().size()));
+        if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+            Tree element = ((JCArrayTypeTree) underlying).getType();
+            if (element instanceof JCAnnotatedType) {
+                annotationPosTable.putAll(mapAnnotations(((JCAnnotatedType) element).getAnnotations(), new HashMap<>()));
+            }
+        }
         List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
         if (!annotationPosTable.isEmpty()) {
             if (node.getUnderlyingType() instanceof JCFieldAccess) {

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -1266,7 +1266,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
                 new HashMap<>(node.getAnnotations().size()));
-        if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+        Tree underlying = node.getUnderlyingType();
+        if (underlying instanceof JCArrayTypeTree) {
             Tree element = ((JCArrayTypeTree) underlying).getType();
             if (element instanceof JCAnnotatedType) {
                 annotationPosTable.putAll(mapAnnotations(((JCAnnotatedType) element).getAnnotations(), new HashMap<>()));

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1356,6 +1356,9 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
                 new HashMap<>(node.getAnnotations().size()));
+        if (node.getUnderlyingType() instanceof JCArrayTypeTree arrayTypeTree && arrayTypeTree.getType() instanceof JCAnnotatedType annotatedType) {
+            annotationPosTable.putAll(mapAnnotations(annotatedType.getAnnotations(), new HashMap<>()));
+        }
         List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
         if (!annotationPosTable.isEmpty()) {
             if (node.getUnderlyingType() instanceof JCFieldAccess) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -1384,6 +1384,9 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
                 new HashMap<>(node.getAnnotations().size()));
+        if (node.getUnderlyingType() instanceof JCArrayTypeTree arrayTypeTree && arrayTypeTree.getType() instanceof JCAnnotatedType annotatedType) {
+            annotationPosTable.putAll(mapAnnotations(annotatedType.getAnnotations(), new HashMap<>()));
+        }
         List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
         if (!annotationPosTable.isEmpty()) {
             if (node.getUnderlyingType() instanceof JCFieldAccess) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1259,6 +1259,12 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
                 new HashMap<>(node.getAnnotations().size()));
+        if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+            Tree element = ((JCArrayTypeTree) underlying).getType();
+            if (element instanceof JCAnnotatedType) {
+                annotationPosTable.putAll(mapAnnotations(((JCAnnotatedType) element).getAnnotations(), new HashMap<>()));
+            }
+        }
         List<J.Annotation> leadingAnnotations = leadingAnnotations(annotationPosTable);
         if (!annotationPosTable.isEmpty()) {
             if (node.getUnderlyingType() instanceof JCFieldAccess) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -1259,7 +1259,8 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
     public J visitAnnotatedType(AnnotatedTypeTree node, Space fmt) {
         Map<Integer, JCAnnotation> annotationPosTable = mapAnnotations(node.getAnnotations(),
                 new HashMap<>(node.getAnnotations().size()));
-        if (node.getUnderlyingType() instanceof JCArrayTypeTree) {
+        Tree underlying = node.getUnderlyingType();
+        if (underlying instanceof JCArrayTypeTree) {
             Tree element = ((JCArrayTypeTree) underlying).getType();
             if (element instanceof JCAnnotatedType) {
                 annotationPosTable.putAll(mapAnnotations(((JCAnnotatedType) element).getAnnotations(), new HashMap<>()));

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/AnnotationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/AnnotationTest.java
@@ -659,4 +659,29 @@ class AnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/5329")
+    @Test
+    void arraysWithAnnotations() {
+        rewriteRun(
+          java(
+            """
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Target;
+            
+            class A {
+               @Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
+               private static @interface C {
+               }
+               @Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
+               private static @interface B {
+               }
+
+               Comparable<@C Object @C []> specialArray1;
+               Comparable<@C Object @B []> specialArray2;
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Any additional context
For the following case: `@C Object @B []` 

Currently the `annotationPosTable` in `visitAnnotatedType` method contains only 1 annotation: 
```
annotationPosTable = {HashMap@5269}  size = 1
 {Integer@5275} 365 -> {JCTree$JCAnnotation@5276} "@B"
```
which makes `leadingAnnotations` to be empty (`size = 0`). That's wrong for `JCAnnotatedType` like `@C Object`

## What's changed?
Adding annotation to the `annotationPosTable` when handling `JCAnnotatedType`.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/5329 

## Have you considered any alternatives or workarounds?
Not. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
