### PR TITLE
Rename argument to hint that autoFormat expects parent cursor

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -67,13 +67,13 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         return maybeAutoFormat(before, after, p, getCursor().getParentTreeCursor());
     }
 
-    public <J2 extends J> J2 maybeAutoFormat(J2 before, J2 after, P p, Cursor cursor) {
-        return maybeAutoFormat(before, after, null, p, cursor);
+    public <J2 extends J> J2 maybeAutoFormat(J2 before, J2 after, P p, Cursor parent) {
+        return maybeAutoFormat(before, after, null, p, parent);
     }
 
-    public <J2 extends J> J2 maybeAutoFormat(J2 before, J2 after, @Nullable J stopAfter, P p, Cursor cursor) {
+    public <J2 extends J> J2 maybeAutoFormat(J2 before, J2 after, @Nullable J stopAfter, P p, Cursor parent) {
         if (before != after) {
-            return autoFormat(after, stopAfter, p, cursor);
+            return autoFormat(after, stopAfter, p, parent);
         }
         return after;
     }
@@ -82,17 +82,17 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         return autoFormat(j, p, getCursor().getParentTreeCursor());
     }
 
-    public <J2 extends J> J2 autoFormat(J2 j, P p, Cursor cursor) {
-        return autoFormat(j, null, p, cursor);
+    public <J2 extends J> J2 autoFormat(J2 j, P p, Cursor parent) {
+        return autoFormat(j, null, p, parent);
     }
 
     @SuppressWarnings({"ConstantConditions", "unchecked"})
-    public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, P p, Cursor cursor) {
+    public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, P p, Cursor parent) {
         JavaSourceFile cu = (j instanceof JavaSourceFile) ?
                 (JavaSourceFile) j :
                 getCursor().firstEnclosingOrThrow(JavaSourceFile.class);
         AutoFormatService service = cu.service(AutoFormatService.class);
-        return (J2) service.autoFormatVisitor(stopAfter).visit(j, p, cursor);
+        return (J2) service.autoFormatVisitor(stopAfter).visit(j, p, parent);
     }
 
     /**


### PR DESCRIPTION
When folks accidentally pass in `getCursor()` they see an error in the tests:
```
Caused by: java.lang.AssertionError: The `parent` cursor must not point to the same `tree` as the tree to be visited.
This usually indicates that you have used getCursor() where getCursor().getParent() is appropriate.
This is a test-only validation which can be opted out of by configuring your test's type validation options with `cursorAcyclic(false)`.
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:145)
	at org.openrewrite.java.format.AutoFormatVisitor.visit(AutoFormatVisitor.java:58)
	at org.openrewrite.java.format.AutoFormatVisitor.visit(AutoFormatVisitor.java:35)
	at org.openrewrite.java.JavaVisitor.autoFormat(JavaVisitor.java:95)
	at org.openrewrite.staticanalysis.ReorderAnnotations$1.visitMethodDeclaration(ReorderAnnotations.java:60)
	at org.openrewrite.staticanalysis.ReorderAnnotations$1.visitMethodDeclaration(ReorderAnnotations.java:47)
	at org.openrewrite.java.tree.J$MethodDeclaration.acceptJava(J.java:4036)
	at org.openrewrite.java.tree.J.accept(J.java:63)
```

Figured we can hint at proper use in the API as well by renaming the arguments to show what's expected.