### PR TITLE
Fix parsing of generics in anonymous class in Groovy

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1374,7 +1374,7 @@ public class GroovyParserVisitor {
                 }
 
                 skip("new");
-                TypeTree clazz = visitTypeTree(ctor.getType(), ctor.getNodeMetaData().containsKey(StaticTypesMarker.INFERRED_TYPE));
+                TypeTree clazz = visitTypeTree(ctor.getType(), isInferred(ctor));
                 JContainer<Expression> args = visit(ctor.getArguments());
                 J.Block body = null;
                 if (ctor.isUsingAnonymousInnerClass() && ctor.getType() instanceof InnerClassNode) {
@@ -2443,7 +2443,17 @@ public class GroovyParserVisitor {
 
         assert expr != null;
         if (classNode != null) {
-            if (classNode.isUsingGenerics() && !classNode.isGenericsPlaceHolder()) {
+            boolean isAnonymousClassWithGenericSuper = classNode instanceof InnerClassNode
+                    && classNode.getUnresolvedSuperClass() != null
+                    && classNode.getUnresolvedSuperClass().isUsingGenerics()
+                    && !classNode.getUnresolvedSuperClass().isGenericsPlaceHolder()
+                    && classNode.getGenericsTypes() == null;
+            if (isAnonymousClassWithGenericSuper) {
+                JContainer<Expression> typeParameters = inferredType ?
+                        JContainer.build(sourceBefore("<"), singletonList(padRight(new J.Empty(randomId(), EMPTY, Markers.EMPTY), sourceBefore(">"))), Markers.EMPTY) :
+                        visitTypeParameterizations(classNode.getUnresolvedSuperClass().getGenericsTypes());
+                expr = new J.ParameterizedType(randomId(), EMPTY, Markers.EMPTY, (NameTree) expr, typeParameters, typeMapping.type(classNode));
+            } else if (classNode.isUsingGenerics() && !classNode.isGenericsPlaceHolder()) {
                 JContainer<Expression> typeParameters = inferredType ?
                         JContainer.build(sourceBefore("<"), singletonList(padRight(new J.Empty(randomId(), EMPTY, Markers.EMPTY), sourceBefore(">"))), Markers.EMPTY) :
                         visitTypeParameterizations(classNode.getGenericsTypes());
@@ -3013,6 +3023,21 @@ public class GroovyParserVisitor {
         } else {
             return inferred;
         }
+    }
+
+    private boolean isInferred(ConstructorCallExpression ctor) {
+        if (ctor.getNodeMetaData().containsKey(StaticTypesMarker.INFERRED_TYPE)) {
+            return true;
+        }
+
+        ClassNode innerClass = ctor.getType();
+        if (!(innerClass instanceof InnerClassNode)) {
+            return false;
+        }
+
+        ClassNode superClass = innerClass.getUnresolvedSuperClass();
+        GenericsType[] generics = superClass != null ? superClass.getGenericsTypes() : null;
+        return generics != null && generics.length == 0;
     }
 
     private static final Map<String, J.Modifier.Type> modifierNameToType;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -82,4 +82,39 @@ class GroovyParserTest implements RewriteTest {
           ));
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/5296")
+    @Test
+    void anonymousClassWithNestedGenericType() {
+        rewriteRun(groovy("new ArrayList<Map<String, String>>() {}"));
+    }
+
+    @Test
+    void deeplyNestedAnonymousGeneric() {
+        rewriteRun(groovy("new HashMap<String, List<Map<Integer, String>>>() {}"));
+    }
+
+    @Test
+    void rawAnonymousClassShouldNotGetGenerics() {
+        rewriteRun(groovy("new ArrayList() {}"));
+    }
+
+    @Test
+    void inferredGenericsWithDiamondOperator() {
+        rewriteRun(groovy("new ArrayList<>() {}"));
+    }
+
+    @Test
+    void nestedAnonymousWithGenerics() {
+        rewriteRun(
+          groovy(
+            """
+              new HashMap<String, List<String>>() {
+                  void inner() {
+                      new ArrayList<Map<Integer, String>>() {}
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
1) For anonymous class instantiations like `new ArrayList<Map<String, String>>() {}`, we now call `visitTypeParameterizations` with `classNode.getUnresolvedSuperClass().getGenericsTypes()` instead of `classNode.getGenericsTypes()` which is `null` in this case. 

2) After adding a test case for `new ArrayList<>() {}` - it failed as well. It turned out that  `ctor.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE)` was not sufficient to detect inferred generics. Looks like Groovy doesn't always set this metadata? 
To address this, I introduced private helper method `isInferred(ConstructorCallExpression)` that detects inferred generic usage (e.g., diamond operator).

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/5296


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
