### PR TITLE
Refactoring, rename ObjectBindingDeclarations to ObjectBindingPattern

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -1151,79 +1151,79 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
     }
 
     /**
-     * Overrides the visitObjectBindingDeclarations method to compare object binding declarations.
+     * Overrides the visitObjectBindingPattern method to compare object binding declarations.
      * 
-     * @param objectBindingDeclarations The object binding declarations to visit
+     * @param objectBindingPattern The object binding declarations to visit
      * @param other The other object binding declarations to compare with
      * @returns The visited object binding declarations, or undefined if the visit was aborted
      */
-    override async visitObjectBindingDeclarations(objectBindingDeclarations: JS.ObjectBindingDeclarations, other: J): Promise<J | undefined> {
-        if (!this.match || other.kind !== JS.Kind.ObjectBindingDeclarations) {
+    override async visitObjectBindingPattern(objectBindingPattern: JS.ObjectBindingPattern, other: J): Promise<J | undefined> {
+        if (!this.match || other.kind !== JS.Kind.ObjectBindingPattern) {
             this.abort();
-            return objectBindingDeclarations;
+            return objectBindingPattern;
         }
 
-        const otherObjectBindingDeclarations = other as JS.ObjectBindingDeclarations;
+        const otherObjectBindingPattern = other as JS.ObjectBindingPattern;
 
         // Compare leading annotations
-        if (objectBindingDeclarations.leadingAnnotations.length !== otherObjectBindingDeclarations.leadingAnnotations.length) {
+        if (objectBindingPattern.leadingAnnotations.length !== otherObjectBindingPattern.leadingAnnotations.length) {
             this.abort();
-            return objectBindingDeclarations;
+            return objectBindingPattern;
         }
 
         // Visit leading annotations in lock step
-        for (let i = 0; i < objectBindingDeclarations.leadingAnnotations.length; i++) {
-            await this.visit(objectBindingDeclarations.leadingAnnotations[i], otherObjectBindingDeclarations.leadingAnnotations[i]);
-            if (!this.match) return objectBindingDeclarations;
+        for (let i = 0; i < objectBindingPattern.leadingAnnotations.length; i++) {
+            await this.visit(objectBindingPattern.leadingAnnotations[i], otherObjectBindingPattern.leadingAnnotations[i]);
+            if (!this.match) return objectBindingPattern;
         }
 
         // Compare modifiers
-        if (objectBindingDeclarations.modifiers.length !== otherObjectBindingDeclarations.modifiers.length) {
+        if (objectBindingPattern.modifiers.length !== otherObjectBindingPattern.modifiers.length) {
             this.abort();
-            return objectBindingDeclarations;
+            return objectBindingPattern;
         }
 
         // Visit modifiers in lock step
-        for (let i = 0; i < objectBindingDeclarations.modifiers.length; i++) {
-            await this.visit(objectBindingDeclarations.modifiers[i], otherObjectBindingDeclarations.modifiers[i]);
-            if (!this.match) return objectBindingDeclarations;
+        for (let i = 0; i < objectBindingPattern.modifiers.length; i++) {
+            await this.visit(objectBindingPattern.modifiers[i], otherObjectBindingPattern.modifiers[i]);
+            if (!this.match) return objectBindingPattern;
         }
 
         // Compare type expression
-        if (!!objectBindingDeclarations.typeExpression !== !!otherObjectBindingDeclarations.typeExpression) {
+        if (!!objectBindingPattern.typeExpression !== !!otherObjectBindingPattern.typeExpression) {
             this.abort();
-            return objectBindingDeclarations;
+            return objectBindingPattern;
         }
 
-        if (objectBindingDeclarations.typeExpression) {
-            await this.visit(objectBindingDeclarations.typeExpression, otherObjectBindingDeclarations.typeExpression!);
-            if (!this.match) return objectBindingDeclarations;
+        if (objectBindingPattern.typeExpression) {
+            await this.visit(objectBindingPattern.typeExpression, otherObjectBindingPattern.typeExpression!);
+            if (!this.match) return objectBindingPattern;
         }
 
         // Compare bindings
-        if (objectBindingDeclarations.bindings.elements.length !== otherObjectBindingDeclarations.bindings.elements.length) {
+        if (objectBindingPattern.bindings.elements.length !== otherObjectBindingPattern.bindings.elements.length) {
             this.abort();
-            return objectBindingDeclarations;
+            return objectBindingPattern;
         }
 
         // Visit bindings in lock step
-        for (let i = 0; i < objectBindingDeclarations.bindings.elements.length; i++) {
-            await this.visit(objectBindingDeclarations.bindings.elements[i].element, 
-                           otherObjectBindingDeclarations.bindings.elements[i].element);
-            if (!this.match) return objectBindingDeclarations;
+        for (let i = 0; i < objectBindingPattern.bindings.elements.length; i++) {
+            await this.visit(objectBindingPattern.bindings.elements[i].element,
+                           otherObjectBindingPattern.bindings.elements[i].element);
+            if (!this.match) return objectBindingPattern;
         }
 
         // Compare initializer
-        if (!!objectBindingDeclarations.initializer !== !!otherObjectBindingDeclarations.initializer) {
+        if (!!objectBindingPattern.initializer !== !!otherObjectBindingPattern.initializer) {
             this.abort();
-            return objectBindingDeclarations;
+            return objectBindingPattern;
         }
 
-        if (objectBindingDeclarations.initializer) {
-            await this.visit(objectBindingDeclarations.initializer.element, otherObjectBindingDeclarations.initializer!.element);
+        if (objectBindingPattern.initializer) {
+            await this.visit(objectBindingPattern.initializer.element, otherObjectBindingPattern.initializer!.element);
         }
 
-        return objectBindingDeclarations;
+        return objectBindingPattern;
     }
 
     /**

--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -119,7 +119,7 @@ const is_expressions: string[] = [
     JS.Kind.MappedType,
     JS.Kind.NamedExports,
     JS.Kind.NamedImports,
-    JS.Kind.ObjectBindingDeclarations,
+    JS.Kind.ObjectBindingPattern,
     JS.Kind.SatisfiesExpression,
     JS.Kind.TaggedTemplateExpression,
     JS.Kind.TemplateExpression,

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -1652,9 +1652,9 @@ export class JavaScriptParserVisitor {
         };
     }
 
-    visitObjectBindingPattern(node: ts.ObjectBindingPattern): JS.ObjectBindingDeclarations {
+    visitObjectBindingPattern(node: ts.ObjectBindingPattern): JS.ObjectBindingPattern {
         return {
-            kind: JS.Kind.ObjectBindingDeclarations,
+            kind: JS.Kind.ObjectBindingPattern,
             id: randomId(),
             prefix: this.prefix(node),
             markers: emptyMarkers,

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -1094,18 +1094,18 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         return mappedTypeParameter;
     }
 
-    override async visitObjectBindingDeclarations(objectBindingDeclarations: JS.ObjectBindingDeclarations, p: PrintOutputCapture): Promise<J | undefined> {
-        await this.beforeSyntax(objectBindingDeclarations, p);
-        await this.visitNodes(objectBindingDeclarations.leadingAnnotations, p);
-        for (const m of objectBindingDeclarations.modifiers) {
+    override async visitObjectBindingPattern(objectBindingPattern: JS.ObjectBindingPattern, p: PrintOutputCapture): Promise<J | undefined> {
+        await this.beforeSyntax(objectBindingPattern, p);
+        await this.visitNodes(objectBindingPattern.leadingAnnotations, p);
+        for (const m of objectBindingPattern.modifiers) {
             await this.visitModifier(m, p);
         }
 
-        objectBindingDeclarations.typeExpression && await this.visit(objectBindingDeclarations.typeExpression, p);
-        await this.visitContainerLocal("{", objectBindingDeclarations.bindings, ",", "}", p);
-        objectBindingDeclarations.initializer && await this.visitLeftPaddedLocal("=", objectBindingDeclarations.initializer, p);
-        await this.afterSyntax(objectBindingDeclarations, p);
-        return objectBindingDeclarations;
+        objectBindingPattern.typeExpression && await this.visit(objectBindingPattern.typeExpression, p);
+        await this.visitContainerLocal("{", objectBindingPattern.bindings, ",", "}", p);
+        objectBindingPattern.initializer && await this.visitLeftPaddedLocal("=", objectBindingPattern.initializer, p);
+        await this.afterSyntax(objectBindingPattern, p);
+        return objectBindingPattern;
     }
 
     override async visitTaggedTemplateExpression(taggedTemplateExpression: JS.TaggedTemplateExpression, p: PrintOutputCapture): Promise<J | undefined> {

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -212,13 +212,13 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         return mappedTypeParameter;
     }
 
-    override async visitObjectBindingDeclarations(objectBindingDeclarations: JS.ObjectBindingDeclarations, q: RpcSendQueue): Promise<J | undefined> {
-        await q.getAndSendList(objectBindingDeclarations, el => el.leadingAnnotations, el => el.id, el => this.visit(el, q));
-        await q.getAndSendList(objectBindingDeclarations, el => el.modifiers, el => el.id, el => this.visit(el, q));
-        await q.getAndSend(objectBindingDeclarations, el => el.typeExpression, el => this.visit(el, q));
-        await q.getAndSend(objectBindingDeclarations, el => el.bindings, el => this.visitContainer(el, q));
-        await q.getAndSend(objectBindingDeclarations, el => el.initializer, el => this.visitLeftPadded(el, q));
-        return objectBindingDeclarations;
+    override async visitObjectBindingPattern(objectBindingPattern: JS.ObjectBindingPattern, q: RpcSendQueue): Promise<J | undefined> {
+        await q.getAndSendList(objectBindingPattern, el => el.leadingAnnotations, el => el.id, el => this.visit(el, q));
+        await q.getAndSendList(objectBindingPattern, el => el.modifiers, el => el.id, el => this.visit(el, q));
+        await q.getAndSend(objectBindingPattern, el => el.typeExpression, el => this.visit(el, q));
+        await q.getAndSend(objectBindingPattern, el => el.bindings, el => this.visitContainer(el, q));
+        await q.getAndSend(objectBindingPattern, el => el.initializer, el => this.visitLeftPadded(el, q));
+        return objectBindingPattern;
     }
 
     override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, q: RpcSendQueue): Promise<J | undefined> {
@@ -755,8 +755,8 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         return finishDraft(draft);
     }
 
-    override async visitObjectBindingDeclarations(objectBindingDeclarations: JS.ObjectBindingDeclarations, q: RpcReceiveQueue): Promise<J | undefined> {
-        const draft = createDraft(objectBindingDeclarations);
+    override async visitObjectBindingPattern(objectBindingPattern: JS.ObjectBindingPattern, q: RpcReceiveQueue): Promise<J | undefined> {
+        const draft = createDraft(objectBindingPattern);
         draft.leadingAnnotations = await q.receiveListDefined(draft.leadingAnnotations, el => this.visitDefined<J.Annotation>(el, q));
         draft.modifiers = await q.receiveListDefined(draft.modifiers, el => this.visitDefined<J.Modifier>(el, q));
         draft.typeExpression = await q.receive(draft.typeExpression, el => this.visitDefined<TypeTree>(el, q));

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -73,7 +73,7 @@ export namespace JS {
         NamedExports: "org.openrewrite.javascript.tree.JS$NamedExports",
         NamedImports: "org.openrewrite.javascript.tree.JS$NamedImports",
         NamespaceDeclaration: "org.openrewrite.javascript.tree.JS$NamespaceDeclaration",
-        ObjectBindingDeclarations: "org.openrewrite.javascript.tree.JS$ObjectBindingDeclarations",
+        ObjectBindingPattern: "org.openrewrite.javascript.tree.JS$ObjectBindingPattern",
         PropertyAssignment: "org.openrewrite.javascript.tree.JS$PropertyAssignment",
         SatisfiesExpression: "org.openrewrite.javascript.tree.JS$SatisfiesExpression",
         ScopedVariableDeclarations: "org.openrewrite.javascript.tree.JS$ScopedVariableDeclarations",
@@ -373,8 +373,8 @@ export namespace JS {
      * Represents object destructuring patterns.
      * @example const { a, b } = obj;
      */
-    export interface ObjectBindingDeclarations extends JS, Expression, TypedTree, VariableDeclarator {
-        readonly kind: typeof Kind.ObjectBindingDeclarations;
+    export interface ObjectBindingPattern extends JS, Expression, TypedTree, VariableDeclarator {
+        readonly kind: typeof Kind.ObjectBindingPattern;
         readonly leadingAnnotations: J.Annotation[];
         readonly modifiers: J.Modifier[];
         readonly typeExpression?: TypeTree;

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -400,19 +400,19 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         });
     }
 
-    protected async visitObjectBindingDeclarations(objectBindingDeclarations: JS.ObjectBindingDeclarations, p: P): Promise<J | undefined> {
-        const expression = await this.visitExpression(objectBindingDeclarations, p);
-           if (!expression?.kind || expression.kind !== JS.Kind.ObjectBindingDeclarations) {
+    protected async visitObjectBindingPattern(objectBindingPattern: JS.ObjectBindingPattern, p: P): Promise<J | undefined> {
+        const expression = await this.visitExpression(objectBindingPattern, p);
+           if (!expression?.kind || expression.kind !== JS.Kind.ObjectBindingPattern) {
                return expression;
            }
-           objectBindingDeclarations = expression as JS.ObjectBindingDeclarations;
+           objectBindingPattern = expression as JS.ObjectBindingPattern;
 
-        return this.produceJavaScript<JS.ObjectBindingDeclarations>(objectBindingDeclarations, p, async draft => {
-            draft.leadingAnnotations = await mapAsync(objectBindingDeclarations.leadingAnnotations, item => this.visitDefined<J.Annotation>(item, p));
-            draft.modifiers = await mapAsync(objectBindingDeclarations.modifiers, item => this.visitDefined<J.Modifier>(item, p));
-            draft.typeExpression = objectBindingDeclarations.typeExpression && await this.visitDefined<TypedTree>(objectBindingDeclarations.typeExpression, p);
-            draft.bindings = await this.visitContainer(objectBindingDeclarations.bindings, p);
-            draft.initializer = objectBindingDeclarations.initializer && await this.visitLeftPadded(objectBindingDeclarations.initializer, p);
+        return this.produceJavaScript<JS.ObjectBindingPattern>(objectBindingPattern, p, async draft => {
+            draft.leadingAnnotations = await mapAsync(objectBindingPattern.leadingAnnotations, item => this.visitDefined<J.Annotation>(item, p));
+            draft.modifiers = await mapAsync(objectBindingPattern.modifiers, item => this.visitDefined<J.Modifier>(item, p));
+            draft.typeExpression = objectBindingPattern.typeExpression && await this.visitDefined<TypedTree>(objectBindingPattern.typeExpression, p);
+            draft.bindings = await this.visitContainer(objectBindingPattern.bindings, p);
+            draft.initializer = objectBindingPattern.initializer && await this.visitLeftPadded(objectBindingPattern.initializer, p);
         });
     }
 
@@ -937,8 +937,8 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
                     return this.visitKeysRemapping(tree as unknown as JS.MappedType.KeysRemapping, p);
                 case JS.Kind.MappedTypeParameter:
                     return this.visitMappedTypeParameter(tree as unknown as JS.MappedType.Parameter, p);
-                case JS.Kind.ObjectBindingDeclarations:
-                    return this.visitObjectBindingDeclarations(tree as unknown as JS.ObjectBindingDeclarations, p);
+                case JS.Kind.ObjectBindingPattern:
+                    return this.visitObjectBindingPattern(tree as unknown as JS.ObjectBindingPattern, p);
                 case JS.Kind.PropertyAssignment:
                     return this.visitPropertyAssignment(tree as unknown as JS.PropertyAssignment, p);
                 case JS.Kind.SatisfiesExpression:

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java
@@ -218,8 +218,8 @@ public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     @Override
-    public JS.ObjectBindingDeclarations visitObjectBindingDeclarations(JS.ObjectBindingDeclarations objectBindingDeclarations, P p) {
-        return (JS.ObjectBindingDeclarations) super.visitObjectBindingDeclarations(objectBindingDeclarations, p);
+    public JS.ObjectBindingPattern visitObjectBindingPattern(JS.ObjectBindingPattern objectBindingPattern, P p) {
+        return (JS.ObjectBindingPattern) super.visitObjectBindingPattern(objectBindingPattern, p);
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -388,15 +388,15 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         return m;
     }
 
-    public J visitObjectBindingDeclarations(JS.ObjectBindingDeclarations objectBindingDeclarations, P p) {
-        JS.ObjectBindingDeclarations o = objectBindingDeclarations;
+    public J visitObjectBindingPattern(JS.ObjectBindingPattern objectBindingPattern, P p) {
+        JS.ObjectBindingPattern o = objectBindingPattern;
         o = o.withPrefix(visitSpace(o.getPrefix(), JsSpace.Location.OBJECT_BINDING_DECLARATIONS_PREFIX, p));
         o = o.withMarkers(visitMarkers(o.getMarkers(), p));
         Expression temp = (Expression) visitExpression(o, p);
-        if (!(temp instanceof JS.ObjectBindingDeclarations)) {
+        if (!(temp instanceof JS.ObjectBindingPattern)) {
             return temp;
         } else {
-            o = (JS.ObjectBindingDeclarations) temp;
+            o = (JS.ObjectBindingPattern) temp;
         }
         o = o.withLeadingAnnotations(requireNonNull(ListUtils.map(o.getLeadingAnnotations(), a -> visitAndCast(a, p))));
         o = o.withModifiers(requireNonNull(ListUtils.map(o.getModifiers(), e -> visitAndCast(e, p))));

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -247,13 +247,13 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     }
 
     @Override
-    public J visitObjectBindingDeclarations(JS.ObjectBindingDeclarations objectBindingDeclarations, RpcReceiveQueue q) {
-        return objectBindingDeclarations
-                .withLeadingAnnotations(q.receiveList(objectBindingDeclarations.getLeadingAnnotations(), annot -> (J.Annotation) visitNonNull(annot, q)))
-                .withModifiers(q.receiveList(objectBindingDeclarations.getModifiers(), mod -> (J.Modifier) visitNonNull(mod, q)))
-                .withTypeExpression(q.receive(objectBindingDeclarations.getTypeExpression(), tree -> (TypeTree) visitNonNull(tree, q)))
-                .getPadding().withBindings(q.receive(objectBindingDeclarations.getPadding().getBindings(), el -> visitContainer(el, q)))
-                .getPadding().withInitializer(q.receive(objectBindingDeclarations.getPadding().getInitializer(), el -> visitLeftPadded(el, q)));
+    public J visitObjectBindingPattern(JS.ObjectBindingPattern objectBindingPattern, RpcReceiveQueue q) {
+        return objectBindingPattern
+                .withLeadingAnnotations(q.receiveList(objectBindingPattern.getLeadingAnnotations(), annot -> (J.Annotation) visitNonNull(annot, q)))
+                .withModifiers(q.receiveList(objectBindingPattern.getModifiers(), mod -> (J.Modifier) visitNonNull(mod, q)))
+                .withTypeExpression(q.receive(objectBindingPattern.getTypeExpression(), tree -> (TypeTree) visitNonNull(tree, q)))
+                .getPadding().withBindings(q.receive(objectBindingPattern.getPadding().getBindings(), el -> visitContainer(el, q)))
+                .getPadding().withInitializer(q.receive(objectBindingPattern.getPadding().getInitializer(), el -> visitLeftPadded(el, q)));
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -244,13 +244,13 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     }
 
     @Override
-    public J visitObjectBindingDeclarations(JS.ObjectBindingDeclarations objectBindingDeclarations, RpcSendQueue q) {
-        q.getAndSendList(objectBindingDeclarations, JS.ObjectBindingDeclarations::getLeadingAnnotations, J.Annotation::getId, el -> visit(el, q));
-        q.getAndSendList(objectBindingDeclarations, JS.ObjectBindingDeclarations::getModifiers, J.Modifier::getId, el -> visit(el, q));
-        q.getAndSend(objectBindingDeclarations, JS.ObjectBindingDeclarations::getTypeExpression, el -> visit(el, q));
-        q.getAndSend(objectBindingDeclarations, el -> el.getPadding().getBindings(), el -> visitContainer(el, q));
-        q.getAndSend(objectBindingDeclarations, el -> el.getPadding().getInitializer(), el -> visitLeftPadded(el, q));
-        return objectBindingDeclarations;
+    public J visitObjectBindingPattern(JS.ObjectBindingPattern objectBindingPattern, RpcSendQueue q) {
+        q.getAndSendList(objectBindingPattern, JS.ObjectBindingPattern::getLeadingAnnotations, J.Annotation::getId, el -> visit(el, q));
+        q.getAndSendList(objectBindingPattern, JS.ObjectBindingPattern::getModifiers, J.Modifier::getId, el -> visit(el, q));
+        q.getAndSend(objectBindingPattern, JS.ObjectBindingPattern::getTypeExpression, el -> visit(el, q));
+        q.getAndSend(objectBindingPattern, el -> el.getPadding().getBindings(), el -> visitContainer(el, q));
+        q.getAndSend(objectBindingPattern, el -> el.getPadding().getInitializer(), el -> visitLeftPadded(el, q));
+        return objectBindingPattern;
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
@@ -218,13 +218,13 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
     }
 
     @Override
-    public JS.ObjectBindingDeclarations visitObjectBindingDeclarations(JS.ObjectBindingDeclarations objectBindingDeclarations, P p) {
-        ListUtils.map(objectBindingDeclarations.getLeadingAnnotations(), el -> visitAndValidateNonNull(el, J.Annotation.class, p));
-        ListUtils.map(objectBindingDeclarations.getModifiers(), el -> visitAndValidateNonNull(el, J.Modifier.class, p));
-        visitAndValidate(objectBindingDeclarations.getTypeExpression(), TypeTree.class, p);
-        visitAndValidate(objectBindingDeclarations.getBindings(), J.class, p);
-        visitAndValidate(objectBindingDeclarations.getInitializer(), Expression.class, p);
-        return objectBindingDeclarations;
+    public JS.ObjectBindingPattern visitObjectBindingPattern(JS.ObjectBindingPattern objectBindingPattern, P p) {
+        ListUtils.map(objectBindingPattern.getLeadingAnnotations(), el -> visitAndValidateNonNull(el, J.Annotation.class, p));
+        ListUtils.map(objectBindingPattern.getModifiers(), el -> visitAndValidateNonNull(el, J.Modifier.class, p));
+        visitAndValidate(objectBindingPattern.getTypeExpression(), TypeTree.class, p);
+        visitAndValidate(objectBindingPattern.getBindings(), J.class, p);
+        visitAndValidate(objectBindingPattern.getInitializer(), Expression.class, p);
+        return objectBindingPattern;
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -2172,11 +2172,11 @@ public interface JS extends J {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class ObjectBindingDeclarations implements JS, Expression, TypedTree, VariableDeclarator {
+    final class ObjectBindingPattern implements JS, Expression, TypedTree, VariableDeclarator {
 
         @Nullable
         @NonFinal
-        transient WeakReference<ObjectBindingDeclarations.Padding> padding;
+        transient WeakReference<ObjectBindingPattern.Padding> padding;
 
         @With
         @EqualsAndHashCode.Include
@@ -2221,7 +2221,7 @@ public interface JS extends J {
             return list;
         }
 
-        public ObjectBindingDeclarations withBindings(List<J> bindings) {
+        public ObjectBindingPattern withBindings(List<J> bindings) {
             return getPadding().withBindings(JContainer.withElements(this.bindings, bindings));
         }
 
@@ -2232,13 +2232,13 @@ public interface JS extends J {
             return initializer == null ? null : initializer.getElement();
         }
 
-        public ObjectBindingDeclarations withInitializer(@Nullable Expression initializer) {
+        public ObjectBindingPattern withInitializer(@Nullable Expression initializer) {
             return getPadding().withInitializer(JLeftPadded.withElement(this.initializer, initializer));
         }
 
         @Override
         public <P> J acceptJavaScript(JavaScriptVisitor<P> v, P p) {
-            return v.visitObjectBindingDeclarations(this, p);
+            return v.visitObjectBindingPattern(this, p);
         }
 
         @Transient
@@ -2270,7 +2270,7 @@ public interface JS extends J {
 
         @SuppressWarnings("unchecked")
         @Override
-        public ObjectBindingDeclarations withType(@Nullable JavaType type) {
+        public ObjectBindingPattern withType(@Nullable JavaType type) {
             return typeExpression == null ? this :
                     withTypeExpression(typeExpression.withType(type));
         }
@@ -2279,15 +2279,15 @@ public interface JS extends J {
             return Modifier.hasModifier(getModifiers(), modifier);
         }
 
-        public ObjectBindingDeclarations.Padding getPadding() {
-            ObjectBindingDeclarations.Padding p;
+        public ObjectBindingPattern.Padding getPadding() {
+            ObjectBindingPattern.Padding p;
             if (this.padding == null) {
-                p = new ObjectBindingDeclarations.Padding(this);
+                p = new ObjectBindingPattern.Padding(this);
                 this.padding = new WeakReference<>(p);
             } else {
                 p = this.padding.get();
                 if (p == null || p.t != this) {
-                    p = new ObjectBindingDeclarations.Padding(this);
+                    p = new ObjectBindingPattern.Padding(this);
                     this.padding = new WeakReference<>(p);
                 }
             }
@@ -2296,22 +2296,22 @@ public interface JS extends J {
 
         @RequiredArgsConstructor
         public static class Padding {
-            private final ObjectBindingDeclarations t;
+            private final ObjectBindingPattern t;
 
             public JContainer<J> getBindings() {
                 return t.bindings;
             }
 
-            public ObjectBindingDeclarations withBindings(JContainer<J> bindings) {
-                return t.bindings == bindings ? t : new ObjectBindingDeclarations(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.typeExpression, bindings, t.initializer);
+            public ObjectBindingPattern withBindings(JContainer<J> bindings) {
+                return t.bindings == bindings ? t : new ObjectBindingPattern(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.typeExpression, bindings, t.initializer);
             }
 
             public @Nullable JLeftPadded<Expression> getInitializer() {
                 return t.initializer;
             }
 
-            public ObjectBindingDeclarations withInitializer(@Nullable JLeftPadded<Expression> initializer) {
-                return t.initializer == initializer ? t : new ObjectBindingDeclarations(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.typeExpression, t.bindings, initializer);
+            public ObjectBindingPattern withInitializer(@Nullable JLeftPadded<Expression> initializer) {
+                return t.initializer == initializer ? t : new ObjectBindingPattern(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.typeExpression, t.bindings, initializer);
             }
         }
     }


### PR DESCRIPTION
## What's changed?

Renaming the Javascript's `ObjectBindingDeclarations` to `ObjectBindingPattern`.

## What's your motivation?

> That would make it both consistent with the ArrayBindingPattern name as well as with the name in the TS Compiler API.

