### PR TITLE
UnfoldProperties respects line breaks

### DIFF
--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/UnfoldPropertiesTest.java
@@ -137,6 +137,31 @@ class UnfoldPropertiesTest implements RewriteTest {
     }
 
     @Test
+    void unfoldAcrossLineBreaks() {
+        rewriteRun(
+          yaml(
+            """
+              a:
+                b1.c: x
+              
+                b2.c: x
+              x.y: z
+              """,
+            """
+              a:
+                b1:
+                  c: x
+              
+                b2:
+                  c: x
+              x:
+                y: z
+              """
+          )
+        );
+    }
+
+    @Test
     void exclusions() {
         rewriteRun(
           spec -> spec.recipe(new UnfoldProperties(List.of(


### PR DESCRIPTION
## What's changed?
Line breaks are supported as well.

## What's your motivation?
Bug mentioned at the OpenRewrite slack: https://rewriteoss.slack.com/archives/C01A843MWG5/p1749845159159399.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
