### PR TITLE
Added check for missing attributeName, but attributeValue requirement in `AddOrUpdateAnnotationAttribute`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -1449,4 +1449,36 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotMisMatchOnMissingNamedAttributeWhenOldAttributeValueShouldMatch() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new AddOrUpdateAnnotationAttribute(
+              "org.example.Foo",
+              "name",
+              "newValue",
+              "oldValue",
+              null,
+              null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String name() default "";
+                  String value() default "";
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import org.example.Foo;
+              
+              @Foo(value = "test")
+              public class A {}
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -1475,7 +1475,7 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
             """
               import org.example.Foo;
               
-              @Foo(value = "test")
+              @Foo(value = "oldValue")
               public class A {}
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -369,8 +369,8 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                     if (newArgs != currentArgs) {
                         a = a.withArguments(newArgs);
                     }
-                    if (!foundOrSetAttributeWithDesiredValue.get() && !attributeValIsAlreadyPresent(newArgs, newAttributeValue)) {
-                        // There was no existing value to update, so add a new value into the argument list
+                    if (!foundOrSetAttributeWithDesiredValue.get() && !attributeValIsAlreadyPresent(newArgs, newAttributeValue) && oldAttributeValue == null) {
+                        // There was no existing value to update and no requirements on a pre-existing old value, so add a new value into the argument list
                         String effectiveName = (attributeName == null) ? "value" : attributeName;
                         //noinspection ConstantConditions
                         J.Assignment as = (J.Assignment) ((J.Annotation) JavaTemplate.builder("#{} = #{}")


### PR DESCRIPTION
## What's changed?
The AddOrUpdateAnnotationAttribute recipe does not add a new attribute if an oldAttributeValue (to match against) is provided.

## What's your motivation?
Especially for Spring `@Bean` annotations they sometimes need a `name`, but most of the time they don't. Without this check changing a name would result in all `@Bean` annotation without a name getting the same name.
