### PR TITLE
Fix for situation that could bypass a check inadvertently on `UpdateMavenProjectPropertyJavaVersion`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersion.java
@@ -96,9 +96,9 @@ public class UpdateMavenProjectPropertyJavaVersion extends Recipe {
                                     try {
                                         float parsed = Float.parseFloat(getResolutionResult().getPom().getProperties().get(property));
                                         if (parsed < version &&
-                                            (plugin.getConfiguration().get("source") != null && plugin.getConfiguration().get("source").textValue().contains(property)) ||
+                                            ((plugin.getConfiguration().get("source") != null && plugin.getConfiguration().get("source").textValue().contains(property)) ||
                                             (plugin.getConfiguration().get("target") != null && plugin.getConfiguration().get("target").textValue().contains(property)) ||
-                                            (plugin.getConfiguration().get("release") != null && plugin.getConfiguration().get("release").textValue().contains(property))) {
+                                            (plugin.getConfiguration().get("release") != null && plugin.getConfiguration().get("release").textValue().contains(property)))) {
                                             d = (Xml.Document) new AddPropertyVisitor(property, String.valueOf(version), null)
                                                     .visitNonNull(d, ctx);
                                             maybeUpdateModel();

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpdateMavenProjectPropertyJavaVersionTest.java
@@ -461,4 +461,58 @@ class UpdateMavenProjectPropertyJavaVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotUpdateWhenMavenCompilerPluginUsesJavaVersionAlreadyHighEnough() {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                      <module>child</module>
+                  </modules>
+                  <properties>
+                      <java.version>21</java.version>
+                  </properties>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <version>3.14.0</version>
+                              <configuration>
+                                  <release>${java.version}</release>
+                                  <parameters>true</parameters>
+                              </configuration>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          ),
+          mavenProject("child",
+            pomXml(
+              //language=xml
+              """
+                <project>
+                    <parent>
+                        <groupId>org.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>child</artifactId>
+                    <properties>
+                        <java.version>21</java.version>
+                    </properties>
+                </project>
+                """
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
Adding test case and fix for situation where if the `maven-compiler-plugin` made use of `java.version` or similar for its `target` or `release` configuration settings, it could bypass the check for whether the version was already high enough, which caused all the `java.version`s to get downgraded potentially.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
