### PR TITLE
`lombok.val` Support

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/LombokTest.java
@@ -782,6 +782,28 @@ class LombokTest implements RewriteTest {
         }
 
         @Test
+        void genericMethod() {
+            rewriteRun(
+              java(
+                """
+                  import lombok.val;
+                  
+                  import java.util.function.Function;
+                  
+                  class A {
+                      <A, B> B methodWithGenerics(Function<A, B> f, A a) {
+                          return f.apply(a);
+                      }
+                      void m() {
+                          val foo = methodWithGenerics(a -> a + "", 2);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void parameter() {
             rewriteRun(
               java(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Added tests to show missing cases for `lombok.val` support. 

## What's your motivation?

While analyzing test failures of in [app.moderne.io run n8tSwIS36](https://app.moderne.io/results/n8tSwIS36?repo=eyJfX3R5cGVuYW1lIjoiR2l0SHViUmVwb3NpdG9yeSIsImlkIjoiR2l0SHViUmVwb3NpdG9yeX5%252BZ2l0aHViLmNvbX5%252BYXBhY2hlL2t5bGlufn5reWxpbjUiLCJicmFuY2giOiJreWxpbjUiLCJvcmlnaW4iOiJnaXRodWIuY29tIiwicGF0aCI6ImFwYWNoZS9reWxpbiIsIm5hbWUiOiJreWxpbiIsIm9yZ2FuaXphdGlvbiI6ImFwYWNoZSJ9&variant=diff0) I discovered that the type attribution for `lombok.val` variables are not always correct.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
