### PR TITLE
Recipe to find maven modules that have no parent

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/ModuleHasNoParentTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/ModuleHasNoParentTest.java
@@ -1,0 +1,302 @@
+package org.openrewrite.maven.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.maven.Assertions;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class ModuleHasNoParentTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ModuleHasNoParent());
+    }
+
+    @DocumentExample
+    @Test
+    void noParent() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>minimal-project</artifactId>
+                    <version>1.0</version>
+                </project>
+                """,
+              """
+                <!--~~(Module has no parent.)~~>--><?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>minimal-project</artifactId>
+                    <version>1.0</version>
+                </project>
+                """
+            ),
+            java(
+              """
+                package org.example;
+                class Example {}
+                """,
+              """
+                /*~~(Module has no parent.)~~>*/package org.example;
+                class Example {}
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void parent() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.5.0</version>
+                    </parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>minimal-project</artifactId>
+                    <version>1.0</version>
+                </project>
+                """
+            ),
+            java(
+              """
+                package org.example;
+                class Example {}
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void multiModuleWithParent() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.5.0</version>
+                    </parent>
+                    <modules>
+                        <module>app</module>
+                    </modules>
+                </project>
+                """
+            )
+          ),
+          mavenProject("project/app",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>project</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </parent>
+                </project>
+                """
+            ),
+            java(
+              """
+                package org.example;
+                class Example {}
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void multiModuleWithoutParent() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>app</module>
+                    </modules>
+                </project>
+                """,
+              """
+                <!--~~(Module has no parent.)~~>--><?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>app</module>
+                    </modules>
+                </project>
+                """
+            )
+          ),
+          mavenProject("project/app",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>project</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </parent>
+                </project>
+                """
+            ),
+            java(
+              """
+                package org.example;
+                class Example {}
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void multiModuleWithParentChildWithoutParent() {
+        rewriteRun(
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <parent>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-parent</artifactId>
+                        <version>3.5.0</version>
+                    </parent>
+                    <packaging>pom</packaging>
+                    <modules>
+                        <module>app</module>
+                    </modules>
+                </project>
+                """
+            )
+          ),
+          mavenProject("project/app",
+            //language=xml
+            pomXml(
+              """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                </project>
+                """,
+              """
+                <!--~~(Module has no parent.)~~>--><?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0\s
+                         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                </project>
+                """
+            ),
+            java(
+              """
+                package org.example;
+                class Example {}
+                """,
+              """
+                /*~~(Module has no parent.)~~>*/package org.example;
+                class Example {}
+                """
+            )
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added a recipe to mark Maven Modules that have no parent

## What's your motivation?
When adding recipe (as part of it's changes) adds a maven parent, the current implementation of the AddParentPom recipe does notting when a parent is already present.

Especially when changes in the recipe depend on the correct parent being present this will cause unexpected and breaking changes.

With this recipe the module can be marked when there is no parent, so it can be used as a precondition for a recipe that requires the correct parent to be present.
