### PR TITLE
Skip update if existing compiler plugin version config is newer

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UseMavenCompilerPluginReleaseConfiguration.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UseMavenCompilerPluginReleaseConfiguration.java
@@ -77,12 +77,13 @@ public class UseMavenCompilerPluginReleaseConfiguration extends Recipe {
                 Optional<String> source = compilerPluginConfig.getChildValue("source");
                 Optional<String> target = compilerPluginConfig.getChildValue("target");
                 Optional<String> release = compilerPluginConfig.getChildValue("release");
-                if (!source.isPresent() &&
-                        !target.isPresent() &&
-                        !release.isPresent() ||
-                        currentNewerThanProposed(release)) {
+
+                if (currentNewerThanProposed(source)
+                        || currentNewerThanProposed(target)
+                        || currentNewerThanProposed(release)) {
                     return t;
                 }
+
                 Xml.Tag updated = filterTagChildren(t, compilerPluginConfig,
                         child -> !("source".equals(child.getName()) || "target".equals(child.getName())));
                 String releaseVersionValue = hasJavaVersionProperty(getCursor().firstEnclosingOrThrow(Xml.Document.class)) ?
@@ -93,12 +94,12 @@ public class UseMavenCompilerPluginReleaseConfiguration extends Recipe {
         };
     }
 
-    private boolean currentNewerThanProposed(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<String> maybeRelease) {
-        if (!maybeRelease.isPresent()) {
+    private boolean currentNewerThanProposed(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<String> config) {
+        if (!config.isPresent()) {
             return false;
         }
         try {
-            float currentVersion = Float.parseFloat(maybeRelease.get());
+            float currentVersion = Float.parseFloat(config.get());
             float proposedVersion = Float.parseFloat(releaseVersion.toString());
             return proposedVersion < currentVersion;
         } catch (NumberFormatException e) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UseMavenCompilerPluginReleaseConfigurationTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UseMavenCompilerPluginReleaseConfigurationTest.java
@@ -16,10 +16,15 @@
 package org.openrewrite.maven;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.stream.Stream;
 
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -619,6 +624,88 @@ class UseMavenCompilerPluginReleaseConfigurationTest implements RewriteTest {
               </project>
               """
           )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("mavenCompilerPluginConfig")
+    void skipsUpdateIfExistingMavenCompilerPluginConfigIsNewerThanRequestedJavaVersion(String mavenCompilerPluginConfig) {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+            """ + mavenCompilerPluginConfig +
+              """
+              </project>
+              """
+          )
+        );
+    }
+
+    private static Stream<Arguments> mavenCompilerPluginConfig() {
+        return Stream.of(
+          Arguments.of("""
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <version>3.8.0</version>
+                  <configuration>
+                    <source>17</source>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+            """),
+          Arguments.of("""
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <version>3.8.0</version>
+                  <configuration>
+                    <target>17</target>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+            """),
+          Arguments.of("""
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <version>3.8.0</version>
+                  <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+            """),
+          Arguments.of("""
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <version>3.8.0</version>
+                  <configuration>
+                    <release>17</release>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+            """)
         );
     }
 }


### PR DESCRIPTION
## What's changed?

Refined the logic that would determine if Maven compiler plugin needs to be updated based on the existing configuration.

## What's your motivation?

Given the following Maven project that configures Java 17 for the source/target compatibility via the Maven compiler plugin.

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.example</groupId>
    <artifactId>demo</artifactId>
    <version>0.0.1-SNAPSHOT</version>
    <build>
        <plugins>
          <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-compiler-plugin</artifactId>
            <version>3.14.0</version>
            <configuration>
              <source>17</source>
              <target>17</target>
            </configuration>
          </plugin>
        </plugins>
      </build>
</project>
```

Running the [Java8toJava11](https://docs.openrewrite.org/recipes/java/migrate/java8tojava11) recipe produces a fix.patch even though the currently used Java version is already higher than 11.