### PR TITLE
Add merge parameter to ChangePluginConfiguration recipe

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginConfigurationTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangePluginConfigurationTest.java
@@ -26,7 +26,7 @@ class ChangePluginConfigurationTest implements RewriteTest {
     @Test
     void removeConfiguration() {
         rewriteRun(
-          spec -> spec.recipe(new ChangePluginConfiguration("org.openrewrite.maven", "rewrite-maven-plugin", null)),
+          spec -> spec.recipe(new ChangePluginConfiguration("org.openrewrite.maven", "rewrite-maven-plugin", null, null)),
           pomXml(
             """
               <project>
@@ -77,7 +77,8 @@ class ChangePluginConfigurationTest implements RewriteTest {
           spec -> spec.recipe(new ChangePluginConfiguration(
             "org.openrewrite.maven",
             "rewrite-maven-plugin",
-            "<activeRecipes>\n<recipe>org.openrewrite.java.cleanup.UnnecessaryThrows</recipe>\n</activeRecipes>")),
+            "<activeRecipes>\n<recipe>org.openrewrite.java.cleanup.UnnecessaryThrows</recipe>\n</activeRecipes>",
+            null)),
           pomXml(
             """
               <project>
@@ -128,7 +129,8 @@ class ChangePluginConfigurationTest implements RewriteTest {
           spec -> spec.recipe(new ChangePluginConfiguration(
             "org.openrewrite.maven",
             "rewrite-maven-plugin",
-            "<activeRecipes>\n<recipe>org.openrewrite.java.cleanup.UnnecessaryThrows</recipe>\n</activeRecipes>")),
+            "<activeRecipes>\n<recipe>org.openrewrite.java.cleanup.UnnecessaryThrows</recipe>\n</activeRecipes>",
+            null)),
           pomXml(
             """
               <project>
@@ -180,6 +182,7 @@ class ChangePluginConfigurationTest implements RewriteTest {
           spec -> spec.recipe(new ChangePluginConfiguration(
             "org.openrewrite.maven",
             "rewrite-maven-plugin",
+            null,
             null)),
           pomXml(
             """
@@ -194,6 +197,72 @@ class ChangePluginConfigurationTest implements RewriteTest {
                               <groupId>org.openrewrite.maven</groupId>
                               <artifactId>rewrite-maven-plugin</artifactId>
                               <version>4.1.5</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void mergeConfiguration() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePluginConfiguration(
+            "org.openrewrite.maven",
+            "rewrite-maven-plugin",
+            "<activeRecipes>\n<recipe>org.openrewrite.java.cleanup.UnnecessaryThrows</recipe>\n</activeRecipes>\n<configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>",
+            true)),
+          pomXml(
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+              
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.openrewrite.maven</groupId>
+                              <artifactId>rewrite-maven-plugin</artifactId>
+                              <version>4.1.5</version>
+                              <configuration>
+                                  <activeRecipes>
+                                      <recipe>org.openrewrite.java.cleanup.NoFinalizer</recipe>
+                                  </activeRecipes>
+                                  <plainTextMasks>
+                                      <mask>**/*.txt</mask>
+                                  </plainTextMasks>
+                                  <failOnDryRunResults>true</failOnDryRunResults>
+                              </configuration>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>org.example</groupId>
+                  <artifactId>foo</artifactId>
+                  <version>1.0</version>
+              
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.openrewrite.maven</groupId>
+                              <artifactId>rewrite-maven-plugin</artifactId>
+                              <version>4.1.5</version>
+                              <configuration>
+                                  <activeRecipes>
+                                      <recipe>org.openrewrite.java.cleanup.UnnecessaryThrows</recipe>
+                                  </activeRecipes>
+                                  <plainTextMasks>
+                                      <mask>**/*.txt</mask>
+                                  </plainTextMasks>
+                                  <failOnDryRunResults>true</failOnDryRunResults>
+                                  <configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>
+                              </configuration>
                           </plugin>
                       </plugins>
                   </build>


### PR DESCRIPTION
## What's changed?
Added merge parameter to ChangePluginConfiguration recipe

## What's your motivation?
https://github.com/openrewrite/rewrite/issues/3810
Also, I have a couple of plugin related upgrades for java 21 upgrade for which this feature would help. I would like to contribute those after this.

## Anything in particular you'd like reviewers to focus on?
The implementation goes through tags directly mentioned in the argument, and calls addOrupdateChild on them. I have not done a recursive check, but let me know if that was the intended solution mentioned by @timtebeek in the issue linked. Atleast the ones I have in mind for the java 21 upgrade do not require a recursive check. 

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
