### PR TITLE
Unifying visitor method names between Java and Javascript

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -436,7 +436,7 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
      * @param other The other JSX expression to compare with
      * @returns The visited JSX expression, or undefined if the visit was aborted
      */
-    override async visitJsxExpression(expr: JSX.EmbeddedExpression, other: J): Promise<J | undefined> {
+    override async visitJsxEmbeddedExpression(expr: JSX.EmbeddedExpression, other: J): Promise<J | undefined> {
         if (!this.match || other.kind !== JS.Kind.JsxEmbeddedExpression) {
             this.abort();
             return expr;
@@ -1100,7 +1100,7 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
      * @param other The other keys remapping to compare with
      * @returns The visited keys remapping, or undefined if the visit was aborted
      */
-    override async visitKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, other: J): Promise<J | undefined> {
+    override async visitMappedTypeKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, other: J): Promise<J | undefined> {
         if (!this.match || other.kind !== JS.Kind.MappedTypeKeysRemapping) {
             this.abort();
             return keysRemapping;
@@ -1661,7 +1661,7 @@ export class JavaScriptComparatorVisitor extends JavaScriptVisitor<J> {
      * @param other The other index type to compare with
      * @returns The visited index type, or undefined if the visit was aborted
      */
-    override async visitIndexType(indexType: JS.IndexedAccessType.IndexType, other: J): Promise<J | undefined> {
+    override async visitIndexedAccessTypeIndexType(indexType: JS.IndexedAccessType.IndexType, other: J): Promise<J | undefined> {
         if (!this.match || other.kind !== JS.Kind.IndexType) {
             this.abort();
             return indexType;

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -147,7 +147,7 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         return spread;
     }
 
-    override async visitJsxExpression(expr: JSX.EmbeddedExpression, p: PrintOutputCapture): Promise<J | undefined> {
+    override async visitJsxEmbeddedExpression(expr: JSX.EmbeddedExpression, p: PrintOutputCapture): Promise<J | undefined> {
         await this.beforeSyntax(expr, p);
         p.append("{");
         if (expr.expression) {
@@ -961,7 +961,7 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         return iat;
     }
 
-    override async visitIndexType(indexType: JS.IndexedAccessType.IndexType, p: PrintOutputCapture): Promise<J | undefined> {
+    override async visitIndexedAccessTypeIndexType(indexType: JS.IndexedAccessType.IndexType, p: PrintOutputCapture): Promise<J | undefined> {
         await this.beforeSyntax(indexType, p);
 
         p.append("[");
@@ -1053,7 +1053,7 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
             await this.visitLeftPaddedLocal("readonly", mappedType.hasReadonly, p);
         }
 
-        await this.visitKeysRemapping(mappedType.keysRemapping, p);
+        await this.visitMappedTypeKeysRemapping(mappedType.keysRemapping, p);
 
         if (mappedType.suffixToken) {
             await this.visitLeftPadded(mappedType.suffixToken, p);
@@ -1071,7 +1071,7 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         return mappedType;
     }
 
-    override async visitKeysRemapping(mappedTypeKeys: JS.MappedType.KeysRemapping, p: PrintOutputCapture): Promise<J | undefined> {
+    override async visitMappedTypeKeysRemapping(mappedTypeKeys: JS.MappedType.KeysRemapping, p: PrintOutputCapture): Promise<J | undefined> {
         await this.beforeSyntax(mappedTypeKeys, p);
         p.append("[");
         await this.visitRightPadded(mappedTypeKeys.typeParameter, p);

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -200,7 +200,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         return mappedType;
     }
 
-    override async visitKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, q: RpcSendQueue): Promise<J | undefined> {
+    override async visitMappedTypeKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSend(keysRemapping, el => el.typeParameter, el => this.visitRightPadded(el, q));
         await q.getAndSend(keysRemapping, el => el.nameType, el => this.visitRightPadded(el, q));
         return keysRemapping;
@@ -314,7 +314,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         return indexedAccessType;
     }
 
-    override async visitIndexType(indexType: JS.IndexedAccessType.IndexType, q: RpcSendQueue): Promise<J | undefined> {
+    override async visitIndexedAccessTypeIndexType(indexType: JS.IndexedAccessType.IndexType, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSend(indexType, el => el.element, el => this.visitRightPadded(el, q));
         await q.getAndSend(indexType, el => asRef(el.type), el => this.visitType(el, q));
         return indexType;
@@ -399,7 +399,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
         return spreadAttribute;
     }
 
-    override async visitJsxExpression(embeddedExpression: JSX.EmbeddedExpression, q: RpcSendQueue): Promise<J | undefined> {
+    override async visitJsxEmbeddedExpression(embeddedExpression: JSX.EmbeddedExpression, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSend(embeddedExpression, el => el.expression, el => this.visitRightPadded(el, q));
         return embeddedExpression;
     }
@@ -741,7 +741,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         return finishDraft(draft);
     }
 
-    override async visitKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, q: RpcReceiveQueue): Promise<J | undefined> {
+    override async visitMappedTypeKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, q: RpcReceiveQueue): Promise<J | undefined> {
         const draft = createDraft(keysRemapping);
         draft.typeParameter = await q.receive(draft.typeParameter, el => this.visitRightPadded(el, q));
         draft.nameType = await q.receive(draft.nameType, el => this.visitRightPadded(el, q));
@@ -872,7 +872,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         return finishDraft(draft);
     }
 
-    override async visitIndexType(indexType: JS.IndexedAccessType.IndexType, q: RpcReceiveQueue): Promise<J | undefined> {
+    override async visitIndexedAccessTypeIndexType(indexType: JS.IndexedAccessType.IndexType, q: RpcReceiveQueue): Promise<J | undefined> {
         const draft = createDraft(indexType);
         draft.element = await q.receive(draft.element, el => this.visitRightPadded(el, q));
         draft.type = await q.receive(draft.type, el => this.visitType(el, q));
@@ -970,7 +970,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
         return finishDraft(draft);
     }
 
-    override async visitJsxExpression(embeddedExpression: JSX.EmbeddedExpression, q: RpcReceiveQueue): Promise<J | undefined> {
+    override async visitJsxEmbeddedExpression(embeddedExpression: JSX.EmbeddedExpression, q: RpcReceiveQueue): Promise<J | undefined> {
         const draft = createDraft(embeddedExpression);
         draft.expression = await q.receive(draft.expression, el => this.visitRightPadded(el, q));
         return finishDraft(draft);

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -142,7 +142,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         });
     }
 
-    protected async visitJsxExpression(expr: JSX.EmbeddedExpression, p: P): Promise<J | undefined> {
+    protected async visitJsxEmbeddedExpression(expr: JSX.EmbeddedExpression, p: P): Promise<J | undefined> {
         return this.produceJavaScript<JSX.EmbeddedExpression>(expr, p, async draft => {
             draft.expression = await this.visitRightPadded(expr.expression, p);
         });
@@ -386,7 +386,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         });
     }
 
-    protected async visitKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, p: P): Promise<J | undefined> {
+    protected async visitMappedTypeKeysRemapping(keysRemapping: JS.MappedType.KeysRemapping, p: P): Promise<J | undefined> {
         return this.produceJavaScript<JS.MappedType.KeysRemapping>(keysRemapping, p, async draft => {
             draft.typeParameter = await this.visitRightPadded(keysRemapping.typeParameter, p);
             draft.nameType = keysRemapping.nameType && await this.visitRightPadded(keysRemapping.nameType, p);
@@ -618,7 +618,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         });
     }
 
-    protected async visitIndexType(indexType: JS.IndexedAccessType.IndexType, p: P): Promise<J | undefined> {
+    protected async visitIndexedAccessTypeIndexType(indexType: JS.IndexedAccessType.IndexType, p: P): Promise<J | undefined> {
         return this.produceJavaScript<JS.IndexedAccessType.IndexType>(indexType, p, async draft => {
             draft.element = await this.visitRightPadded(indexType.element, p);
             draft.type = indexType.type && await this.visitType(indexType.type, p);
@@ -922,7 +922,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
                 case JS.Kind.JsxSpreadAttribute:
                     return this.visitJsxSpreadAttribute(tree as unknown as JSX.SpreadAttribute, p);
                 case JS.Kind.JsxEmbeddedExpression:
-                    return this.visitJsxExpression(tree as unknown as JSX.EmbeddedExpression, p);
+                    return this.visitJsxEmbeddedExpression(tree as unknown as JSX.EmbeddedExpression, p);
                 case JS.Kind.JsxNamespacedName:
                     return this.visitJsxNamespacedName(tree as unknown as JSX.NamespacedName, p);
                 case JS.Kind.JsxTag:
@@ -934,7 +934,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
                 case JS.Kind.MappedType:
                     return this.visitMappedType(tree as unknown as JS.MappedType, p);
                 case JS.Kind.MappedTypeKeysRemapping:
-                    return this.visitKeysRemapping(tree as unknown as JS.MappedType.KeysRemapping, p);
+                    return this.visitMappedTypeKeysRemapping(tree as unknown as JS.MappedType.KeysRemapping, p);
                 case JS.Kind.MappedTypeParameter:
                     return this.visitMappedTypeParameter(tree as unknown as JS.MappedType.Parameter, p);
                 case JS.Kind.ObjectBindingPattern:
@@ -968,7 +968,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
                 case JS.Kind.IndexedAccessType:
                     return this.visitIndexedAccessType(tree as unknown as JS.IndexedAccessType, p);
                 case JS.Kind.IndexType:
-                    return this.visitIndexType(tree as unknown as JS.IndexedAccessType.IndexType, p);
+                    return this.visitIndexedAccessTypeIndexType(tree as unknown as JS.IndexedAccessType.IndexType, p);
                 case JS.Kind.TypeQuery:
                     return this.visitTypeQuery(tree as unknown as JS.TypeQuery, p);
                 case JS.Kind.TypeInfo:

--- a/rewrite-javascript/rewrite/test/javascript/completeness.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/completeness.test.ts
@@ -17,17 +17,50 @@ import fs = require('fs');
 import path = require('path');
 
 
+function readFileToString(relativePath: string): string {
+    return fs.readFileSync(path.resolve(__dirname + "/../../src/", relativePath), 'utf8');
+}
+
 describe('JS LST element tree', () => {
     test("should have a .java class counterpart for every JS LST element type", () => {
-        const treeTSContent = fs.readFileSync(path.resolve(__dirname, '../../src/javascript/tree.ts'), 'utf8')
-            .split("export namespace JSX")[0];
-        const tsInterfaces = Array.from(treeTSContent.matchAll(/export interface (\w+) extends JS/gm), m => m[1]);
-        tsInterfaces.sort()
+        const treeTSContent = readFileToString('javascript/tree.ts').split("export namespace JSX")[0];
+        const tsInterfaces = Array.from(treeTSContent.matchAll(/export interface (\w+) extends JS/gm), m => m[1])
+            .sort();
 
-        const javaContent = fs.readFileSync(path.resolve(__dirname, '../../../src/main/java/org/openrewrite/javascript/tree/JS.java'), 'utf8');
-        const javaClasses = Array.from(javaContent.matchAll(/class (\w+) implements JS/gm), m => m[1]);
-        javaClasses.sort()
+        const javaClasses = Array.from(readFileToString('../../src/main/java/org/openrewrite/javascript/tree/JS.java')
+            .matchAll(/class (\w+) implements JS/gm), m => m[1])
+            .sort();
 
         expect(tsInterfaces).toEqual(javaClasses);
+    })
+
+    const visitorJavascriptMethods = Array.from(
+        readFileToString('javascript/visitor.ts').matchAll(/protected async (visit\w+)[(<]/gm), m => m[1])
+        .sort();
+    const visitorJavaMethods = Array.from(
+        readFileToString('java/visitor.ts').matchAll(/protected async (visit\w+)[(<]/gm), m => m[1])
+        .sort();
+    const excused = ["visitContainer", "visitExpression", "visitStatement", "visitSpace",
+                                "visitLeftPadded", "visitRightPadded",
+                                "visitOptionalContainer", "visitOptionalLeftPadded", "visitOptionalRightPadded",
+                                "visitType", "visitTypeName"];
+    const visitorMethods = visitorJavascriptMethods.concat(visitorJavaMethods)
+        .filter(m => !excused.includes(m))
+        .sort();
+
+    test("comparator.ts", () => {
+        const comparatorTsMethods = Array.from(
+            readFileToString('javascript/comparator.ts').matchAll(/override async (visit\w+)[(<]/gm), m => m[1])
+            .sort();
+
+        expect(comparatorTsMethods).toEqual(visitorMethods);
+    })
+
+    test("JavaScriptVisitor.java", () => {
+        const javaVisitorMethods = Array.from(readFileToString('../../src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java')
+            .matchAll(/public J (visit\w+)(?:[<][^(]+[>])?[(]JSX?[.]/gm), m => m[1])
+            .sort();
+
+        expect(visitorJavascriptMethods).toEqual(javaVisitorMethods);
     })
 });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java
@@ -23,8 +23,8 @@ import org.openrewrite.javascript.tree.JS;
 public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
 
     @Override
-    public JS.CompilationUnit visitCompilationUnit(JS.CompilationUnit cu, P p) {
-        return (JS.CompilationUnit) super.visitCompilationUnit(cu, p);
+    public JS.CompilationUnit visitJsCompilationUnit(JS.CompilationUnit cu, P p) {
+        return (JS.CompilationUnit) super.visitJsCompilationUnit(cu, p);
     }
 
     @Override
@@ -43,8 +43,8 @@ public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     @Override
-    public JS.AssignmentOperation visitAssignmentOperation(JS.AssignmentOperation assignOp, P p) {
-        return (JS.AssignmentOperation) super.visitAssignmentOperation(assignOp, p);
+    public JS.AssignmentOperation visitAssignmentOperationExtensions(JS.AssignmentOperation assignOp, P p) {
+        return (JS.AssignmentOperation) super.visitAssignmentOperationExtensions(assignOp, p);
     }
 
     @Override
@@ -108,13 +108,13 @@ public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     @Override
-    public JS.Binary visitBinary(JS.Binary binary, P p) {
-        return (JS.Binary) super.visitBinary(binary, p);
+    public JS.Binary visitBinaryExtensions(JS.Binary binary, P p) {
+        return (JS.Binary) super.visitBinaryExtensions(binary, p);
     }
 
     @Override
-    public JS.Import visitImport(JS.Import anImport, P p) {
-        return (JS.Import) super.visitImport(anImport, p);
+    public JS.Import visitImportDeclaration(JS.Import anImport, P p) {
+        return (JS.Import) super.visitImportDeclaration(anImport, p);
     }
 
     @Override

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -45,7 +45,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         throw new UnsupportedOperationException("JS has a different structure for its compilation unit. See JS.CompilationUnit.");
     }
 
-    public J visitCompilationUnit(JS.CompilationUnit cu, P p) {
+    public J visitJsCompilationUnit(JS.CompilationUnit cu, P p) {
         JS.CompilationUnit c = cu;
         c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COMPILATION_UNIT_PREFIX, p));
         c = c.withMarkers(visitMarkers(c.getMarkers(), p));
@@ -228,7 +228,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         return t;
     }
 
-    public J visitBinary(JS.Binary binary, P p) {
+    public J visitBinaryExtensions(JS.Binary binary, P p) {
         JS.Binary b = binary;
         b = b.withPrefix(visitSpace(b.getPrefix(), JsSpace.Location.BINARY_PREFIX, p));
         b = b.withMarkers(visitMarkers(b.getMarkers(), p));
@@ -245,7 +245,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         return b;
     }
 
-    public J visitImport(JS.Import jsImport, P p) {
+    public J visitImportDeclaration(JS.Import jsImport, P p) {
         JS.Import i = jsImport;
         i = i.withPrefix(visitSpace(i.getPrefix(), JsSpace.Location.IMPORT_PREFIX, p));
         i = i.withMarkers(visitMarkers(i.getMarkers(), p));
@@ -990,7 +990,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         return c;
     }
 
-    public J visitAssignmentOperation(JS.AssignmentOperation assignOp, P p) {
+    public J visitAssignmentOperationExtensions(JS.AssignmentOperation assignOp, P p) {
         JS.AssignmentOperation a = assignOp;
         a = a.withPrefix(visitSpace(a.getPrefix(), JsSpace.Location.ASSIGNMENT_OPERATION_PREFIX, p));
         a = a.withMarkers(visitMarkers(a.getMarkers(), p));

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -61,7 +61,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     }
 
     @Override
-    public J visitCompilationUnit(JS.CompilationUnit cu, RpcReceiveQueue q) {
+    public J visitJsCompilationUnit(JS.CompilationUnit cu, RpcReceiveQueue q) {
         return cu.withSourcePath(q.<Path, String>receiveAndGet(cu.getSourcePath(), Paths::get))
                 .withCharset(q.<Charset, String>receiveAndGet(cu.getCharset(), Charset::forName))
                 .withCharsetBomMarked(q.receive(cu.isCharsetBomMarked()))
@@ -151,7 +151,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     }
 
     @Override
-    public J visitImport(JS.Import anImport, RpcReceiveQueue q) {
+    public J visitImportDeclaration(JS.Import anImport, RpcReceiveQueue q) {
         return anImport
                 .withImportClause(q.receive(anImport.getImportClause(), el -> (JS.ImportClause) visitNonNull(el, q)))
                 .getPadding().withModuleSpecifier(q.receive(anImport.getPadding().getModuleSpecifier(), el -> visitLeftPadded(el, q)))
@@ -205,7 +205,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     }
 
     @Override
-    public J visitBinary(JS.Binary binary, RpcReceiveQueue q) {
+    public J visitBinaryExtensions(JS.Binary binary, RpcReceiveQueue q) {
         return binary
                 .withLeft(q.receive(binary.getLeft(), expr -> (Expression) visitNonNull(expr, q)))
                 .getPadding().withOperator(q.receive(binary.getPadding().getOperator(), el -> visitLeftPadded(el, q, toEnum(JS.Binary.Type.class))))
@@ -347,7 +347,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     }
 
     @Override
-    public J visitAssignmentOperation(JS.AssignmentOperation assignmentOperation, RpcReceiveQueue q) {
+    public J visitAssignmentOperationExtensions(JS.AssignmentOperation assignmentOperation, RpcReceiveQueue q) {
         return assignmentOperation
                 .withVariable(q.receive(assignmentOperation.getVariable(), expr -> (Expression) visitNonNull(expr, q)))
                 .getPadding().withOperator(q.receive(assignmentOperation.getPadding().getOperator(), el -> visitLeftPadded(el, q, toEnum(JS.AssignmentOperation.Type.class))))

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -56,7 +56,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     }
 
     @Override
-    public J visitCompilationUnit(JS.CompilationUnit cu, RpcSendQueue q) {
+    public J visitJsCompilationUnit(JS.CompilationUnit cu, RpcSendQueue q) {
         q.getAndSend(cu, c -> c.getSourcePath().toString());
         q.getAndSend(cu, c -> c.getCharset().name());
         q.getAndSend(cu, JS.CompilationUnit::isCharsetBomMarked);
@@ -148,7 +148,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     }
 
     @Override
-    public J visitImport(JS.Import jsImport, RpcSendQueue q) {
+    public J visitImportDeclaration(JS.Import jsImport, RpcSendQueue q) {
         q.getAndSend(jsImport, JS.Import::getImportClause, el -> visit(el, q));
         q.getAndSend(jsImport, el -> el.getPadding().getModuleSpecifier(), el -> visitLeftPadded(el, q));
         q.getAndSend(jsImport, JS.Import::getAttributes, el -> visit(el, q));
@@ -202,7 +202,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     }
 
     @Override
-    public J visitBinary(JS.Binary binary, RpcSendQueue q) {
+    public J visitBinaryExtensions(JS.Binary binary, RpcSendQueue q) {
         q.getAndSend(binary, JS.Binary::getLeft, el -> visit(el, q));
         q.getAndSend(binary, el -> el.getPadding().getOperator(), el -> visitLeftPadded(el, q));
         q.getAndSend(binary, JS.Binary::getRight, el -> visit(el, q));
@@ -344,7 +344,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     }
 
     @Override
-    public J visitAssignmentOperation(JS.AssignmentOperation assignmentOperation, RpcSendQueue q) {
+    public J visitAssignmentOperationExtensions(JS.AssignmentOperation assignmentOperation, RpcSendQueue q) {
         q.getAndSend(assignmentOperation, JS.AssignmentOperation::getVariable, el -> visit(el, q));
         q.getAndSend(assignmentOperation, el -> el.getPadding().getOperator(), el -> visitLeftPadded(el, q));
         q.getAndSend(assignmentOperation, JS.AssignmentOperation::getAssignment, el -> visit(el, q));

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
@@ -49,7 +49,7 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
     }
 
     @Override
-    public JS.CompilationUnit visitCompilationUnit(JS.CompilationUnit compilationUnit, P p) {
+    public JS.CompilationUnit visitJsCompilationUnit(JS.CompilationUnit compilationUnit, P p) {
         ListUtils.map(compilationUnit.getImports(), el -> visitAndValidateNonNull(el, J.Import.class, p));
         ListUtils.map(compilationUnit.getStatements(), el -> visitAndValidateNonNull(el, Statement.class, p));
         return compilationUnit;
@@ -134,7 +134,7 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
     }
 
     @Override
-    public JS.Import visitImport(JS.Import import_, P p) {
+    public JS.Import visitImportDeclaration(JS.Import import_, P p) {
         visitAndValidate(import_.getImportClause(), JS.ImportClause.class, p);
         visitAndValidate(import_.getModuleSpecifier(), Expression.class, p);
         visitAndValidate(import_.getAttributes(), JS.ImportAttributes.class, p);
@@ -182,7 +182,7 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
     }
 
     @Override
-    public JS.Binary visitBinary(JS.Binary binary, P p) {
+    public JS.Binary visitBinaryExtensions(JS.Binary binary, P p) {
         visitAndValidateNonNull(binary.getLeft(), Expression.class, p);
         visitAndValidateNonNull(binary.getRight(), Expression.class, p);
         return binary;
@@ -456,7 +456,7 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
     }
 
     @Override
-    public JS.AssignmentOperation visitAssignmentOperation(JS.AssignmentOperation assignmentOperation, P p) {
+    public JS.AssignmentOperation visitAssignmentOperationExtensions(JS.AssignmentOperation assignmentOperation, P p) {
         visitAndValidateNonNull(assignmentOperation.getVariable(), Expression.class, p);
         visitAndValidateNonNull(assignmentOperation.getAssignment(), Expression.class, p);
         return assignmentOperation;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -191,7 +191,7 @@ public interface JS extends J {
 
         @Override
         public <P> J acceptJavaScript(JavaScriptVisitor<P> v, P p) {
-            return v.visitCompilationUnit(this, p);
+            return v.visitJsCompilationUnit(this, p);
         }
 
         @Override
@@ -1210,7 +1210,7 @@ public interface JS extends J {
 
         @Override
         public <P> J acceptJavaScript(JavaScriptVisitor<P> v, P p) {
-            return v.visitImport(this, p);
+            return v.visitImportDeclaration(this, p);
         }
 
         @Override
@@ -1767,7 +1767,7 @@ public interface JS extends J {
 
         @Override
         public <P> J acceptJavaScript(JavaScriptVisitor<P> v, P p) {
-            return v.visitBinary(this, p);
+            return v.visitBinaryExtensions(this, p);
         }
 
         @Transient
@@ -4924,7 +4924,7 @@ public interface JS extends J {
 
         @Override
         public <P> J acceptJavaScript(JavaScriptVisitor<P> v, P p) {
-            return v.visitAssignmentOperation(this, p);
+            return v.visitAssignmentOperationExtensions(this, p);
         }
 
         @Override


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
