### PR TITLE
Javascript - Adding more completeness checks, adding missing JSX visit methods

### DIFF
--- a/rewrite-javascript/rewrite/test/javascript/completeness.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/completeness.test.ts
@@ -58,7 +58,23 @@ describe('JS LST element tree', () => {
 
     test("JavaScriptVisitor.java", () => {
         const javaVisitorMethods = Array.from(readFileToString('../../src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java')
-            .matchAll(/public J (visit\w+)(?:[<][^(]+[>])?[(]JSX?[.]/gm), m => m[1])
+            .matchAll(/public J (visit\w+)(?:<[^(]+>)?[(]JSX?[.]/gm), m => m[1])
+            .sort();
+
+        expect(visitorJavascriptMethods).toEqual(javaVisitorMethods);
+    })
+
+    test("JavaScriptValidator.java", () => {
+        const javaVisitorMethods = Array.from(readFileToString('../../src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java')
+            .matchAll(/public [^ ]+ (visit\w+)(?:<[^(]+>)?[(]JSX?[.]/gm), m => m[1])
+            .sort();
+
+        expect(visitorJavascriptMethods).toEqual(javaVisitorMethods);
+    })
+
+    test("JavaScriptIsoVisitor.java", () => {
+        const javaVisitorMethods = Array.from(readFileToString('../../src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java')
+            .matchAll(/public [^ ]+ (visit\w+)(?:<[^(]+>)?[(]JSX?[.]/gm), m => m[1])
             .sort();
 
         expect(visitorJavascriptMethods).toEqual(javaVisitorMethods);

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptIsoVisitor.java
@@ -19,6 +19,7 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.javascript.tree.JS;
+import org.openrewrite.javascript.tree.JSX;
 
 public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
 
@@ -328,8 +329,8 @@ public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     @Override
-    public JS.Yield visitYield(JS.Yield yield, P p) {
-        return (JS.Yield) super.visitYield(yield, p);
+    public JS.Yield visitYield(J.Yield yield, P p) {
+        return (J.Yield) super.visitYield(yield, p);
     }
 
     // J overrides.
@@ -683,5 +684,30 @@ public class JavaScriptIsoVisitor<P> extends JavaScriptVisitor<P> {
     @Override
     public J.Unknown.Source visitUnknownSource(J.Unknown.Source source, P p) {
         return (J.Unknown.Source) super.visitUnknownSource(source, p);
+    }
+
+    @Override
+    public JSX.Tag visitJsxTag(JSX.Tag tag, P p) {
+        return (JSX.Tag) super.visitJsxTag(tag, p);
+    }
+
+    @Override
+    public JSX.Attribute visitJsxAttribute(JSX.Attribute attribute, P p) {
+        return (JSX.Attribute) super.visitJsxAttribute(attribute, p);
+    }
+
+    @Override
+    public JSX.SpreadAttribute visitJsxSpreadAttribute(JSX.SpreadAttribute spreadAttribute, P p) {
+        return (JSX.SpreadAttribute) super.visitJsxSpreadAttribute(spreadAttribute, p);
+    }
+
+    @Override
+    public JSX.EmbeddedExpression visitJsxEmbeddedExpression(JSX.EmbeddedExpression embeddedExpression, P p) {
+        return (JSX.EmbeddedExpression) super.visitJsxEmbeddedExpression(embeddedExpression, p);
+    }
+
+    @Override
+    public JSX.NamespacedName visitJsxNamespacedName(JSX.NamespacedName namespacedName, P p) {
+        return (JSX.NamespacedName) super.visitJsxNamespacedName(namespacedName, p);
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
@@ -21,6 +21,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.javascript.JavaScriptIsoVisitor;
 import org.openrewrite.javascript.tree.JS;
+import org.openrewrite.javascript.tree.JSX;
 
 import java.util.List;
 import java.util.Objects;
@@ -942,4 +943,37 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
         return erroneous;
     }
 
+    @Override
+    public JSX.Tag visitJsxTag(JSX.Tag tag, P p) {
+        visitAndValidateNonNull(tag.getOpenName(), NameTree.class, p);
+        ListUtils.map(tag.getChildren(), el -> visitAndValidateNonNull(el, Statement.class, p));
+        ListUtils.map(tag.getAttributes(), el -> visitAndValidateNonNull(el, JSX.class, p));
+        return tag;
+    }
+
+    @Override
+    public JSX.Attribute visitJsxAttribute(JSX.Attribute attribute, P p) {
+        visitAndValidateNonNull(attribute.getKey(), NameTree.class, p);
+        visitAndValidate(attribute.getValue(), Expression.class, p);
+        return attribute;
+    }
+
+    @Override
+    public JSX.SpreadAttribute visitJsxSpreadAttribute(JSX.SpreadAttribute spreadAttribute, P p) {
+        visitAndValidateNonNull(spreadAttribute.getExpression(), Expression.class, p);
+        return spreadAttribute;
+    }
+
+    @Override
+    public JSX.EmbeddedExpression visitJsxEmbeddedExpression(JSX.EmbeddedExpression embeddedExpression, P p) {
+        visitAndValidateNonNull(embeddedExpression.getExpression(), Expression.class, p);
+        return embeddedExpression;
+    }
+
+    @Override
+    public JSX.NamespacedName visitJsxNamespacedName(JSX.NamespacedName namespacedName, P p) {
+        visitAndValidateNonNull(namespacedName.getNamespace(), Expression.class, p);
+        visitAndValidateNonNull(namespacedName.getName(), Expression.class, p);
+        return namespacedName;
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding more completeness checks to Javascript LST element definitions.
And thanks to it:
- adding missing visit JSX methods to some of the visitors

## What's your motivation?

Prevent inconsistencies on subsequent LST changes for Javascript.
