### PR TITLE
Fix Semver Version Comparator incorrectly comparing RC releases

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -149,6 +149,19 @@ public class LatestRelease implements VersionComparator {
             throw new IllegalStateException("Illegal state while comparing versions : [" + nv1 + "] and [" + nv2 + "]. Metadata = [" + metadataPattern + "]", exception);
         }
 
+        // When all numeric parts are equal, we need to handle pre-release versions properly
+        // A pre-release version should be considered less than a release version
+        // e.g., "3.5.0-RC1" < "3.5.0"
+        boolean v1IsPreRelease = v1Gav.group(6) != null && PRE_RELEASE_ENDING.matcher(v1Gav.group(6)).find();
+        boolean v2IsPreRelease = v2Gav.group(6) != null && PRE_RELEASE_ENDING.matcher(v2Gav.group(6)).find();
+        
+        if (v1IsPreRelease && !v2IsPreRelease) {
+            return -1; // v1 is pre-release, v2 is not, so v1 < v2
+        } else if (!v1IsPreRelease && v2IsPreRelease) {
+            return 1;  // v1 is not pre-release, v2 is, so v1 > v2
+        }
+        
+        // Both are either pre-release or release versions, do string comparison
         return normalized1.compareTo(normalized2);
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -44,7 +44,9 @@ public class XRange extends LatestRelease {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        if (!super.isValid(currentVersion, version)) {
+        // For X-range patterns, we need to check if the version matches the pattern
+        // but we should not exclude it just because it's a pre-release version
+        if (!VersionComparator.checkVersion(version, getMetadataPattern(), false)) {
             return false;
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
@@ -173,4 +173,15 @@ class LatestReleaseTest {
     void matchCustomMetadata() {
         assertThat(new LatestRelease(".Final-custom-\\d+").isValid(null, "3.2.9.Final-custom-00003")).isTrue();
     }
+
+    @Test
+    void preReleaseVersionsShouldBeLessThanReleaseVersions() {
+        assertThat(latestRelease.compare(null, "3.5.0-RC1", "3.5.0")).isLessThan(0);
+        assertThat(latestRelease.compare(null, "3.5.0", "3.5.0-RC1")).isGreaterThan(0);
+        assertThat(latestRelease.compare(null, "3.5.0-RC1", "3.5.0-RC2")).isLessThan(0);
+        assertThat(latestRelease.compare(null, "3.5.0-alpha", "3.5.0-beta")).isLessThan(0);
+        // String comparison: "beta" > "RC1" lexicographically
+        assertThat(latestRelease.compare(null, "3.5.0-beta", "3.5.0-RC1")).isGreaterThan(0);
+        assertThat(latestRelease.compare(null, "3.5.0-RC1", "3.5.0-beta")).isLessThan(0);
+    }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
@@ -110,4 +110,20 @@ class XRangeTest {
     void matchCustomMetadata() {
         assertThat(new XRange("3", "2", "*", "", ".Final-custom-\\d+").isValid(null, "3.2.9.Final-custom-00003")).isTrue();
     }
+
+    @Test
+    void compareRCVersion() {
+        XRange xRange = XRange.build("3.5.x", null).getValue();
+        assertThat(xRange).isNotNull();
+        assertThat(xRange.upgrade("3.5.0-RC1", java.util.Arrays.asList("3.5.0")).orElse(null)).isEqualTo("3.5.0");
+    }
+
+    @Test
+    void rcVersionsShouldBeValidForXRange() {
+        XRange xRange = XRange.build("3.5.x", null).getValue();
+        assertThat(xRange).isNotNull();
+        assertThat(xRange.isValid("3.5.0-RC1", "3.5.0-RC1")).isTrue();
+        assertThat(xRange.isValid("3.5.0-RC1", "3.5.0")).isTrue();
+        assertThat(xRange.isValid("3.5.0", "3.5.1-RC1")).isTrue();
+    }
 }


### PR DESCRIPTION
## Problem
The Semver VersionComparator's upgrade function was returning null when comparing RC (release candidate) versions with full release versions.
For example, when trying to upgrade from "3.5.0-RC1" to "3.5.0" with an X-range pattern like "3.5.x", the comparator would incorrectly return
null instead of "3.5.0".

## Root Cause
1. The `XRange.isValid()` method was calling the parent class's `isValid()` method which excludes pre-release versions by setting
`requireRelease=true`. This caused RC versions to be considered invalid for X-range patterns.
2. The `LatestRelease.compare()` method was not properly handling the comparison between pre-release and release versions. When all numeric
parts were equal (e.g., 3.5.0-RC1 vs 3.5.0), it fell back to string comparison, which incorrectly considered "3.5.0-RC1" > "3.5.0"
lexicographically.

## Solution
1. Modified `XRange.isValid()` to call `VersionComparator.checkVersion()` with `requireRelease=false`, allowing pre-release versions to be
considered valid candidates for X-range patterns.
2. Enhanced `LatestRelease.compare()` to properly handle pre-release vs release version comparisons:
   - Pre-release versions are now correctly considered less than release versions
   - When both versions are either pre-release or release, the existing string comparison logic is used

## Testing
- Added `compareRCVersion()` test in XRangeTest to verify the exact scenario from the issue
- Added `rcVersionsShouldBeValidForXRange()` test to verify RC versions are valid for X-range patterns
- Added `preReleaseVersionsShouldBeLessThanReleaseVersions()` test in LatestReleaseTest to verify comparison logic

Fixes:
 - #5660
