### PR TITLE
Fix ChangeProjectVersion to ignore Maven CI-friendly version placeholders

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeProjectVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeProjectVersionTest.java
@@ -303,4 +303,61 @@ class ChangeProjectVersionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doNotChangeProjectVersionIfRevisionPlaceholderProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeProjectVersion("org.openrewrite", "rewrite-maven", "${revision}", null)),
+          pomXml(
+            """
+              <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>rewrite-maven</artifactId>
+                  <version>${revision}</version>
+                  <properties>
+                      <revision>8.55.5</revision>
+                  </properties>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeProjectVersionIfSha1PlaceholderProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeProjectVersion("org.openrewrite", "rewrite-maven", "${sha1}", null)),
+          pomXml(
+            """
+              <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>rewrite-maven</artifactId>
+                  <version>${sha1}</version>
+                  <properties>
+                      <sha1>abc123</sha1>
+                  </properties>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeProjectVersionIfChangelistPlaceholderProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeProjectVersion("org.openrewrite", "rewrite-maven", "${changelist}", null)),
+          pomXml(
+            """
+              <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>rewrite-maven</artifactId>
+                  <version>${changelist}</version>
+                  <properties>
+                      <changelist>SNAPSHOT</changelist>
+                  </properties>
+              </project>
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
This PR fixes an issue where the ChangeProjectVersion recipe would incorrectly attempt to update Maven CI-friendly version placeholder properties (`${revision}`, `${sha1}`, and `${changelist}`) when they were used in the version tag, causing circular reference errors.

The fix adds these placeholders to the list of implicitly defined version properties that should not be updated, and adds an additional check to skip processing when the current version tag value already matches the new version.

This enables proper support for Maven CI-friendly versioning workflows where projects use these standard placeholders for version management.

- Fixes #5667
