### PR TITLE
Pin JUnit to 5.+

### DIFF
--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(platform("org.junit:junit-bom:latest.release"))
+    api(platform("org.junit:junit-bom:5.+")) // JUnit 6 requires Java 17
     api(project(":rewrite-core"))
     compileOnly("io.micrometer:micrometer-core:latest.release")
     api("org.junit.jupiter:junit-jupiter-api")

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    api(platform("org.junit:junit-bom:5.+"))
     api(project(":rewrite-core"))
     compileOnly("io.micrometer:micrometer-core:latest.release")
     api("org.junit.jupiter:junit-jupiter-api")

--- a/rewrite-test/build.gradle.kts
+++ b/rewrite-test/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    api(platform("org.junit:junit-bom:5.+")) // JUnit 6 requires Java 17
     api(project(":rewrite-core"))
     compileOnly("io.micrometer:micrometer-core:latest.release")
     api("org.junit.jupiter:junit-jupiter-api")


### PR DESCRIPTION
## What's changed?

Pinning the JUnit version to 5 major.

## What's your motivation?

JUnit has just released `6.0.0-M1` an hour ago. And these versions require Java 17, which we are not ready to take.
