### PR TITLE
Adjusting the `isValid` check for `XRange` so that it doesn't allow for going from release to pre-release versions when upgrading.

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -46,7 +46,7 @@ public class XRange extends LatestRelease {
     public boolean isValid(@Nullable String currentVersion, String version) {
         // For X-range patterns, we need to check if the version matches the pattern
         // but we should not exclude it just because it's a pre-release version
-        if (!VersionComparator.checkVersion(version, getMetadataPattern(), false)) {
+        if (!VersionComparator.checkVersion(version, getMetadataPattern(), getMetadataPattern() == null)) {
             return false;
         }
 

--- a/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/XRange.java
@@ -44,9 +44,7 @@ public class XRange extends LatestRelease {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public boolean isValid(@Nullable String currentVersion, String version) {
-        // For X-range patterns, we need to check if the version matches the pattern
-        // but we should not exclude it just because it's a pre-release version
-        if (!VersionComparator.checkVersion(version, getMetadataPattern(), getMetadataPattern() == null)) {
+        if (!super.isValid(currentVersion, version)) {
             return false;
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
@@ -121,11 +121,13 @@ class XRangeTest {
     }
 
     @Test
-    void allowSameMetadataUpgrade() {
+    void allowSpecificMetadataUpgrade() {
         XRange xRange = XRange.build("3.5.x", "-beta").getValue();
         assertThat(xRange).isNotNull();
         assertThat(xRange.isValid(null, "3.5.0-beta")).isTrue();
         assertThat(xRange.upgrade("3.4.0-beta", List.of("3.5.1", "3.5.1-beta")).orElse(null)).isEqualTo("3.5.1-beta");
+        assertThat(xRange.upgrade("3.4.0-RC1", List.of("3.5.1", "3.5.1-beta")).orElse(null)).isEqualTo("3.5.1-beta");
+        assertThat(xRange.upgrade("3.4.0", List.of("3.5.2", "3.5.1", "3.5.1-beta")).orElse(null)).isEqualTo("3.5.1-beta");
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/XRangeTest.java
@@ -111,6 +111,8 @@ class XRangeTest {
     @Test
     void matchCustomMetadata() {
         assertThat(new XRange("3", "2", "*", "", ".Final-custom-\\d+").isValid(null, "3.2.9.Final-custom-00003")).isTrue();
+        // -beta is a recognized pre-release pattern, which isn't allowed.
+        assertThat(XRange.build("3.5.x", "-beta").getValue().isValid(null, "3.5.1-beta")).isFalse();
     }
 
     @Test
@@ -118,16 +120,6 @@ class XRangeTest {
         XRange xRange = XRange.build("3.5.x", null).getValue();
         assertThat(xRange).isNotNull();
         assertThat(xRange.upgrade("3.5.0-RC1", List.of("3.5.0", "3.5.1-RC1")).orElse(null)).isEqualTo("3.5.0");
-    }
-
-    @Test
-    void allowSpecificMetadataUpgrade() {
-        XRange xRange = XRange.build("3.5.x", "-beta").getValue();
-        assertThat(xRange).isNotNull();
-        assertThat(xRange.isValid(null, "3.5.0-beta")).isTrue();
-        assertThat(xRange.upgrade("3.4.0-beta", List.of("3.5.1", "3.5.1-beta")).orElse(null)).isEqualTo("3.5.1-beta");
-        assertThat(xRange.upgrade("3.4.0-RC1", List.of("3.5.1", "3.5.1-beta")).orElse(null)).isEqualTo("3.5.1-beta");
-        assertThat(xRange.upgrade("3.4.0", List.of("3.5.2", "3.5.1", "3.5.1-beta")).orElse(null)).isEqualTo("3.5.1-beta");
     }
 
     @Test


### PR DESCRIPTION
## What's changed?
- Changed the `isValid` check for `XRange` back to calling the `super`'s version of the method first, so if you're on `3.5.0` and trying to upgrade to `3.6.x`, if there are `3.6.1-SNAPSHOT` and `3.6.0` available, it will take `3.6.0`.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
