### PR TITLE
`Yaml.Document` precondition example

### DIFF
--- a/rewrite-yaml/src/main/resources/META-INF/rewrite/example.yml
+++ b/rewrite-yaml/src/main/resources/META-INF/rewrite/example.yml
@@ -1,0 +1,35 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.yaml.example
+displayName: Example
+description: Example.
+
+preconditions:
+  - org.openrewrite.yaml.search.FindKey:
+      key: "$.kind[?(@ == 'Deployment')]"
+
+recipeList:
+  # Add OpenRewrite tracking annotations
+  - org.openrewrite.yaml.MergeYaml:
+      key: $.metadata
+      yaml: |
+        annotations:
+          openrewrite/injected-by: "OpenRewrite Recipe"
+          openrewrite/recipe-version: "1.0.0"
+          openrewrite/agent-type: "Java"

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlExampleTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/YamlExampleTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.yaml;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.yaml.Assertions.yaml;
+
+@SuppressWarnings({"KubernetesUnknownResourcesInspection", "KubernetesNonEditableResources"})
+class YamlExampleTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.yaml.example");
+    }
+
+    @DocumentExample
+    @Test
+    void nonExistentBlock() {
+        rewriteRun(
+          yaml(
+            """
+              apiVersion: apps/v1
+              kind: ReplicaSet
+              metadata:
+                name: frontend
+                labels:
+                  app: guestbook
+                  tier: frontend
+              ---
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: nginx-deployment
+                labels:
+                  app: nginx
+              """,
+            """
+              apiVersion: apps/v1
+              kind: ReplicaSet
+              metadata:
+                name: frontend
+                labels:
+                  app: guestbook
+                  tier: frontend
+              ---
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: nginx-deployment
+                labels:
+                  app: nginx
+                annotations:
+                  openrewrite/injected-by: "OpenRewrite Recipe"
+                  openrewrite/recipe-version: "1.0.0"
+                  openrewrite/agent-type: "Java"
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Added example to showcase the desire for `Yaml.Document` level preconditions

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
In YAML there are often multiple documents in a single file whereas that's not often the case in Java with Classes

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Perhaps a `documentCondition` option for Yaml recipes

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
