### PR TITLE
Fix AddOrUpdateAnnotation recipe changing implicit `value` into explicit `value` in annotations

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/AddOrUpdateAnnotationAttributeTest.java
@@ -1481,4 +1481,75 @@ class AddOrUpdateAnnotationAttributeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotAddOrRemoveValueWhenOldAtrributeValueDoesNotMatchAndAttributeNameIsNotValue() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new AddOrUpdateAnnotationAttribute(
+              "org.example.Foo",
+              "name",
+              "newValue",
+              "oldValue",
+              null,
+              null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String name() default "";
+                  String value() default "";
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import org.example.Foo;
+              
+              @Foo("oldValue")
+              public class A {}
+              
+              @Foo(value = "oldExplicitValue")
+              public class B {}
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void doNotAddOrRemoveValueWhenOldAtrributeValueDoesMatchAndAttributeNameIsValue() {
+        rewriteRun(
+          spec -> spec.recipe(
+            new AddOrUpdateAnnotationAttribute(
+              "org.example.Foo",
+              "value",
+              "newValue",
+              "oldValue",
+              null,
+              null)),
+          java(
+            """
+              package org.example;
+              public @interface Foo {
+                  String name() default "";
+                  String value() default "";
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import org.example.Foo;
+              
+              @Foo("oldValue")
+              public class A {}
+              
+              @Foo(value = "oldValue")
+              public class B {}
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddOrUpdateAnnotationAttribute.java
@@ -250,7 +250,7 @@ public class AddOrUpdateAnnotationAttribute extends Recipe {
                                     return it;
                                 }
                                 return ((J.Literal) it).withValue(newAttributeValue).withValueSource(newAttributeValue);
-                            } else {
+                            } else if (oldAttributeValue == null) {
                                 // Make the attribute name explicit, before we add the new value below
                                 //noinspection ConstantConditions
                                 return ((J.Annotation) JavaTemplate.builder("value = #{}")


### PR DESCRIPTION
## What's changed?
When updating an existing annotation property the recipe should not change whether `value` is implicit or explicit.

## What's your motivation?
The recipe makes unnecessary changes which is noisy. 
