### PR TITLE
Fixes for Java RPC

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -451,7 +451,6 @@ public class GroovyParserVisitor {
                     modifiers,
                     typeExpr,
                     null,
-                    emptyList(),
                     singletonList(JRightPadded.build(namedVariable))
             );
 
@@ -558,7 +557,7 @@ public class GroovyParserVisitor {
 
                 params.add(JRightPadded.build((Statement) new J.VariableDeclarations(randomId(), EMPTY,
                         Markers.EMPTY, paramAnnotations, paramModifiers, paramType,
-                        varargs, emptyList(),
+                        varargs,
                         singletonList(paramName))).withAfter(rightPad));
             }
 
@@ -1109,7 +1108,7 @@ public class GroovyParserVisitor {
             skip(")");
             JRightPadded<J.VariableDeclarations> variable = JRightPadded.build(new J.VariableDeclarations(randomId(), paramType.getPrefix(),
                     Markers.EMPTY, emptyList(), emptyList(), paramType.withPrefix(EMPTY),
-                    null, emptyList(),
+                    null,
                     singletonList(paramName))
             ).withAfter(rightPad);
 
@@ -1205,7 +1204,7 @@ public class GroovyParserVisitor {
                     JavaType type = typeMapping.type(staticType(p));
                     J expr = new J.VariableDeclarations(randomId(), whitespace(), Markers.EMPTY,
                             emptyList(), emptyList(), p.isDynamicTyped() ? null : visitTypeTree(p.getType()),
-                            null, emptyList(),
+                            null,
                             singletonList(
                                     JRightPadded.build(
                                             new J.VariableDeclarations.NamedVariable(randomId(), sourceBefore(p.getName()), Markers.EMPTY,
@@ -1451,7 +1450,6 @@ public class GroovyParserVisitor {
                     modifiers,
                     typeExpr,
                     null,
-                    emptyList(),
                     singletonList(JRightPadded.build(namedVariable))
             );
             if (multiVariable.isPresent()) {
@@ -1541,7 +1539,7 @@ public class GroovyParserVisitor {
                     }
 
                     JRightPadded<Statement> variable = JRightPadded.<Statement>build(
-                            new J.VariableDeclarations(randomId(), paramFmt, Markers.EMPTY, emptyList(), modifiers, paramType, null, emptyList(), singletonList(paramName))
+                            new J.VariableDeclarations(randomId(), paramFmt, Markers.EMPTY, emptyList(), modifiers, paramType, null, singletonList(paramName))
                     ).withAfter(rightPad);
 
                     JRightPadded<Expression> iterable = JRightPadded.build((Expression) visit(forLoop.getCollectionExpression()))

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 import static org.openrewrite.groovy.internal.Delimiter.DOUBLE_QUOTE_STRING;
-import static org.openrewrite.groovy.tree.G.Unary.Type.Spread;
 
 public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
     private final GroovyJavaPrinter delegate = new GroovyJavaPrinter();
@@ -302,13 +301,6 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
                 p.append(",");
             });
             visit(multiVariable.getTypeExpression(), p);
-            // For backwards compatibility.
-            for (JLeftPadded<Space> dim : multiVariable.getDimensionsBeforeName()) {
-                visitSpace(dim.getBefore(), Space.Location.DIMENSION_PREFIX, p);
-                p.append('[');
-                visitSpace(dim.getElement(), Space.Location.DIMENSION, p);
-                p.append(']');
-            }
             if (multiVariable.getVarargs() != null) {
                 visitSpace(multiVariable.getVarargs(), Space.Location.VARARGS, p);
                 p.append("...");

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -1664,8 +1664,6 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             typeExpr = new J.AnnotatedType(randomId(), prefix, Markers.EMPTY, ListUtils.mapFirst(typeExprAnnotations, a -> a.withPrefix(EMPTY)), typeExpr);
         }
 
-        List<JLeftPadded<Space>> beforeDimensions = emptyList();
-
         Space varargs = null;
         if (typeExpr != null && typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
             int varargStart = indexOfNextNonWhitespace(cursor, source);
@@ -1700,7 +1698,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             );
         }
 
-        return new J.VariableDeclarations(randomId(), fmt, Markers.EMPTY, modifierResults.getLeadingAnnotations(), modifierResults.getModifiers(), typeExpr, varargs, beforeDimensions, vars);
+        return new J.VariableDeclarations(randomId(), fmt, Markers.EMPTY, modifierResults.getLeadingAnnotations(), modifierResults.getModifiers(), typeExpr, varargs, vars);
     }
 
     private List<JLeftPadded<Space>> arrayDimensions() {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -26,7 +26,6 @@ import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.*;
 import com.sun.tools.javac.util.Context;
-import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.FileAttributes;
@@ -1692,8 +1691,6 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             typeExpr = new J.AnnotatedType(randomId(), prefix, Markers.EMPTY, ListUtils.mapFirst(typeExprAnnotations, a -> a.withPrefix(EMPTY)), typeExpr);
         }
 
-        List<JLeftPadded<Space>> beforeDimensions = emptyList();
-
         Space varargs = null;
         if (typeExpr != null && typeExpr.getMarkers().findFirst(JavaVarKeyword.class).isEmpty()) {
             int varargStart = indexOfNextNonWhitespace(cursor, source);
@@ -1728,7 +1725,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             );
         }
 
-        return new J.VariableDeclarations(randomId(), fmt, Markers.EMPTY, modifierResults.getLeadingAnnotations(), modifierResults.getModifiers(), typeExpr, varargs, beforeDimensions, vars);
+        return new J.VariableDeclarations(randomId(), fmt, Markers.EMPTY, modifierResults.getLeadingAnnotations(), modifierResults.getModifiers(), typeExpr, varargs, vars);
     }
 
     private List<JLeftPadded<Space>> arrayDimensions() {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeCastTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeCastTest.java
@@ -45,7 +45,7 @@ class TypeCastTest implements RewriteTest {
             """
               import java.io.Serializable;
               import java.util.function.BiFunction;
-                            
+              
               class Test {
                   Serializable s = (Serializable & BiFunction<Integer, Integer, Integer>) Integer::sum;
               }
@@ -62,7 +62,7 @@ class TypeCastTest implements RewriteTest {
             """
               import java.io.Serializable;
               import java.util.function.BiFunction;
-                            
+              
               class Test {
                   void m() {
                       var s = (Serializable & BiFunction<Integer, Integer, Integer>) Integer::sum;

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddMethodParameter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddMethodParameter.java
@@ -144,7 +144,6 @@ public class AddMethodParameter extends Recipe {
                     emptyList(),
                     typeTree,
                     null,
-                    emptyList(),
                     singletonList(
                             new JRightPadded<>(
                                     new J.VariableDeclarations.NamedVariable(

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -409,19 +409,19 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
     protected void printStatementTerminator(Statement s, PrintOutputCapture<P> p) {
         while (true) {
             if (s instanceof Assert ||
-                s instanceof Assignment ||
-                s instanceof AssignmentOperation ||
-                s instanceof Break ||
-                s instanceof Continue ||
-                s instanceof DoWhileLoop ||
-                s instanceof Empty ||
-                s instanceof MethodInvocation ||
-                s instanceof NewClass ||
-                s instanceof Return ||
-                s instanceof Throw ||
-                s instanceof Unary ||
-                s instanceof VariableDeclarations ||
-                s instanceof Yield) {
+                    s instanceof Assignment ||
+                    s instanceof AssignmentOperation ||
+                    s instanceof Break ||
+                    s instanceof Continue ||
+                    s instanceof DoWhileLoop ||
+                    s instanceof Empty ||
+                    s instanceof MethodInvocation ||
+                    s instanceof NewClass ||
+                    s instanceof Return ||
+                    s instanceof Throw ||
+                    s instanceof Unary ||
+                    s instanceof VariableDeclarations ||
+                    s instanceof Yield) {
                 p.append(';');
                 return;
             }
@@ -442,8 +442,8 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
                         getCursor()
                                 .dropParentUntil(
                                         c -> c instanceof Switch ||
-                                             c instanceof SwitchExpression ||
-                                             c == Cursor.ROOT_VALUE
+                                                c instanceof SwitchExpression ||
+                                                c == Cursor.ROOT_VALUE
                                 )
                                 .getValue();
                 if (aSwitch instanceof SwitchExpression) {
@@ -873,13 +873,6 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
             visitModifier(m, p);
         }
         visit(multiVariable.getTypeExpression(), p);
-        // For backwards compatibility.
-        for (JLeftPadded<Space> dim : multiVariable.getDimensionsBeforeName()) {
-            visitSpace(dim.getBefore(), Space.Location.DIMENSION_PREFIX, p);
-            p.append('[');
-            visitSpace(dim.getElement(), Space.Location.DIMENSION, p);
-            p.append(']');
-        }
         if (multiVariable.getVarargs() != null) {
             visitSpace(multiVariable.getVarargs(), Space.Location.VARARGS, p);
             p.append("...");

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -952,12 +952,6 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         m = m.withVarargs(m.getVarargs() == null ?
                 null :
                 visitSpace(m.getVarargs(), Space.Location.VARARGS, p));
-        // For backwards compatibility.
-        //noinspection deprecation
-        m = m.withDimensionsBeforeName(ListUtils.map(m.getDimensionsBeforeName(), dim ->
-                dim.withBefore(visitSpace(dim.getBefore(), Space.Location.DIMENSION_PREFIX, p))
-                        .withElement(visitSpace(dim.getElement(), Space.Location.DIMENSION, p))
-        ));
         m = m.getPadding().withVariables(ListUtils.map(m.getPadding().getVariables(), t -> visitRightPadded(t, JRightPadded.Location.NAMED_VARIABLE, p)));
         return m;
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/NoWhitespaceAfter.java
@@ -17,15 +17,11 @@ package org.openrewrite.java.format;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.java.tree.Space;
 import org.openrewrite.style.Style;
-
-import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -90,22 +86,6 @@ public class NoWhitespaceAfter extends Recipe {
                 m = (J.MemberReference) new SpacesVisitor<>(spacesStyle, emptyForInitializerPadStyle, emptyForIteratorPadStyle).visitNonNull(m, ctx);
             }
             return m;
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
-            J.VariableDeclarations vd = super.visitVariableDeclarations(multiVariable, ctx);
-            if (Boolean.TRUE.equals(noWhitespaceAfterStyle.getArrayDeclarator())) {
-                // For backwards compatibility.
-                if (vd.getDimensionsBeforeName().stream().anyMatch(d -> d.getBefore().getWhitespace().contains(" "))) {
-                    vd = vd.withDimensionsBeforeName(ListUtils.map(vd.getDimensionsBeforeName(), d -> {
-                        d = d.withBefore(d.getBefore().withWhitespace(""));
-                        return d;
-                    }));
-                }
-            }
-            return vd;
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
@@ -305,8 +305,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
     @Override
     public J visitIntersectionType(J.IntersectionType intersectionType, RpcReceiveQueue q) {
         return intersectionType
-                .getPadding().withBounds(q.receive(intersectionType.getPadding().getBounds(), b -> visitContainer(b, q)))
-                .withType(q.receive(intersectionType.getType(), t -> visitType(t, q)));
+                .getPadding().withBounds(q.receive(intersectionType.getPadding().getBounds(), b -> visitContainer(b, q)));
     }
 
     @Override
@@ -428,8 +427,8 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
     @Override
     public J visitPackage(J.Package pkg, RpcReceiveQueue q) {
         return pkg
-                .withAnnotations(q.receiveList(pkg.getAnnotations(), a -> (J.Annotation) visitNonNull(a, q)))
-                .withExpression(q.receive(pkg.getExpression(), e -> (Expression) visitNonNull(e, q)));
+                .withExpression(q.receive(pkg.getExpression(), e -> (Expression) visitNonNull(e, q)))
+                .withAnnotations(q.receiveList(pkg.getAnnotations(), a -> (J.Annotation) visitNonNull(a, q)));
     }
 
     @Override
@@ -526,7 +525,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
     @Override
     public J visitTryResource(J.Try.Resource tryResource, RpcReceiveQueue q) {
         return tryResource
-                .withVariableDeclarations(q.receive(tryResource.getVariableDeclarations(), v -> (J.VariableDeclarations) visitNonNull(v, q)))
+                .withVariableDeclarations(q.receive(tryResource.getVariableDeclarations(), v -> (TypedTree) visitNonNull(v, q)))
                 .withTerminatedWithSemicolon(q.receive(tryResource.isTerminatedWithSemicolon()));
     }
 
@@ -592,7 +591,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
     @Override
     public J visitWildcard(J.Wildcard wildcard, RpcReceiveQueue q) {
         return wildcard
-                .withBound(q.receiveAndGet(wildcard.getBound(), toEnum(J.Wildcard.Bound.class)))
+                .getPadding().withBound(q.receive(wildcard.getPadding().getBound(), o -> visitLeftPadded(o, q, toEnum(J.Wildcard.Bound.class))))
                 .withBoundedType(q.receive(wildcard.getBoundedType(), b -> (TypeTree) visitNonNull(b, q)));
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
@@ -300,7 +300,6 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
     @Override
     public J visitIntersectionType(J.IntersectionType intersectionType, RpcSendQueue q) {
         q.getAndSend(intersectionType, i -> i.getPadding().getBounds(), bounds -> visitContainer(bounds, q));
-        q.getAndSend(intersectionType, a -> asRef(a.getType()), type -> visitType(getValueNonNull(type), q));
         return intersectionType;
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -155,7 +155,7 @@ public interface J extends Tree, RpcCodec<J> {
             List<J.Annotation> allAnnotations = annotations;
             List<J.Annotation> moreAnnotations;
             if (typeExpression instanceof FieldAccess &&
-                !(moreAnnotations = ((FieldAccess) typeExpression).getName().getAnnotations()).isEmpty()) {
+                    !(moreAnnotations = ((FieldAccess) typeExpression).getName().getAnnotations()).isEmpty()) {
                 if (allAnnotations.isEmpty()) {
                     allAnnotations = moreAnnotations;
                 } else {
@@ -2144,8 +2144,8 @@ public interface J extends Tree, RpcCodec<J> {
 
         public boolean isFullyQualifiedClassReference(String className) {
             if (getName().getFieldType() == null && getName().getType() instanceof JavaType.FullyQualified &&
-                !(getName().getType() instanceof JavaType.Unknown) &&
-                TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) getName().getType()).getFullyQualifiedName(), className)) {
+                    !(getName().getType() instanceof JavaType.Unknown) &&
+                    TypeUtils.fullyQualifiedNamesAreEqual(((JavaType.FullyQualified) getName().getType()).getFullyQualifiedName(), className)) {
                 return true;
             } else if (!className.contains(".")) {
                 return false;
@@ -2985,7 +2985,7 @@ public interface J extends Tree, RpcCodec<J> {
                 String name = part.getSimpleName();
                 if (part.getTarget() instanceof J.Identifier) {
                     typeName.insert(0, ((Identifier) part.getTarget()).getSimpleName() +
-                                       "." + name);
+                            "." + name);
                     break;
                 } else if (part.getTarget() instanceof J.FieldAccess) {
                     part = (FieldAccess) part.getTarget();
@@ -3404,11 +3404,11 @@ public interface J extends Tree, RpcCodec<J> {
         public static class Padding {
             private final IntersectionType t;
 
-            public @Nullable JContainer<TypeTree> getBounds() {
+            public JContainer<TypeTree> getBounds() {
                 return t.bounds;
             }
 
-            public IntersectionType withBounds(@Nullable JContainer<TypeTree> bounds) {
+            public IntersectionType withBounds(JContainer<TypeTree> bounds) {
                 return t.bounds == bounds ? t : new IntersectionType(t.id, t.prefix, t.markers, bounds);
             }
         }
@@ -3732,9 +3732,9 @@ public interface J extends Tree, RpcCodec<J> {
         @Override
         public List<J.Identifier> getNames() {
             return Collections.singletonList(
-                // TODO this creates an artificial identifier. Revise this decision.
-                new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(),
-                        String.valueOf(value), JavaType.Primitive.String, null)
+                    // TODO this creates an artificial identifier. Revise this decision.
+                    new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(),
+                            String.valueOf(value), JavaType.Primitive.String, null)
             );
         }
 
@@ -4084,8 +4084,8 @@ public interface J extends Tree, RpcCodec<J> {
         @Override
         public String toString() {
             return "MethodDeclaration{" +
-                   (getMethodType() == null ? "unknown" : getMethodType()) +
-                   "}";
+                    (getMethodType() == null ? "unknown" : getMethodType()) +
+                    "}";
         }
 
         @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
@@ -6091,7 +6091,7 @@ public interface J extends Tree, RpcCodec<J> {
 
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
+    @RequiredArgsConstructor(onConstructor_ = @JsonCreator)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     final class VariableDeclarations implements J, Statement, TypedTree {
         @Nullable
@@ -6129,17 +6129,30 @@ public interface J extends Tree, RpcCodec<J> {
         @Getter
         Space varargs;
 
-        /**
-         * @deprecated Use {@link ArrayType} instead.
-         */
-        // For backwards compatibility.
-        @SuppressWarnings("DeprecatedIsStillUsed")
         @Deprecated
-        @With
-        @Getter
-        List<JLeftPadded<Space>> dimensionsBeforeName;
+        public List<JLeftPadded<Space>> getDimensionsBeforeName() {
+            return emptyList();
+        }
+
+        @Deprecated
+        public VariableDeclarations withDimensionsBeforeName(List<JLeftPadded<Space>> dimensionsBeforeName) {
+            return this;
+        }
 
         List<JRightPadded<NamedVariable>> variables;
+
+        @Deprecated
+        // TO-BE-REMOVED(2025-10-31)
+        public VariableDeclarations(UUID id, Space prefix, Markers markers, List<Annotation> leadingAnnotations, List<Modifier> modifiers, @Nullable TypeTree typeExpression, @Nullable Space varargs, @Nullable List<JLeftPadded<Space>> dimensionsBeforeName, List<JRightPadded<NamedVariable>> variables) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.leadingAnnotations = leadingAnnotations;
+            this.modifiers = modifiers;
+            this.typeExpression = typeExpression;
+            this.varargs = varargs;
+            this.variables = variables;
+        }
 
         public List<NamedVariable> getVariables() {
             return JRightPadded.getElements(variables);
@@ -6286,15 +6299,15 @@ public interface J extends Tree, RpcCodec<J> {
             public Cursor getDeclaringScope(Cursor cursor) {
                 return cursor.dropParentUntil(it ->
                         it instanceof J.Block ||
-                        it instanceof J.Lambda ||
-                        it instanceof J.MethodDeclaration ||
-                        it == Cursor.ROOT_VALUE);
+                                it instanceof J.Lambda ||
+                                it instanceof J.MethodDeclaration ||
+                                it == Cursor.ROOT_VALUE);
             }
 
             public boolean isField(Cursor cursor) {
                 Cursor declaringScope = getDeclaringScope(cursor);
                 return declaringScope.getValue() instanceof J.Block &&
-                       declaringScope.getParentTreeCursor().getValue() instanceof J.ClassDeclaration;
+                        declaringScope.getParentTreeCursor().getValue() instanceof J.ClassDeclaration;
             }
 
             public Padding getPadding() {
@@ -6359,7 +6372,7 @@ public interface J extends Tree, RpcCodec<J> {
             }
 
             public VariableDeclarations withVariables(List<JRightPadded<NamedVariable>> variables) {
-                return t.variables == variables ? t : new VariableDeclarations(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.typeExpression, t.varargs, t.dimensionsBeforeName, variables);
+                return t.variables == variables ? t : new VariableDeclarations(t.id, t.prefix, t.markers, t.leadingAnnotations, t.modifiers, t.typeExpression, t.varargs, variables);
             }
         }
     }

--- a/rewrite-javascript/rewrite/src/java/rpc.ts
+++ b/rewrite-javascript/rewrite/src/java/rpc.ts
@@ -212,7 +212,6 @@ export class JavaSender extends JavaVisitor<RpcSendQueue> {
 
     protected async visitIntersectionType(intersectionType: J.IntersectionType, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSend(intersectionType, i => i.bounds, bounds => this.visitContainer(bounds, q));
-        await q.getAndSend(intersectionType, i => asRef(i.type), type => this.visitType(type, q));
         return intersectionType;
     }
 
@@ -421,7 +420,7 @@ export class JavaSender extends JavaVisitor<RpcSendQueue> {
     }
 
     protected async visitWildcard(wildcard: J.Wildcard, q: RpcSendQueue): Promise<J | undefined> {
-        await q.getAndSend(wildcard, w => w.bound);
+        await q.getAndSend(wildcard, w => w.bound, b => this.visitLeftPadded(b, q));
         await q.getAndSend(wildcard, w => w.boundedType, type => this.visit(type, q));
         return wildcard;
     }
@@ -862,7 +861,6 @@ export class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
         const draft = createDraft(intersectionType);
 
         draft.bounds = await q.receive(intersectionType.bounds, bounds => this.visitContainer(bounds, q));
-        draft.type = await q.receive(intersectionType.type, type => this.visitType(type, q));
 
         return finishDraft(draft);
     }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -311,7 +311,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 receiverExp = new J.NullableType(randomId(),
                         receiverExp.getPrefix(),
                         Markers.EMPTY,
-                        Collections.emptyList(),
+                        emptyList(),
                         padRight(receiverExp.withPrefix(Space.EMPTY), prefix(questionMark))
                 );
             }
@@ -879,7 +879,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         return new J.NullableType(randomId(),
                 merge(deepPrefix(nullableType), j.getPrefix()),
                 Markers.EMPTY,
-                Collections.emptyList(),
+                emptyList(),
                 padRight(j, prefix(findFirstChild(nullableType, c -> c.getNode().getElementType() == KtTokens.QUEST)))
         );
     }
@@ -900,7 +900,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
         if (valOrVarOffset < modifierOffset) {
             if (parameter.getValOrVarKeyword() != null) {
-                modifiers.add(mapModifier(parameter.getValOrVarKeyword(), Collections.emptyList(), consumedSpaces));
+                modifiers.add(mapModifier(parameter.getValOrVarKeyword(), emptyList(), consumedSpaces));
             }
 
             if (parameter.getModifierList() != null) {
@@ -952,7 +952,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 modifiers,
                 typeExpression,
                 null,
-                emptyList(),
                 vars
         );
     }
@@ -978,7 +977,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         }
 
         if (constructor.getConstructorKeyword() != null) {
-            modifiers.add(mapModifier(constructor.getConstructorKeyword(), Collections.emptyList(), consumedSpaces));
+            modifiers.add(mapModifier(constructor.getConstructorKeyword(), emptyList(), consumedSpaces));
         }
 
         JavaType.Method type = methodDeclarationType(constructor);
@@ -2353,7 +2352,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 Markers.EMPTY,
                 multiDeclaration.isVar() ? "var" : null,
                 multiDeclaration.isVar() ? J.Modifier.Type.LanguageExtension : J.Modifier.Type.Final,
-                Collections.emptyList()
+                emptyList()
         );
         modifiers.add(modifier);
 
@@ -2412,7 +2411,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     emptyList(),
                     typeExpression,
                     null,
-                    emptyList(),
                     singletonList(padRight(namedVariable, prefix(entry.getColon())))
             );
 
@@ -2438,7 +2436,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 modifiers,
                 null,
                 null,
-                emptyList(),
                 singletonList(padRight(emptyWithInitializer, Space.EMPTY))
         );
 
@@ -2701,7 +2698,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     emptyList(),
                     null,
                     null,
-                    emptyList(),
                     singletonList(infixReceiver)
             );
             implicitParam = implicitParam.withMarkers(implicitParam.getMarkers().addIfAbsent(new TypeReferencePrefix(randomId(), Space.EMPTY)));
@@ -2974,7 +2970,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 modifiers,
                 typeExpression,
                 null,
-                Collections.emptyList(),
                 variables
         );
 
@@ -3996,7 +3991,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 emptyList(),
                 null,
                 null,
-                emptyList(),
                 variables
         );
 


### PR DESCRIPTION
The `JavaSender` and `JavaReceiver` logic contained a few small bugs leading to RPC transmission errors.

Additionally, the JS implementation of `J.VariableDeclarations` doesn't have the property `dimensionsBeforeName`, which was deprecated a long time ago and indeed isn't used anywhere. So removing that field on the Java side too.
