### PR TITLE
JavaScript - printing out the missing Generator asterisk for ComputedPropertyMethods

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -752,6 +752,12 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
             await this.visitModifier(it, p);
         }
 
+        const generator = findMarker<Generator>(method, JS.Markers.Generator);
+        if (generator) {
+            await this.visitSpace(generator.prefix, p);
+            p.append("*");
+        }
+
         await this.visit(method.name, p);
 
         const typeParameters = method.typeParameters;

--- a/rewrite-javascript/rewrite/test/javascript/parser/method.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/method.test.ts
@@ -221,4 +221,14 @@ describe('method mapping', () => {
                 }
             `)
         ));
+
+    test('generator with computed property name', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                class R {
+                    *[Symbol.iterator](): Generator<number> { yield 1;}
+                }
+            `)
+        ));
 });


### PR DESCRIPTION
## What's changed?

Adding the logic to print out the `*` for generator methods with computed property name.
Similar to what we have for functions and methods.

## What's your motivation?

It was missing. Thus parsing was not idempotent.
