### PR TITLE
Support trailing comma in GroovyParser

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleParserTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.java.tree.J;
@@ -363,5 +364,23 @@ class GradleParserTest implements RewriteTest {
         assertThat(optionalSourceFile).isPresent();
         SourceFile sourceFile = optionalSourceFile.get();
         assertThat(sourceFile).isNotInstanceOf(ParseError.class);
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4614")
+    void trailingComma() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              dependencies {
+                  implementation platform("commons-lang:commons-lang:2.6", )
+                  implementation platform("commons-lang:commons-lang3:3.0",)
+              }
+              """
+          )
+        );
     }
 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -796,12 +796,11 @@ public class GroovyParserVisitor {
                     }
 
                     Space after = EMPTY;
-                    Markers markers = Markers.EMPTY;
                     if (i == unparsedArgs.size() - 1) {
                         if (hasParentheses) {
                             saveCursor = cursor;
                             Space before = whitespace();
-                            if (sourceStartsWith(",")) {
+                            if (source.charAt(cursor) == ',') {
                                 skip(",");
                                 JRightPadded<Expression> arg = JRightPadded.build(exp)
                                         .withMarkers(exp.getMarkers().add(new TrailingComma(randomId(), sourceBefore(")"))))
@@ -823,7 +822,7 @@ public class GroovyParserVisitor {
                         cursor++;
                     }
 
-                    args.add(JRightPadded.build(exp).withAfter(after).withMarkers(markers));
+                    args.add(JRightPadded.build(exp).withAfter(after));
                 }
             }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -796,9 +796,16 @@ public class GroovyParserVisitor {
                     }
 
                     Space after = EMPTY;
+                    Markers markers = Markers.EMPTY;
                     if (i == unparsedArgs.size() - 1) {
                         if (hasParentheses) {
-                            after = sourceBefore(")");
+                            if (source.charAt(cursor) == ',') {
+                                skip(",");
+                                TrailingComma t = new TrailingComma(randomId(), sourceBefore(")"));
+                                markers = Markers.build(singletonList(t));
+                            } else {
+                                after = sourceBefore(")");
+                            }
                         }
                     } else if (!(arg instanceof J.Lambda && lastArgumentsAreAllClosures && !hasParentheses)) {
                         after = whitespace();
@@ -809,7 +816,7 @@ public class GroovyParserVisitor {
                         cursor++;
                     }
 
-                    args.add(JRightPadded.build(arg).withAfter(after));
+                    args.add(JRightPadded.build(arg).withAfter(after).withMarkers(markers));
                 }
             }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -128,4 +128,18 @@ class GroovyParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4614")
+    void trailingCommaInMethodCall() {
+        rewriteRun(
+          groovy(
+            """
+              System.out.println("Hello World", )
+              System.out.println("Hello World with no extra space",)
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyParserTest.java
@@ -135,8 +135,10 @@ class GroovyParserTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              System.out.println("Hello World", )
               System.out.println("Hello World with no extra space",)
+              System.out.println("Hello World with space before comma" ,)
+              System.out.println("Hello World with space after comma", )
+              System.out.println("Hello World with space before & after comma" , )
               """
           )
         );


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added support for trailing comma in GroovyParser. Using `Marker.TrailingComma` as suggested in the original issue.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/4614

## Anything in particular you'd like reviewers to focus on?
Usage of the `Marker`

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
