### PR TITLE
Fix `AnnotationTemplateGenerator` to handle nested annotations correctly

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -57,7 +57,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             private boolean substituted;
 
             @Override
-            public J visitAnnotation(J.Annotation annotation, Integer integer) {
+            public J visitAnnotation(J.Annotation annotation, Integer p) {
                 if (loc == ANNOTATION_PREFIX && mode == JavaCoordinates.Mode.REPLACEMENT &&
                     isScope(annotation)) {
                     List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), substitutedTemplate));
@@ -66,14 +66,14 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                                         substitutedTemplate +
                                                         "\nUse JavaTemplate.Builder.doBeforeParseTemplate() to see what stub is being generated and include it in any bug report.");
                     }
-                    return gen.get(0).withPrefix(annotation.getPrefix());
+                    return autoFormat(gen.get(0).withPrefix(annotation.getPrefix()), p, getCursor().getParentOrThrow());
                 } else if (loc == ANNOTATION_ARGUMENTS && mode == JavaCoordinates.Mode.REPLACEMENT &&
                            isScope(annotation)) {
                     List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), "@Example(" + substitutedTemplate + ")"));
                     return annotation.withArguments(gen.get(0).getArguments());
                 }
 
-                return super.visitAnnotation(annotation, integer);
+                return super.visitAnnotation(annotation, p);
             }
 
             @Override


### PR DESCRIPTION
The `AnnotationTemplateGenerator` was failing with an `IndexOutOfBoundsException` when processing nested
annotations (e.g., repeatable annotations within annotation arrays). This occurred because the template
generator couldn't find a "typical annotation target" for annotations nested inside other annotations' array
values.

The fix adds proper handling for nested annotations by:
1. Walking up the parent hierarchy to find the ultimate annotation target (method, variable, or class)
2. Adding a fallback case that generates `@interface $Placeholder {}` when no typical target can be found
3. Updating both the `template()` and `cacheKey()` methods to handle nested annotation cases consistently

This ensures that `JavaTemplate` can successfully process and transform nested annotations without throwing
exceptions.

Added a test case that demonstrates the fix by transforming nested repeatable annotations' attributes using
`JavaTemplate`.

Fixes:
- #5712
