### PR TITLE
RemoveDependency recipe removes or alters comments

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java
@@ -29,7 +29,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public class StringUtils {
-    private static final Pattern LINE_BREAK = Pattern.compile("\\R");
+    public static final Pattern LINE_BREAK = Pattern.compile("\\R");
 
     private StringUtils() {
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveDependency.java
@@ -137,13 +137,12 @@ public class RemoveDependency extends Recipe {
                                 }
                                 return null;
                             }
-                        } else if (stmt instanceof J.MethodInvocation || stmt instanceof J.Return) {
+                        } else {
                             stmt = stmt.withPrefix(stmt.getPrefix().withWhitespace(whitespace.get()))
                                     .withComments(ListUtils.concatAll(new ArrayList<>(comments), stmt.getComments()));
                             whitespace.set("");
                             comments.clear();
                         }
-
                         return stmt;
                     }));
                     if (!comments.isEmpty()) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -146,7 +146,7 @@ class RemoveDependencyTest implements RewriteTest {
                   testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
                   // and more
                   /* and more */ implementation "org.springframework.boot:spring-boot-starter-web:2.7.0"
-                  def someStatementWithinDepBlock = 33
+                  def someStatementWithinDepBlock = 33  // some other comment
                   implementation "com.google.guava:guava:29.0-jre"
               }
               """,
@@ -161,7 +161,7 @@ class RemoveDependencyTest implements RewriteTest {
               
               dependencies {
                   testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
-                  def someStatementWithinDepBlock = 33
+                  def someStatementWithinDepBlock = 33  // some other comment
                   implementation "com.google.guava:guava:29.0-jre"
               }
               """
@@ -187,7 +187,8 @@ class RemoveDependencyTest implements RewriteTest {
                   // Comment 1
                   implementation "org.springframework.boot:spring-boot-starter-web:2.7.0" /* comment 2 */ /* comment 3 */ // comment 4
                   // and more
-                  implementation "com.google.guava:guava:29.0-jre"
+                  implementation "com.google.guava:guava:29.0-jre" // some other comment
+                  implementation "org.yaml:snakeyaml:latest.release"
               }
               """,
             """
@@ -202,7 +203,8 @@ class RemoveDependencyTest implements RewriteTest {
               dependencies {
                   testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
                   // and more
-                  implementation "com.google.guava:guava:29.0-jre"
+                  implementation "com.google.guava:guava:29.0-jre" // some other comment
+                  implementation "org.yaml:snakeyaml:latest.release"
               }
               """
           )

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -146,6 +146,7 @@ class RemoveDependencyTest implements RewriteTest {
                   testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
                   // and more
                   /* and more */ implementation "org.springframework.boot:spring-boot-starter-web:2.7.0"
+                  def someStatementWithinDepBlock = 33
                   implementation "com.google.guava:guava:29.0-jre"
               }
               """,
@@ -160,6 +161,7 @@ class RemoveDependencyTest implements RewriteTest {
               
               dependencies {
                   testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
+                  def someStatementWithinDepBlock = 33
                   implementation "com.google.guava:guava:29.0-jre"
               }
               """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -170,6 +170,46 @@ class RemoveDependencyTest implements RewriteTest {
     }
 
     @Test
+    void removeCommentsOfDependencyWhenDependencyIsRemoved() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
+                  // Comment 1
+                  implementation "org.springframework.boot:spring-boot-starter-web:2.7.0" /* comment 2 */ /* comment 3 */ // comment 4
+                  // and more
+                  implementation "com.google.guava:guava:29.0-jre"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
+                  // and more
+                  implementation "com.google.guava:guava:29.0-jre"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeGradleDependencyWithCommentAfterSecondToLastDependency() {
         rewriteRun(
           buildGradle(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -130,6 +130,76 @@ class RemoveDependencyTest implements RewriteTest {
     }
 
     @Test
+    void removeGradleDependencyWithCommentAfterDependency() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2" // comment
+                  implementation "org.springframework.boot:spring-boot-starter-web:2.7.0"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2" // comment
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeGradleDependencyWithCommentAfterLatestDependency() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
+                  implementation "org.springframework.boot:spring-boot-starter-web:2.7.0" // comment
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeGradleDependencyUsingMapNotation() {
         rewriteRun(
           buildGradle(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -143,8 +143,10 @@ class RemoveDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2" // comment
-                  implementation "org.springframework.boot:spring-boot-starter-web:2.7.0"
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
+                  // and more
+                  /* and more */ implementation "org.springframework.boot:spring-boot-starter-web:2.7.0"
+                  implementation "com.google.guava:guava:29.0-jre"
               }
               """,
             """
@@ -157,7 +159,8 @@ class RemoveDependencyTest implements RewriteTest {
               }
               
               dependencies {
-                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2" // comment
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
+                  implementation "com.google.guava:guava:29.0-jre"
               }
               """
           )
@@ -165,7 +168,42 @@ class RemoveDependencyTest implements RewriteTest {
     }
 
     @Test
-    void removeGradleDependencyWithCommentAfterLatestDependency() {
+    void removeGradleDependencyWithCommentAfterSecondToLastDependency() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
+                  implementation "org.springframework.boot:spring-boot-starter-web:2.7.0" // comment 4 */ /* comment 5 */ // comment 6
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"        /* comment 1 */ /* comment 2 */ // comment 3
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeGradleDependencyWithCommentAfterLastDependency() {
         rewriteRun(
           buildGradle(
             """

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveDependencyTest.java
@@ -130,7 +130,7 @@ class RemoveDependencyTest implements RewriteTest {
     }
 
     @Test
-    void removeGradleDependencyWithCommentAfterDependency() {
+    void removeGradleDependencyWithCommentAfterPreviousDependency() {
         rewriteRun(
           buildGradle(
             """


### PR DESCRIPTION
## What's changed?
Comments after dependencies are removed as you would expected.

## What's your motivation?
Comments after a dependency should either stay if dependency is not removed or removed if dependency is not removed. Before the fix in this PR, the comments were put on a different dependency or were removed altogether, because all whitespace data is located in the prefix. By removing a method invocation you basically 'move' the comment to another line.

E.g. when using this recipe prior to this fix and we remove `io.github.classgraph:classgraph`:

**Before**
```groovy
implementation("io.micrometer:micrometer-core:1.9.+")
implementation("io.github.classgraph:classgraph:latest.release") // there's something specific about the classgraph
implementation("org.yaml:snakeyaml:latest.release")
```

**After**
```groovy
implementation("io.micrometer:micrometer-core:1.9.+") // there's something specific about the classgraph
implementation("org.yaml:snakeyaml:latest.release")
```

## Any additional context
You could argue this PR tries to fix a flaw of the LST model (as there is no suffix element). I do not suggest we apply this kind of fix to all recipes where we remove method invocations. But as this is one of the core recipes, I think it makes sense to have this fix for this recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
