### PR TITLE
Fix `NullPointerException` in `AddPropertyVisitor`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddPropertyVisitor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddPropertyVisitor.java
@@ -24,6 +24,7 @@ import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.TagNameComparator;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Value
@@ -55,9 +56,12 @@ public class AddPropertyVisitor extends MavenIsoVisitor<ExecutionContext> {
     @Override
     public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
         if (!Boolean.TRUE.equals(preserveExistingValue) &&
-            isPropertyTag() && key.equals(tag.getName()) &&
-            !value.equals(tag.getValue().orElse(null))) {
-            doAfterVisit(new ChangeTagValueVisitor<>(tag, value));
+            isPropertyTag() && key.equals(tag.getName())) {
+            String tagValue = tag.getValue().orElse(null);
+            // Only update if values are different, considering null values
+            if (!Objects.equals(value, tagValue)) {
+                doAfterVisit(new ChangeTagValueVisitor<>(tag, value));
+            }
         }
         return super.visitTag(tag, ctx);
     }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -214,7 +214,7 @@ public class ChangeParentPom extends Recipe {
                             Map<String, String> propertiesInUse = getPropertiesInUse(getCursor().firstEnclosingOrThrow(Xml.Document.class), ctx);
                             Map<String, String> newParentProps = newParent.getProperties();
                             for (Map.Entry<String, String> propInUse : propertiesInUse.entrySet()) {
-                                if (!newParentProps.containsKey(propInUse.getKey())) {
+                                if (!newParentProps.containsKey(propInUse.getKey()) && propInUse.getValue() != null) {
                                     changeParentTagVisitors.add(new AddPropertyVisitor(propInUse.getKey(), propInUse.getValue(), false));
                                 }
                             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java
@@ -251,4 +251,58 @@ class UpgradeParentVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/5707")
+    @Test
+    void upgradeParentWithCIFriendlyVersionsAndNullProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeParentVersion("org.openrewrite", "rewrite-bom", "8.56.0", null, null)),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>rewrite-bom</artifactId>
+                  <version>8.55.0</version>
+                </parent>
+                
+                <groupId>foo</groupId>
+                <artifactId>bar</artifactId>
+                <version>${revision}${sha1}${changelist}</version>
+                
+                <properties>
+                  <revision>1.2.3</revision>
+                  <changelist>-SNAPSHOT</changelist>
+                  <sha1 />
+                </properties>
+              
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                
+                <parent>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>rewrite-bom</artifactId>
+                  <version>8.56.0</version>
+                </parent>
+                
+                <groupId>foo</groupId>
+                <artifactId>bar</artifactId>
+                <version>${revision}${sha1}${changelist}</version>
+                
+                <properties>
+                  <revision>1.2.3</revision>
+                  <changelist>-SNAPSHOT</changelist>
+                  <sha1 />
+                </properties>
+              
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Fix Summary

The issue was a `NullPointerException` in `AddPropertyVisitor` when processing Maven projects using CI-friendly versions with null property values (e.g., `<sha1 />`).

## Root Cause

1. When a property is defined as a self-closing tag like `<sha1 />`, its value is null
2. `AddPropertyVisitor.visitTag()` was calling `value.equals()` without null-safety, causing NPE when this.value was null
3. `ChangeParentPom` was creating `AddPropertyVisitor` instances with null values when preserving properties from the old parent

## Solution

1. Fixed `AddPropertyVisitor`: Used `Objects.equals()` instead of direct `equals()` call to handle null values safely
2. Fixed ChangeParentPom: Added a null check to prevent creating `AddPropertyVisitor` instances with null values
3. Added test case: Created a test to reproduce the issue and verify the fix

## Files Modified

- /rewrite-maven/src/main/java/org/openrewrite/maven/AddPropertyVisitor.java: Added null-safe comparison using `Objects.equals()`
- /rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java: Added null check before creating `AddPropertyVisitor`
- /rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeParentVersionTest.java: Added test case to reproduce the issue

- Fixes: #5707
