### PR TITLE
Changing what `LatestRelease` recognizes as the latest release or latest snapshot keyword versions by expanding it to include those from Ivy/Gradle

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
+++ b/rewrite-core/src/main/java/org/openrewrite/semver/LatestRelease.java
@@ -87,13 +87,13 @@ public class LatestRelease implements VersionComparator {
     public int compare(@Nullable String currentVersion, String v1, String v2) {
         if (v1.equalsIgnoreCase(v2)) {
             return 0;
-        } else if (v1.equalsIgnoreCase("LATEST")) {
+        } else if (v1.equalsIgnoreCase("LATEST") || v1.equalsIgnoreCase("latest.integration")) {
             return 1;
-        } else if (v2.equalsIgnoreCase("LATEST")) {
+        } else if (v2.equalsIgnoreCase("LATEST") || v2.equalsIgnoreCase("latest.integration")) {
             return -1;
-        } else if (v1.equalsIgnoreCase("RELEASE")) {
+        } else if (v1.equalsIgnoreCase("RELEASE") || v1.equalsIgnoreCase("latest.release")) {
             return 1;
-        } else if (v2.equalsIgnoreCase("RELEASE")) {
+        } else if (v2.equalsIgnoreCase("RELEASE") || v2.equalsIgnoreCase("latest.release")) {
             return -1;
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/semver/LatestReleaseTest.java
@@ -120,6 +120,22 @@ class LatestReleaseTest {
     }
 
     @Test
+    void latestReleaseOrLatestIntegrationKeyword_beatsEverything() {
+        assertThat(latestRelease.compare(null, "latest.release", "1.2.3")).isPositive();
+        assertThat(latestRelease.compare(null, "1.2.3", "latest.release")).isNegative();
+        assertThat(latestRelease.compare(null, "latest.release", "999.999.999")).isPositive();
+        assertThat(latestRelease.compare(null, "latest.release", "latest.release")).isZero();
+
+        assertThat(latestRelease.compare(null, "latest.integration", "1.2.3")).isPositive();
+        assertThat(latestRelease.compare(null, "1.2.3", "latest.integration")).isNegative();
+        assertThat(latestRelease.compare(null, "latest.integration", "999.999.999")).isPositive();
+        assertThat(latestRelease.compare(null, "latest.integration", "latest.integration")).isZero();
+
+        assertThat(latestRelease.compare(null, "lATesT.reLeaSE", "1.2.3")).isPositive();
+        assertThat(latestRelease.compare(null, "lATesT.inTegRATion", "1.2.3")).isPositive();
+    }
+
+    @Test
     void compareQualifiers() {
         assertThat(latestRelease.compare(null, "1.2.3.final", "1.2.3")).isEqualTo(0);
         assertThat(latestRelease.compare(null, "1.2.3.ga", "1.2.3")).isEqualTo(0);
@@ -139,6 +155,12 @@ class LatestReleaseTest {
     void latestKeywordIsNewerThanReleaseKeyword() {
         assertThat(latestRelease.compare(null, "RELEASE", "LATEST")).isNegative();
         assertThat(latestRelease.compare(null, "LATEST", "RELEASE")).isPositive();
+    }
+
+    @Test
+    void latestIntegrationKeywordIsNewerThanLatestReleaseKeyword() {
+        assertThat(latestRelease.compare(null, "latest.release", "latest.integration")).isNegative();
+        assertThat(latestRelease.compare(null, "latest.integration", "latest.release")).isPositive();
     }
 
     @Test

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -987,6 +987,29 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void retainLatestReleaseOrLatestIntegrationIfUsed() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.projectlombok", "lombok", "1.18.*", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+              
+              dependencies {
+                  implementation("org.projectlombok:lombok:latest.release")
+                  testImplementation("org.projectlombok:lombok:latest.integration")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void dontDowngradeWhenExactVersion() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "28.0", "-jre")),

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -509,6 +509,36 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void retainReleaseOrLatestIfUsed() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.projectlombok", "lombok", "1.18.*", null, null, null)),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                    <version>RELEASE</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                    <version>LATEST</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void upgradeGuava() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "*", "25-28", "-android", null, null)),


### PR DESCRIPTION
## What's changed?
- Expanded `LatestRelease` to not only recognize `LATEST` and `RELEASE` from Maven, but also their equivalents from Ivy / Gradle (`latest.integration` and `latest.release`)

## What's your motivation?
We were seeing `UpgradeDependencyVersion` for Gradle change `latest.release` to a specific version number rather than leaving it alone.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
