### PR TITLE
Added additional tests for nested annotations, and a fix to break out of the `J.Assignment` for finding an annotation parent that is more significant when the nearest desired parent is a not a `J.ClassDeclaration`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -16,10 +16,12 @@
 package org.openrewrite.java;
 
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Recipe;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
@@ -161,10 +163,10 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/5712")
-    @Test
-    void replaceArgumentsInNestedAnnotation() {
+    @Nested
+    class NestedAnnotations {
         @Language("java")
-        String annotations = """
+        private final String annotations = """
           package foo;
 
           import java.lang.annotation.*;
@@ -179,55 +181,313 @@ class JavaTemplateAnnotationTest implements RewriteTest {
               NestedAnnotation[] value();
           }
           """;
-        rewriteRun(
-          spec -> spec
-            .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-                @Override
-                public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                    if (annotation.getSimpleName().equals("NestedAnnotation") &&
-                      !annotation.getArguments().isEmpty()) {
-                        // Check if this annotation still has the 'a' attribute that needs to be replaced
-                        J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
-                        if (arg.getVariable() instanceof J.Identifier &&
-                          ((J.Identifier) arg.getVariable()).getSimpleName().equals("a")) {
-                            // Only apply the template if we haven't already transformed this annotation
-                            J.Literal value = (J.Literal) arg.getAssignment();
 
-                            // Replace 'a' with 'b' in the annotation
-                            return JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
-                              .javaParser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                              .imports("foo.*")
-                              .build()
-                              .apply(getCursor(), annotation.getCoordinates().replace(), value);
-                        }
+        private final Recipe recipe = toRecipe(() -> new JavaIsoVisitor<>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                if (annotation.getSimpleName().equals("NestedAnnotation") &&
+                  !annotation.getArguments().isEmpty()) {
+                    // Check if this annotation still has the 'a' attribute that needs to be replaced
+                    J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
+                    if (arg.getVariable() instanceof J.Identifier &&
+                      ((J.Identifier) arg.getVariable()).getSimpleName().equals("a")) {
+                        // Only apply the template if we haven't already transformed this annotation
+                        J.Literal value = (J.Literal) arg.getAssignment();
+
+                        // Replace 'a' with 'b' in the annotation
+                        return JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
+                          .javaParser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                          .imports("foo.*")
+                          .build()
+                          .apply(getCursor(), annotation.getCoordinates().replace(), value);
                     }
-                    return super.visitAnnotation(annotation, ctx);
                 }
-            })),
-          java(
-            """
-              import foo.*;
+                return super.visitAnnotation(annotation, ctx);
+            }
+        });
 
-              @NestedAnnotations({
-                      @NestedAnnotation(a = "1"),
-                      @NestedAnnotation(a = "2")
-              })
-              class Test {
-              }
-              """,
-            """
-              import foo.*;
+        @Test
+        void replaceWhenFieldAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                            @NestedAnnotation(a = "first"),
+                            @NestedAnnotation(a = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                            @NestedAnnotation(b = "first"),
+                            @NestedAnnotation(b = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
 
-              @NestedAnnotations({
-                      @NestedAnnotation(b = "1"),
-                      @NestedAnnotation(b = "2")
-              })
-              class Test {
-              }
-              """
-          )
-        );
+        @Test
+        void replaceWhenFieldAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                            @NestedAnnotation(a = "first"),
+                            @NestedAnnotation(a = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                            @NestedAnnotation(b = "first"),
+                            @NestedAnnotation(b = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenMethodAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                            @NestedAnnotation(a = "first"),
+                            @NestedAnnotation(a = "second")
+                    })
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                            @NestedAnnotation(b = "first"),
+                            @NestedAnnotation(b = "second")
+                    })
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenMethodAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                            @NestedAnnotation(a = "first"),
+                            @NestedAnnotation(a = "second")
+                    })
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                            @NestedAnnotation(b = "first"),
+                            @NestedAnnotation(b = "second")
+                    })
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenOuterClassAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations({
+                          @NestedAnnotation(a = "first"),
+                          @NestedAnnotation(a = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations({
+                          @NestedAnnotation(b = "first"),
+                          @NestedAnnotation(b = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenOuterClassAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations(value = {
+                          @NestedAnnotation(a = "first"),
+                          @NestedAnnotation(a = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations(value = {
+                          @NestedAnnotation(b = "first"),
+                          @NestedAnnotation(b = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenInnerClassAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations({
+                              @NestedAnnotation(a = "first"),
+                              @NestedAnnotation(a = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations({
+                              @NestedAnnotation(b = "first"),
+                              @NestedAnnotation(b = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenInnerClassAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations(value = {
+                              @NestedAnnotation(a = "first"),
+                              @NestedAnnotation(a = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations(value = {
+                              @NestedAnnotation(b = "first"),
+                              @NestedAnnotation(b = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
-
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -77,7 +77,7 @@ public class AnnotationTemplateGenerator {
                     J annotationParent = j instanceof J.Annotation && cursor.getParent() != null ? cursor.getParent().firstEnclosing(J.class) : null;
 
                     int level = 1;
-                    while (annotationParent instanceof J.NewArray || annotationParent instanceof J.Annotation) {
+                    while (annotationParent instanceof J.NewArray || annotationParent instanceof J.Assignment || annotationParent instanceof J.Annotation) {
                         level += 1;
                         if (cursor.getParent(level) == null) {
                             break;


### PR DESCRIPTION
- Finishes https://github.com/openrewrite/rewrite/issues/5712
- Follow-on to https://github.com/openrewrite/rewrite/pull/5713 to fix case when the nearest desired parent isn't a `J.ClassDeclaration` and your wrapping annotation uses a `J.Assignment` for the `J.NewArray` rather than just a raw `J.NewArray`.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
