### PR TITLE
Re enable `DoesNotIncludeDependencyTest` tests

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
@@ -285,6 +285,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
     @Nested
     class DontCheckTransitive {
+
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided", "compile", "runtime"})
         void dependencyPresentSpecificScopeFailsApplicability(String scope) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
@@ -15,526 +15,563 @@
  */
 package org.openrewrite.maven.search;
 
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.maven.Assertions.pomXml;
+
 class DoesNotIncludeDependencyTest implements RewriteTest {
-//    @Nested
-//    class CheckTransitive {
-//        @Test
-//        void dependencyPresentFailsApplicability() {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null))),
-//              pomXml("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """));
-//        }
-//
-//        @Test
-//        void dependencyPresentTransitivelyFailsApplicability() {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null))),
-//              pomXml("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework.boot</groupId>
-//                      <artifactId>spring-boot-starter-actuator</artifactId>
-//                      <version>3.0.0</version>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"test", "provided", "compile", "runtime"})
-//        void dependencyPresentTransitivelyWithSpecificScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework.boot</groupId>
-//                      <artifactId>spring-boot-starter-actuator</artifactId>
-//                      <version>3.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"test", "provided", "compile", "runtime"})
-//        void dependencyPresentWithSpecificScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"test", "provided"})
-//        void dependencyPresentButNotInSpecifiedCompileScopePassesApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope),
-//                String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"compile", "runtime"})
-//        void dependencyPresentSpecifiedCompileScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"provided"})
-//        void dependencyPresentButNotInSpecifiedTestScopePassesApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope),
-//                String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"compile", "runtime", "test"})
-//        void dependencyPresentSpecifiedTestScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//    }
-//
-//    @Nested
-//    class DontCheckTransitive {
-//        @ParameterizedTest
-//        @ValueSource(strings = {"test", "provided", "compile", "runtime"})
-//        void dependencyPresentSpecificScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"test", "provided"})
-//        void dependencyPresentButNotInSpecifiedCompileScopePassesApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope),
-//                String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"compile", "runtime"})
-//        void dependencyPresentSpecifiedCompileScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"provided"})
-//        void dependencyPresentButNotInSpecifiedTestScopePassesApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope),
-//                String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @ParameterizedTest
-//        @ValueSource(strings = {"compile", "runtime", "test"})
-//        void dependencyPresentSpecifiedTestScopeFailsApplicability(String scope) {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test"))),
-//              pomXml(String.format("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                      <scope>%s</scope>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, scope)));
-//        }
-//
-//        @DocumentExample
-//        @Test
-//        void dependencyPresentTransitivelyPassesApplicability() {
-//            rewriteRun(
-//              spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//                .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null))),
-//              pomXml("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework.boot</groupId>
-//                      <artifactId>spring-boot-starter-actuator</artifactId>
-//                      <version>3.0.0</version>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, """
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework.boot</groupId>
-//                      <artifactId>spring-boot-starter-actuator</artifactId>
-//                      <version>3.0.0</version>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """));
-//        }
-//    }
-//
-//    @Test
-//    void multimodule() {
-//        rewriteRun(
-//          spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//            .addSingleSourceApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null))),
-//          pomXml("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>a</artifactId>
-//                  <version>1.0.0</version>
-//                  <dependencies>
-//                    <dependency>
-//                      <groupId>org.springframework</groupId>
-//                      <artifactId>spring-beans</artifactId>
-//                      <version>6.0.0</version>
-//                    </dependency>
-//                  </dependencies>
-//                </project>
-//                """, spec -> spec.path("a/pom.xml")),
-//          pomXml("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>b</artifactId>
-//                  <version>1.0.0</version>
-//                </project>
-//                """, """
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>b</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                </project>
-//                """, spec -> spec.path("b/pom.xml"))
-//          );
-//    }
-//
-//    @Test
-//    void dependencyNotPresentPassesApplicability() {
-//        rewriteRun(
-//          spec -> spec.recipe(new AddProperty("foo", "bar", null, null)
-//            .addApplicableTest(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null))),
-//          pomXml("""
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                </project>
-//                """, """
-//                <?xml version="1.0" encoding="UTF-8"?>
-//                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-//                  <modelVersion>4.0.0</modelVersion>
-//                  <groupId>org.sample</groupId>
-//                  <artifactId>sample</artifactId>
-//                  <version>1.0.0</version>
-//                  <properties>
-//                    <foo>bar</foo>
-//                  </properties>
-//                </project>
-//                """));
-//    }
+
+    @Nested
+    class CheckTransitive {
+        @Test
+        void dependencyPresentFailsApplicability() {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """,
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @Test
+        void dependencyPresentTransitivelyFailsApplicability() {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                        <version>3.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """,
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"test", "provided", "compile", "runtime"})
+        void dependencyPresentTransitivelyWithSpecificScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                        <version>3.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"test", "provided", "compile", "runtime"})
+        void dependencyPresentWithSpecificScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"test", "provided"})
+        void dependencyPresentButNotInSpecifiedCompileScopePassesApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe((new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile"))),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                String.format("""
+                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope)
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"compile", "runtime"})
+        void dependencyPresentSpecifiedCompileScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"provided"})
+        void dependencyPresentButNotInSpecifiedTestScopePassesApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                String.format("""
+                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope)
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"compile", "runtime", "test"})
+        void dependencyPresentSpecifiedTestScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+    }
+
+    @Nested
+    class DontCheckTransitive {
+        @ParameterizedTest
+        @ValueSource(strings = {"test", "provided", "compile", "runtime"})
+        void dependencyPresentSpecificScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"test", "provided"})
+        void dependencyPresentButNotInSpecifiedCompileScopePassesApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                String.format("""
+                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope)
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"compile", "runtime"})
+        void dependencyPresentSpecifiedCompileScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"provided"})
+        void dependencyPresentButNotInSpecifiedTestScopePassesApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                String.format("""
+                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope)
+              )
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"compile", "runtime", "test"})
+        void dependencyPresentSpecifiedTestScopeFailsApplicability(String scope) {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test")),
+              pomXml(
+                String.format("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                        <version>6.0.0</version>
+                        <scope>%s</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """, scope),
+                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+              )
+            );
+        }
+
+        @DocumentExample
+        @Test
+        void dependencyPresentTransitivelyPassesApplicability() {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                        <version>3.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """,
+                """
+                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                        <version>3.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """
+              )
+            );
+        }
+    }
+
+    @Test
+    void multimodule() {
+        rewriteRun(
+          spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>a</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                    <version>6.0.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec -> spec.path("a/pom.xml")
+              .afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+          ),
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>b</artifactId>
+                <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>b</artifactId>
+                <version>1.0.0</version>
+              </project>
+              """,
+            spec -> spec.path("b/pom.xml")
+          )
+        );
+    }
+
+    @Test
+    void dependencyNotPresentPassesApplicability() {
+        rewriteRun(
+          spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+              </project>
+              """,
+            """
+              <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0.0</version>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
@@ -32,7 +32,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
     class CheckTransitive {
 
         @Test
-        void dependencyPresentFailsApplicability() {
+        void dependencyPresentNotMarked() {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
@@ -56,7 +56,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
         }
 
         @Test
-        void dependencyPresentTransitivelyFailsApplicability() {
+        void dependencyPresentTransitivelyNotMarked() {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
@@ -81,7 +81,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided", "compile", "runtime"})
-        void dependencyPresentTransitivelyWithSpecificScopeFailsApplicability(String scope) {
+        void dependencyPresentTransitivelyWithSpecificScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
@@ -107,7 +107,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided", "compile", "runtime"})
-        void dependencyPresentWithSpecificScopeFailsApplicability(String scope) {
+        void dependencyPresentWithSpecificScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
@@ -133,7 +133,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided"})
-        void dependencyPresentButNotInSpecifiedCompileScopePassesApplicability(String scope) {
+        void dependencyPresentButNotInSpecifiedCompileScopeMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe((new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile"))),
               pomXml(
@@ -175,7 +175,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"compile", "runtime"})
-        void dependencyPresentSpecifiedCompileScopeFailsApplicability(String scope) {
+        void dependencyPresentSpecifiedCompileScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile")),
               pomXml(
@@ -201,7 +201,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"provided"})
-        void dependencyPresentButNotInSpecifiedTestScopePassesApplicability(String scope) {
+        void dependencyPresentButNotInSpecifiedTestScopeMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test")),
               pomXml(
@@ -243,7 +243,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"compile", "runtime", "test"})
-        void dependencyPresentSpecifiedTestScopeFailsApplicability(String scope) {
+        void dependencyPresentSpecifiedTestScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test")),
               pomXml(
@@ -273,7 +273,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @DocumentExample
         @Test
-        void dependencyPresentTransitivelyPassesApplicability() {
+        void dependencyPresentTransitivelyMarked() {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
               pomXml(
@@ -313,7 +313,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided", "compile", "runtime"})
-        void dependencyPresentSpecificScopeFailsApplicability(String scope) {
+        void dependencyPresentSpecificScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
               pomXml(
@@ -339,7 +339,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided"})
-        void dependencyPresentButNotInSpecifiedCompileScopePassesApplicability(String scope) {
+        void dependencyPresentButNotInSpecifiedCompileScopeMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile")),
               pomXml(
@@ -381,7 +381,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"compile", "runtime"})
-        void dependencyPresentSpecifiedCompileScopeFailsApplicability(String scope) {
+        void dependencyPresentSpecifiedCompileScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile")),
               pomXml(
@@ -407,7 +407,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"provided"})
-        void dependencyPresentButNotInSpecifiedTestScopePassesApplicability(String scope) {
+        void dependencyPresentButNotInSpecifiedTestScopeMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test")),
               pomXml(
@@ -449,7 +449,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"compile", "runtime", "test"})
-        void dependencyPresentSpecifiedTestScopeFailsApplicability(String scope) {
+        void dependencyPresentSpecifiedTestScopeNotMarked(String scope) {
             rewriteRun(
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test")),
               pomXml(
@@ -475,12 +475,11 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
     }
 
     @Test
-    void multimodule() {
+    void multimoduleMarksOnlyCorrectModule() {
         rewriteRun(
           spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
               <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
@@ -500,7 +499,6 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
           ),
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
               <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
@@ -509,8 +507,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               </project>
               """,
             """
-              <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-              <project>
+              <!--~~>--><project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>b</artifactId>
@@ -523,12 +520,11 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
     }
 
     @Test
-    void dependencyNotPresentPassesApplicability() {
+    void dependencyNotPresentMarked() {
         rewriteRun(
           spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
               <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
@@ -537,8 +533,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               </project>
               """,
             """
-              <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-              <project>
+              <!--~~>--><project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>sample</artifactId>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
@@ -37,8 +37,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
                 """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -51,8 +50,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """,
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """
               )
             );
         }
@@ -63,8 +61,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
                 """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -77,8 +74,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """,
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """
               )
             );
         }
@@ -90,8 +86,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -105,8 +100,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -118,8 +112,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, null)),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -133,8 +126,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -146,8 +138,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe((new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile"))),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -163,8 +154,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                   </project>
                   """, scope),
                 String.format("""
-                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <!--~~>--><project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -190,8 +180,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "compile")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -205,8 +194,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -218,8 +206,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -235,8 +222,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                   </project>
                   """, scope),
                 String.format("""
-                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <!--~~>--><project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -262,8 +248,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", null, "test")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -277,8 +262,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -294,8 +278,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
               pomXml(
                 """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -310,8 +293,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                   </project>
                   """,
                 """
-                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <!--~~>--><project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -336,8 +318,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -351,8 +332,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -364,8 +344,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -381,8 +360,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                   </project>
                   """, scope),
                 String.format("""
-                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <!--~~>--><project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -408,8 +386,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "compile")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -423,8 +400,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -436,8 +412,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -453,8 +428,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                   </project>
                   """, scope),
                 String.format("""
-                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <!--~~>--><project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -480,8 +454,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, "test")),
               pomXml(
                 String.format("""
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <project>
                     <modelVersion>4.0.0</modelVersion>
                     <groupId>org.sample</groupId>
                     <artifactId>sample</artifactId>
@@ -495,8 +468,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </project>
-                  """, scope),
-                spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
+                  """, scope)
               )
             );
         }
@@ -509,7 +481,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>a</artifactId>
@@ -529,7 +501,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>b</artifactId>
@@ -538,7 +510,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               """,
             """
               <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>b</artifactId>
@@ -557,7 +529,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
           pomXml(
             """
               <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>sample</artifactId>
@@ -566,7 +538,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               """,
             """
               <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>org.sample</groupId>
                 <artifactId>sample</artifactId>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/DoesNotIncludeDependencyTest.java
@@ -30,6 +30,7 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
 
     @Nested
     class CheckTransitive {
+
         @Test
         void dependencyPresentFailsApplicability() {
             rewriteRun(
@@ -286,6 +287,48 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
     @Nested
     class DontCheckTransitive {
 
+        @DocumentExample
+        @Test
+        void dependencyPresentTransitivelyPassesApplicability() {
+            rewriteRun(
+              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
+              pomXml(
+                """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                        <version>3.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """,
+                """
+                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                        <version>3.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """
+              )
+            );
+        }
+
         @ParameterizedTest
         @ValueSource(strings = {"test", "provided", "compile", "runtime"})
         void dependencyPresentSpecificScopeFailsApplicability(String scope) {
@@ -454,48 +497,6 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
                   </project>
                   """, scope),
                 spec -> spec.afterRecipe(doc -> assertThat(doc.getMarkers().getMarkers()).noneMatch(marker -> marker instanceof SearchResult))
-              )
-            );
-        }
-
-        @DocumentExample
-        @Test
-        void dependencyPresentTransitivelyPassesApplicability() {
-            rewriteRun(
-              spec -> spec.recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", true, null)),
-              pomXml(
-                """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-actuator</artifactId>
-                        <version>3.0.0</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """,
-                """
-                  <!--~~>--><?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>org.sample</groupId>
-                    <artifactId>sample</artifactId>
-                    <version>1.0.0</version>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-actuator</artifactId>
-                        <version>3.0.0</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """
               )
             );
         }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Re enabled and brought back into shape the `DoesNotIncludeDependencyTest` tests

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Some work is being done on a Gradle variant so good to have a maven example

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
