### PR TITLE
Reverting `autoFormat` in `JavaTemplateJavaExtension` that was causing unnecessary extra indentation for annotations.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -164,7 +164,7 @@ class JavaTemplateAnnotationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/5712")
     @Nested
-    class NestedAnnotations {
+    class NestedAnnotationsTests {
         @Language("java")
         private final String annotations = """
           package foo;

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -195,11 +195,11 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                         J.Literal value = (J.Literal) arg.getAssignment();
 
                         // Replace 'a' with 'b' in the annotation
-                        return JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
+                        return JavaTemplate.builder("@NestedAnnotation(b = \"#{}\")")
                           .javaParser(JavaParser.fromJavaVersion().dependsOn(annotations))
                           .imports("foo.*")
                           .build()
-                          .apply(getCursor(), annotation.getCoordinates().replace(), value);
+                          .apply(getCursor(), annotation.getCoordinates().replace(), value.getValue());
                     }
                 }
                 return super.visitAnnotation(annotation, ctx);
@@ -219,8 +219,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations({
-                            @NestedAnnotation(a = "first"),
-                            @NestedAnnotation(a = "second")
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
                     })
                     String field;
                     void method() {}
@@ -231,8 +231,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations({
-                            @NestedAnnotation(b = "first"),
-                            @NestedAnnotation(b = "second")
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
                     })
                     String field;
                     void method() {}
@@ -255,8 +255,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations(value = {
-                            @NestedAnnotation(a = "first"),
-                            @NestedAnnotation(a = "second")
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
                     })
                     String field;
                     void method() {}
@@ -267,8 +267,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations(value = {
-                            @NestedAnnotation(b = "first"),
-                            @NestedAnnotation(b = "second")
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
                     })
                     String field;
                     void method() {}
@@ -291,8 +291,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations({
-                            @NestedAnnotation(a = "first"),
-                            @NestedAnnotation(a = "second")
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
                     })
                     void method() {}
                   }
@@ -302,8 +302,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations({
-                            @NestedAnnotation(b = "first"),
-                            @NestedAnnotation(b = "second")
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
                     })
                     void method() {}
                   }
@@ -325,8 +325,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations(value = {
-                            @NestedAnnotation(a = "first"),
-                            @NestedAnnotation(a = "second")
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
                     })
                     void method() {}
                   }
@@ -336,8 +336,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                     @NestedAnnotations(value = {
-                            @NestedAnnotation(b = "first"),
-                            @NestedAnnotation(b = "second")
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
                     })
                     void method() {}
                   }
@@ -358,8 +358,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   import foo.*;
                   
                   @NestedAnnotations({
-                          @NestedAnnotation(a = "first"),
-                          @NestedAnnotation(a = "second")
+                    @NestedAnnotation(a = "first"),
+                    @NestedAnnotation(a = "second")
                   })
                   class A {
                     void method() {}
@@ -369,8 +369,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   import foo.*;
                   
                   @NestedAnnotations({
-                          @NestedAnnotation(b = "first"),
-                          @NestedAnnotation(b = "second")
+                    @NestedAnnotation(b = "first"),
+                    @NestedAnnotation(b = "second")
                   })
                   class A {
                     void method() {}
@@ -392,8 +392,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   import foo.*;
                   
                   @NestedAnnotations(value = {
-                          @NestedAnnotation(a = "first"),
-                          @NestedAnnotation(a = "second")
+                    @NestedAnnotation(a = "first"),
+                    @NestedAnnotation(a = "second")
                   })
                   class A {
                     void method() {}
@@ -403,8 +403,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   import foo.*;
                   
                   @NestedAnnotations(value = {
-                          @NestedAnnotation(b = "first"),
-                          @NestedAnnotation(b = "second")
+                    @NestedAnnotation(b = "first"),
+                    @NestedAnnotation(b = "second")
                   })
                   class A {
                     void method() {}
@@ -427,8 +427,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                       @NestedAnnotations({
-                              @NestedAnnotation(a = "first"),
-                              @NestedAnnotation(a = "second")
+                        @NestedAnnotation(a = "first"),
+                        @NestedAnnotation(a = "second")
                       })
                       class B {
                           void method() {}
@@ -440,8 +440,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                       @NestedAnnotations({
-                              @NestedAnnotation(b = "first"),
-                              @NestedAnnotation(b = "second")
+                        @NestedAnnotation(b = "first"),
+                        @NestedAnnotation(b = "second")
                       })
                       class B {
                           void method() {}
@@ -465,8 +465,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                       @NestedAnnotations(value = {
-                              @NestedAnnotation(a = "first"),
-                              @NestedAnnotation(a = "second")
+                        @NestedAnnotation(a = "first"),
+                        @NestedAnnotation(a = "second")
                       })
                       class B {
                           void method() {}
@@ -478,8 +478,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   
                   class A {
                       @NestedAnnotations(value = {
-                              @NestedAnnotation(b = "first"),
-                              @NestedAnnotation(b = "second")
+                        @NestedAnnotation(b = "first"),
+                        @NestedAnnotation(b = "second")
                       })
                       class B {
                           void method() {}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -66,7 +66,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                                         substitutedTemplate +
                                                         "\nUse JavaTemplate.Builder.doBeforeParseTemplate() to see what stub is being generated and include it in any bug report.");
                     }
-                    return autoFormat(gen.get(0).withPrefix(annotation.getPrefix()), p, getCursor().getParentOrThrow());
+                    return gen.get(0).withPrefix(annotation.getPrefix());
                 } else if (loc == ANNOTATION_ARGUMENTS && mode == JavaCoordinates.Mode.REPLACEMENT &&
                            isScope(annotation)) {
                     List<J.Annotation> gen = unsubstitute(templateParser.parseAnnotations(getCursor(), "@Example(" + substitutedTemplate + ")"));


### PR DESCRIPTION
Removed `autoFormat` when processing annotations as it was causing broader indentation issues downstream

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
