### PR TITLE
Fix bug in AnnotationTemplateGenerator relative to finding the correct "target" of the annotation.

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -16,10 +16,12 @@
 package org.openrewrite.java;
 
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Recipe;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
@@ -39,22 +41,22 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     @Test
     void replaceClassAnnotation() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(toRecipe(() -> new JavaVisitor<>() {
-              @Override
-              public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
-                  return JavaTemplate.apply(
-                    "@Deprecated(since = \"#{}\", forRemoval = true)",
-                    getCursor(),
-                    annotation.getCoordinates().replace(),
-                    "2.0"
-                  );
+          spec -> spec.expectedCyclesThatMakeChanges(2)
+            .recipe(toRecipe(() -> new JavaVisitor<>() {
+                  @Override
+                  public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                      return JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",
+                        getCursor(), annotation.getCoordinates().replace(), "2.0");
+                  }
               }
-          })), java(
+            )),
+          java(
             """
               @Deprecated(since = "1.0", forRemoval = true)
               class A {
               }
-              """, """
+              """,
+            """
               @Deprecated(since = "2.0", forRemoval = true)
               class A {
               }
@@ -66,24 +68,24 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     @Test
     void replaceNestedClassAnnotation() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(toRecipe(() -> new JavaVisitor<>() {
-              @Override
-              public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
-                  return JavaTemplate.apply(
-                    "@Deprecated(since = \"#{}\", forRemoval = true)",
-                    getCursor(),
-                    annotation.getCoordinates().replace(),
-                    "2.0"
-                  );
+          spec -> spec.expectedCyclesThatMakeChanges(2)
+            .recipe(toRecipe(() -> new JavaVisitor<>() {
+                  @Override
+                  public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                      return JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",
+                        getCursor(), annotation.getCoordinates().replace(), "2.0");
+                  }
               }
-          })), java(
+            )),
+          java(
             """
               class A {
                   @Deprecated(since = "1.0", forRemoval = true)
                   class B {
                   }
               }
-              """, """
+              """,
+            """
               class A {
                   @Deprecated(since = "2.0", forRemoval = true)
                   class B {
@@ -98,22 +100,23 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     void replaceAnnotation2() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
-              @Override
-              public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                  annotation = JavaTemplate.apply(
-                    "@Deprecated(since = \"#{}\", forRemoval = true)",
-                    getCursor(),
-                    annotation.getCoordinates().replace(),
-                    "2.0"
-                  );
-                  return annotation;
+                  @Override
+                  public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                      annotation = JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",
+                        getCursor(), annotation.getCoordinates().replace(), "2.0");
+                      return annotation;
+                  }
               }
-          })).cycles(1).expectedCyclesThatMakeChanges(1), java(
+            ))
+            .cycles(1)
+            .expectedCyclesThatMakeChanges(1),
+          java(
             """
               @Deprecated(since = "1.0", forRemoval = true)
               class A {
               }
-              """, """
+              """,
+            """
               @Deprecated(since = "2.0", forRemoval = true)
               class A {
               }
@@ -140,17 +143,19 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   }
                   return annotation;
               }
-          })), java(
+          })),
+          java(
             """
               import org.jetbrains.annotations.NotNull;
-              
+
               public record Person(
                   @NotNull String firstName,
                   @NotNull String lastName
               ) {}
-              """, """
+              """,
+            """
               import lombok.NonNull;
-              
+
               public record Person(
                   @NonNull String firstName,
                   @NonNull String lastName
@@ -161,148 +166,332 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/5712")
-    @Test
-    void replaceArgumentsInNestedAnnotation() {
-        @Language("java") String annotations = """
+    @Nested
+    class NestedAnnotationsTests {
+        @Language("java")
+        private final String annotations = """
           package foo;
-          
+
           import java.lang.annotation.*;
-          
+
           @Repeatable(NestedAnnotations.class)
           public @interface NestedAnnotation {
               String a() default "";
               String b() default "";
           }
-          
+
           public @interface NestedAnnotations {
               NestedAnnotation[] value();
           }
           """;
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-                @Override
-                public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                    if (annotation.getSimpleName().equals("NestedAnnotation") && !annotation.getArguments()
-                      .isEmpty()) {
-                        // Check if this annotation still has the 'a' attribute that needs to be replaced
-                        J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
-                        if (arg.getVariable() instanceof J.Identifier && ((J.Identifier) arg.getVariable()).getSimpleName()
-                          .equals(
-                            "a")) {
-                            // Only apply the template if we haven't already transformed this annotation
-                            J.Literal value = (J.Literal) arg.getAssignment();
 
-                            // Replace 'a' with 'b' in the annotation
-                            return maybeAutoFormat(annotation , JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
-                              .javaParser(JavaParser.fromJavaVersion()
-                                .dependsOn(annotations))
-                              .imports("foo.*")
-                              .build()
-                              .apply(
-                                getCursor(),
-                                annotation.getCoordinates().replace(),
-                                value
-                              ), ctx);
-                        }
+        private final Recipe recipe = toRecipe(() -> new JavaIsoVisitor<>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                if (annotation.getSimpleName().equals("NestedAnnotation") &&
+                  !annotation.getArguments().isEmpty()) {
+                    // Check if this annotation still has the 'a' attribute that needs to be replaced
+                    J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
+                    if (arg.getVariable() instanceof J.Identifier &&
+                      ((J.Identifier) arg.getVariable()).getSimpleName().equals("a")) {
+                        // Only apply the template if we haven't already transformed this annotation
+                        J.Literal value = (J.Literal) arg.getAssignment();
+
+                        // Replace 'a' with 'b' in the annotation
+                        return JavaTemplate.builder("@NestedAnnotation(b = \"#{}\")")
+                          .javaParser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                          .imports("foo.*")
+                          .build()
+                          .apply(getCursor(), annotation.getCoordinates().replace(), value.getValue());
                     }
-                    return super.visitAnnotation(annotation, ctx);
                 }
-            })), java(
-            """
-              import foo.*;
-              
-              @NestedAnnotations({
-                      @NestedAnnotation(a = "1"),
-                      @NestedAnnotation(a = "2")
-              })
-              class Test {
-              }
-              """,
-                """
-              import foo.*;
-              
-              @NestedAnnotations({
-                      @NestedAnnotation(b = "1"),
-                      @NestedAnnotation(b = "2")
-              })
-              class Test {
-              }
-              """
-          )
-        );
-    }
+                return super.visitAnnotation(annotation, ctx);
+            }
+        });
 
-    @Test
-    void replaceArgumentsInNestedAnnotationWithValueAssignment() {
-        @Language("java") String annotations = """
-          package foo;
-          
-          import java.lang.annotation.*;
-          
-          @Repeatable(NestedAnnotations.class)
-          public @interface NestedAnnotation {
-              String a() default "";
-              String b() default "";
-          }
-          
-          public @interface NestedAnnotations {
-              NestedAnnotation[] value();
-          }
-          """;
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-                @Override
-                public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                    if (annotation.getSimpleName().equals("NestedAnnotation") && !annotation.getArguments()
-                      .isEmpty()) {
-                        // Check if this annotation still has the 'a' attribute that needs to be replaced
-                        J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
-                        if (arg.getVariable() instanceof J.Identifier && ((J.Identifier) arg.getVariable()).getSimpleName()
-                          .equals(
-                            "a")) {
-                            // Only apply the template if we haven't already transformed this annotation
-                            J.Literal value = (J.Literal) arg.getAssignment();
-
-                            // Replace 'a' with 'b' in the annotation
-                            return maybeAutoFormat(annotation ,JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
-                              .javaParser(JavaParser.fromJavaVersion()
-                                .dependsOn(annotations))
-                              .imports("foo.*")
-                              .build()
-                              .apply(
-                                getCursor(),
-                                annotation.getCoordinates().replace(),
-                                value
-                              ), ctx);
-                        }
-                    }
-                    return super.visitAnnotation(annotation, ctx);
-                }
-            })), java(
-            """
-              import foo.*;
-              
-              @NestedAnnotations( value = {
-                      @NestedAnnotation(a = "1"),
-                      @NestedAnnotation(a = "2")
-              })
-              class Test {
-              }
-              """,
+        @Test
+        void replaceWhenFieldAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
                 """
-              import foo.*;
-              
-              @NestedAnnotations( value = {
-                      @NestedAnnotation(b = "1"),
-                      @NestedAnnotation(b = "2")
-              })
-              class Test {
-              }
-              """
-          )
-        );
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenFieldAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
+                    })
+                    String field;
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenMethodAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
+                    })
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations({
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
+                    })
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenMethodAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                      @NestedAnnotation(a = "first"),
+                      @NestedAnnotation(a = "second")
+                    })
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                    @NestedAnnotations(value = {
+                      @NestedAnnotation(b = "first"),
+                      @NestedAnnotation(b = "second")
+                    })
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenOuterClassAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations({
+                    @NestedAnnotation(a = "first"),
+                    @NestedAnnotation(a = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations({
+                    @NestedAnnotation(b = "first"),
+                    @NestedAnnotation(b = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenOuterClassAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations(value = {
+                    @NestedAnnotation(a = "first"),
+                    @NestedAnnotation(a = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  @NestedAnnotations(value = {
+                    @NestedAnnotation(b = "first"),
+                    @NestedAnnotation(b = "second")
+                  })
+                  class A {
+                    void method() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenInnerClassAnnotatedNoIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations({
+                        @NestedAnnotation(a = "first"),
+                        @NestedAnnotation(a = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations({
+                        @NestedAnnotation(b = "first"),
+                        @NestedAnnotation(b = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void replaceWhenInnerClassAnnotatedWithIdentifier() {
+            rewriteRun(
+              spec -> spec
+                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+                .recipe(recipe),
+              //language=java
+              java(
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations(value = {
+                        @NestedAnnotation(a = "first"),
+                        @NestedAnnotation(a = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """,
+                """
+                  import foo.*;
+                  
+                  class A {
+                      @NestedAnnotations(value = {
+                        @NestedAnnotation(b = "first"),
+                        @NestedAnnotation(b = "second")
+                      })
+                      class B {
+                          void method() {}
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 
     @Test

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -218,7 +218,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
               })
               class Test {
               }
-              """, """
+              """,
+                """
               import foo.*;
               
               @NestedAnnotations({
@@ -289,7 +290,8 @@ class JavaTemplateAnnotationTest implements RewriteTest {
               })
               class Test {
               }
-              """, """
+              """,
+                """
               import foo.*;
               
               @NestedAnnotations( value = {

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -16,14 +16,15 @@
 package org.openrewrite.java;
 
 import org.intellij.lang.annotations.Language;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
-import org.openrewrite.Recipe;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.Optional;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -38,22 +39,22 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     @Test
     void replaceClassAnnotation() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2)
-            .recipe(toRecipe(() -> new JavaVisitor<>() {
-                  @Override
-                  public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
-                      return JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",
-                        getCursor(), annotation.getCoordinates().replace(), "2.0");
-                  }
+          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                  return JavaTemplate.apply(
+                    "@Deprecated(since = \"#{}\", forRemoval = true)",
+                    getCursor(),
+                    annotation.getCoordinates().replace(),
+                    "2.0"
+                  );
               }
-            )),
-          java(
+          })), java(
             """
               @Deprecated(since = "1.0", forRemoval = true)
               class A {
               }
-              """,
-            """
+              """, """
               @Deprecated(since = "2.0", forRemoval = true)
               class A {
               }
@@ -65,24 +66,24 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     @Test
     void replaceNestedClassAnnotation() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2)
-            .recipe(toRecipe(() -> new JavaVisitor<>() {
-                  @Override
-                  public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
-                      return JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",
-                        getCursor(), annotation.getCoordinates().replace(), "2.0");
-                  }
+          spec -> spec.expectedCyclesThatMakeChanges(2).recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+                  return JavaTemplate.apply(
+                    "@Deprecated(since = \"#{}\", forRemoval = true)",
+                    getCursor(),
+                    annotation.getCoordinates().replace(),
+                    "2.0"
+                  );
               }
-            )),
-          java(
+          })), java(
             """
               class A {
                   @Deprecated(since = "1.0", forRemoval = true)
                   class B {
                   }
               }
-              """,
-            """
+              """, """
               class A {
                   @Deprecated(since = "2.0", forRemoval = true)
                   class B {
@@ -97,23 +98,22 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     void replaceAnnotation2() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
-                  @Override
-                  public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                      annotation = JavaTemplate.apply("@Deprecated(since = \"#{}\", forRemoval = true)",
-                        getCursor(), annotation.getCoordinates().replace(), "2.0");
-                      return annotation;
-                  }
+              @Override
+              public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  annotation = JavaTemplate.apply(
+                    "@Deprecated(since = \"#{}\", forRemoval = true)",
+                    getCursor(),
+                    annotation.getCoordinates().replace(),
+                    "2.0"
+                  );
+                  return annotation;
               }
-            ))
-            .cycles(1)
-            .expectedCyclesThatMakeChanges(1),
-          java(
+          })).cycles(1).expectedCyclesThatMakeChanges(1), java(
             """
               @Deprecated(since = "1.0", forRemoval = true)
               class A {
               }
-              """,
-            """
+              """, """
               @Deprecated(since = "2.0", forRemoval = true)
               class A {
               }
@@ -140,19 +140,17 @@ class JavaTemplateAnnotationTest implements RewriteTest {
                   }
                   return annotation;
               }
-          })),
-          java(
+          })), java(
             """
               import org.jetbrains.annotations.NotNull;
-
+              
               public record Person(
                   @NotNull String firstName,
                   @NotNull String lastName
               ) {}
-              """,
-            """
+              """, """
               import lombok.NonNull;
-
+              
               public record Person(
                   @NonNull String firstName,
                   @NonNull String lastName
@@ -163,331 +161,273 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/5712")
-    @Nested
-    class NestedAnnotationsTests {
-        @Language("java")
-        private final String annotations = """
+    @Test
+    void replaceArgumentsInNestedAnnotation() {
+        @Language("java") String annotations = """
           package foo;
-
+          
           import java.lang.annotation.*;
-
+          
           @Repeatable(NestedAnnotations.class)
           public @interface NestedAnnotation {
               String a() default "";
               String b() default "";
           }
-
+          
           public @interface NestedAnnotations {
               NestedAnnotation[] value();
           }
           """;
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                @Override
+                public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                    if (annotation.getSimpleName().equals("NestedAnnotation") && !annotation.getArguments()
+                      .isEmpty()) {
+                        // Check if this annotation still has the 'a' attribute that needs to be replaced
+                        J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
+                        if (arg.getVariable() instanceof J.Identifier && ((J.Identifier) arg.getVariable()).getSimpleName()
+                          .equals(
+                            "a")) {
+                            // Only apply the template if we haven't already transformed this annotation
+                            J.Literal value = (J.Literal) arg.getAssignment();
 
-        private final Recipe recipe = toRecipe(() -> new JavaIsoVisitor<>() {
-            @Override
-            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                if (annotation.getSimpleName().equals("NestedAnnotation") &&
-                  !annotation.getArguments().isEmpty()) {
-                    // Check if this annotation still has the 'a' attribute that needs to be replaced
-                    J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
-                    if (arg.getVariable() instanceof J.Identifier &&
-                      ((J.Identifier) arg.getVariable()).getSimpleName().equals("a")) {
-                        // Only apply the template if we haven't already transformed this annotation
-                        J.Literal value = (J.Literal) arg.getAssignment();
-
-                        // Replace 'a' with 'b' in the annotation
-                        return JavaTemplate.builder("@NestedAnnotation(b = \"#{}\")")
-                          .javaParser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                          .imports("foo.*")
-                          .build()
-                          .apply(getCursor(), annotation.getCoordinates().replace(), value.getValue());
+                            // Replace 'a' with 'b' in the annotation
+                            return maybeAutoFormat(annotation , JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
+                              .javaParser(JavaParser.fromJavaVersion()
+                                .dependsOn(annotations))
+                              .imports("foo.*")
+                              .build()
+                              .apply(
+                                getCursor(),
+                                annotation.getCoordinates().replace(),
+                                value
+                              ), ctx);
+                        }
                     }
+                    return super.visitAnnotation(annotation, ctx);
                 }
-                return super.visitAnnotation(annotation, ctx);
-            }
-        });
-
-        @Test
-        void replaceWhenFieldAnnotatedNoIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations({
-                      @NestedAnnotation(a = "first"),
-                      @NestedAnnotation(a = "second")
-                    })
-                    String field;
-                    void method() {}
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations({
-                      @NestedAnnotation(b = "first"),
-                      @NestedAnnotation(b = "second")
-                    })
-                    String field;
-                    void method() {}
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenFieldAnnotatedWithIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations(value = {
-                      @NestedAnnotation(a = "first"),
-                      @NestedAnnotation(a = "second")
-                    })
-                    String field;
-                    void method() {}
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations(value = {
-                      @NestedAnnotation(b = "first"),
-                      @NestedAnnotation(b = "second")
-                    })
-                    String field;
-                    void method() {}
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenMethodAnnotatedNoIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations({
-                      @NestedAnnotation(a = "first"),
-                      @NestedAnnotation(a = "second")
-                    })
-                    void method() {}
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations({
-                      @NestedAnnotation(b = "first"),
-                      @NestedAnnotation(b = "second")
-                    })
-                    void method() {}
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenMethodAnnotatedWithIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations(value = {
-                      @NestedAnnotation(a = "first"),
-                      @NestedAnnotation(a = "second")
-                    })
-                    void method() {}
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  class A {
-                    @NestedAnnotations(value = {
-                      @NestedAnnotation(b = "first"),
-                      @NestedAnnotation(b = "second")
-                    })
-                    void method() {}
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenOuterClassAnnotatedNoIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  @NestedAnnotations({
-                    @NestedAnnotation(a = "first"),
-                    @NestedAnnotation(a = "second")
-                  })
-                  class A {
-                    void method() {}
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  @NestedAnnotations({
-                    @NestedAnnotation(b = "first"),
-                    @NestedAnnotation(b = "second")
-                  })
-                  class A {
-                    void method() {}
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenOuterClassAnnotatedWithIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  @NestedAnnotations(value = {
-                    @NestedAnnotation(a = "first"),
-                    @NestedAnnotation(a = "second")
-                  })
-                  class A {
-                    void method() {}
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  @NestedAnnotations(value = {
-                    @NestedAnnotation(b = "first"),
-                    @NestedAnnotation(b = "second")
-                  })
-                  class A {
-                    void method() {}
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenInnerClassAnnotatedNoIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  class A {
-                      @NestedAnnotations({
-                        @NestedAnnotation(a = "first"),
-                        @NestedAnnotation(a = "second")
-                      })
-                      class B {
-                          void method() {}
-                      }
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  class A {
-                      @NestedAnnotations({
-                        @NestedAnnotation(b = "first"),
-                        @NestedAnnotation(b = "second")
-                      })
-                      class B {
-                          void method() {}
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void replaceWhenInnerClassAnnotatedWithIdentifier() {
-            rewriteRun(
-              spec -> spec
-                .parser(JavaParser.fromJavaVersion().dependsOn(annotations))
-                .recipe(recipe),
-              //language=java
-              java(
-                """
-                  import foo.*;
-                  
-                  class A {
-                      @NestedAnnotations(value = {
-                        @NestedAnnotation(a = "first"),
-                        @NestedAnnotation(a = "second")
-                      })
-                      class B {
-                          void method() {}
-                      }
-                  }
-                  """,
-                """
-                  import foo.*;
-                  
-                  class A {
-                      @NestedAnnotations(value = {
-                        @NestedAnnotation(b = "first"),
-                        @NestedAnnotation(b = "second")
-                      })
-                      class B {
-                          void method() {}
-                      }
-                  }
-                  """
-              )
-            );
-        }
+            })), java(
+            """
+              import foo.*;
+              
+              @NestedAnnotations({
+                      @NestedAnnotation(a = "1"),
+                      @NestedAnnotation(a = "2")
+              })
+              class Test {
+              }
+              """, """
+              import foo.*;
+              
+              @NestedAnnotations({
+                      @NestedAnnotation(b = "1"),
+                      @NestedAnnotation(b = "2")
+              })
+              class Test {
+              }
+              """
+          )
+        );
     }
+
+    @Test
+    void replaceArgumentsInNestedAnnotationWithValueAssignment() {
+        @Language("java") String annotations = """
+          package foo;
+          
+          import java.lang.annotation.*;
+          
+          @Repeatable(NestedAnnotations.class)
+          public @interface NestedAnnotation {
+              String a() default "";
+              String b() default "";
+          }
+          
+          public @interface NestedAnnotations {
+              NestedAnnotation[] value();
+          }
+          """;
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(annotations))
+            .recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+                @Override
+                public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                    if (annotation.getSimpleName().equals("NestedAnnotation") && !annotation.getArguments()
+                      .isEmpty()) {
+                        // Check if this annotation still has the 'a' attribute that needs to be replaced
+                        J.Assignment arg = (J.Assignment) annotation.getArguments().get(0);
+                        if (arg.getVariable() instanceof J.Identifier && ((J.Identifier) arg.getVariable()).getSimpleName()
+                          .equals(
+                            "a")) {
+                            // Only apply the template if we haven't already transformed this annotation
+                            J.Literal value = (J.Literal) arg.getAssignment();
+
+                            // Replace 'a' with 'b' in the annotation
+                            return maybeAutoFormat(annotation ,JavaTemplate.builder("@NestedAnnotation(b = #{any(java.lang.String)})")
+                              .javaParser(JavaParser.fromJavaVersion()
+                                .dependsOn(annotations))
+                              .imports("foo.*")
+                              .build()
+                              .apply(
+                                getCursor(),
+                                annotation.getCoordinates().replace(),
+                                value
+                              ), ctx);
+                        }
+                    }
+                    return super.visitAnnotation(annotation, ctx);
+                }
+            })), java(
+            """
+              import foo.*;
+              
+              @NestedAnnotations( value = {
+                      @NestedAnnotation(a = "1"),
+                      @NestedAnnotation(a = "2")
+              })
+              class Test {
+              }
+              """, """
+              import foo.*;
+              
+              @NestedAnnotations( value = {
+                      @NestedAnnotation(b = "1"),
+                      @NestedAnnotation(b = "2")
+              })
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void renameAttributeInSubAnnotationDefaultAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(this::getSubAnnotationVisitor)),
+          java(
+            """
+              package com.test.annotation;
+              public @interface InnerA {
+                  Class changeme() default Object.class;
+              }
+              """
+          ),
+          java(
+            """
+              package com.test.annotation;
+              public @interface OuterA {
+                  InnerA[] value() default {};
+              }
+              """
+          ),
+          java(
+            """
+              import com.test.annotation.OuterA;
+              import com.test.annotation.InnerA;
+              
+              class A {
+                  @OuterA({@InnerA(changeme = com.example.class)})
+                  void method(){}
+              }
+              """,
+            """
+              import com.test.annotation.OuterA;
+              import com.test.annotation.InnerA;
+              
+              class A {
+                  @OuterA({@InnerA(iamchanged = com.example.class)})
+                  void method(){}
+              }
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void renameAttributeInSubAnnotationWithAssignment() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(this::getSubAnnotationVisitor)),
+          java(
+            """
+              package com.test.annotation;
+              public @interface InnerA {
+                  Class changeme() default Object.class;
+              }
+              """
+          ),
+          java(
+            """
+              package com.test.annotation;
+              public @interface OuterA {
+                  InnerA[] value() default {};
+              }
+              """
+          ),
+          java(
+            """
+              import com.test.annotation.OuterA;
+              import com.test.annotation.InnerA;
+              
+              class A {
+                  @OuterA(value = {@InnerA(changeme = com.example.class)})
+                  void method(){}
+              }
+              """,
+            """
+              import com.test.annotation.OuterA;
+              import com.test.annotation.InnerA;
+              
+              class A {
+                  @OuterA(value = {@InnerA(iamchanged = com.example.class)})
+                  void method(){}
+              }
+              """
+          )
+        );
+    }
+
+    private JavaIsoVisitor<ExecutionContext> getSubAnnotationVisitor() {
+
+        return new JavaIsoVisitor<>() {
+            final String annotationType = "com.test.annotation.InnerA";
+            final String origAttributeName = "changeme";
+            final String newAttributeName = "iamchanged";
+
+            final AnnotationMatcher ANNOTATION_MATCHER = new AnnotationMatcher("@" + annotationType);
+
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {
+
+                if (!ANNOTATION_MATCHER.matches(annotation)) {
+                    return super.visitAnnotation(annotation, executionContext);
+                }
+
+                Optional<Expression> mayBeResponse = findArgumentByName(annotation, origAttributeName);
+                if (mayBeResponse.isPresent()) {
+                    Object[] templateArgs = mayBeResponse.map(expression -> new Object[]{
+                      newAttributeName, ((J.Assignment) expression).getAssignment()
+                    }).orElseGet(() -> new Object[]{newAttributeName});
+
+
+                    return maybeAutoFormat(annotation, JavaTemplate.apply(
+                      "#{} = #{any()}",
+                      getCursor(), annotation.getCoordinates().replaceArguments(), templateArgs), executionContext);
+                }
+                return super.visitAnnotation(annotation, executionContext);
+            }
+
+            private Optional<Expression> findArgumentByName(J.Annotation an, String name) {
+                return an.getArguments().stream()
+                  .filter(arg -> arg instanceof J.Assignment &&
+                    ((J.Identifier) ((J.Assignment) arg).getVariable()).getSimpleName().equalsIgnoreCase(name))
+                  .findFirst();
+            }
+        };
+
+    }
+
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -341,8 +341,7 @@ public class AnnotationTemplateGenerator {
         return !isAnnotationTarget(candidate);
     }
 
-    @Nullable
-    private J getEnclosingClass(@Nullable Cursor cursor) {
+    private @Nullable J getEnclosingClass(@Nullable Cursor cursor) {
         return cursor == null ? null : cursor.firstEnclosing(J.class);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -71,18 +71,18 @@ public class AnnotationTemplateGenerator {
                     StringBuilder before = new StringBuilder();
                     StringBuilder after = new StringBuilder();
 
-            J j = cursor.getValue();
+                    J j = cursor.getValue();
 
-            template(next(cursor), j, before, after, newSetFromMap(new IdentityHashMap<>()));
+                    template(next(cursor), j, before, after, newSetFromMap(new IdentityHashMap<>()));
 
-            int level            = 1;
-            J   annotationParent = getEnclosingClass(cursor.getParent(level));
-            if (j instanceof J.Annotation) {
-                while (isNotAnnotationTarget(annotationParent)) {
-                    level++;
-                    annotationParent = getEnclosingClass(cursor.getParent(level));
-                }
-            }
+                    int level            = 1;
+                    J   annotationParent = getEnclosingClass(cursor.getParent(level));
+                    if (j instanceof J.Annotation) {
+                        while (isNotAnnotationTarget(annotationParent)) {
+                            level++;
+                            annotationParent = getEnclosingClass(cursor.getParent(level));
+                        }
+                    }
 
                     if (j instanceof J.MethodDeclaration || annotationParent instanceof J.MethodDeclaration) {
                         after.insert(0, " void $method() {}");

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/AnnotationTemplateGenerator.java
@@ -45,18 +45,22 @@ public class AnnotationTemplateGenerator {
         J j = cursor.getValue();
         if (j instanceof J.MethodDeclaration) {
             after.insert(0, " void $method() {}");
-        } else if (j instanceof J.VariableDeclarations) {
+        }
+        else if (j instanceof J.VariableDeclarations) {
             after.insert(0, " int $variable;");
-        } else if (j instanceof J.ClassDeclaration) {
+        }
+        else if (j instanceof J.ClassDeclaration) {
             if (cursor.getParentOrThrow().getValue() instanceof JavaSourceFile) {
                 after.insert(0, "class $Clazz {}");
-            } else {
+            }
+            else {
                 after.insert(0, "static class $Clazz {}");
             }
         }
 
-        if (cursor.getParentOrThrow().getValue() instanceof J.ClassDeclaration &&
-                cursor.getParentOrThrow().getParentOrThrow().getValue() instanceof JavaSourceFile) {
+        if (cursor.getParentOrThrow().getValue() instanceof J.ClassDeclaration && cursor.getParentOrThrow()
+                                                                                        .getParentOrThrow()
+                                                                                        .getValue() instanceof JavaSourceFile) {
             after.append("class $Template {}");
         }
 
@@ -65,41 +69,41 @@ public class AnnotationTemplateGenerator {
 
     public String template(Cursor cursor, String template) {
         //noinspection ConstantConditions
-        return Timer.builder("rewrite.template.generate.statement")
-                .register(Metrics.globalRegistry)
-                .record(() -> {
-                    StringBuilder before = new StringBuilder();
-                    StringBuilder after = new StringBuilder();
+        return Timer.builder("rewrite.template.generate.statement").register(Metrics.globalRegistry).record(() -> {
+            StringBuilder before = new StringBuilder();
+            StringBuilder after  = new StringBuilder();
 
-                    template(next(cursor), cursor.getValue(), before, after, newSetFromMap(new IdentityHashMap<>()));
+            J j = cursor.getValue();
 
-                    J j = cursor.getValue();
-                    J annotationParent = j instanceof J.Annotation && cursor.getParent() != null ? cursor.getParent().firstEnclosing(J.class) : null;
+            template(next(cursor), j, before, after, newSetFromMap(new IdentityHashMap<>()));
 
-                    int level = 1;
-                    while (annotationParent instanceof J.NewArray || annotationParent instanceof J.Assignment || annotationParent instanceof J.Annotation) {
-                        level += 1;
-                        if (cursor.getParent(level) == null) {
-                            break;
-                        }
-                        annotationParent = cursor.getParent(level).firstEnclosing(J.class);
-                    }
+            int level            = 1;
+            J   annotationParent = getEnclosingClass(cursor.getParent(level));
+            if (j instanceof J.Annotation) {
+                while (isNotAnnotationTarget(annotationParent)) {
+                    level++;
+                    annotationParent = getEnclosingClass(cursor.getParent(level));
+                }
+            }
 
-                    if (j instanceof J.MethodDeclaration || annotationParent instanceof J.MethodDeclaration) {
-                        after.insert(0, " void $method() {}");
-                    } else if (j instanceof J.VariableDeclarations || annotationParent instanceof J.VariableDeclarations) {
-                        after.insert(0, " int $variable;");
-                    } else if (j instanceof J.ClassDeclaration || annotationParent instanceof J.ClassDeclaration) {
-                        // Check if this is a top-level class or nested class
-                        Cursor classCursor = j instanceof J.ClassDeclaration ? cursor : cursor.getParent(level);
-                        if (classCursor != null && classCursor.getParentOrThrow().getValue() instanceof JavaSourceFile) {
-                            after.insert(0, "class $Clazz {}");
-                        } else {
-                            after.insert(0, "static class $Clazz {}");
-                        }
-                    }
-                    return before + "/*" + TEMPLATE_COMMENT + "*/" + template + "\n" + after;
-                });
+            if (j instanceof J.MethodDeclaration || annotationParent instanceof J.MethodDeclaration) {
+                after.insert(0, " void $method() {}");
+            }
+            else if (j instanceof J.VariableDeclarations || annotationParent instanceof J.VariableDeclarations) {
+                after.insert(0, " int $variable;");
+            }
+            else if (j instanceof J.ClassDeclaration || annotationParent instanceof J.ClassDeclaration) {
+                // Check if this is a top-level class or nested class
+                Cursor classCursor = j instanceof J.ClassDeclaration ? cursor : cursor.getParent(level);
+                if (classCursor != null && classCursor.getParentOrThrow().getValue() instanceof JavaSourceFile) {
+                    after.insert(0, "class $Clazz {}");
+                }
+                else {
+                    after.insert(0, "static class $Clazz {}");
+                }
+            }
+            return before + "/*" + TEMPLATE_COMMENT + "*/" + template + "\n" + after;
+        });
     }
 
     public List<J.Annotation> listAnnotations(JavaSourceFile cu) {
@@ -108,15 +112,18 @@ public class AnnotationTemplateGenerator {
         new JavaIsoVisitor<Integer>() {
 
             private @Nullable Comment filterTemplateComment(Comment comment) {
-                return comment instanceof TextComment && ((TextComment) comment).getText().equals(TEMPLATE_COMMENT) ?
-                        null : comment;
+                return comment instanceof TextComment && ((TextComment) comment).getText().equals(TEMPLATE_COMMENT)
+                       ? null
+                       : comment;
             }
 
             @Override
             public J.Annotation visitAnnotation(J.Annotation annotation, Integer integer) {
                 List<Comment> combinedComments = ListUtils.concatAll(
-                        getCursor().getParentOrThrow().<J>getValue().getComments(),
-                        annotation.getComments());
+                        getCursor().getParentOrThrow()
+                                   .<J>getValue()
+                                   .getComments(), annotation.getComments()
+                                                                    );
                 List<Comment> filteredComments = ListUtils.map(combinedComments, this::filterTemplateComment);
                 if (combinedComments != filteredComments) {
                     annotations.add(annotation.withComments(filteredComments));
@@ -148,9 +155,11 @@ public class AnnotationTemplateGenerator {
                 after.append("\n@interface $Placeholder {}");
             }
             return;
-        } else if (j instanceof J.ClassDeclaration) {
+        }
+        else if (j instanceof J.ClassDeclaration) {
             classDeclaration(before, after, (J.ClassDeclaration) j, templated, cursor, prior);
-        } else if (j instanceof J.Block) {
+        }
+        else if (j instanceof J.Block) {
             J parent = next(cursor).getValue();
             if (parent instanceof J.MethodDeclaration) {
                 J.MethodDeclaration m = (J.MethodDeclaration) parent;
@@ -160,32 +169,36 @@ public class AnnotationTemplateGenerator {
                 for (Statement statement : m.getBody().getStatements()) {
                     if (statement == prior) {
                         break;
-                    } else if (statement instanceof J.VariableDeclarations) {
-                        before.insert(0, "\n" +
-                                variable((J.VariableDeclarations) statement, cursor) +
-                                ";\n");
+                    }
+                    else if (statement instanceof J.VariableDeclarations) {
+                        before.insert(0, "\n" + variable((J.VariableDeclarations) statement, cursor) + ";\n");
                     }
                 }
 
-                if (m.getReturnTypeExpression() != null && JavaType.Primitive.Void != m.getReturnTypeExpression().getType()) {
-                    after.append("return ")
-                            .append(valueOfType(m.getReturnTypeExpression().getType()))
-                            .append(";\n");
+                if (m.getReturnTypeExpression() != null && JavaType.Primitive.Void != m.getReturnTypeExpression()
+                                                                                       .getType()) {
+                    after.append("return ").append(valueOfType(m.getReturnTypeExpression().getType())).append(";\n");
                 }
 
-                before.insert(0, m.withBody(null)
-                        .withLeadingAnnotations(emptyList())
-                        .withPrefix(Space.EMPTY)
-                        .printTrimmed(cursor).trim() + '{');
+                before.insert(
+                        0,
+                        m.withBody(null)
+                         .withLeadingAnnotations(emptyList())
+                         .withPrefix(Space.EMPTY)
+                         .printTrimmed(cursor)
+                         .trim() + '{'
+                             );
                 after.append('}');
-            } else if (parent instanceof J.Block) {
+            }
+            else if (parent instanceof J.Block) {
                 J.Block b = (J.Block) j;
 
                 // variable declarations up to the point of insertion
                 for (Statement statement : b.getStatements()) {
                     if (statement == prior) {
                         break;
-                    } else if (statement instanceof J.VariableDeclarations) {
+                    }
+                    else if (statement instanceof J.VariableDeclarations) {
                         J.VariableDeclarations v = (J.VariableDeclarations) statement;
                         if (v.hasModifier(J.Modifier.Type.Final)) {
                             before.insert(0, "\n" + variable(v, cursor) + ";\n");
@@ -199,7 +212,8 @@ public class AnnotationTemplateGenerator {
                 }
                 after.append('}');
             }
-        } else if (j instanceof J.NewClass) {
+        }
+        else if (j instanceof J.NewClass) {
             J.NewClass n = (J.NewClass) j;
             n = n.withBody(null).withPrefix(Space.EMPTY);
             before.insert(0, '{');
@@ -210,9 +224,16 @@ public class AnnotationTemplateGenerator {
         template(next(cursor), j, before, after, templated);
     }
 
-    private void classDeclaration(StringBuilder before, StringBuilder after, J.ClassDeclaration parent, Set<J> templated, Cursor cursor, J prior) {
-        J.ClassDeclaration c = parent;
-        boolean annotated = isAnnotated(cursor, prior);
+    private void classDeclaration(
+            StringBuilder before,
+            StringBuilder after,
+            J.ClassDeclaration parent,
+            Set<J> templated,
+            Cursor cursor,
+            J prior
+                                 ) {
+        J.ClassDeclaration c         = parent;
+        boolean            annotated = isAnnotated(cursor, prior);
         if (!annotated) {
             for (Statement statement : c.getBody().getStatements()) {
                 if (templated.contains(statement)) {
@@ -224,7 +245,8 @@ public class AnnotationTemplateGenerator {
                     if (v.hasModifier(J.Modifier.Type.Final) && v.hasModifier(J.Modifier.Type.Static)) {
                         before.insert(0, variable((J.VariableDeclarations) statement, cursor) + ";\n");
                     }
-                } else if (statement instanceof J.ClassDeclaration) {
+                }
+                else if (statement instanceof J.ClassDeclaration) {
                     // this is a sibling class. we need declarations for all variables and methods.
                     // setting prior to null will cause them all to be written.
                     before.insert(0, '}');
@@ -233,15 +255,16 @@ public class AnnotationTemplateGenerator {
             }
         }
         c = c.withBody(J.Block.createEmptyBlock())
-                .withLeadingAnnotations(null)
-                .withPrefix(Space.EMPTY)
-                .withKind(J.ClassDeclaration.Kind.Type.Class)
-                .withPrimaryConstructor(null);
-        String printed = c.printTrimmed(cursor);
-        int braceIndex = printed.lastIndexOf('{');
+             .withLeadingAnnotations(null)
+             .withPrefix(Space.EMPTY)
+             .withKind(J.ClassDeclaration.Kind.Type.Class)
+             .withPrimaryConstructor(null);
+        String printed    = c.printTrimmed(cursor);
+        int    braceIndex = printed.lastIndexOf('{');
         if (annotated) {
             after.append(braceIndex == -1 ? printed + '{' : printed.substring(0, braceIndex + 1));
-        } else {
+        }
+        else {
             before.insert(0, braceIndex == -1 ? printed + '{' : printed.substring(0, braceIndex + 1));
         }
         after.append('}');
@@ -251,8 +274,9 @@ public class AnnotationTemplateGenerator {
         if (!(maybeAnnotation instanceof J.Annotation)) {
             return false;
         }
-        Cursor sourceFileCursor = cursor.dropParentUntil(is -> is instanceof JavaSourceFile);
-        AnnotationService annotationService = sourceFileCursor.<JavaSourceFile>getValue().service(AnnotationService.class);
+        Cursor            sourceFileCursor  = cursor.dropParentUntil(is -> is instanceof JavaSourceFile);
+        AnnotationService annotationService = sourceFileCursor.<JavaSourceFile>getValue()
+                                                              .service(AnnotationService.class);
         return annotationService.getAllAnnotations(cursor).contains(maybeAnnotation);
     }
 
@@ -262,8 +286,7 @@ public class AnnotationTemplateGenerator {
             for (J.Modifier modifier : variable.getModifiers()) {
                 varBuilder.append(modifier.getType().toString().toLowerCase()).append(' ');
             }
-            varBuilder.append(variable.getTypeExpression().withPrefix(Space.EMPTY).printTrimmed(cursor))
-                    .append(' ');
+            varBuilder.append(variable.getTypeExpression().withPrefix(Space.EMPTY).printTrimmed(cursor)).append(' ');
         }
 
         List<J.VariableDeclarations.NamedVariable> variables = variable.getVariables();
@@ -308,5 +331,18 @@ public class AnnotationTemplateGenerator {
 
     private Cursor next(Cursor c) {
         return c.getParentTreeCursor();
+    }
+
+    private boolean isAnnotationTarget(@Nullable J candidate) {
+        return candidate == null || candidate instanceof J.MethodDeclaration || candidate instanceof J.ClassDeclaration || candidate instanceof J.VariableDeclarations;
+    }
+
+    private boolean isNotAnnotationTarget(@Nullable J candidate) {
+        return !isAnnotationTarget(candidate);
+    }
+
+    @Nullable
+    private J getEnclosingClass(@Nullable Cursor cursor) {
+        return cursor == null ? null : cursor.firstEnclosing(J.class);
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
AnnotationTemplateGenerator has been updated to correctly determine the annotationParent (target).

## What's your motivation?
This is affecting recipes that rewrite complex nested annotations (such as ApiResponse/(es) in swagger)

## Anything in particular you'd like reviewers to focus on?
I have added two tests to the JavaTemplateAnnotationTest. One that ensures the code continued to work as it did before my changes relative to determining annotationParent when the engineer used default or non specified name for the assignment and one where the subannotation collection (array) is assigned (value = ).  The latter test failed before my code change. The new code will only fall through when no parent is found or a valid one (e.g. variable/method/class declaration).

## Anyone you would like to review specifically?
Whoever is most familiar with this area of the internal templating code.

## Have you considered any alternatives or workarounds?
I exhausted all attempts to work around this problem.

## Any additional context
I changed only these two files and ran all the tests in the JavaTemplateAnnotationTest class but did not run your full suite of tests.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
