### PR TITLE
refactor: Remove redundant null checks before instanceof

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/MethodMatcher.java
@@ -372,8 +372,7 @@ public class MethodMatcher {
             return false;
         }
 
-        if (method.getSelect() != null &&
-            method.getSelect() instanceof J.Identifier &&
+        if (method.getSelect() instanceof J.Identifier &&
             !matchesSelectBySimpleNameAlone(((J.Identifier) method.getSelect()))) {
             return false;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/UnnecessaryParenthesesVisitor.java
@@ -137,7 +137,7 @@ public class UnnecessaryParenthesesVisitor<P> extends JavaVisitor<P> {
     @Override
     public J visitVariable(J.VariableDeclarations.NamedVariable variable, P ctx) {
         J.VariableDeclarations.NamedVariable v = (J.VariableDeclarations.NamedVariable) super.visitVariable(variable, ctx);
-        if (getStyle().getAssign() && v.getInitializer() != null && v.getInitializer() instanceof J.Parentheses) {
+        if (getStyle().getAssign() && v.getInitializer() instanceof J.Parentheses) {
             v = (J.VariableDeclarations.NamedVariable) new UnwrapParentheses<>((J.Parentheses<?>) v.getInitializer()).visitNonNull(v, ctx, getCursor().getParentOrThrow());
         }
         return v;

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -6182,7 +6182,7 @@ public interface J extends Tree, RpcCodec<J> {
             for (J.Modifier modifier : modifiers) {
                 allAnnotations.addAll(modifier.getAnnotations());
             }
-            if (typeExpression != null && typeExpression instanceof J.AnnotatedType) {
+            if (typeExpression instanceof J.AnnotatedType) {
                 allAnnotations.addAll(((J.AnnotatedType) typeExpression).getAnnotations());
             }
             return allAnnotations;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -2318,7 +2318,7 @@ public interface JS extends J {
             for (J.Modifier modifier : modifiers) {
                 allAnnotations.addAll(modifier.getAnnotations());
             }
-            if (typeExpression != null && typeExpression instanceof J.AnnotatedType) {
+            if (typeExpression instanceof J.AnnotatedType) {
                 allAnnotations.addAll(((J.AnnotatedType) typeExpression).getAnnotations());
             }
             return allAnnotations;

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3576,7 +3576,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
     private J.NewClass mapType(J.NewClass tree) {
         J.NewClass n = tree;
-        if (n.getClazz() != null && n.getClazz() instanceof J.Identifier) {
+        if (n.getClazz() instanceof J.Identifier) {
             if (n.getClazz().getType() instanceof JavaType.Parameterized) {
                 J.Identifier clazz = (J.Identifier) n.getClazz();
                 n = n.withClazz(clazz.withType(((JavaType.Parameterized) clazz.getType()).getType()));

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -62,7 +62,7 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
                 element.acceptChildren(this, data)
                 if (element is FirResolvedTypeRef) {
                     // Do not visit FirUserTypeRef, since it's not mappable to a type.
-                    if (element.delegatedTypeRef != null && element.delegatedTypeRef !is FirUserTypeRef) {
+                    if (element.delegatedTypeRef !is FirUserTypeRef) {
                         // not sure why this isn't taken care of by `FirResolvedTypeRefImpl#acceptChildren()`
                         element.delegatedTypeRef?.accept(this, data)
                     }


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeInstanceof?organizationId=ODQ2MGExMTUtNDg0My00N2EwLTgzMGMtNGE1NGExMTBmZDkw