### PR TITLE
Do not check all-service endpoint if exact version requested

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateGradleWrapper.java
@@ -139,7 +139,7 @@ public class UpdateGradleWrapper extends ScanningRecipe<UpdateGradleWrapper.Grad
                 return gradleWrapper = GradleWrapper.create(URI.create(wrapperUri), ctx);
             }
             try {
-                gradleWrapper = GradleWrapper.create(distribution, version, null, ctx);
+                gradleWrapper = GradleWrapper.create(distribution, version, ctx);
             } catch (Exception e) {
                 // services.gradle.org is unreachable
                 // If the user didn't specify a wrapperUri, but they did provide a specific version we assume they know this version

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleWrapperScriptDownloader.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleWrapperScriptDownloader.java
@@ -52,7 +52,7 @@ public class GradleWrapperScriptDownloader {
     public static void main(String[] args) throws IOException, InterruptedException {
         Lock lock = new ReentrantLock();
         InMemoryExecutionContext ctx = new InMemoryExecutionContext();
-        List<GradleWrapper.GradleVersion> allGradleReleases = GradleWrapper.listAllVersions(null, ctx);
+        List<GradleWrapper.GradleVersion> allGradleReleases = GradleWrapper.listAllVersions(ctx);
         Map<String, GradleWrapperScriptLoader.Version> allDownloadedVersions =
                 new ConcurrentHashMap<>(new GradleWrapperScriptLoader().getAllVersions());
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/internal/GradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/internal/GradleWrapperTest.java
@@ -24,7 +24,7 @@ public class GradleWrapperTest {
 
     @Test
     void listGradleWrappers() {
-        RemoteResource resource = GradleWrapper.create(null, null, null, new InMemoryExecutionContext())
+        RemoteResource resource = GradleWrapper.create(null, null, new InMemoryExecutionContext())
                 .gradlew();
     }
 }


### PR DESCRIPTION
## What's changed?

The https://services.gradle.org/versions/all endpoint is really only needed to determine the latest version available if a version wildcard notation (e.g. 8.x) or null has been requested by the end user. In all other cases, we are making an unnecessary HTTPS call.

_Side note:_ The `repositoryUrl` always used the null value. I removed the parameter to make the logic less confusing.

## What's your motivation?

Many declarative recipes add the UpdateGradleWrapper recipe and provide a specific version as a default value. For example, the [MigrateToGradle8](https://docs.openrewrite.org/recipes/gradle/migratetogradle8) recipe sets the version option value to 8.x.

Within enterprises, the https://services.gradle.org endpoint is often times not exposed. Calling the endpoint simply results in a failure after running into a HTTP timeout or by not being able to resolve it. End users usually do not know that the Wrapper distribution needs to be resolved from an in-house binary repository; nevertheless they execute the recipe with the default values. For scenarios where the user provided an exact version, we'll increase the performance of the recipe execution.

## Anything in particular you'd like reviewers to focus on?

No