### PR TITLE
Support GString interpolation in dependency version declaration

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -613,11 +613,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
 
                         String versionVariableName = ((J.Identifier) versionValue.getTree()).getSimpleName();
-                        getCursor().dropParentUntil(p -> p instanceof SourceFile)
-                                .computeMessageIfAbsent(VERSION_VARIABLE_KEY, v -> new HashMap<String, Map<GroupArtifact, Set<String>>>())
-                                .computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                                .computeIfAbsent(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()), it -> new HashSet<>())
-                                .add(method.getSimpleName());
+                        replaceVariableValue(versionVariableName, method, dep.getGroupId(), dep.getArtifactId());
                     }
                 } else if (arg instanceof K.StringTemplate) {
                     K.StringTemplate template = (K.StringTemplate) arg;
@@ -639,11 +635,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
 
                         String versionVariableName = ((J.Identifier) versionValue.getTree()).getSimpleName();
-                        getCursor().dropParentUntil(p -> p instanceof SourceFile)
-                                .computeMessageIfAbsent(VERSION_VARIABLE_KEY, v -> new HashMap<String, Map<GroupArtifact, Set<String>>>())
-                                .computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                                .computeIfAbsent(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()), it -> new HashSet<>())
-                                .add(method.getSimpleName());
+                        replaceVariableValue(versionVariableName, method, dep.getGroupId(), dep.getArtifactId());
                     }
                 } else if (arg instanceof J.Literal) {
                     J.Literal literal = (J.Literal) arg;
@@ -741,11 +733,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         return m.withArguments(newArgs);
                     } else if (versionExp instanceof J.Identifier) {
                         String versionVariableName = ((J.Identifier) versionExp).getSimpleName();
-                        getCursor().dropParentUntil(p -> p instanceof SourceFile)
-                                .computeMessageIfAbsent(VERSION_VARIABLE_KEY, v -> new HashMap<String, Map<GroupArtifact, Set<String>>>())
-                                .computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                                .computeIfAbsent(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()), it -> new HashSet<>())
-                                .add(m.getSimpleName());
+                        replaceVariableValue(versionVariableName, m, (String) groupLiteral.getValue(), (String) artifactLiteral.getValue());
                     } else if (versionExp instanceof G.GString) {
                         G.GString gString = (G.GString) versionExp;
 
@@ -757,14 +745,10 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         String versionVariableName = versionLiteral.printTrimmed(getCursor());
 
                         if (versionVariableName.startsWith("$")) {
-                            versionVariableName = versionVariableName.replace("$", "").replace("{", "").replace("}", "");
+                            versionVariableName = versionVariableName.replaceAll("^\\$\\{?|}?$", "");
                         }
 
-                        getCursor().dropParentUntil(p -> p instanceof SourceFile)
-                                .computeMessageIfAbsent(VERSION_VARIABLE_KEY, v -> new HashMap<String, Map<GroupArtifact, Set<String>>>())
-                                .computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                                .computeIfAbsent(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()), it -> new HashSet<>())
-                                .add(m.getSimpleName());
+                        replaceVariableValue(versionVariableName, m, (String) groupLiteral.getValue(), (String) artifactLiteral.getValue());
                     }
                 } else if (depArgs.get(0) instanceof J.Assignment &&
                            depArgs.get(1) instanceof J.Assignment &&
@@ -816,22 +800,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         return m.withArguments(newArgs);
                     } else if (versionExp instanceof J.Identifier) {
                         String versionVariableName = ((J.Identifier) versionExp).getSimpleName();
-                        replaceVariableValue(versionVariableName, m, groupLiteral, artifactLiteral);
-                    } else if (versionExp instanceof G.GString) {
-                        G.GString gString = (G.GString) versionExp;
-
-                        if (gString.getStrings().size() != 1) {
-                            return m;
-                        }
-
-                        G.GString.Value versionLiteral = (G.GString.Value) gString.getStrings().get(0);
-                        String versionVariableName = versionLiteral.printTrimmed(getCursor());
-
-                        if (versionVariableName.startsWith("$")) {
-                            versionVariableName = versionVariableName.replaceAll("^\\$\\{?|}?$", "");
-                        }
-
-                        replaceVariableValue(versionVariableName, m, groupLiteral, artifactLiteral);
+                        replaceVariableValue(versionVariableName, m, (String) groupLiteral.getValue(), (String) artifactLiteral.getValue());
                     }
                 }
             }
@@ -839,11 +808,11 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             return m;
         }
 
-        private void replaceVariableValue(String versionVariableName, J.MethodInvocation m, J.Literal groupLiteral, J.Literal artifactLiteral) {
+        private void replaceVariableValue(String versionVariableName, J.MethodInvocation m, String groupId, String artifactId) {
             getCursor().dropParentUntil(p -> p instanceof SourceFile)
                     .computeMessageIfAbsent(VERSION_VARIABLE_KEY, v -> new HashMap<String, Map<GroupArtifact, Set<String>>>())
                     .computeIfAbsent(versionVariableName, it -> new HashMap<>())
-                    .computeIfAbsent(new GroupArtifact((String) groupLiteral.getValue(), (String) artifactLiteral.getValue()), it -> new HashSet<>())
+                    .computeIfAbsent(new GroupArtifact(groupId, artifactId), it -> new HashSet<>())
                     .add(m.getSimpleName());
         }
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.gradle;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
@@ -386,6 +388,45 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                 implementation (group: "com.google.guava", name: "guava", version: '30.1.1-jre')
               }
               """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$guavaVersion", "${guavaVersion}"})
+    void mapNotationGStringInterpolation(String stringInterpolationReference) {
+        rewriteRun(
+          buildGradle(
+            String.format("""
+              plugins {
+                id 'java-library'
+              }
+              
+              repositories {
+                mavenCentral()
+              }
+              
+              def guavaVersion = '29.0-jre'
+              
+              dependencies {
+                implementation (group: "com.google.guava", name: "guava", version: "%s")
+              }
+              """, stringInterpolationReference),
+            String.format("""
+              plugins {
+                id 'java-library'
+              }
+              
+              repositories {
+                mavenCentral()
+              }
+              
+              def guavaVersion = '30.1.1-jre'
+              
+              dependencies {
+                implementation (group: "com.google.guava", name: "guava", version: "%s")
+              }
+              """, stringInterpolationReference)
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Supports GString interpolation in a dependency declaration.

```
dependencies {
    implementation (group: "com.google.guava", name: "guava", version: "${guavaVersion}")
}
```

## What's your motivation?

Gradle's dependency declaration notation allows for two different ways to specify the GAV: string notation and map notation. When using Groovy, you can wrap a variable into parenthesis and evaluate it with string interpolation.

Generally speaking, this is a misuse of the Groovy language as you can simply reference the variable by name without wrapping it into a string. However, the language does not prevent you from doing so. This change adds support for it.