### PR TITLE
Fix: handle implicit closure call in Groovy

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1706,14 +1706,23 @@ public class GroovyParserVisitor {
                 }
 
                 Space prefix = whitespace();
-                if (methodNameExpression.equals(source.substring(cursor, cursor + methodNameExpression.length()))) {
-                    skip(methodNameExpression);
-                    name = new J.Identifier(randomId(), prefix, Markers.EMPTY, emptyList(), methodNameExpression, null, null);
-                } else if (select != null && select.getElement() instanceof J.Identifier) {
-                    name = (J.Identifier) select.getElement();
-                    select = null;
+                boolean implicitCall = (methodNameExpression != null && cursor < source.length() &&
+                        source.charAt(cursor) == '(' && (cursor + methodNameExpression.length() > source.length() ||
+                        !methodNameExpression.equals(source.substring(cursor, cursor + methodNameExpression.length())))
+                );
+                if (implicitCall) {
+                    // This is an implicit call() method - create identifier but it doesn't get printed
+                    name = new J.Identifier(randomId(), prefix, Markers.EMPTY, emptyList(), "", null, null);
                 } else {
-                    throw new IllegalArgumentException("Unable to parse method call");
+                    if (methodNameExpression.equals(source.substring(cursor, cursor + methodNameExpression.length()))) {
+                        skip(methodNameExpression);
+                        name = new J.Identifier(randomId(), prefix, Markers.EMPTY, emptyList(), methodNameExpression, null, null);
+                    } else if (select != null && select.getElement() instanceof J.Identifier) {
+                        name = (J.Identifier) select.getElement();
+                        select = null;
+                    } else {
+                        throw new IllegalArgumentException("Unable to parse method call");
+                    }
                 }
 
                 if (call.isSpreadSafe()) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -533,4 +533,119 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5729")
+    void closureChainedCall() {
+        rewriteRun(
+          groovy(
+            """
+              foo { }()
+              """
+          )
+        );
+    }
+
+    @Test
+    void closureCallWithArgs() {
+        rewriteRun(
+          groovy(
+            """
+              def bar(closure) {
+                  return { x -> println x }
+              }
+              bar { }("hello")
+              """
+          )
+        );
+    }
+
+    @Test
+    void multipleChainedCalls() {
+        rewriteRun(
+          groovy(
+            """
+              def chain() {
+                  return { { println "nested" } }
+              }
+              chain()()
+              """
+          )
+        );
+    }
+
+    @Test
+    void closureWithParamCall() {
+        rewriteRun(
+          groovy(
+            """
+              def create(x) {
+                  return { y -> println '$x $y' }
+              }
+              create("hello") { }("world")
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedMethodClosureCall() {
+        rewriteRun(
+          groovy(
+            """
+              def outer() {
+                  return { inner() }
+              }
+              def inner() {
+                  return { println "inner" }
+              }
+              outer()()
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableClosureCall() {
+        rewriteRun(
+          groovy(
+            """
+              def factory() {
+                  return { x -> x * 2 }
+              }
+              def closure = factory()
+              closure(5)
+              """
+          )
+        );
+    }
+
+    @Test
+    void closureComplexArgs() {
+        rewriteRun(
+          groovy(
+            """
+              def builder(closure) {
+                  return { a, b -> closure(a + b) }
+              }
+              builder { println it }(10, 20)
+              """
+          )
+        );
+    }
+
+    @Test
+    void safeNavigationClosureCall() {
+        rewriteRun(
+          groovy(
+            """
+              def maybe() {
+                  return Math.random() > 0.5 ? { println "yes" } : null
+              }
+              maybe()?.call()
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/5729

## What's changed?
Added `boolean implicitCall` which checks if the method that is being invoked (e.g. "call") is not actually present at the current cursor position in the source.

## Any additional context
Groovy allows implicit invocation of closures using syntax like `foo { }()`, which look like `foo({}).call()`. 
In these cases, `visitMethodCallExpression(MethodCallExpression call)` gets `call = "call"` and tries to extract the method name from the source using substring, which caused `StringIndexOutOfBoundsException` - because the `call` identifier is not present in the source.

## Have you considered any alternatives or workarounds?
Another way would be just to hardcode the `call` name, like:
```
if("call".equals(methodNameExpression))
```


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
