### PR TITLE
Fix: handle semicolon after class

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -37,6 +37,7 @@ import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.internal.JavaTypeCache;
 import org.openrewrite.java.marker.CompactConstructor;
 import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.marker.Semicolon;
 import org.openrewrite.java.marker.TrailingComma;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -558,7 +559,12 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         J.Block body = new J.Block(randomId(), bodyPrefix, Markers.EMPTY, new JRightPadded<>(false, EMPTY, Markers.EMPTY),
                 members, sourceBefore("}"));
 
-        return new J.ClassDeclaration(randomId(), fmt, Markers.EMPTY, modifierResults.getLeadingAnnotations(), modifierResults.getModifiers(), kind, name, typeParams,
+        Markers classMarkers = Markers.EMPTY;
+        if (skip(";") != null) {
+            classMarkers = Markers.build(singletonList(new Semicolon(randomId())));
+        }
+
+        return new J.ClassDeclaration(randomId(), fmt, classMarkers, modifierResults.getLeadingAnnotations(), modifierResults.getModifiers(), kind, name, typeParams,
                 primaryConstructor, extendings, implementings, permitting, body, (JavaType.FullyQualified) typeMapping.type(node));
     }
 

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
@@ -432,6 +433,32 @@ class JavaParserTest implements RewriteTest {
               }
             }
             """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5735")
+    void semicolonAfterClass() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              class A{};
+              """
+          )
+        );
+    }
+
+    @Test
+    @ExpectedToFail
+    void semicolonAfterClassWithSpace() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              class A{ } ;
+              """
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaPrinter.java
@@ -21,6 +21,7 @@ import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
 import org.openrewrite.java.marker.CompactConstructor;
 import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.marker.Semicolon;
 import org.openrewrite.java.marker.TrailingComma;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.java.tree.J.*;
@@ -556,6 +557,13 @@ public class JavaPrinter<P> extends JavaVisitor<PrintOutputCapture<P>> {
                 classDecl.getPadding().getImplements(), JContainer.Location.IMPLEMENTS, ",", null, p);
         visitContainer("permits", classDecl.getPadding().getPermits(), JContainer.Location.PERMITS, ",", null, p);
         visit(classDecl.getBody(), p);
+        // Check for trailing semicolon marker and print it
+        for (Marker marker : classDecl.getMarkers().getMarkers()) {
+            if (marker instanceof Semicolon) {
+                p.append(";");
+                break;
+            }
+        }
         afterSyntax(classDecl, p);
         return classDecl;
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
tbd

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite/issues/5735


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
