### PR TITLE
Add headers to HttpSender.Response

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/ipc/http/HttpSender.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ipc/http/HttpSender.java
@@ -414,16 +414,26 @@ public interface HttpSender {
     class Response implements AutoCloseable {
         private final int code;
         private final InputStream body;
+        private final Map<String, List<String>> headers;
         private final Runnable onClose;
 
         public Response(int code, @Nullable InputStream body, Runnable onClose) {
+            this(code, body, Collections.emptyMap(), onClose);
+        }
+
+        public Response(int code, @Nullable InputStream body, Map<String, List<String>> headers, Runnable onClose) {
             this.code = code;
             this.body = body;
+            this.headers = headers;
             this.onClose = onClose;
         }
 
         public int getCode() {
             return code;
+        }
+
+        public Map<String, List<String>> getHeaders() {
+            return headers;
         }
 
         public InputStream getBody() {

--- a/rewrite-core/src/main/java/org/openrewrite/ipc/http/HttpUrlConnectionSender.java
+++ b/rewrite-core/src/main/java/org/openrewrite/ipc/http/HttpUrlConnectionSender.java
@@ -117,9 +117,9 @@ public class HttpUrlConnectionSender implements HttpSender {
             } else if (status < 400 && con.getInputStream() != null) {
                 is = con.getInputStream();
             } else {
-                return new Response(status, new ByteArrayInputStream(new byte[0]), onClose);
+                return new Response(status, new ByteArrayInputStream(new byte[0]), con.getHeaderFields(), onClose);
             }
-            return new Response(status, is, onClose);
+            return new Response(status, is, con.getHeaderFields(), onClose);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/http/OkHttpSender.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/http/OkHttpSender.java
@@ -23,6 +23,9 @@ import org.openrewrite.ipc.http.HttpSender;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,8 +59,8 @@ public class OkHttpSender implements HttpSender {
         if (entity.length > 0) {
             String contentType = request.getRequestHeaders().get("Content-Type");
             MediaType mediaType = contentType != null ?
-                    MediaType.get(contentType + "; charset=utf-8") :
-                    MEDIA_TYPE_APPLICATION_JSON;
+              MediaType.get(contentType + "; charset=utf-8") :
+              MEDIA_TYPE_APPLICATION_JSON;
             RequestBody body = RequestBody.create(entity, mediaType);
             requestBuilder.method(methodValue, body);
         } else {
@@ -73,7 +76,9 @@ public class OkHttpSender implements HttpSender {
             //noinspection resource
             okhttp3.Response response = client.newCall(requestBuilder.build()).execute();
             ResponseBody body = response.body();
-            return new Response(response.code(), body == null ? null : body.byteStream(), response::close);
+
+            return new Response(response.code(), body == null ? null : body.byteStream(),
+              response.headers().toMultimap(), response::close);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/rewrite-test/src/main/java/org/openrewrite/test/MockHttpSender.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/MockHttpSender.java
@@ -18,6 +18,9 @@ package org.openrewrite.test;
 import org.openrewrite.ipc.http.HttpSender;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Issues no HTTP requests, instead returning the supplied input stream whenever send() is invoked.
@@ -26,6 +29,7 @@ import java.io.InputStream;
 public class MockHttpSender implements HttpSender {
     final UncheckedSupplier<InputStream> is;
     int responseCode = 200;
+    Map<String, List<String>> responseHeaders = Collections.emptyMap();
 
     public MockHttpSender(UncheckedSupplier<InputStream> is) {
         this.is = is;
@@ -36,13 +40,18 @@ public class MockHttpSender implements HttpSender {
         this.responseCode = responseCode;
     }
 
+    public MockHttpSender withResponseHeaders(Map<String, List<String>> headers) {
+        this.responseHeaders = headers;
+        return this;
+    }
+
     @Override
     public Response send(Request request) {
         if (responseCode != 200) {
-            return new Response(responseCode, null, () -> {
+            return new Response(responseCode, null, responseHeaders, () -> {
             });
         } else {
-            return new Response(responseCode, is.get(), () -> {
+            return new Response(responseCode, is.get(), responseHeaders, () -> {
             });
         }
     }


### PR DESCRIPTION
## What's changed?
Adding the exposure of response headers in `HttpSender.Response`.

## What's your motivation?
We have a downstream service that requires headers.