### PR TITLE
Support for external properties for UpgradeTransitiveDependencyVersion recipe

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -552,8 +552,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             ((J.MethodInvocation) depArgs.get(0)).getSimpleName().equals("enforcedPlatform"))) {
                     m = m.withArguments(ListUtils.mapFirst(depArgs, platform -> updateDependency((J.MethodInvocation) platform, ctx)));
                 }
-            } else if ("ext".equals(method.getSimpleName()) && isSettingsGradle()) {
-                // rare case that gradle versions are set via settings.gradle ext block
+            } else if ("ext".equals(method.getSimpleName()) && getCursor().firstEnclosingOrThrow(SourceFile.class).getSourcePath().endsWith("settings.gradle")) {
+                // rare case that gradle versions are set via settings.gradle ext block (only possible for Groovy DSL)
                 m = (J.MethodInvocation) new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext executionContext) {
@@ -583,11 +583,6 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 }.visitNonNull(m, ctx, getCursor().getParentTreeCursor());
             }
             return m;
-        }
-
-        private boolean isSettingsGradle() {
-            String path = requireNonNull(getCursor().firstEnclosing(SourceFile.class)).getSourcePath().toString();
-            return path.endsWith("settings.gradle") || path.endsWith("settings.gradle.kts");
         }
 
         private J.MethodInvocation updateDependency(J.MethodInvocation method, ExecutionContext ctx) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -184,6 +184,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
 
         private boolean dependenciesToUpdateCalculated = false;
         private final Map<GroupArtifact, String> dependenciesToUpdate = new HashMap<>();
+
         /**
          * Collects a map of dependencies that require an update, regardless of which project they belong to.
          * <p>

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1233,7 +1233,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
 
         @Override
         public UpgradeTransitiveDependencyVersion.DependencyVersionState getInitialValue(ExecutionContext ctx) {
-            return new UpgradeTransitiveDependencyVersion.DependencyVersionState();
+            return new UpgradeTransitiveDependencyVersion.DependencyVersionState("com.fasterxml*", "jackson-core");
         }
 
         @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1073,6 +1073,102 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void updateConstraintForVersionInSettings() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  constraints {
+                      implementation("com.fasterxml.jackson.core:jackson-core:${gradle.jacksonCoreVersion}") {
+                          because 'some reason'
+                      }
+                  }
+              
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+              }
+              """,
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  constraints {
+                      implementation("com.fasterxml.jackson.core:jackson-core:${gradle.jacksonCoreVersion}") {
+                          because 'CVE-2024-BAD'
+                      }
+                  }
+              
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+              }
+              """
+          ),
+          settingsGradle(
+            """
+              gradle.ext {
+                  jacksonCoreVersion = '2.12.0'
+              }
+              """,
+            """
+              gradle.ext {
+                  jacksonCoreVersion = '2.12.5'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinDslUpdateConstraintForVersionInSettings() {
+        rewriteRun(
+          buildGradleKts(
+            """
+              plugins { `java-library` }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  constraints {
+                      implementation("com.fasterxml.jackson.core:jackson-core:${gradle.jacksonCoreVersion}") {
+                          because("some reason")
+                      }
+                  }
+              
+                  implementation("org.openrewrite:rewrite-java:7.0.0")
+              }
+              """,
+            """
+              plugins { `java-library` }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  constraints {
+                      implementation("com.fasterxml.jackson.core:jackson-core:${gradle.jacksonCoreVersion}") {
+                          because("CVE-2024-BAD")
+                      }
+                  }
+              
+                  implementation("org.openrewrite:rewrite-java:7.0.0")
+              }
+              """
+          ),
+          settingsGradle(
+            """
+              gradle.ext {
+                  jacksonCoreVersion = '2.12.0'
+              }
+              """,
+            """
+              gradle.ext {
+                  jacksonCoreVersion = '2.12.5'
+              }
+              """
+          )
+        );
+    }
+
     @Value
     @EqualsAndHashCode(callSuper = false)
     public static class ScanningAccumulatedUpgradeRecipe extends ScanningRecipe<UpgradeTransitiveDependencyVersion.DependencyVersionState> {


### PR DESCRIPTION
## What's changed?
The UpgradeTransitiveDependencyVersion recipe does support properties:
- defined in a properties file
- defined in the `ext` block in the settings.gradle file (Groovy DSL only)

## What's your motivation?
Improvement of thie recipe, just like https://github.com/openrewrite/rewrite/commit/c323d4cced0815c17dbcd9c34af34300c924c81c did for the UpgradeDependencyVersion recipe.

## Additional context
At one point we should consider to either introduce utility methods or merge this recipe with UpgradeDependencyVersion, as both recipes have a lot of common code. For now I just improved this recipe, so it does support external properties without relying on other components.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
