### PR TITLE
nightly-ci was missing node_auth_token

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -19,3 +19,4 @@ jobs:
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
       OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+      node_auth_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What's changed?
fix nightly ci?

Its been failing for approximately 2 weeks.

<img width="1340" height="397" alt="Screenshot 2025-07-15 at 3 34 32 PM" src="https://github.com/user-attachments/assets/8c0bd3da-6360-4f69-863a-1150a4e733cc" />

the CI workflow works and when i compare the two workflows i noticed the node auth token was missing.

## What's your motivation?
☝️ 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
