### PR TITLE
Add a space between `yield` and its expression

### DIFF
--- a/rewrite-java-17/src/test/java/org/openrewrite/java/SwitchEnhancementsTest.java
+++ b/rewrite-java-17/src/test/java/org/openrewrite/java/SwitchEnhancementsTest.java
@@ -1,0 +1,88 @@
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.format.AutoFormat;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class SwitchEnhancementsTest implements RewriteTest {
+    @DocumentExample
+    @Test
+    void yieldFromJavaTemplate() {
+        rewriteRun(spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+
+            @Override
+            public J.Case visitCase(J.Case _case, ExecutionContext executionContext) {
+                if (((J.Literal)((J.Yield)_case.getStatements().get(0)).getValue()).getValue().equals("replaced")) {
+                    return _case;
+                }
+                String template = """
+                        Object x = switch (o) {
+                            default: yield #{any()};
+                        };
+                        """;
+
+                J.VariableDeclarations vd = JavaTemplate.apply(
+                        template,
+                        new Cursor(getCursor(), _case), _case.getCoordinates().replace(),
+                        new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, "replaced", "\"replaced\"", null, JavaType.Primitive.String)
+                );
+
+                J.SwitchExpression switchExpression = (J.SwitchExpression) vd.getVariables().get(0).getInitializer();
+                Statement updatedStatement = ((J.Case) switchExpression.getCases().getStatements().get(0)).getStatements().get(0);
+                return super.visitCase(_case.withStatements(List.of(updatedStatement)), executionContext);
+            }
+        })), java("""
+                class Test {
+                    String yielded(int i) {
+                        return switch (i) {
+                            default: yield "value";
+                        };
+                    }
+                }
+                """, """
+                class Test {
+                    String yielded(int i) {
+                        return switch (i) {
+                            default: yield "replaced";
+                        };
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void yieldReformated() {
+        rewriteRun(spec -> spec.recipe(new AutoFormat()),
+                java("""
+                class Test {
+                    String yielded(int i) {
+                        return switch (i) {
+                            default: yield"value";
+                        };
+                    }
+                }
+                """, """
+                class Test {
+                    String yielded(int i) {
+                        return switch (i) {
+                            default: yield "value";
+                        };
+                    }
+                }
+                """));
+    }
+}

--- a/rewrite-java-17/src/test/java/org/openrewrite/java/SwitchEnhancementsTest.java
+++ b/rewrite-java-17/src/test/java/org/openrewrite/java/SwitchEnhancementsTest.java
@@ -1,88 +1,34 @@
 package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Cursor;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.format.AutoFormat;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Space;
-import org.openrewrite.java.tree.Statement;
-import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.List;
-
-import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.test.RewriteTest.toRecipe;
 
 public class SwitchEnhancementsTest implements RewriteTest {
     @DocumentExample
     @Test
-    void yieldFromJavaTemplate() {
-        rewriteRun(spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
-
-            @Override
-            public J.Case visitCase(J.Case _case, ExecutionContext executionContext) {
-                if (((J.Literal)((J.Yield)_case.getStatements().get(0)).getValue()).getValue().equals("replaced")) {
-                    return _case;
-                }
-                String template = """
-                        Object x = switch (o) {
-                            default: yield #{any()};
-                        };
-                        """;
-
-                J.VariableDeclarations vd = JavaTemplate.apply(
-                        template,
-                        new Cursor(getCursor(), _case), _case.getCoordinates().replace(),
-                        new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, "replaced", "\"replaced\"", null, JavaType.Primitive.String)
-                );
-
-                J.SwitchExpression switchExpression = (J.SwitchExpression) vd.getVariables().get(0).getInitializer();
-                Statement updatedStatement = ((J.Case) switchExpression.getCases().getStatements().get(0)).getStatements().get(0);
-                return super.visitCase(_case.withStatements(List.of(updatedStatement)), executionContext);
-            }
-        })), java("""
-                class Test {
-                    String yielded(int i) {
-                        return switch (i) {
-                            default: yield "value";
-                        };
-                    }
-                }
-                """, """
-                class Test {
-                    String yielded(int i) {
-                        return switch (i) {
-                            default: yield "replaced";
-                        };
-                    }
-                }
-                """));
-    }
-
-    @Test
     void yieldReformated() {
-        rewriteRun(spec -> spec.recipe(new AutoFormat()),
+        rewriteRun(
+                spec -> spec.recipe(new AutoFormat()),
                 java("""
-                class Test {
-                    String yielded(int i) {
-                        return switch (i) {
-                            default: yield"value";
-                        };
-                    }
-                }
-                """, """
-                class Test {
-                    String yielded(int i) {
-                        return switch (i) {
-                            default: yield "value";
-                        };
-                    }
-                }
-                """));
+                        class Test {
+                            String yielded(int i) {
+                                return switch (i) {
+                                    default: yield"value";
+                                };
+                            }
+                        }
+                        """, """
+                        class Test {
+                            String yielded(int i) {
+                                return switch (i) {
+                                    default: yield "value";
+                                };
+                            }
+                        }
+                        """));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MinimumViableSpacingVisitor.java
@@ -212,6 +212,11 @@ public class MinimumViableSpacingVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     @Override
+    public J.Yield visitYield(J.Yield yield, P p) {
+        return super.visitYield(yield.withValue(yield.getValue().withPrefix(yield.getValue().getPrefix().withWhitespace(" "))), p);
+    }
+
+    @Override
     public J.Case visitCase(J.Case _case, P p) {
         J.Case c = super.visitCase(_case, p);
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
`yield "expression"` in a switch case statement requires a space between `yield` and `"expression"`.

## What's your motivation?
Using a JavaTemplate such as:
```
StringBuilder template = new StringBuilder(
        "Object o = switch (#{any()}) {\n" +
        "  default: yield #{any()};\n" +
        "}");
```
would generate `yield"string"` when using a String and `yield55` when using an int.
Interestingly enough, the `yield"string"` syntax is valid and compiles; whereas `yield55` is an error as expected.


## Have you considered any alternatives or workarounds?
The current "fix" works for the tests but I really didn't put time to think about it and it might be inadequate, the main goal was to create a bug report.

## Any additional context
The bug was first discovered when using JavaTemplate to generate the LST for a switch expression. The test case uses `org.openrewrite.java.format.AutoFormat` directly to keep the test small but `JavaTemplate` eventually calls it too. 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
