### PR TITLE
Catch block should support modifiers

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/TryTest.java
@@ -31,13 +31,13 @@ class TryTest implements RewriteTest {
           groovy(
             """
               try {
-               
+              
               } catch (RuntimeException e) {
-               
+              
               } catch (Exception e) {
-                           
+              
               }
-               """
+              """
           )
         );
     }
@@ -51,6 +51,19 @@ class TryTest implements RewriteTest {
               
               } catch (all) {
               
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void modifier() {
+        rewriteRun(
+          groovy(
+            """
+              try {
+              } catch (final RuntimeException e) {
               }
               """
           )
@@ -84,7 +97,7 @@ class TryTest implements RewriteTest {
              } finally {
                  def a = ""
              }
-              """
+             """
           )
         );
     }


### PR DESCRIPTION
## What's changed?
The `final` keyword can be used.

## What's your motivation?
Support for:

```groovy
try {
} catch (final RuntimeException e) {
}
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
