### PR TITLE
Support for method pointers and array constructor method references

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -347,6 +347,21 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
         }
 
         @Override
+        public J visitMemberReference(J.MemberReference memberRef, PrintOutputCapture<P> p) {
+            beforeSyntax(memberRef, Space.Location.MEMBER_REFERENCE_PREFIX, p);
+            visitRightPadded(memberRef.getPadding().getContaining(), JRightPadded.Location.MEMBER_REFERENCE_CONTAINING, p);
+            if (memberRef.getMarkers().findFirst(MethodPointer.class).isPresent()) {
+                p.append(".&");
+            } else {
+                p.append("::");
+            }
+            visitContainer("<", memberRef.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);
+            visitLeftPadded("", memberRef.getPadding().getReference(), JLeftPadded.Location.MEMBER_REFERENCE_NAME, p);
+            afterSyntax(memberRef, p);
+            return memberRef;
+        }
+
+        @Override
         public J visitFieldAccess(J.FieldAccess fieldAccess, PrintOutputCapture<P> p) {
             beforeSyntax(fieldAccess, Space.Location.FIELD_ACCESS_PREFIX, p);
             visit(fieldAccess.getTarget(), p);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/MethodPointer.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/marker/MethodPointer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+@Value
+@With
+public class MethodPointer implements Marker {
+    UUID id;
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -199,11 +199,33 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void staticMethodPointer() {
+        rewriteRun(
+          groovy(
+            """
+              Integer.&parseInt
+              """
+          )
+        );
+    }
+
+    @Test
     void staticMethodReference() {
         rewriteRun(
           groovy(
             """
               Integer::parseInt
+              """
+          )
+        );
+    }
+
+    @Test
+    void instanceMethodPointer() {
+        rewriteRun(
+          groovy(
+            """
+              ["a", "b", "c"].forEach(System.out.&println)
               """
           )
         );
@@ -221,11 +243,33 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void constructorMethodPointer() {
+        rewriteRun(
+          groovy(
+            """
+              ArrayList.&new
+              """
+          )
+        );
+    }
+
+    @Test
     void constructorMethodReference() {
         rewriteRun(
           groovy(
             """
               ArrayList::new
+              """
+          )
+        );
+    }
+
+    @Test
+    void arrayConstructorMethodReference() {
+        rewriteRun(
+          groovy(
+            """
+              [1, 2, 3].stream().toArray(Integer[]::new)
               """
           )
         );


### PR DESCRIPTION
## What's changed?
- Method pointer operator is supported (`.&`)
- Array constructor method references are supported

## What's your motivation?
- https://github.com/openrewrite/rewrite/issues/4061

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
