### PR TITLE
Add support for diamond operator in Groovy Parser

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -3095,8 +3095,7 @@ public class GroovyParserVisitor {
 
         ClassNode innerClass = ctor.getType();
         if (!(innerClass instanceof InnerClassNode)) {
-            GenericsType[] generics = innerClass != null ? innerClass.getGenericsTypes() : null;
-            return generics != null && generics.length == 0;
+            return innerClass.getGenericsTypes() != null && innerClass.getGenericsTypes().length == 0;
         }
 
         ClassNode superClass = innerClass.getUnresolvedSuperClass();

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2516,15 +2516,10 @@ public class GroovyParserVisitor {
                     && classNode.getUnresolvedSuperClass().isUsingGenerics()
                     && !classNode.getUnresolvedSuperClass().isGenericsPlaceHolder()
                     && classNode.getGenericsTypes() == null;
-            if (isAnonymousClassWithGenericSuper) {
+            if (isAnonymousClassWithGenericSuper || (classNode.isUsingGenerics() && !classNode.isGenericsPlaceHolder())) {
                 JContainer<Expression> typeParameters = inferredType ?
                         JContainer.build(sourceBefore("<"), singletonList(padRight(new J.Empty(randomId(), EMPTY, Markers.EMPTY), sourceBefore(">"))), Markers.EMPTY) :
-                        visitTypeParameterizations(classNode.getUnresolvedSuperClass().getGenericsTypes());
-                expr = new J.ParameterizedType(randomId(), EMPTY, Markers.EMPTY, (NameTree) expr, typeParameters, typeMapping.type(classNode));
-            } else if (classNode.isUsingGenerics() && !classNode.isGenericsPlaceHolder()) {
-                JContainer<Expression> typeParameters = inferredType ?
-                        JContainer.build(sourceBefore("<"), singletonList(padRight(new J.Empty(randomId(), EMPTY, Markers.EMPTY), sourceBefore(">"))), Markers.EMPTY) :
-                        visitTypeParameterizations(classNode.getGenericsTypes());
+                        visitTypeParameterizations(isAnonymousClassWithGenericSuper ? classNode.getUnresolvedSuperClass().getGenericsTypes() : classNode.getGenericsTypes());
                 expr = new J.ParameterizedType(randomId(), EMPTY, Markers.EMPTY, (NameTree) expr, typeParameters, typeMapping.type(classNode));
             }
         }
@@ -3100,7 +3095,8 @@ public class GroovyParserVisitor {
 
         ClassNode innerClass = ctor.getType();
         if (!(innerClass instanceof InnerClassNode)) {
-            return false;
+            GenericsType[] generics = innerClass != null ? innerClass.getGenericsTypes() : null;
+            return generics != null && generics.length == 0;
         }
 
         ClassNode superClass = innerClass.getUnresolvedSuperClass();

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ConstructorTest.java
@@ -35,6 +35,28 @@ class ConstructorTest implements RewriteTest {
     }
 
     @Test
+    void withGenerics() {
+        rewriteRun(
+          groovy(
+            """              
+              new ArrayList<String>()
+              """
+          )
+        );
+    }
+
+    @Test
+    void withDiamondOperator() {
+        rewriteRun(
+          groovy(
+            """
+              new ArrayList<>()
+              """
+          )
+        );
+    }
+
+    @Test
     void declaration() {
         rewriteRun(
           groovy(


### PR DESCRIPTION
## What's changed?
Diamond operators (`<>`) are now correctly supported when creating new generic instances like `new ArrayList<>()`.

## What's your motivation?
Previously, using `new ArrayList<>()` would incorrectly render as `new ArrayList<>()>()`, due to missing type inference information.

## Any additional context
We did already support `new HashMap<>()`; this was only because the Groovy compiler happened to set the `StaticTypesMarker.INFERRED_TYPE` flag in that case. However, this flag is not consistently applied. This change ensures support even when the flag is missing by also checking if the generic type list is empty.

Interestingly, when the flag is present, the generic types are populated, which means we need to handle both cases: either rely on the flag or detect when the generics are empty.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
