### PR TITLE
Groovy parser supports lambda's with curly braces

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1061,7 +1061,11 @@ public class GroovyParserVisitor {
             Space staticInitPadding = EMPTY;
             boolean isStaticInit = sourceStartsWith("static");
             Object parent = nodeCursor.getParentOrThrow().getValue();
-            boolean withinClosure = parent instanceof ClosureExpression || (parent instanceof ExpressionStatement && ((ExpressionStatement) parent).getExpression() instanceof ClosureExpression);
+            boolean withinClosure = !(parent instanceof LambdaExpression) && parent instanceof ClosureExpression ||
+                                    (parent instanceof ExpressionStatement &&
+                                            !(((ExpressionStatement) parent).getExpression() instanceof LambdaExpression) &&
+                                            ((ExpressionStatement) parent).getExpression() instanceof ClosureExpression
+                                    );
             if (isStaticInit) {
                 fmt = sourceBefore("static");
                 staticInitPadding = whitespace();
@@ -1281,7 +1285,9 @@ public class GroovyParserVisitor {
                     arrowPrefix,
                     body,
                     closureType));
-            skip("}");
+            if (cursor < source.length() && source.charAt(cursor) == '}') {
+                skip("}");
+            }
         }
 
         @Override

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -332,7 +332,7 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
                 visitSpace(lambda.getArrow(), Space.Location.LAMBDA_ARROW_PREFIX, p);
                 p.append("->");
             }
-            if (lambda.getBody() instanceof J.Block) {
+            if (lambda.getBody() instanceof J.Block && !ls.isJavaStyle()) {
                 J.Block block = (J.Block) lambda.getBody();
                 visitStatements(block.getPadding().getStatements(), JRightPadded.Location.BLOCK_STATEMENT, p);
                 visitSpace(block.getEnd(), Space.Location.BLOCK_END, p);

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
@@ -36,6 +36,17 @@ class LambdaTest implements RewriteTest {
     }
 
     @Test
+    void lambdaExpressionWithParens() {
+        rewriteRun(
+          groovy(
+            """
+              def lambda = a -> { a }
+              """
+          )
+        );
+    }
+
+    @Test
     void lambdaExpressionNoArguments() {
         rewriteRun(
           groovy(
@@ -45,6 +56,7 @@ class LambdaTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void lambdaExpressionWithArgument() {
         rewriteRun(

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
@@ -25,7 +25,7 @@ import static org.openrewrite.groovy.Assertions.groovy;
 class LambdaTest implements RewriteTest {
 
     @Test
-    void lambdaExpressionNoParens() {
+    void lambdaExpression() {
         rewriteRun(
           groovy(
                 """
@@ -36,7 +36,7 @@ class LambdaTest implements RewriteTest {
     }
 
     @Test
-    void lambdaExpressionWithParens() {
+    void lambdaExpressionWithCurlyBraces() {
         rewriteRun(
           groovy(
             """


### PR DESCRIPTION
## What's changed?
Lambda's within curly braces are supported.

## What's your motivation?
Parser failed with:

```groovy
assertThrows(IllegalArgumentException.class, () -> {
  // some statement
})
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
