### PR TITLE
Groovy Parser supports negative literals with trailing zeros

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1330,23 +1330,11 @@ public class GroovyParserVisitor {
                     jType = JavaType.Primitive.Char;
                 } else if (type == ClassHelper.double_TYPE || Double.class.getName().equals(type.getName())) {
                     jType = JavaType.Primitive.Double;
-                    if (expression.getNodeMetaData().get("_FLOATING_POINT_LITERAL_TEXT") instanceof String) {
-                        text = (String) expression.getNodeMetaData().get("_FLOATING_POINT_LITERAL_TEXT");
-                    }
                 } else if (type == ClassHelper.float_TYPE || Float.class.getName().equals(type.getName())) {
                     jType = JavaType.Primitive.Float;
-                    if (expression.getNodeMetaData().get("_FLOATING_POINT_LITERAL_TEXT") instanceof String) {
-                        text = (String) expression.getNodeMetaData().get("_FLOATING_POINT_LITERAL_TEXT");
-                    }
                 } else if (type == ClassHelper.int_TYPE || Integer.class.getName().equals(type.getName())) {
                     jType = JavaType.Primitive.Int;
-                    if (expression.getNodeMetaData().get("_INTEGER_LITERAL_TEXT") instanceof String) {
-                        text = (String) expression.getNodeMetaData().get("_INTEGER_LITERAL_TEXT");
-                    }
                 } else if (type == ClassHelper.long_TYPE || Long.class.getName().equals(type.getName())) {
-                    if (expression.getNodeMetaData().get("_INTEGER_LITERAL_TEXT") instanceof String) {
-                        text = (String) expression.getNodeMetaData().get("_INTEGER_LITERAL_TEXT");
-                    }
                     jType = JavaType.Primitive.Long;
                 } else if (type == ClassHelper.short_TYPE || Short.class.getName().equals(type.getName())) {
                     jType = JavaType.Primitive.Short;
@@ -1375,20 +1363,23 @@ public class GroovyParserVisitor {
                     throw new IllegalStateException("Unexpected constant type " + type);
                 }
 
-                if (cursor < source.length() && source.charAt(cursor) == '+' && !text.startsWith("+")) {
-                    // A unaryPlus operator is implied on numerics and needs to be manually detected / added via the source.
-                    text = "+" + text;
-                }
-                cursor += text.length();
-                // Numeric literals may be followed by "L", "f", or "d" to indicate Long, float, or double respectively
-                if (jType == JavaType.Primitive.Long || jType == JavaType.Primitive.Float || jType == JavaType.Primitive.Double) {
-                    if (source.startsWith("L", cursor) || source.startsWith("f", cursor) || source.startsWith("d", cursor)) {
-                        text += source.charAt(cursor);
-                        cursor++;
+                // Get the string literal from the source, as numeric literals may have a unary operator, underscores, dots and can be followed by "L", "f", or "d"
+                if (jType == JavaType.Primitive.Int || jType == JavaType.Primitive.Long || jType == JavaType.Primitive.Float || jType == JavaType.Primitive.Double) {
+                    int i = cursor;
+                    if (source.charAt(cursor) == '-' || source.charAt(cursor) == '+') {
+                        i = indexOfNextNonWhitespace(cursor + 1, source);
                     }
+                    for (; i < source.length(); i++) {
+                        char c = source.charAt(i);
+                        if (!(isJavaIdentifierPart(c) || (c == '.' && source.length() > (i + 1) && isJavaIdentifierPart(source.charAt(i + 1))))) {
+                            break;
+                        }
+                    }
+                    text = source.substring(cursor, i);
                 }
-                return new J.Literal(randomId(), fmt, Markers.EMPTY, value, text,
-                        null, jType);
+
+                skip(text);
+                return new J.Literal(randomId(), fmt, Markers.EMPTY, value, text, null, jType);
             }));
         }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LiteralTest.java
@@ -296,9 +296,41 @@ class LiteralTest implements RewriteTest {
           groovy(
             """
               float a = 0.1
-              def b = 0.1f
-              double c = 1.0d
-              long d = 1L
+              def b = 0.10f
+              def c = -0.10f
+              double d = 1.0d
+              double e = -1.0d
+              long f = +1L
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/2752")
+    @Test
+    void numericLiteralsWithUnderscores() {
+        rewriteRun(
+          groovy(
+            """
+              def l1 = 10_000L
+              def l2 = 10_000l
+              def i = 10_000
+              def d1 = 10_000d
+              def d2 = 10_000D
+              def f1 = 10_000f
+              def f2 = -10_000.0F
+              """
+          )
+        );
+    }
+
+    @Test
+    void numericLiteralWithSpacing() {
+        rewriteRun(
+          groovy(
+            """
+              def a = -           0.10
+              def b = +           0.10
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/VariableDeclarationsTest.java
@@ -111,24 +111,6 @@ class VariableDeclarationsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2752")
-    @Test
-    void numericValueWithUnderscores() {
-        rewriteRun(
-          groovy(
-                """
-          def l1 = 10_000L
-          def l2 = 10_000l
-          def i = 10_000
-          def d1 = 10_000d
-          def d2 = 10_000D
-          def f1 = 10_000f
-          def f2 = 10_000.0F
-          """
-          )
-        );
-    }
-
     @Test
     void singleTypeMultipleVariableDeclaration() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Even better support for numeric literals.

## What's your motivation?
Literals like `-0.10f` were printed as `-0.1,f`.

## Any additional context
To support numbers with special cases like underscores or trailing zeros, we used the metadata flags like `_FLOATING_POINT_LITERAL_TEXT` to get the correct text. Sadly enough, this flag is not produced by the Groovy compiler for negative numbers. So I removed the dependency on those flags and used the source code itself to get the actual text.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
