### PR TITLE
Groovy parser supports method invocations with type parameters

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1721,6 +1721,7 @@ public class GroovyParserVisitor {
                     }
                     select = JRightPadded.build(selectExpr).withAfter(afterSelect);
                 }
+                JContainer<Expression> typeParameters = call.getGenericsTypes() != null ? visitTypeParameterizations(call.getGenericsTypes()) : null;
                 // Closure invocations that are written as closure.call() and closure() are parsed into identical MethodCallExpression
                 // closure() has implicitThis set to false
                 // So the "select" that was just parsed _may_ have actually been the method name
@@ -1832,11 +1833,10 @@ public class GroovyParserVisitor {
                             break;
                         }
                     }
-
                 } else {
                     methodType = typeMapping.methodType(methodNode);
                 }
-                return new J.MethodInvocation(randomId(), fmt, markers, select, null, name, args, methodType);
+                return new J.MethodInvocation(randomId(), fmt, markers, select, typeParameters, name, args, methodType);
             }));
         }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/MethodInvocationTest.java
@@ -681,4 +681,20 @@ class MethodInvocationTest implements RewriteTest {
         );
     }
 
+    @Test
+    void generics() {
+        rewriteRun(
+          groovy(
+            """
+              class Util {
+                  static <T> boolean compare(T t1, T t2) {
+                      return t1 == t2
+                  }
+              }
+              Util.<String>compare("A", "B")
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Method invocation with type parameters are supported.

## What's your motivation?
Type parameters for method invocation were not implemented, so using `Util.<String>compare("A", "B")` would be printed as `Util.compare("A", "B")`.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
