### PR TITLE
Add Flag.Enum to allow identifying enum constants from other members in a JavaType.Class of Enum Kind

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/EnumTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/EnumTest.java
@@ -230,4 +230,18 @@ class EnumTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void enumClassHasJavaTypeClassEnumFlagEnabled() {
+        rewriteRun(
+          java(
+            """    
+              enum Color {}
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                assertTrue(requireNonNull(cu.getClasses().get(0).getType()).hasFlags(Flag.Enum));
+            })
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/Flag.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/Flag.java
@@ -52,7 +52,7 @@ public enum Flag {
 
     private final long bitMask;
 
-    public static final long VALID_CLASS_FLAGS = Stream.of(Public, Private, Protected, Static,  Final, Interface, Abstract, Strictfp)
+    public static final long VALID_CLASS_FLAGS = Stream.of(Public, Private, Protected, Static,  Final, Interface, Abstract, Strictfp, Enum)
             .map(Flag::getBitMask).reduce(0L, (m1, m2) -> m1 | m2);
     public static final long VALID_FLAGS = Arrays.stream(Flag.values())
             .map(Flag::getBitMask)


### PR DESCRIPTION
## What's changed?
A new flag `Enum` in `org.openrewrite.java.tree.Flag`.

## What's your motivation?
For the new `SwitchCaseAssigningToSwitchExpression` [recipe being developed](https://github.com/openrewrite/rewrite-migrate-java/pull/795), it's necessary to be able to tell if a switch statement applied to an enum is "exhaustive". This implies being able to tell if items of `JavaType.Class.members` are an [enum constant](https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-EnumConstant) or not.

Without the present change, there's no way to tell if a member is an [enum constant](https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-EnumConstant) or a normal class field in the enum.

## Anything in particular you'd like reviewers to focus on?
* Would that change have an unforseen impact? `JavaType.Variable#getFlagsBitMap()` allows getting direct access to the bitmap but the "unknown" flags are zeroed when a `Variable` is instantiated so no existing code should be using/expecting anything out of bit 14 already.

## Anyone you would like to review specifically?
@jkschneider @timtebeek 

## Have you considered any alternatives or workarounds?
There doesn't seem to be a way to get that information otherwise.

## Any additional context
* When visiting the enum declaration in the tree it's very clear which fields are enum constant or not, but the `JavaType.Class.members` items don't contain that information.
* At [type mapping time](https://github.com/openrewrite/rewrite/blob/45c438972d37db6b1f1903c87c752e141e4cc997/rewrite-java/src/main/java/org/openrewrite/java/internal/JavaReflectionTypeMapping.java#L290-L290) the flags (modifiers but contains more than just the modifiers flags) for the field as passed to construct a `JavaType.Variable` but the ['unknown' flags are zeroed](https://github.com/openrewrite/rewrite/blob/45c438972d37db6b1f1903c87c752e141e4cc997/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java#L1625-L1625), which includes the `Enum` flag.
* The [downstream change waiting for that fix](https://github.com/openrewrite/rewrite-migrate-java/pull/795/commits/c29b44c6f3760731bc777c9c1e985f7d81e764f8)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
