### PR TITLE
Add identical and power operators to Groovy Parser

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -1021,6 +1021,18 @@ public class GroovyParserVisitor {
                     case "?=":
                         gBinaryOp = G.Binary.Type.ElvisAssignment;
                         break;
+                    case "**":
+                        gBinaryOp = G.Binary.Type.Power;
+                        break;
+                    case "**=":
+                        gBinaryOp = G.Binary.Type.PowerAssignment;
+                        break;
+                    case "===":
+                        gBinaryOp = G.Binary.Type.IdentityEquals;
+                        break;
+                    case "!==":
+                        gBinaryOp = G.Binary.Type.IdentityNotEquals;
+                        break;
                 }
 
                 cursor += binary.getOperation().getText().length();

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -172,6 +172,18 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
             case ElvisAssignment:
                 keyword = "?=";
                 break;
+            case Power:
+                keyword = "**";
+                break;
+            case PowerAssignment:
+                keyword = "**=";
+                break;
+            case IdentityEquals:
+                keyword = "===";
+                break;
+            case IdentityNotEquals:
+                keyword = "!==";
+                break;
         }
         beforeSyntax(binary, GSpace.Location.BINARY_PREFIX, p);
         visit(binary.getLeft(), p);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -796,7 +796,11 @@ public interface G extends J {
             NotIn,
             Access,
             Spaceship,
-            ElvisAssignment
+            ElvisAssignment,
+            Power,
+            PowerAssignment,
+            IdentityEquals,
+            IdentityNotEquals
         }
 
         public Padding getPadding() {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/BinaryTest.java
@@ -281,13 +281,49 @@ class BinaryTest implements RewriteTest {
         rewriteRun(
           groovy(
             """
-              def justPrint(){
-                  println(1 <=> 2)
-                  println('a' <=> 'z')
-                  def a = 'tiger'
-                  def b = 'cheetah'
-                  println(a <=> b)
-              }
+              println(1 <=> 2)
+              println('a' <=> 'z')
+              def a = 'tiger'
+              def b = 'cheetah'
+              println(a <=> b)
+              """
+          ));
+    }
+
+    @Test
+    void powerOperator() {
+        rewriteRun(
+          groovy(
+            """
+              4 ** 3
+              """
+          ));
+    }
+
+    @Test
+    void powerAssigmentOperator() {
+        rewriteRun(
+          groovy(
+            """
+              def f = 3
+              f **= 2
+              """
+          ));
+    }
+
+    @Test
+    void identicalOperators() {
+        rewriteRun(
+          groovy(
+            """
+              class Creature {}
+              
+              def cat = new Creature()
+              def copyCat = cat
+              def lion = new Creature()
+              
+              assert cat === copyCat
+              assert cat !== lion
               """
           ));
     }


### PR DESCRIPTION
## What's changed?
The `**`, `**=`, `===` and `!==` operators are supported.

## What's your motivation?
Improve groovy parser completeness.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
