### PR TITLE
Fix `UseStaticImport` creating ambiguous imports

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/UseStaticImportTest.java
@@ -346,4 +346,44 @@ class UseStaticImportTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/4776")
+    @Test
+    void shouldNotImportDuplicateMethod() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("test.B *(..)")),
+          java(
+            """
+              package test;
+              
+              public class A {
+                  public static void method() {}
+              }
+              """
+          ),
+          java(
+            """
+              package test;
+              
+              public class B {
+                  public static void method() {}
+              }
+              """
+          ),
+          java(
+            """
+              package test;
+              
+              import static test.A.method;
+              
+              public class Test {
+                  public static void test() {
+                      method();
+                      test.B.method();
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -102,6 +102,19 @@ public class UseStaticImport extends Recipe {
                     }
 
                     JavaType.FullyQualified receiverType = m.getMethodType().getDeclaringType();
+                    
+                    // Check if there's already a static import for a method with the same name from a different class
+                    J.CompilationUnit cu = getCursor().firstEnclosing(J.CompilationUnit.class);
+                    if (cu != null) {
+                        for (J.Import imp : cu.getImports()) {
+                            if (imp.isStatic() && imp.getQualid().getSimpleName().equals(m.getSimpleName())) {
+                                // There's already a static import for a method with this name
+                                // Don't add another one to avoid ambiguity
+                                return m;
+                            }
+                        }
+                    }
+                    
                     maybeRemoveImport(receiverType);
 
                     maybeAddImport(

--- a/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/UseStaticImport.java
@@ -102,25 +102,8 @@ public class UseStaticImport extends Recipe {
                     }
 
                     JavaType.FullyQualified receiverType = m.getMethodType().getDeclaringType();
-                    
-                    // Check if there's already a static import for a method with the same name from a different class
-                    J.CompilationUnit cu = getCursor().firstEnclosing(J.CompilationUnit.class);
-                    if (cu != null) {
-                        for (J.Import imp : cu.getImports()) {
-                            if (imp.isStatic() && imp.getQualid().getSimpleName().equals(m.getSimpleName())) {
-                                // There's already a static import for a method with this name
-                                // Don't add another one to avoid ambiguity
-                                return m;
-                            }
-                        }
-                    }
-                    
                     maybeRemoveImport(receiverType);
-
-                    maybeAddImport(
-                            receiverType.getFullyQualifiedName(),
-                            m.getSimpleName(),
-                            false);
+                    maybeAddImport(receiverType.getFullyQualifiedName(), m.getSimpleName(), false);
                 }
 
                 if (m.getSelect() != null) {
@@ -146,6 +129,15 @@ public class UseStaticImport extends Recipe {
     }
 
     private static boolean methodNameConflicts(String methodName, Cursor cursor) {
+        J.CompilationUnit cu = cursor.firstEnclosing(J.CompilationUnit.class);
+        if (cu != null) {
+            for (J.Import imp : cu.getImports()) {
+                if (imp.isStatic() && methodName.equals(imp.getQualid().getSimpleName())) {
+                    return true;
+                }
+            }
+        }
+
         Cursor cdCursor = cursor.dropParentUntil(it -> it instanceof J.ClassDeclaration || it == Cursor.ROOT_VALUE);
         Object maybeCd = cdCursor.getValue();
         if (!(maybeCd instanceof J.ClassDeclaration)) {
@@ -157,7 +149,7 @@ public class UseStaticImport extends Recipe {
             return false;
         }
 
-        if(methodNameConflicts(methodName, ct)) {
+        if (methodNameConflicts(methodName, ct)) {
             return true;
         }
 
@@ -165,7 +157,7 @@ public class UseStaticImport extends Recipe {
     }
 
     private static boolean methodNameConflicts(String methodName, JavaType.@Nullable FullyQualified ct) {
-        if(ct == null) {
+        if (ct == null) {
             return false;
         }
         for (JavaType.Method method : ct.getMethods()) {


### PR DESCRIPTION
## Summary
- Fixes #4776 where `UseStaticImport` recipe was creating ambiguous imports
- Adds check to prevent adding static imports when a method with the same name is already statically imported from a different class
- Closes https://github.com/openrewrite/rewrite/pull/5184

## Problem
The `UseStaticImport` recipe would add a static import for a method even when there was already a static import for a method with the same name from a different class. This caused compilation errors due to ambiguous method references.

For example, with existing static import `import static test.A.method;`, the recipe would still add `import static test.B.method;` when processing `test.B.method()`, causing an ambiguous reference error.

## Solution
Added a check in `UseStaticImportVisitor.visitMethodInvocation()` to verify if there's already a static import for a method with the same name before adding a new one. If found, the method invocation is left unchanged to avoid creating ambiguous imports.

## Test plan
- [x] Added test case `shouldNotImportDuplicateMethod()` that reproduces the issue
- [x] Verified the test fails without the fix and passes with the fix
- [x] All existing tests in `UseStaticImportTest` pass
- [x] Applied license formatting

🤖 Generated with [Claude Code](https://claude.ai/code)