### PR TITLE
Improve EmptyNewlineAtEndOfFile recipe

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/EmptyNewlineAtEndOfFileTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/EmptyNewlineAtEndOfFileTest.java
@@ -122,4 +122,27 @@ class EmptyNewlineAtEndOfFileTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void cleanupTooMuchEmptyNewlineCRLF() {
+        rewriteRun(
+          generalFormat(true),
+          java(
+            "class Test {}\r\n\r\n",
+            "class Test {}\r\n",
+            SourceSpec::noTrim
+          )
+        );
+    }
+
+    @Test
+    void dontChangeAnything() {
+        rewriteRun(
+          generalFormat(false),
+          java(
+            "class Test {}\r\n",
+            SourceSpec::noTrim
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Nothing.

## What's your motivation?
The recipe was in need of some refactoring, as it used a deprecated method + could use some utility methods as well.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
