### PR TITLE
remove duplicate dependency from Gradle build

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
@@ -70,6 +70,43 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
     }
 
     @Test
+    void remove_duplicate_when_no_version_present() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.apache.commons:commons-lang3")
+                  implementation("org.apache.commons:commons-lang3")
+              }
+              """,
+            """
+              plugins {
+                  id "java"
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
+                  implementation("org.apache.commons:commons-lang3")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void mapEntry() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Adding a test case for RemoveRedundantDependencyVersions

**Gradle build file**
```
dependencies {
  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
  implementation("org.apache.commons:commons-lang3")
  implementation("org.apache.commons:commons-lang3")
}
```

**Desired result**
```
dependencies {
  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.3.3"))
  implementation("org.apache.commons:commons-lang3")
}
```



## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
