### PR TITLE
`UpdateJavaCompatibility` supports `jvmToolchain` shorthand

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
@@ -558,6 +558,49 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
     }
 
     @Test
+    void handlesKotlinJvmToolchainInKotlinDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradleKts(
+            """
+              kotlin {
+                  jvmToolchain {
+                      languageVersion.set(JavaLanguageVersion.of(8))
+                  }
+              }
+              """,
+            """
+              kotlin {
+                  jvmToolchain {
+                      languageVersion.set(JavaLanguageVersion.of(11))
+                  }
+              }
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void handlesKotlinJvmToolchainShorthandInKotlinDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradleKts(
+            """
+              kotlin {
+                  jvmToolchain(8)
+              }
+              """,
+            """
+              kotlin {
+                  jvmToolchain(11)
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void toVersionInKotlinDSL() {
         rewriteRun(
           spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
@@ -179,8 +179,12 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
         );
     }
 
-    @Test
-    void handlesJavaToolchains() {
+    @CsvSource(textBlock = """
+      1.8,11
+      '1.8','11'
+      """, quoteCharacter = '`')
+    @ParameterizedTest
+    void handlesJavaToolchains(String beforeCompatibility, String afterCompatibility) {
         rewriteRun(
           spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
           buildGradle(
@@ -191,10 +195,10 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
               
               java {
                   toolchain {
-                      languageVersion = JavaLanguageVersion.of(8)
+                      languageVersion = JavaLanguageVersion.of(%s)
                   }
               }
-              """,
+              """.formatted(beforeCompatibility),
             """
               plugins {
                   id "java"
@@ -202,10 +206,10 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
               
               java {
                   toolchain {
-                      languageVersion = JavaLanguageVersion.of(11)
+                      languageVersion = JavaLanguageVersion.of(%s)
                   }
               }
-              """
+              """.formatted(afterCompatibility)
           )
         );
     }


### PR DESCRIPTION
## What's changed?
- Shorthand [jvmToolchain](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support) is updated.
- Support for [JavaLanguageVersion.of(‹string›)](https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaLanguageVersion.html#of(java.lang.String)).

## What's your motivation?
Code like 

```kotlin
kotlinVersion = '1.9.21'
 
kotlin {
  jvmToolchain(11)
}
```
 
was not picked up to be upgraded to a newer version.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
