### PR TITLE
Avoid overwriting parent pom from marker when going in child.

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -230,7 +230,7 @@ public class MavenResolutionResult implements Marker {
     }
 
     private Map<Path, Pom> getProjectPomsRecursive(Map<Path, Pom> projectPoms) {
-        projectPoms.put(requireNonNull(pom.getRequested().getSourcePath()), pom.getRequested());
+        projectPoms.putIfAbsent(requireNonNull(pom.getRequested().getSourcePath()), pom.getRequested());
         if (parent != null) {
             parent.getProjectPomsRecursive(projectPoms);
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/MavenResolutionResult.java
@@ -230,10 +230,10 @@ public class MavenResolutionResult implements Marker {
     }
 
     private Map<Path, Pom> getProjectPomsRecursive(Map<Path, Pom> projectPoms) {
-        projectPoms.putIfAbsent(requireNonNull(pom.getRequested().getSourcePath()), pom.getRequested());
-        if (parent != null) {
+        if (parent != null && !projectPoms.containsKey(parent.getPom().getRequested().getSourcePath())) {
             parent.getProjectPomsRecursive(projectPoms);
         }
+        projectPoms.put(requireNonNull(pom.getRequested().getSourcePath()), pom.getRequested());
         for (MavenResolutionResult module : modules) {
             if (!projectPoms.containsKey(module.getPom().getRequested().getSourcePath())) {
                 module.getProjectPomsRecursive(projectPoms);

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveLog4JBomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveLog4JBomTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.maven;
 
 import org.junit.jupiter.api.Test;

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveLog4JBomTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/RemoveLog4JBomTest.java
@@ -1,0 +1,98 @@
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class RemoveLog4JBomTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromYaml(
+          """
+            type: specs.openrewrite.org/v1beta/recipe
+            name: org.openrewrite.maven.RemoveLog4JBom
+            description: >-
+              Remove log4j-bom dependency because it's already defined in SB's BOM.
+            recipeList:
+              - org.openrewrite.maven.RemoveManagedDependency:
+                  groupId: org.apache.logging.log4j
+                  artifactId: log4j-bom
+              - org.openrewrite.maven.RemoveDependency:
+                  groupId: org.apache.logging.log4j
+                  artifactId: log4j-bom
+              - org.openrewrite.maven.RemoveProperty:
+                  propertyName: log4j2.version
+            """,
+          "org.openrewrite.maven.RemoveLog4JBom");
+    }
+
+    @Test
+    void removeLog4JBom() {
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <groupId>dummyGroupId</groupId>
+                  <artifactId>parentArtifactId</artifactId>
+                  <version>1.0.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+              
+                  <properties>
+                      <log4j2.version>2.17.1</log4j2.version>
+                  </properties>
+              
+                  <modules>
+                      <module>child-module</module>
+                  </modules>
+              
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.apache.logging.log4j</groupId>
+                               <artifactId>log4j-bom</artifactId>
+                              <version>${log4j2.version}</version>
+                              <scope>import</scope>
+                              <type>pom</type>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>dummyGroupId</groupId>
+                  <artifactId>parentArtifactId</artifactId>
+                  <version>1.0.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+              
+                  <modules>
+                      <module>child-module</module>
+                  </modules>
+              </project>
+              """,
+            s -> s.path("pom.xml")
+          ),
+          pomXml(
+            """
+              <project>
+                  <parent>
+                    <groupId>dummyGroupId</groupId>
+                    <artifactId>parentArtifactId</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <relativePath>../pom.xml</relativePath>
+                  </parent>
+              
+                  <artifactId>child-artifact</artifactId>
+                  <packaging>jar</packaging>
+                  <name>child-module</name>
+              
+              </project>
+              """,
+            s -> s.path("child-module/pom.xml")
+          )
+        );
+    }
+}


### PR DESCRIPTION
Thanks for the helpful reproducers @xLitil 

## What's changed?
By only `put`ting if absent, the resulting `Map` now contains the requested pom of the level in the hierarchy and not the deeper nested ones. As we make changes to the pom itself and not to the child's parent references, the update marker was failing to resolve due to a child's requested pom overwriting the parent requested pom.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite/issues/5673

## Anything in particular you'd like reviewers to focus on?
Should we rework the code to update all the child's parent references when removing dependency? I think this should suffice as the parents references are update in a later stage to the newly calculated parent. We just had to be able to calculate the parent which was failing. 

Now I also wonder if we can ever come in the situation where we do not start from the parent in that marker building that Map as that would then use the nested one and not the parent However, we could easily traverse to the highest parent first before building the map resulting in always the same MAP/pom values to be present iso the entry point where you called the method. Traversing to `parent == null` first would mean some more loops, but also acceptable imho. That would be more correct. 

## Anyone you would like to review specifically?
@timtebeek please see comment above and inform me what you think would be best

## Related issues
- https://github.com/openrewrite/rewrite/issues/4949
- https://github.com/openrewrite/rewrite/issues/5144

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
