### PR TITLE
Add `exclusions` and `applyTo` options to CoalesceProperties

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
@@ -15,11 +15,37 @@
  */
 package org.openrewrite.yaml;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
 public class CoalesceProperties extends Recipe {
+
+    @Option(displayName = "Exclusions",
+            description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions to specify keys that should not be unfolded.",
+            example = "$..[org.springframework.security]")
+    List<String> exclusions;
+
+    @Option(displayName = "Apply to",
+            description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions that specify which keys the recipe should target only. " +
+                    "Only the properties matching these expressions will be unfolded.",
+            example = "$..[org.springframework.security]")
+    List<String> applyTo;
+
+    public CoalesceProperties(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
+        this.exclusions = exclusions == null ? emptyList() : exclusions;
+        this.applyTo = applyTo == null ? emptyList() : applyTo;
+    }
 
     @Override
     public String getDisplayName() {
@@ -33,6 +59,6 @@ public class CoalesceProperties extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new CoalescePropertiesVisitor<>();
+        return new CoalescePropertiesVisitor<>(exclusions, applyTo);
     }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
@@ -42,6 +42,10 @@ public class CoalesceProperties extends Recipe {
             example = "$..[org.springframework.security]")
     List<String> applyTo;
 
+    public CoalesceProperties() {
+        this(null, null);
+    }
+
     public CoalesceProperties(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
         this.exclusions = exclusions == null ? emptyList() : exclusions;
         this.applyTo = applyTo == null ? emptyList() : applyTo;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalesceProperties.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.yaml;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
@@ -46,6 +47,7 @@ public class CoalesceProperties extends Recipe {
         this(null, null);
     }
 
+    @JsonCreator
     public CoalesceProperties(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
         this.exclusions = exclusions == null ? emptyList() : exclusions;
         this.applyTo = applyTo == null ? emptyList() : applyTo;

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
@@ -94,9 +94,8 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
             Cursor current = c;
             if (matchers.stream().anyMatch(it -> it.matches(current))) {
                 return true;
-            } else {
-                c = c.getParent();
             }
+            c = c.getParent();
         }
         return false;
     }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
@@ -16,6 +16,7 @@
 
 package org.openrewrite.yaml;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.internal.ListUtils;
@@ -36,6 +37,7 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
         this(null, null);
     }
 
+    @JsonCreator
     public CoalescePropertiesVisitor(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
         exclusionMatchers = exclusions == null ? emptyList() : exclusions.stream().map(JsonPathMatcher::new).collect(toList());
         applyToMatchers = applyTo == null ? emptyList() : applyTo.stream().map(JsonPathMatcher::new).collect(toList());

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
@@ -18,10 +18,10 @@ package org.openrewrite.yaml;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.yaml.search.FindIndentYamlVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -29,16 +29,12 @@ import static java.util.stream.Collectors.toList;
 
 public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
     private final FindIndentYamlVisitor<P> findIndent = new FindIndentYamlVisitor<>();
-    private final List<String> exclusions;
-    private final List<String> applyTo;
-    private List<JsonPathMatcher> exclusionMatchers;
-    private List<JsonPathMatcher> applyToMatchers;
+    private final List<JsonPathMatcher> exclusionMatchers;
+    private final List<JsonPathMatcher> applyToMatchers;
 
     public CoalescePropertiesVisitor(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
-        this.exclusions = exclusions == null ? emptyList() : exclusions;
-        this.applyTo = applyTo == null ? emptyList() : applyTo;
-        exclusionMatchers = this.exclusions.stream().map(JsonPathMatcher::new).collect(toList());
-        applyToMatchers = this.applyTo.stream().map(JsonPathMatcher::new).collect(toList());
+        exclusionMatchers = exclusions == null ? emptyList() : exclusions.stream().map(JsonPathMatcher::new).collect(toList());
+        applyToMatchers = applyTo == null ? emptyList() : applyTo.stream().map(JsonPathMatcher::new).collect(toList());
     }
 
     @Override
@@ -51,99 +47,53 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
     }
 
     @Override
-    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, P p) {
-        int levels = 0;
-        Cursor c = getCursor();
-        while (c != null && !c.isRoot()) {
-            Cursor current = c;
-            boolean foundMatch = exclusionMatchers.stream().anyMatch(it -> it.matches(current));
-            if (foundMatch) {
-                for (int i = 0; i <= levels; i++) {
-                    getCursor().getParent(i).putMessage("COALESCE_COLLAPSING", false);
-                }
-                break;
-            } else {
-                c = c.getParent();
-                levels++;
-            }
-        }
-        return e;
-    }
-
-    @Override
     public Yaml.Mapping visitMapping(Yaml.Mapping mapping, P p) {
         Yaml.Mapping m = super.visitMapping(mapping, p);
 
-        boolean allowCoalesce = getCursor().getMessage("COALESCE_COLLAPSING", true);
-        if (!allowCoalesce) {
-            return m;
-        }
-        boolean changed = false;
-        List<Yaml.Mapping.Entry> entries = new ArrayList<>();
-
-        for (Yaml.Mapping.Entry entry : m.getEntries()) {
+        return m.withEntries(ListUtils.map(m.getEntries(), entry -> {
             if (entry.getValue() instanceof Yaml.Mapping) {
                 Yaml.Mapping valueMapping = (Yaml.Mapping) entry.getValue();
-                if (valueMapping.getEntries().size() == 1) { //&& !matchesExclusion(entry) && matchesApplyTo(entry)) {
+                if (valueMapping.getEntries().size() == 1) {
                     Yaml.Mapping.Entry subEntry = valueMapping.getEntries().iterator().next();
-                    if (!subEntry.getPrefix().contains("#")) {// && !matchesExclusion(subEntry) && matchesApplyTo(subEntry)) {
-                        Yaml.Scalar coalescedKey = ((Yaml.Scalar) entry.getKey()).withValue(entry.getKey().getValue() + "." + subEntry.getKey().getValue());
-
-                        entries.add(entry.withKey(coalescedKey)
-                                .withValue(subEntry.getValue()));
-
+                    if (!subEntry.getPrefix().contains("#") && !isExcluded(entry, subEntry) && isApplied(entry)) {
                         int indentToUse = findIndent.getMostCommonIndent() > 0 ? findIndent.getMostCommonIndent() : 4;
                         doAfterVisit(new ShiftFormatLeftVisitor<>(subEntry.getValue(), indentToUse));
 
-                        changed = true;
-                    } else {
-                        entries.add(entry);
+                        Yaml.Scalar coalescedKey = ((Yaml.Scalar) entry.getKey()).withValue(entry.getKey().getValue() + "." + subEntry.getKey().getValue());
+                        return entry.withKey(coalescedKey).withValue(subEntry.getValue());
                     }
-                } else {
-                    entries.add(entry);
                 }
-            } else {
-                entries.add(entry);
             }
-        }
-
-        if (changed) {
-            m = m.withEntries(entries);
-        }
-
-        return m;
+            return entry;
+        }));
     }
 
-    private boolean matchesExclusion(Yaml.Mapping.Entry entry) {
-        boolean foundMatch = false;
+    private boolean isExcluded(Yaml.Mapping.Entry entry, Yaml.Mapping.Entry subEntry) {
+        if (exclusionMatchers.isEmpty()) {
+            return false;
+        }
         Cursor c = new Cursor(getCursor(), entry);
-        while (c != null && !c.isRoot()) {
-            Cursor current = c;
-            foundMatch = exclusionMatchers.stream().anyMatch(it -> it.matches(current));
-            if (foundMatch) {
-                return foundMatch;
-            } else {
-                c = c.getParent();
-            }
-        }
-        return foundMatch;
+        Cursor c2 = new Cursor(c, subEntry);
+        return match(c, exclusionMatchers) || exclusionMatchers.stream().anyMatch(it -> it.matches(c2));
     }
 
-    private boolean matchesApplyTo(Yaml.Mapping.Entry entry) {
+    private boolean isApplied(Yaml.Mapping.Entry entry) {
         if (applyToMatchers.isEmpty()) {
             return true;
         }
-        boolean foundMatch = false;
         Cursor c = new Cursor(getCursor(), entry);
+        return match(c, applyToMatchers);
+    }
+
+    private boolean match(Cursor c, List<JsonPathMatcher> matchers) {
         while (c != null && !c.isRoot()) {
             Cursor current = c;
-            foundMatch = applyToMatchers.stream().anyMatch(it -> it.matches(current));
-            if (foundMatch) {
-                return foundMatch;
+            if (matchers.stream().anyMatch(it -> it.matches(current))) {
+                return true;
             } else {
                 c = c.getParent();
             }
         }
-        return foundMatch;
+        return false;
     }
 }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
@@ -60,7 +60,7 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
             if (entry.getValue() instanceof Yaml.Mapping) {
                 Yaml.Mapping valueMapping = (Yaml.Mapping) entry.getValue();
                 if (valueMapping.getEntries().size() == 1) {
-                    Yaml.Mapping.Entry subEntry = valueMapping.getEntries().iterator().next();
+                    Yaml.Mapping.Entry subEntry = valueMapping.getEntries().get(0);
                     if (!subEntry.getPrefix().contains("#") && !isExcluded(entry, subEntry) && isApplied(entry)) {
                         int indentToUse = findIndent.getMostCommonIndent() > 0 ? findIndent.getMostCommonIndent() : 4;
                         doAfterVisit(new ShiftFormatLeftVisitor<>(subEntry.getValue(), indentToUse));

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/CoalescePropertiesVisitor.java
@@ -32,6 +32,10 @@ public class CoalescePropertiesVisitor<P> extends YamlIsoVisitor<P> {
     private final List<JsonPathMatcher> exclusionMatchers;
     private final List<JsonPathMatcher> applyToMatchers;
 
+    public CoalescePropertiesVisitor() {
+        this(null, null);
+    }
+
     public CoalescePropertiesVisitor(@Nullable final List<String> exclusions, @Nullable final List<String> applyTo) {
         exclusionMatchers = exclusions == null ? emptyList() : exclusions.stream().map(JsonPathMatcher::new).collect(toList());
         applyToMatchers = applyTo == null ? emptyList() : applyTo.stream().map(JsonPathMatcher::new).collect(toList());

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/UnfoldProperties.java
@@ -42,12 +42,12 @@ public class UnfoldProperties extends Recipe {
     private static final Pattern LINE_BREAK = Pattern.compile("\\R");
 
     @Option(displayName = "Exclusions",
-            description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions to specify keys that should not be unfolded.",
+            description = "An optional list of [JsonPath Plus](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions to specify keys that should not be unfolded.",
             example = "$..[org.springframework.security]")
     List<String> exclusions;
 
     @Option(displayName = "Apply to",
-            description = "An optional list of [JsonPath](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions that specify which keys the recipe should target only. " +
+            description = "An optional list of [JsonPath Plus](https://docs.openrewrite.org/reference/jsonpath-and-jsonpathmatcher-reference) expressions that specify which keys the recipe should target only. " +
                     "Only the properties matching these expressions will be unfolded.",
             example = "$..[org.springframework.security]")
     List<String> applyTo;
@@ -174,7 +174,7 @@ public class UnfoldProperties extends Recipe {
 
             /**
              * Matches a key against a JsonPath pattern.
-             * It uses a custom JsonPathParser to parse keys with dots, like `logging.level`.
+             * It uses a custom JsonPathParser to parse keys with dots, like `logging.level`, and support the @property.match operator.
              *
              * @return found group or empty if no match was found
              */

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
@@ -128,7 +128,7 @@ public class YamlVisitor<P> extends TreeVisitor<Yaml, P> {
     @Deprecated
     public void maybeCoalesceProperties() {
         if (getAfterVisit().stream().noneMatch(CoalescePropertiesVisitor.class::isInstance)) {
-            doAfterVisit(new CoalescePropertiesVisitor<>());
+            doAfterVisit(new CoalescePropertiesVisitor<>(null, null));
         }
     }
 

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlVisitor.java
@@ -128,7 +128,7 @@ public class YamlVisitor<P> extends TreeVisitor<Yaml, P> {
     @Deprecated
     public void maybeCoalesceProperties() {
         if (getAfterVisit().stream().noneMatch(CoalescePropertiesVisitor.class::isInstance)) {
-            doAfterVisit(new CoalescePropertiesVisitor<>(null, null));
+            doAfterVisit(new CoalescePropertiesVisitor<>());
         }
     }
 

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
@@ -33,6 +33,76 @@ class CoalescePropertiesTest implements RewriteTest {
     }
 
     @Test
+    void blah2() {
+        rewriteRun(
+          // "$..[\"endpoint.health\"]"
+          spec -> spec.recipe(new CoalesceProperties(List.of("$..[endpoint.health]"), null)),
+          //language=yaml
+          yaml(
+//            """
+//              spring:
+//                application:
+//                  name: my-app
+//              logging:
+//                level:
+//                  root: INFO
+//                  org.springframework.web: DEBUG
+//              management:
+//                metrics:
+//                  enable.process.files: true
+//                endpoint:
+//                  health:
+//                    something:
+//                      yeah: true
+//                    show-components: always
+//                    show-details: always
+//              """,
+            """
+              management:
+                metrics:
+                  enable.process.files: true
+                endpoint:
+                  health:
+                    something:
+                      yeah: true
+                    show-components: always
+                    show-details: always
+              """,
+//            """
+//              management:
+//                metrics:
+//                  enable.process.files: true
+//                endpoint.health:
+//                  something:
+//                    yeah: true
+//                  show-components: always
+//                  show-details: always
+//              """,
+//            """
+//              spring.application.name: my-app
+//              logging.level:
+//                root: INFO
+//                org.springframework.web: DEBUG
+//              management:
+//                metrics.enable.process.files: true
+//                endpoint.health:
+//                  something.yeah: true
+//                  show-components: always
+//                  show-details: always
+//              """,
+            """
+              management:
+                metrics.enable.process.files: true
+                endpoint.health:
+                  something.yeah: true
+                  show-components: always
+                  show-details: always
+              """
+          )
+        );
+    }
+
+    @Test
     void blah() {
         rewriteRun(
           spec -> spec.recipe(new CoalesceProperties(List.of("$..[endpoint.health][?(@property.match(/.*/))]", "$..[logging.level][?(@property.match(/.*/))]"), List.of("$..spring[?(@property.match(/.*/))]"))),

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
@@ -32,140 +32,26 @@ class CoalescePropertiesTest implements RewriteTest {
         spec.recipe(new CoalesceProperties(null, null));
     }
 
-    @Test
-    void blah2() {
-        rewriteRun(
-          // "$..[\"endpoint.health\"]"
-          spec -> spec.recipe(new CoalesceProperties(List.of("$..[endpoint.health]"), null)),
-          //language=yaml
-          yaml(
-//            """
-//              spring:
-//                application:
-//                  name: my-app
-//              logging:
-//                level:
-//                  root: INFO
-//                  org.springframework.web: DEBUG
-//              management:
-//                metrics:
-//                  enable.process.files: true
-//                endpoint:
-//                  health:
-//                    something:
-//                      yeah: true
-//                    show-components: always
-//                    show-details: always
-//              """,
-            """
-              management:
-                metrics:
-                  enable.process.files: true
-                endpoint:
-                  health:
-                    something:
-                      yeah: true
-                    show-components: always
-                    show-details: always
-              """,
-//            """
-//              management:
-//                metrics:
-//                  enable.process.files: true
-//                endpoint.health:
-//                  something:
-//                    yeah: true
-//                  show-components: always
-//                  show-details: always
-//              """,
-//            """
-//              spring.application.name: my-app
-//              logging.level:
-//                root: INFO
-//                org.springframework.web: DEBUG
-//              management:
-//                metrics.enable.process.files: true
-//                endpoint.health:
-//                  something.yeah: true
-//                  show-components: always
-//                  show-details: always
-//              """,
-            """
-              management:
-                metrics.enable.process.files: true
-                endpoint.health:
-                  something.yeah: true
-                  show-components: always
-                  show-details: always
-              """
-          )
-        );
-    }
-
-    @Test
-    void blah() {
-        rewriteRun(
-          spec -> spec.recipe(new CoalesceProperties(List.of("$..[endpoint.health][?(@property.match(/.*/))]", "$..[logging.level][?(@property.match(/.*/))]"), List.of("$..spring[?(@property.match(/.*/))]"))),
-          yaml(
-            """
-              spring:
-                application:
-                  name: my-app
-              logging:
-                level:
-                  root: INFO
-                  org.springframework.web: DEBUG
-              management:
-                metrics:
-                  enable.process.files: true
-                endpoint:
-                  health:
-                    something:
-                      yeah: true
-                    show-components: always
-                    show-details: always
-              """,
-            """
-              spring:
-                application.name: my-app
-              logging:
-                level:
-                  root: INFO
-                  org.springframework.web: DEBUG
-              management:
-                metrics:
-                  enable.process.files: true
-                endpoint:
-                  health:
-                    something:
-                      yeah: true
-                    show-components: always
-                    show-details: always
-              """
-          )
-        );
-    }
-
     @DocumentExample
     @Test
     void fold() {
         rewriteRun(
           yaml(
             """
-                  management:
-                      metrics:
-                          enable.process.files: true
-                      endpoint:
-                          health:
-                              show-components: always
-                              show-details: always
-              """,
-            """
-                  management:
-                      metrics.enable.process.files: true
-                      endpoint.health:
+              management:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health:
                           show-components: always
                           show-details: always
+              """,
+            """
+              management:
+                  metrics.enable.process.files: true
+                  endpoint.health:
+                      show-components: always
+                      show-details: always
               """
           )
         );
@@ -177,19 +63,8 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                foo:
-                  bar:
-                    sequence:
-                      - name: name
-                        propertyA: fieldA
-                        propertyB: fieldB
-                      - name: name
-                        propertyA: fieldA
-                        propertyB: fieldB
-                    scalar: value
-              """,
-            """
-                foo.bar:
+              foo:
+                bar:
                   sequence:
                     - name: name
                       propertyA: fieldA
@@ -198,6 +73,17 @@ class CoalescePropertiesTest implements RewriteTest {
                       propertyA: fieldA
                       propertyB: fieldB
                   scalar: value
+              """,
+            """
+              foo.bar:
+                sequence:
+                  - name: name
+                    propertyA: fieldA
+                    propertyB: fieldB
+                  - name: name
+                    propertyA: fieldA
+                    propertyB: fieldB
+                scalar: value
               """
           )
         );
@@ -209,19 +95,8 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                matrix:
-                  include:
-                  # comment-a
-                  # comment-b
-                  - name: entry-0-name # comment-c
-                      # comment-d
-                    value: entry-0-value
-                    # comment-e
-                  - name: entry-1-name
-                    value: entry-1-value
-              """,
-            """
-                matrix.include:
+              matrix:
+                include:
                 # comment-a
                 # comment-b
                 - name: entry-0-name # comment-c
@@ -230,6 +105,17 @@ class CoalescePropertiesTest implements RewriteTest {
                   # comment-e
                 - name: entry-1-name
                   value: entry-1-value
+              """,
+            """
+              matrix.include:
+              # comment-a
+              # comment-b
+              - name: entry-0-name # comment-c
+                  # comment-d
+                value: entry-0-value
+                # comment-e
+              - name: entry-1-name
+                value: entry-1-value
               """
           )
         );
@@ -271,9 +157,9 @@ class CoalescePropertiesTest implements RewriteTest {
               management.metrics.enable.jvm: true
               """,
             """
-                  management.metrics.enable:
-                      process.files: true
-                      jvm: true
+              management.metrics.enable:
+                  process.files: true
+                  jvm: true
               """
           )
         );
@@ -285,18 +171,18 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                  a:
-                    b:
-                      # d-comment
-                      d:
-                        e.f: true
-                      c: c-value
+              a:
+                b:
+                  # d-comment
+                  d:
+                    e.f: true
+                  c: c-value
               """,
             """
-                  a.b:
-                    # d-comment
-                    d.e.f: true
-                    c: c-value
+              a.b:
+                # d-comment
+                d.e.f: true
+                c: c-value
               """
           )
         );
@@ -308,21 +194,21 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                  a:
-                    b:
-                    # d-comment
-                      d:
-                        e.f: true
-                     # c-comment
-                      c:
-                        d: d-value
+              a:
+                b:
+                # d-comment
+                  d:
+                    e.f: true
+                 # c-comment
+                  c:
+                    d: d-value
               """,
             """
-                  a.b:
-                  # d-comment
-                    d.e.f: true
-                   # c-comment
-                    c.d: d-value
+              a.b:
+              # d-comment
+                d.e.f: true
+               # c-comment
+                c.d: d-value
               """
           )
         );
@@ -334,23 +220,23 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                  a:
-                    b:
-                      d: # d-comment
-                        e:
-                          f: f-value # f-comment
-                      c:
-                        # g-comment
-                        g:
-                          h: h-value
+              a:
+                b:
+                  d: # d-comment
+                    e:
+                      f: f-value # f-comment
+                  c:
+                    # g-comment
+                    g:
+                      h: h-value
               """,
             """
-                  a.b:
-                    d: # d-comment
-                      e.f: f-value # f-comment
-                    c:
-                      # g-comment
-                      g.h: h-value
+              a.b:
+                d: # d-comment
+                  e.f: f-value # f-comment
+                c:
+                  # g-comment
+                  g.h: h-value
               """
           )
         );
@@ -362,21 +248,21 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                a:
-                  b:
-                    c: c-value  # c-comment
-                    d: d-value # d-comment
-                    e: e-value   # e-comment
-                    f: f-value
-                    g: g-value
+              a:
+                b:
+                  c: c-value  # c-comment
+                  d: d-value # d-comment
+                  e: e-value   # e-comment
+                  f: f-value
+                  g: g-value
               """,
             """
-                  a.b:
-                    c: c-value  # c-comment
-                    d: d-value # d-comment
-                    e: e-value   # e-comment
-                    f: f-value
-                    g: g-value
+              a.b:
+                c: c-value  # c-comment
+                d: d-value # d-comment
+                e: e-value   # e-comment
+                f: f-value
+                g: g-value
               """
           )
         );
@@ -388,14 +274,104 @@ class CoalescePropertiesTest implements RewriteTest {
         rewriteRun(
           yaml(
             """
-                  management:
-                      metrics:
-                          &id enable.process.files: true
-                      endpoint:
-                          health:
-                              show-components: always
-                              show-details: always
-                              *id: false
+              management:
+                  metrics:
+                      &id enable.process.files: true
+                  endpoint:
+                      health:
+                          show-components: always
+                          show-details: always
+                          *id: false
+              """
+          )
+        );
+    }
+
+    @Test
+    void exclusion() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(List.of("$..logging", "$..some"), null)),
+          yaml(
+            """
+              a:
+                first:
+                  logging:
+                    level:
+                      com.company.extern.service: DEBUG
+                      com.another.package: INFO
+              some:
+                things:
+                  else: value
+              """,
+            """
+              a.first:
+                logging:
+                  level:
+                    com.company.extern.service: DEBUG
+                    com.another.package: INFO
+              some:
+                things:
+                  else: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void applyTo() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(null, List.of("$..logging", "$..some"))),
+          yaml(
+            """
+              a:
+                first:
+                  logging:
+                    level:
+                      com.company.extern.service: DEBUG
+                      com.another.package: INFO
+              some:
+                things:
+                  else: value
+              """,
+            """
+              a:
+                first:
+                  logging.level:
+                    com.company.extern.service: DEBUG
+                    com.another.package: INFO
+              some.things.else: value
+              """
+          )
+        );
+    }
+
+    @Test
+    void applyToWithExclusion() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(List.of("$..endpoint"), List.of("$.management2"))),
+          yaml(
+            """
+              management:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              management2:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              """,
+            """
+              management:
+                  metrics:
+                      enable.process.files: true
+                  endpoint:
+                      health.show-components: always
+              management2:
+                  metrics.enable.process.files: true
+                  endpoint:
+                      health.show-components: always
               """
           )
         );

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
@@ -29,7 +29,7 @@ import static org.openrewrite.yaml.Assertions.yaml;
 class CoalescePropertiesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new CoalesceProperties(null, null));
+        spec.recipe(new CoalesceProperties());
     }
 
     @DocumentExample

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/CoalescePropertiesTest.java
@@ -22,12 +22,58 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
 import static org.openrewrite.yaml.Assertions.yaml;
 
 class CoalescePropertiesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new CoalesceProperties());
+        spec.recipe(new CoalesceProperties(null, null));
+    }
+
+    @Test
+    void blah() {
+        rewriteRun(
+          spec -> spec.recipe(new CoalesceProperties(List.of("$..[endpoint.health][?(@property.match(/.*/))]", "$..[logging.level][?(@property.match(/.*/))]"), List.of("$..spring[?(@property.match(/.*/))]"))),
+          yaml(
+            """
+              spring:
+                application:
+                  name: my-app
+              logging:
+                level:
+                  root: INFO
+                  org.springframework.web: DEBUG
+              management:
+                metrics:
+                  enable.process.files: true
+                endpoint:
+                  health:
+                    something:
+                      yeah: true
+                    show-components: always
+                    show-details: always
+              """,
+            """
+              spring:
+                application.name: my-app
+              logging:
+                level:
+                  root: INFO
+                  org.springframework.web: DEBUG
+              management:
+                metrics:
+                  enable.process.files: true
+                endpoint:
+                  health:
+                    something:
+                      yeah: true
+                    show-components: always
+                    show-details: always
+              """
+          )
+        );
     }
 
     @DocumentExample


### PR DESCRIPTION
## What’s changed?
The CoalesceProperties recipe now supports two additional options: exclusions and applyTo.

## What’s the motivation?
With the introduction and growing use of the UnfoldProperties recipe, which acts as the counterpart to CoalesceProperties, the two recipes became slightly unbalanced in terms of functionality. By adding these two new options, the CoalesceProperties recipe now aligns more closely with its counterpart.

## Additional context
The UnfoldProperties recipe supports certain features of JsonPath Plus syntax. This was essential for that recipe to handle dotted keys correctly, as it would not function without that capability. However, this is not the case for CoalesceProperties, which can operate without dot support. Therefore, I opted to keep this version simpler and limited the enhancement to elevating the JsonPathMatcher.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
