### PR TITLE
Javascript - add support for generics in JSX/TSX tags

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,8 @@
       "mcp__idea__search_in_files_content",
       "Bash(cat:*)",
       "Bash(../gradlew dependencies:*)",
-      "Bash(gradle:*)"
+      "Bash(gradle:*)",
+      "Bash(npm run build:*)"
     ],
     "deny": []
   }

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3548,6 +3548,7 @@ export class JavaScriptParserVisitor {
             prefix: this.prefix(node),
             markers: emptyMarkers,
             openName: this.leftPadded(this.prefix(node.openingElement), this.visit(node.openingElement.tagName)),
+            typeArguments: node.openingElement.typeArguments && this.mapTypeArguments(this.suffix(node.openingElement.tagName), node.openingElement.typeArguments),
             afterName: attrs.length === 0 ?
                 this.prefix(this.findChildNode(node.openingElement, ts.SyntaxKind.GreaterThanToken)!) :
                 emptySpace,
@@ -3571,6 +3572,7 @@ export class JavaScriptParserVisitor {
             prefix: this.prefix(node),
             markers: emptyMarkers,
             openName: this.leftPadded(this.prefix(node.tagName), this.visit(node.tagName)),
+            typeArguments: node.typeArguments && this.mapTypeArguments(this.suffix(node.tagName), node.typeArguments),
             afterName: attrs.length === 0 ?
                 this.prefix(this.findChildNode(node, ts.SyntaxKind.GreaterThanToken)!) :
                 emptySpace,

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -98,6 +98,9 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
     override async visitJsxTag(element: JSX.Tag, p: PrintOutputCapture): Promise<J | undefined> {
         await this.beforeSyntax(element, p);
         await this.visitLeftPaddedLocal("<", element.openName, p);
+        if (element.typeArguments) {
+            await this.visitContainerLocal("<", element.typeArguments, ",", ">", p);
+        }
         await this.visitSpace(element.afterName, p);
         await this.visitRightPaddedLocal(element.attributes, "", p);
 

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -383,6 +383,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
 
     override async visitJsxTag(tag: JSX.Tag, q: RpcSendQueue): Promise<J | undefined> {
         await q.getAndSend(tag, el => el.openName, el => this.visitLeftPadded(el, q));
+        await q.getAndSend(tag, el => el.typeArguments, el => this.visitContainer(el, q));
         await q.getAndSend(tag, el => el.afterName, space => this.visitSpace(space, q));
         await q.getAndSendList(tag, el => el.attributes, attr => attr.element.id, attr => this.visitRightPadded(attr, q));
 
@@ -962,6 +963,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     override async visitJsxTag(tag: JSX.Tag, q: RpcReceiveQueue): Promise<J | undefined> {
         const draft = createDraft(tag);
         draft.openName = await q.receive(draft.openName, el => this.visitLeftPadded(el, q));
+        draft.typeArguments = await q.receive(draft.typeArguments, el => this.visitContainer(el, q));
         draft.afterName = await q.receive(draft.afterName, space => this.visitSpace(space, q));
         draft.attributes = await q.receiveListDefined(draft.attributes, attr => this.visitRightPadded(attr, q));
 

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -857,6 +857,7 @@ export namespace JSX {
     interface BaseTag extends JS, Expression {
         readonly kind: typeof JS.Kind.JsxTag;
         readonly openName: J.LeftPadded<J.Identifier | J.FieldAccess | NamespacedName | J.Empty>;
+        readonly typeArguments?: J.Container<Expression>;
         readonly afterName: J.Space;
         readonly attributes: J.RightPadded<Attribute | SpreadAttribute>[];
     }

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -127,6 +127,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
     protected async visitJsxTag(element: JSX.Tag, p: P): Promise<J | undefined> {
         return this.produceJavaScript<JSX.Tag>(element, p, async draft => {
             draft.openName = await this.visitLeftPadded(element.openName, p);
+            draft.typeArguments = element.typeArguments && await this.visitContainer(element.typeArguments, p);
             draft.afterName = await this.visitSpace(element.afterName, p);
             draft.attributes = await mapAsync(element.attributes, attr => this.visitRightPadded(attr, p));
             draft.selfClosing = element.selfClosing && await this.visitSpace(element.selfClosing, p);

--- a/rewrite-javascript/rewrite/test/javascript/parser/jsx.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/jsx.test.ts
@@ -96,4 +96,57 @@ describe("jsx mapping", () => {
             `)
         )
     );
+
+    test("jsx element with single generic type argument", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`<SeeHowToRunGraphQL<DevCenterQueryVariables> />`)
+        )
+    );
+
+    test("jsx element with multiple generic type arguments", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`<Component<string, number> prop="value" />`)
+        )
+    );
+
+    test("jsx element with generic type arguments and children", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`
+                <Container<ItemType>>
+                    <Item />
+                </Container>
+            `)
+        )
+    );
+
+    test("jsx self-closing element with complex generic types", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`<DataTable<{ id: number; name: string }> data={items} />`)
+        )
+    );
+
+    test("jsx element with nested generics", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`<List<Array<Record<string, any>>> items={data} />`)
+        )
+    );
+
+    test("jsx element with union type generic", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`<Component<string | number> props={data} />`)
+        )
+    );
+
+    test("jsx element with member expression and generics", () =>
+        spec.rewriteRun(
+            //language=tsx
+            tsx(`<Components.Table<UserData> columns={columns} />`)
+        )
+    );
 });

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/JavaScriptParserTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/JavaScriptParserTest.java
@@ -166,6 +166,13 @@ class JavaScriptParserTest {
                   >
                     <p>This div uses regular attributes, spread attributes, and namespaced attributes</p>
                   </div>
+
+                  {/* JSX elements with generics */}
+                  <DataTable<User> data={[]} />
+                  <Component<string, number> prop="value" />
+                  <Form<FormData> onSubmit={() => {}}>
+                    <Input name="username" />
+                  </Form>
                 </div>
           
                 {/* Short fragment syntax */}

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -1030,6 +1030,9 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         }
 
         t = t.getPadding().withOpenName(requireNonNull(visitLeftPadded(t.getPadding().getOpenName(), JLeftPadded.Location.LANGUAGE_EXTENSION, p)));
+        if (t.getTypeArguments() != null) {
+            t = t.withTypeArguments(visitContainer(t.getTypeArguments(), JContainer.Location.TYPE_PARAMETERS, p));
+        }
         t = t.withAfterName(visitSpace(t.getAfterName(), Space.Location.LANGUAGE_EXTENSION, p));
         t = t.getPadding().withAttributes(requireNonNull(ListUtils.map(t.getPadding().getAttributes(), attr -> visitRightPadded(attr, JRightPadded.Location.LANGUAGE_EXTENSION, p))));
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -444,6 +444,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     public J visitJsxTag(JSX.Tag tag, RpcReceiveQueue q) {
         return tag
                 .getPadding().withOpenName(q.receive(tag.getPadding().getOpenName(), name1 -> visitLeftPadded(name1, q)))
+                .withTypeArguments(q.receive(tag.getTypeArguments(), el -> visitContainer(el, q)))
                 .withAfterName(q.receive(tag.getAfterName(), space2 -> visitSpace(space2, q)))
                 .getPadding().withAttributes(q.receiveList(tag.getPadding().getAttributes(), attr -> visitRightPadded(attr, q)))
                 .withSelfClosing(q.receive(tag.getSelfClosing(), space1 -> visitSpace(space1, q)))

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -433,6 +433,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     @Override
     public J visitJsxTag(JSX.Tag tag, RpcSendQueue q) {
         q.getAndSend(tag, el -> el.getPadding().getOpenName(), el -> visitLeftPadded(el, q));
+        q.getAndSend(tag, JSX.Tag::getTypeArguments, el -> visitContainer(el, q));
         q.getAndSend(tag, JSX.Tag::getAfterName, space -> visitSpace(space, q));
         q.getAndSendList(tag, el -> el.getPadding().getAttributes(), attr -> attr.getElement().getId(), attr -> visitRightPadded(attr, q));
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JSX.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JSX.java
@@ -72,6 +72,17 @@ public interface JSX extends JS {
             return getPadding().withOpenName(JLeftPadded.withElement(this.openName, openName));
         }
 
+        @Nullable
+        JContainer<Expression> typeArguments;
+
+        public @Nullable JContainer<Expression> getTypeArguments() {
+            return typeArguments;
+        }
+
+        public Tag withTypeArguments(@Nullable JContainer<Expression> typeArguments) {
+            return getPadding().withTypeArguments(typeArguments);
+        }
+
         @Getter
         @With
         Space afterName;
@@ -164,7 +175,15 @@ public interface JSX extends JS {
             }
 
             public Tag withOpenName(JLeftPadded<NameTree> openName) {
-                return t.openName == openName ? t : new Tag(t.id, t.prefix, t.markers, openName, t.afterName, t.attributes, t.selfClosing, t.children, t.closingName, t.afterClosingName);
+                return t.openName == openName ? t : new Tag(t.id, t.prefix, t.markers, openName, t.typeArguments, t.afterName, t.attributes, t.selfClosing, t.children, t.closingName, t.afterClosingName);
+            }
+
+            public @Nullable JContainer<Expression> getTypeArguments() {
+                return t.typeArguments;
+            }
+
+            public Tag withTypeArguments(@Nullable JContainer<Expression> typeArguments) {
+                return t.typeArguments == typeArguments ? t : new Tag(t.id, t.prefix, t.markers, t.openName, typeArguments, t.afterName, t.attributes, t.selfClosing, t.children, t.closingName, t.afterClosingName);
             }
 
             public List<JRightPadded<JSX>> getAttributes() {
@@ -172,7 +191,7 @@ public interface JSX extends JS {
             }
 
             public Tag withAttributes(List<JRightPadded<JSX>> attributes) {
-                return t.attributes == attributes ? t : new Tag(t.id, t.prefix, t.markers, t.openName, t.afterName, attributes, t.selfClosing, t.children, t.closingName, t.afterClosingName);
+                return t.attributes == attributes ? t : new Tag(t.id, t.prefix, t.markers, t.openName, t.typeArguments, t.afterName, attributes, t.selfClosing, t.children, t.closingName, t.afterClosingName);
             }
 
             public @Nullable JLeftPadded<J> getClosingName() {
@@ -180,7 +199,7 @@ public interface JSX extends JS {
             }
 
             public Tag withClosingName(@Nullable JLeftPadded<J> closingName) {
-                return t.closingName == closingName ? t : new Tag(t.id, t.prefix, t.markers, t.openName, t.afterName, t.attributes, t.selfClosing, t.children, closingName, t.afterClosingName);
+                return t.closingName == closingName ? t : new Tag(t.id, t.prefix, t.markers, t.openName, t.typeArguments, t.afterName, t.attributes, t.selfClosing, t.children, closingName, t.afterClosingName);
             }
         }
     }


### PR DESCRIPTION
## What's changed?

Adding support for generics in JSX tags.

## What's your motivation?

It was missed when JSX supported was added. And people use this feature, so why not?
