### PR TITLE
 fix: prevent variable renaming in class literal references

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RenameVariableTest.java
@@ -957,6 +957,30 @@ class RenameVariableTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/5843")
+    @Test
+    void doNotRenameClassLiterals() {
+        rewriteRun(
+          spec -> spec.recipe(renameVariableTest("FooBarBaz", "fooBarBaz", true)),
+          java(
+            """
+              class FooBarBaz {}
+              class A {
+                FooBarBaz FooBarBaz = new FooBarBaz();
+                Class<?> clazz = FooBarBaz.class;
+              }
+              """,
+            """
+              class FooBarBaz {}
+              class A {
+                FooBarBaz fooBarBaz = new FooBarBaz();
+                Class<?> clazz = FooBarBaz.class;
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4059")
     @Test
     void renameTypeCastedField() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RenameVariable.java
@@ -88,6 +88,10 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
                     it instanceof SourceFile).getValue() instanceof Javadoc.Parameter) {
                 return ident;
             }
+            
+            // Skip if this identifier is part of a class literal (e.g., FooBarBaz.class)
+            if (isClassLiteralReference(getCursor())) return ident;
+            
             Cursor parent = getCursor().getParentTreeCursor();
             if (ident.getSimpleName().equals(renameVariable.getSimpleName())) {
                 if (ident.getFieldType() != null && ident.getFieldType().getOwner() instanceof JavaType.FullyQualified &&
@@ -126,6 +130,16 @@ public class RenameVariable<P> extends JavaIsoVisitor<P> {
                 }
             }
             return super.visitIdentifier(ident, p);
+        }
+
+        // Returns true if the identifier is part of a class literal (e.g., FooBarBaz.class)
+        private boolean isClassLiteralReference(Cursor cursor) {
+            Cursor parent = cursor.getParentTreeCursor();
+            if (parent.getValue() instanceof J.FieldAccess) {
+                J.FieldAccess parentValue = parent.getValue();
+                return "class".equals(parentValue.getName().getSimpleName());
+            }
+            return false;
         }
 
         @Override


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This PR fixes an issue in the `RenameVariable` recipe where class literal references (e.g., `SomeClass.class`) were not correctly detected, potentially causing incorrect renaming. The detection logic now checks if the parent AST node is a `J.FieldAccess` whose name is `"class"`, which is the canonical OpenRewrite representation of a class literal.

## What's your motivation?
Fixes incorrect renaming of variables when encountering class literal references. This ensures that class literals are not affected by the rename operation. (No linked issue, but discovered during recipe usage and test coverage.)

- Closes https://github.com/openrewrite/rewrite/issues/5843

## Anything in particular you'd like reviewers to focus on?
Please review the logic in `RenameVariable.RenameVariableVisitor#isClassLiteralReference` and the associated unit test `RenameVariableTest#doNotRenameClassLiterals`. I'm not sure if you guys prefer to use the getCursor() in the isClassLiteralReference directly.

## Have you considered any alternatives or workarounds?
I considered walking further up the AST or using a utility, but the current approach is the canonical and idiomatic way for OpenRewrite's AST structure.

## Any additional context
- An issue was openned https://github.com/openrewrite/rewrite/issues/5843
A unit test was added in `RenameVariableTest` named `doNotRenameClassLiterals` to demonstrate the issue and verify the fix. All tests pass locally.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
