### PR TITLE
Don't use sonatype.org repositories when downloading artifacts

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -827,6 +827,11 @@ public class MavenPomDownloader {
 
         // Add repositories passed as parameter
         for (MavenRepository repo : repositories) {
+            // Skip decommissioned sonatype repositories, as these are no longer functional and will slow down the dependency resolution by 60 seconds
+            // See also: https://central.sonatype.org/news/20240109_issues_sonatype_org_deprecation/ and https://central.sonatype.org/pages/ossrh-eol/
+            if (repo.getUri().contains("sonatype.org")) {
+                continue;
+            }
             repositoriesById.put(repo.getId(), repo);
         }
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -132,7 +132,7 @@ class MavenPomDownloaderTest implements RewriteTest {
                   <repositories>
                       <repository>
                           <id>local-provided</id>
-                          <url>https://oss.sonatype.org/content/repositories/releases</url>
+                          <url>https://repo1.maven.org/maven2/</url>
                       </repository>
                   </repositories>
               </project>


### PR DESCRIPTION
## What's changed?
The `sonatype.org` repositories are no longer used when doing the dependency resolution/

## What's your motivation?
As of June 30, 2025 OSSRH has reached end of life and has been shut down (see [this](https://central.sonatype.org/pages/ossrh-eol/)). If you still try to resolve dependencies from there, I doesn't do anything but can add up a 60-second delay in dependency resolution (depending whether this repository will be used when actually resolving dependencies).

## Have you considered any alternatives or workarounds?
Is removing these repositories from resolution the right way? Or should we not add this to the code base at all, as the actual problem lies in the user settings and/or in the pom / gradle files. 