### PR TITLE
Fix the error message when a recipe test generates source files the test does not expect

### DIFF
--- a/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/RewriteTest.java
@@ -596,8 +596,7 @@ public interface RewriteTest extends SourceSpecs {
             String paths = resultToUnexpected.entrySet().stream()
                     .map(it -> {
                         Result result = it.getKey();
-                        assert result.getAfter() != null;
-                        String beforePath = (result.getBefore() == null) ? "null" : result.getAfter().getSourcePath().toString();
+                        String beforePath = (result.getBefore() == null) ? "null" : result.getBefore().getSourcePath().toString();
                         String afterPath = (result.getAfter() == null) ? "null" : result.getAfter().getSourcePath().toString();
                         String status = it.getValue() ? "❌️" : "✔";
                         return "    " + beforePath + " | " + afterPath + " | " + status;


### PR DESCRIPTION
## What's changed?
Error message "The recipe generated source files the test did not expect" is always shown when needed.

## What's your motivation?
When the `after` result is null and a test-fail message should be reported, it throwed a npe. Also the report was wrong when the `after` result was not null, as the after source was used as before source.
