### PR TITLE
UpgradeTransitiveDependencyVersion should only compare name when comparing the config with the GradleDependencyConfiguration

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -267,10 +267,16 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                                     for (GradleDependencyConfiguration config : all.keySet()) {
                                                         outer:
                                                         for (GradleDependencyConfiguration gc : c.allExtendsFrom()) {
-                                                            if (gc.getName().equals(config.getName()) && gc.getRequested().size() == config.getRequested().size()) {
+                                                            if (gc.getName().equals(config.getName()) &&
+                                                                    gc.getRequested().size() == config.getRequested().size()) {
+                                                                // Check if all dependencies match, only looking at groupId and artifactId
                                                                 for (int i = 0; i < gc.getRequested().size(); i++) {
-                                                                    if (!Objects.equals(gc.getRequested().get(i).getGroupId(), config.getRequested().get(i).getGroupId()) ||
-                                                                        !gc.getRequested().get(i).getArtifactId().equals(config.getRequested().get(i).getArtifactId())) {
+                                                                    if (!Objects.equals(
+                                                                            gc.getRequested().get(i).getGroupId(),
+                                                                            config.getRequested().get(i).getGroupId()) ||
+                                                                        !Objects.equals(
+                                                                                gc.getRequested().get(i).getArtifactId(),
+                                                                                config.getRequested().get(i).getArtifactId())) {
                                                                         continue outer;
                                                                     }
                                                                 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -241,7 +241,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                             }
                         }
                         for (ResolvedDependency resolved : configuration.getResolved()) {
-                            if (resolved.getDepth() > 0 && dependencyMatcher.matches(resolved.getGroupId(), resolved.getArtifactId(), resolved.getVersion())) {
+                            if (resolved.isTransitive() && dependencyMatcher.matches(resolved.getGroupId(), resolved.getArtifactId(), resolved.getVersion())) {
                                 try {
                                     String selected = versionSelector.select(resolved.getGav(), configuration.getName(), version, versionPattern, ctx);
                                     if (selected == null || resolved.getVersion().equals(selected)) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -265,8 +265,17 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                                     }
 
                                                     for (GradleDependencyConfiguration config : all.keySet()) {
-                                                        if (c.allExtendsFrom().contains(config)) {
-                                                            return true;
+                                                        outer:
+                                                        for (GradleDependencyConfiguration gc : c.allExtendsFrom()) {
+                                                            if (gc.getName().equals(config.getName()) && gc.getRequested().size() == config.getRequested().size()) {
+                                                                for (int i = 0; i < gc.getRequested().size(); i++) {
+                                                                    if (!Objects.equals(gc.getRequested().get(i).getGroupId(), config.getRequested().get(i).getGroupId()) ||
+                                                                        !gc.getRequested().get(i).getArtifactId().equals(config.getRequested().get(i).getArtifactId())) {
+                                                                        continue outer;
+                                                                    }
+                                                                }
+                                                                return true;
+                                                            }
                                                         }
 
                                                         // TODO there has to be a better way!

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -265,21 +265,8 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                                     }
 
                                                     for (GradleDependencyConfiguration config : all.keySet()) {
-                                                        extendsFrom:
                                                         for (GradleDependencyConfiguration gc : c.allExtendsFrom()) {
-                                                            if (gc.getName().equals(config.getName()) &&
-                                                                    gc.getRequested().size() == config.getRequested().size()) {
-                                                                // Check if all dependencies match, only looking at groupId and artifactId
-                                                                for (int i = 0; i < gc.getRequested().size(); i++) {
-                                                                    if (!Objects.equals(
-                                                                            gc.getRequested().get(i).getGroupId(),
-                                                                            config.getRequested().get(i).getGroupId()) ||
-                                                                        !Objects.equals(
-                                                                                gc.getRequested().get(i).getArtifactId(),
-                                                                                config.getRequested().get(i).getArtifactId())) {
-                                                                        continue extendsFrom;
-                                                                    }
-                                                                }
+                                                            if (gc.getName().equals(config.getName())) {
                                                                 return true;
                                                             }
                                                         }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -265,7 +265,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                                     }
 
                                                     for (GradleDependencyConfiguration config : all.keySet()) {
-                                                        outer:
+                                                        extendsFrom:
                                                         for (GradleDependencyConfiguration gc : c.allExtendsFrom()) {
                                                             if (gc.getName().equals(config.getName()) &&
                                                                     gc.getRequested().size() == config.getRequested().size()) {
@@ -277,7 +277,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                                                         !Objects.equals(
                                                                                 gc.getRequested().get(i).getArtifactId(),
                                                                                 config.getRequested().get(i).getArtifactId())) {
-                                                                        continue outer;
+                                                                        continue extendsFrom;
                                                                     }
                                                                 }
                                                                 return true;

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1298,7 +1298,9 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
               @Override
               public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
                   if (tree instanceof G.CompilationUnit) {
-                      // A recipe that makes changes to an existing dependency in the Gradle's build file
+                      // A recipe that updates an existing dependency in the Gradle build file.
+                      // That dependency itself declares the one targeted by UpgradeTransitiveDependencyVersion as a transitive dependency.
+                      // In this case, "org.openrewrite:rewrite-java" has "com.fasterxml.jackson.core:jackson-databind" as a transitive dependency.
                       UpgradeDependencyVersion upgrade = new UpgradeDependencyVersion("org.openrewrite", "rewrite-java", "8.0.0", null);
                       UpgradeDependencyVersion.DependencyVersionState acc = upgrade.getInitialValue(ctx);
                       upgrade.getScanner(acc).visit(tree, ctx);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1291,18 +1291,19 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
     @Test
     void upgradeDependencyVersionBeforeApplyingTheUpgradeTransitiveDependencyVersion() {
         rewriteRun(
-          // This test simulates a scenario where a recipe first applies an UpgradeDependencyVersion, followed immediately by an UpgradeTransitiveDependencyVersion internally.
           // We use an imperative recipe rather than a declarative recipeList, because in a declarative recipeList, all recipes perform their scanning phase first and only then perform their editing phase.
-          // In this test case, we want the second recipe to scan and edit based on the output of the first recipe’s changes.
+          // In this test case, we want the UpgradeTransitiveDependencyVersion recipe to scan and edit based on the output of the first recipe’s changes.
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
               @Override
               public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
                   if (tree instanceof G.CompilationUnit) {
+                      // A recipe that makes changes to Gradle's build file
                       UpgradeDependencyVersion upgrade = new UpgradeDependencyVersion("org.openrewrite", "rewrite-java", "8.0.0", null);
                       UpgradeDependencyVersion.DependencyVersionState acc = upgrade.getInitialValue(ctx);
                       upgrade.getScanner(acc).visit(tree, ctx);
                       tree = upgrade.getVisitor(acc).visit(tree, ctx);
 
+                      // Use the changed tree as input for a UpgradeTransitiveDependencyVersion run
                       UpgradeTransitiveDependencyVersion upgradeTransitive = new UpgradeTransitiveDependencyVersion("com.fasterxml.jackson.core", "jackson-databind", "2.15.1", null, null, null);
                       UpgradeTransitiveDependencyVersion.DependencyVersionState accTransitive2 = upgradeTransitive.getInitialValue(ctx);
                       upgradeTransitive.getScanner(accTransitive2).visit(tree, ctx);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1329,7 +1329,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
 
               dependencies {
                   constraints {
-                      testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
+                      implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
                   }
 
                   implementation 'org.openrewrite:rewrite-java:7.0.0'
@@ -1344,7 +1344,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
 
               dependencies {
                   constraints {
-                      implementation('com.fasterxml.jackson.core:jackson-databind:2.15.1')
+                      implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
                   }
 
                   implementation 'org.openrewrite:rewrite-java:8.0.1'

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -31,6 +33,7 @@ import java.util.List;
 import static org.openrewrite.gradle.Assertions.*;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
 
@@ -1278,6 +1281,74 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
             """
               gradle.ext {
                   jacksonVersion = '2.12.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void upgradeDependencyVersionAndThenTransitiveTwice() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                  // First round
+                  UpgradeDependencyVersion upgrade = new UpgradeDependencyVersion("org.openrewrite", "rewrite-java", "8.0.0", null);
+                  UpgradeDependencyVersion.DependencyVersionState acc = upgrade.getInitialValue(ctx);
+                  upgrade.getScanner(acc).visit(tree, ctx);
+
+                  UpgradeTransitiveDependencyVersion upgradeTransitive = new UpgradeTransitiveDependencyVersion("com.fasterxml.jackson.core", "jackson-databind", "2.12.3", null, null, null);
+                  UpgradeTransitiveDependencyVersion.DependencyVersionState accTransitive = upgradeTransitive.getInitialValue(ctx);
+                  upgradeTransitive.getScanner(accTransitive).visit(tree, ctx);
+
+                  tree = upgrade.getVisitor(acc).visit(tree, ctx);
+                  tree = upgradeTransitive.getVisitor(accTransitive).visit(tree, ctx);
+
+                  // Second round
+                  UpgradeDependencyVersion upgrade2 = new UpgradeDependencyVersion("org.openrewrite", "rewrite-java", "8.0.1", null);
+                  UpgradeDependencyVersion.DependencyVersionState acc2 = upgrade2.getInitialValue(ctx);
+                  upgrade2.getScanner(acc2).visit(tree, ctx);
+
+                  UpgradeTransitiveDependencyVersion upgradeTransitive2 = new UpgradeTransitiveDependencyVersion("com.fasterxml.jackson.core", "jackson-databind", "2.15.1", null, null, null);
+                  UpgradeTransitiveDependencyVersion.DependencyVersionState accTransitive2 = upgradeTransitive2.getInitialValue(ctx);
+                  upgradeTransitive2.getScanner(accTransitive2).visit(tree, ctx);
+
+                  tree = upgrade2.getVisitor(acc2).visit(tree, ctx);
+                  tree = upgradeTransitive2.getVisitor(accTransitive2).visit(tree, ctx);
+
+                  return super.visit(tree, ctx);
+              }
+          })),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  constraints {
+                      testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
+                  }
+
+                  implementation 'org.openrewrite:rewrite-java:7.0.0'
+                  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+              }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  constraints {
+                      implementation('com.fasterxml.jackson.core:jackson-databind:2.15.1')
+                  }
+
+                  implementation 'org.openrewrite:rewrite-java:8.0.1'
+                  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
               }
               """
           )

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1292,12 +1292,13 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
     void upgradeDependencyVersionBeforeApplyingTheUpgradeTransitiveDependencyVersion() {
         rewriteRun(
           // We use an imperative recipe rather than a declarative recipeList, because in a declarative recipeList, all recipes perform their scanning phase first and only then perform their editing phase.
-          // In this test case, we want the UpgradeTransitiveDependencyVersion recipe to scan and edit based on the output of the first recipe’s changes.
+          // In this test case, we want the UpgradeTransitiveDependencyVersion recipe to scan and edit based on the output of the first recipe’s changes,
+          // to reflect a recipe downstream that uses this kind of setup.
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
               @Override
               public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
                   if (tree instanceof G.CompilationUnit) {
-                      // A recipe that makes changes to Gradle's build file
+                      // A recipe that makes changes to an existing dependency in the Gradle's build file
                       UpgradeDependencyVersion upgrade = new UpgradeDependencyVersion("org.openrewrite", "rewrite-java", "8.0.0", null);
                       UpgradeDependencyVersion.DependencyVersionState acc = upgrade.getInitialValue(ctx);
                       upgrade.getScanner(acc).visit(tree, ctx);
@@ -1323,9 +1324,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                   constraints {
                       implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
                   }
-
                   implementation 'org.openrewrite:rewrite-java:7.0.0'
-                  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
               }
               """,
             """
@@ -1338,9 +1337,7 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
                   constraints {
                       implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
                   }
-
                   implementation 'org.openrewrite:rewrite-java:8.0.0'
-                  testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
               }
               """
           )

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersion.java
@@ -136,7 +136,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<AddManage
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
                 Set<ResolvedDependency> matchingDependencies = getResolutionResult().findDependencies(groupId, artifactId, null)
                         .stream()
-                        .filter(dep -> dep.getDepth() > 0)
+                        .filter(ResolvedDependency::isTransitive)
                         .collect(toCollection(LinkedHashSet::new));
                 if (matchingDependencies.isEmpty()) {
                     return document;


### PR DESCRIPTION
## What's changed?
When the GradleDependencyConfiguration is compared, it should not take the version into account. This PR replaces by a `c.allExtendsFrom().contains(config)` call to a loop where only the _name_ is used for comparison.

## What's your motivation?
With the change of
- https://github.com/openrewrite/rewrite/pull/5794

the recipe turned into a scanning recipe, which means when in the scanning phase, no changes to the code have been made. If this recipe is run multiple times by another recipe (so still one recipe run), this has an impact on the resolution. Instead of the versions already been upgraded, it can differ between runs and scans. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
