### PR TITLE
Ensure Maven parser uses last-wins strategy for duplicate dependencies

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -980,7 +980,7 @@ public class ResolvedPom {
             Scope dScope = Scope.fromName(d.getScope());
             if (dScope == scope || dScope.transitiveOf(scope) == scope) {
                 // TODO can we always use the Map.put approach? Using the latest one is Maven specific, but this resolving is also used for gradle which does use highest version.
-                //  We could introduce a ResolutionStrategy to handle this and use Map.merge where we take later occurring one for LAST_WINS/MAVEN and higher version one for HIGHEST_VERSION_WINS/GRADLE
+                //  We could introduce a ResolutionStrategy to handle this and use Map.merge where we take later occurring one for LAST_WINS/MAVEN and higher version one for LATEST_WINS/GRADLE
                 rootDependencies.put(d.getGav().asGroupArtifact(), new DependencyAndDependent(requestedDependency, Scope.Compile, null, requestedDependency, this));
             }
         }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ResolvedPom.java
@@ -974,17 +974,20 @@ public class ResolvedPom {
                                                         MavenPomDownloader downloader, ExecutionContext ctx) throws MavenDownloadingExceptions {
         List<ResolvedDependency> dependencies = new ArrayList<>();
 
-        List<DependencyAndDependent> dependenciesAtDepth = new ArrayList<>();
+        Map<GroupArtifact, DependencyAndDependent> rootDependencies = new HashMap<>();
         for (Dependency requestedDependency : getRequestedDependencies()) {
             Dependency d = getValues(requestedDependency, 0);
             Scope dScope = Scope.fromName(d.getScope());
             if (dScope == scope || dScope.transitiveOf(scope) == scope) {
-                dependenciesAtDepth.add(new DependencyAndDependent(requestedDependency, Scope.Compile, null, requestedDependency, this));
+                // TODO can we always use the Map.put approach? Using the latest one is Maven specific, but this resolving is also used for gradle which does use highest version.
+                //  We could introduce a ResolutionStrategy to handle this and use Map.merge where we take later occurring one for LAST_WINS/MAVEN and higher version one for HIGHEST_VERSION_WINS/GRADLE
+                rootDependencies.put(d.getGav().asGroupArtifact(), new DependencyAndDependent(requestedDependency, Scope.Compile, null, requestedDependency, this));
             }
         }
 
         MavenDownloadingExceptions exceptions = null;
         int depth = 0;
+        Collection<DependencyAndDependent> dependenciesAtDepth = rootDependencies.values();
         while (!dependenciesAtDepth.isEmpty()) {
             List<DependencyAndDependent> dependenciesAtNextDepth = new ArrayList<>();
 

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/ChangeDependencyGroupIdAndArtifactIdTest.java
@@ -98,6 +98,62 @@ class ChangeDependencyGroupIdAndArtifactIdTest implements RewriteTest {
         );
     }
 
+    @Test
+    void recurringDependenciesGetUpdated() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeDependencyGroupIdAndArtifactId(
+            "com.google.guava",
+            "guava",
+            "jakarta.activation",
+            "jakarta.activation-api",
+            "1.2.1",
+            null
+          )),
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.google.guava</groupId>
+                          <artifactId>guava</artifactId>
+                          <version>25.0-jre</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.google.guava</groupId>
+                          <artifactId>guava</artifactId>
+                          <version>23.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jakarta.activation</groupId>
+                          <artifactId>jakarta.activation-api</artifactId>
+                          <version>1.2.1</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>jakarta.activation</groupId>
+                          <artifactId>jakarta.activation-api</artifactId>
+                          <version>1.2.1</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4514")
     @Test
     void shouldNotAddNewIfDependencyAlreadyExists() {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -4099,8 +4099,8 @@ class MavenParserTest implements RewriteTest {
         );
     }
 
-    @ValueSource(strings = {"latest", "release"})
     @ParameterizedTest
+    @ValueSource(strings = {"latest", "release"})
     void latestOrReleaseVersionInDependencyManagement(String version) {
         rewriteRun(
           pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
 import org.openrewrite.maven.http.OkHttpSender;
@@ -3966,6 +3967,134 @@ class MavenParserTest implements RewriteTest {
                     );
               }
             )
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.13.0,2.13.0"})
+    void lastListedDependencyIsUsed(String firstVersion, String secondVersion) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>%s</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>%s</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """.formatted(firstVersion, secondVersion),
+            spec -> spec.afterRecipe(pom -> {
+                MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(secondVersion);
+            })
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2.15.0,runtime,2.13.0,test", "2.13.0,runtime,2.15.0,test", "2.13.0,runtime,2.13.0,test", "2.15.0,compile,2.13.0,test", "2.13.0,compile,2.15.0,test", "2.13.0,compile,2.13.0,test"})
+    void lastListedDependencyIsUsedForScope(String firstVersion, String firstScope, String secondVersion, String secondScope) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>%s</version>
+                    <scope>%s</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>%s</version>
+                    <scope>%s</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """.formatted(firstVersion, firstScope, secondVersion, secondScope),
+            spec -> spec.afterRecipe(pom -> {
+                MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.fromName(firstScope)))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(firstVersion);
+                assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.fromName(secondScope)))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(secondVersion);
+            })
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.13.0,2.13.0"})
+    void lastListedDependencyIsUsedForTransitiveScope(String firstVersion, String secondVersion) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+
+                <dependencies>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>%s</version>
+                    <scope>test</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                    <version>%s</version>
+                    <scope>compile</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """.formatted(firstVersion, secondVersion),
+            spec -> spec.afterRecipe(pom -> {
+                MavenResolutionResult resolution = pom.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow();
+                assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Test))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(secondVersion);
+                assertThat(resolution.findDependencies("com.fasterxml.jackson.core", "jackson-core", Scope.Compile))
+                  .hasSize(1)
+                  .extracting(ResolvedDependency::getGav)
+                  .extracting(ResolvedGroupArtifactVersion::getVersion)
+                  .containsExactly(secondVersion);
+            })
           )
         );
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -3971,8 +3971,8 @@ class MavenParserTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
     @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.13.0,2.13.0"})
+    @ParameterizedTest
     void lastListedDependencyIsUsed(String firstVersion, String secondVersion) {
         rewriteRun(
           pomXml(
@@ -4009,8 +4009,8 @@ class MavenParserTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
     @CsvSource({"2.15.0,runtime,2.13.0,test", "2.13.0,runtime,2.15.0,test", "2.13.0,runtime,2.13.0,test", "2.15.0,compile,2.13.0,test", "2.13.0,compile,2.15.0,test", "2.13.0,compile,2.13.0,test"})
+    @ParameterizedTest
     void lastListedDependencyIsUsedForScope(String firstVersion, String firstScope, String secondVersion, String secondScope) {
         rewriteRun(
           pomXml(
@@ -4054,8 +4054,8 @@ class MavenParserTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
     @CsvSource({"2.15.0,2.13.0", "2.13.0,2.15.0", "2.13.0,2.13.0"})
+    @ParameterizedTest
     void lastListedDependencyIsUsedForTransitiveScope(String firstVersion, String secondVersion) {
         rewriteRun(
           pomXml(
@@ -4099,8 +4099,8 @@ class MavenParserTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
     @ValueSource(strings = {"latest", "release"})
+    @ParameterizedTest
     void latestOrReleaseVersionInDependencyManagement(String version) {
         rewriteRun(
           pomXml(

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -2008,6 +2008,53 @@ class UpgradeDependencyVersionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void mavenUsesLatestMentionedArtifactForResolution() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "29.0", "-jre", null, null)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>25.0-jre</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>23.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>25.0-jre</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>29.0-jre</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
     @Disabled("Service Unavailable")
     @Test
     void exactVersionMissingInMavenMetadata() {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/cleanup/PrefixlessExpressionsTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/cleanup/PrefixlessExpressionsTest.java
@@ -39,9 +39,9 @@ class PrefixlessExpressionsTest implements RewriteTest {
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
-                <version>1.0</version>
+                <version>1.0.0</version>
                 <properties>
-                  <other.version>1.0.0</other.version>
+                  <other.version>1.0</other.version>
                 </properties>
                 <dependencies>
                   <dependency>
@@ -72,9 +72,9 @@ class PrefixlessExpressionsTest implements RewriteTest {
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
-                <version>1.0</version>
+                <version>1.0.0</version>
                 <properties>
-                  <other.version>1.0.0</other.version>
+                  <other.version>1.0</other.version>
                 </properties>
                 <dependencies>
                   <dependency>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsDotTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsDotTest.java
@@ -59,8 +59,8 @@ class PrintMavenAsDotTest implements RewriteTest {
             """
             <!--~~(digraph main {
             0 [label="com.mycompany.app:my-app:1"];
-            1 [label="org.yaml:snakeyaml:1.27"];
-            2 [label="org.junit.jupiter:junit-jupiter:5.7.0"];
+            1 [label="org.junit.jupiter:junit-jupiter:5.7.0"];
+            2 [label="org.yaml:snakeyaml:1.27"];
             3 [label="org.junit.jupiter:junit-jupiter-api:5.7.0"];
             4 [label="org.junit.jupiter:junit-jupiter-params:5.7.0"];
             5 [label="org.junit.jupiter:junit-jupiter-engine:5.7.0"];
@@ -69,16 +69,16 @@ class PrintMavenAsDotTest implements RewriteTest {
             8 [label="org.opentest4j:opentest4j:1.2.0"];
             9 [label="org.junit.platform:junit-platform-commons:1.7.0"];
             10 [label="org.junit.platform:junit-platform-engine:1.7.0"];
-            0 -> 1 [taillabel="Compile"];
-            0 -> 2 [taillabel="Test"];
-            2 -> 3 [taillabel="Test"];
+            0 -> 2 [taillabel="Compile"];
+            0 -> 1 [taillabel="Test"];
+            1 -> 3 [taillabel="Test"];
             3 -> 7 [taillabel="Test"];
             3 -> 8 [taillabel="Test"];
             3 -> 9 [taillabel="Test"];
-            2 -> 4 [taillabel="Test"];
-            2 -> 5 [taillabel="Test"];
+            1 -> 4 [taillabel="Test"];
+            1 -> 5 [taillabel="Test"];
             5 -> 10 [taillabel="Test"];
-            2 -> 6 [taillabel="Test"];
+            1 -> 6 [taillabel="Test"];
             })~~>--><project>
               <groupId>com.mycompany.app</groupId>
               <artifactId>my-app</artifactId>

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsDotTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/utilities/PrintMavenAsDotTest.java
@@ -59,8 +59,8 @@ class PrintMavenAsDotTest implements RewriteTest {
             """
             <!--~~(digraph main {
             0 [label="com.mycompany.app:my-app:1"];
-            1 [label="org.junit.jupiter:junit-jupiter:5.7.0"];
-            2 [label="org.yaml:snakeyaml:1.27"];
+            1 [label="org.yaml:snakeyaml:1.27"];
+            2 [label="org.junit.jupiter:junit-jupiter:5.7.0"];
             3 [label="org.junit.jupiter:junit-jupiter-api:5.7.0"];
             4 [label="org.junit.jupiter:junit-jupiter-params:5.7.0"];
             5 [label="org.junit.jupiter:junit-jupiter-engine:5.7.0"];
@@ -69,16 +69,16 @@ class PrintMavenAsDotTest implements RewriteTest {
             8 [label="org.opentest4j:opentest4j:1.2.0"];
             9 [label="org.junit.platform:junit-platform-commons:1.7.0"];
             10 [label="org.junit.platform:junit-platform-engine:1.7.0"];
-            0 -> 2 [taillabel="Compile"];
-            0 -> 1 [taillabel="Test"];
-            1 -> 3 [taillabel="Test"];
+            0 -> 1 [taillabel="Compile"];
+            0 -> 2 [taillabel="Test"];
+            2 -> 3 [taillabel="Test"];
             3 -> 7 [taillabel="Test"];
             3 -> 8 [taillabel="Test"];
             3 -> 9 [taillabel="Test"];
-            1 -> 4 [taillabel="Test"];
-            1 -> 5 [taillabel="Test"];
+            2 -> 4 [taillabel="Test"];
+            2 -> 5 [taillabel="Test"];
             5 -> 10 [taillabel="Test"];
-            1 -> 6 [taillabel="Test"];
+            2 -> 6 [taillabel="Test"];
             })~~>--><project>
               <groupId>com.mycompany.app</groupId>
               <artifactId>my-app</artifactId>


### PR DESCRIPTION
## What's changed?
Using a `Map<GroupArtifact, DependencyAndDependent>` instead of a `List<DependencyAndDependent>` we can use the `put` method to overwrite earlier occurring requested `DependencyAndDependent` objects in the pom. 
**TODO**: verify with @sambsnyd if we do not want to use the `merge` method and introduce a ResolutionStrategy to differentiate between Maven's last-wins and Gradle's latest-wins.

## What's your motivation?
Maven resolves duplicate dependencies by using the last declaration. Previously, our parser did not follow this behavior, causing issues where only the first occurrence was updated by recipes, but the effective version was still determined by the last. This change updates the parser logic to ensure that, when multiple dependencies with the same coordinates are declared, the last one takes precedence, matching Maven's resolution strategy.

## Anyone you would like to review specifically?
@sambsnyd 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
