### PR TITLE
Parse extra semicolons into whitespace

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/ToBeRemoved.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/ToBeRemoved.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * be commented like in this example:
  * <pre>
  * // TO-BE-REMOVED(2025-12-31): for unexplainable reasons this code is required in production
- * for (int i = 0; i < 42; i++) {
+ * for (int i = 0; i != 42; i++) {
  *     System.out.println(i);
  * }
  * </pre>

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ImportTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/ImportTest.java
@@ -15,9 +15,11 @@
  */
 package org.openrewrite.java.tree;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
@@ -181,6 +183,58 @@ class ImportTest implements RewriteTest {
           java(
             """
               import java.util.List ;
+              """
+          )
+        );
+    }
+
+    @Disabled("Parser does not support semicolon after package declaration yet")
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/396")
+    @Test
+    void semicolonAfterPackage() {
+        //language=java
+        rewriteRun(
+          spec -> spec
+            .typeValidationOptions(TypeValidation.all().allowNonWhitespaceInWhitespace(true)),
+          java(
+            """
+              package p;;
+              import java.util.List;
+              class AfterPackage { }
+              """
+          )
+        );
+    }
+
+    @Disabled("Parser does not support semicolon between imports yet")
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/396")
+    @Test
+    void semicolonBetweenImports() {
+        //language=java
+        rewriteRun(
+          spec -> spec
+            .typeValidationOptions(TypeValidation.all().allowNonWhitespaceInWhitespace(true)),
+          java(
+            """
+              import java.util.List;
+              ;import java.util.Set;
+              class BetweenImport { }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/396")
+    @Test
+    void semicolonAfterImports() {
+        //language=java
+        rewriteRun(
+          spec -> spec
+            .typeValidationOptions(TypeValidation.all().allowNonWhitespaceInWhitespace(true)),
+          java(
+            """
+              import java.util.List;
+              ;class BetweenImport { }
               """
           )
         );

--- a/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
@@ -146,14 +146,14 @@ class RewriteTestTest implements RewriteTest {
     @Test
     void allowNonWhitespaceInWhitespace() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.builder().allowNonWhitespaceInWhitespace(true).build()),
+          spec -> spec.typeValidationOptions(TypeValidation.all().allowNonWhitespaceInWhitespace(true)),
           java(
-                """
-          import java.util.List;;
-          interface A {
-              List<String> getList();
-          }
-          """
+            """
+              import java.util.List;;
+              interface A {
+                  List<String> getList();
+              }
+              """
           )
         );
     }
@@ -238,7 +238,8 @@ class ImproperCursorUsage extends Recipe {
         return new TreeVisitor<>() {
             @Override
             public @Nullable Tree visit(Tree tree, ExecutionContext ctx) {
-                return new TreeVisitor<>(){}.visit(tree, ctx, new Cursor(getCursor(), tree));
+                return new TreeVisitor<>() {
+                }.visit(tree, ctx, new Cursor(getCursor(), tree));
             }
         };
     }
@@ -257,7 +258,7 @@ class CreatesTwoFilesSamePath extends ScanningRecipe<AtomicBoolean> {
     @Override
     public String getDescription() {
         return "A source file's path must be unique. " +
-               "This recipe creates two source files with the same path to show that the test framework helps protect against this mistake.";
+          "This recipe creates two source files with the same path to show that the test framework helps protect against this mistake.";
     }
 
     @Override


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
