### PR TITLE
Adding recipe for adding comments to import statements

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
@@ -65,7 +65,7 @@ public class AddCommentToImport extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        TypeMatcher typeMatcher = new TypeMatcher(typePattern, false);
+        TypeMatcher typeMatcher = new TypeMatcher(typePattern);
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.Import visitImport(J.Import anImport, ExecutionContext ctx) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.System.lineSeparator;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class AddCommentToImport extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Add comment to import statement";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add a comment to an import statement in a Java source file.";
+    }
+
+    @Option(displayName = "Comment",
+            description = "The comment to add.",
+            example = "This is a comment.")
+    String comment;
+
+    @Option(displayName = "Type pattern",
+            description = "A type pattern that is used to find matching imports uses.",
+            example = "org.springframework..*")
+    @Nullable
+    String typePattern;
+
+    @Override
+    public String getInstanceNameSuffix() {
+        return "matching `" + typePattern + "`";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        TypeMatcher typeMatcher = new TypeMatcher(typePattern, false);
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Import visitImport(J.Import anImport, ExecutionContext ctx) {
+                if (typeMatcher.matchesPackage(anImport.getTypeName())) {
+                    String prefixWhitespace = anImport.getPrefix().getWhitespace();
+                    Matcher newlineMatcher = Pattern.compile("\\R").matcher(comment.trim());
+                    String newCommentText = comment.trim()
+                            .replaceAll("\\R", prefixWhitespace + " * ")
+                            .replace("*/", "*");
+                    String formattedCommentText = newlineMatcher.find() ? lineSeparator() + " * " + newCommentText + lineSeparator() + " " : " " + newCommentText + " ";
+                    if (doesNotHaveComment(formattedCommentText, anImport.getComments())) {
+                        TextComment textComment = new TextComment(true, formattedCommentText, prefixWhitespace, Markers.EMPTY);
+                        return autoFormat(anImport.withComments(ListUtils.concat(anImport.getComments(), textComment)), ctx);
+                    }
+                }
+                return super.visitImport(anImport, ctx);
+            }
+
+            private boolean doesNotHaveComment(String lookFor, List<Comment> comments) {
+                for (Comment c : comments) {
+                    if (c instanceof TextComment &&
+                            lookFor.trim().equals(((TextComment) c).getText().trim())) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        };
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddCommentToImport.java
@@ -17,7 +17,6 @@ package org.openrewrite.java;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
@@ -55,7 +54,6 @@ public class AddCommentToImport extends Recipe {
     @Option(displayName = "Type pattern",
             description = "A type pattern that is used to find matching imports uses.",
             example = "org.springframework..*")
-    @Nullable
     String typePattern;
 
     @Override
@@ -67,9 +65,15 @@ public class AddCommentToImport extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         TypeMatcher typeMatcher = new TypeMatcher(typePattern);
         return new JavaIsoVisitor<ExecutionContext>() {
+            private boolean foundImport = false;
+
             @Override
             public J.Import visitImport(J.Import anImport, ExecutionContext ctx) {
+                if (foundImport) {
+                    return anImport;
+                }
                 if (typeMatcher.matchesPackage(anImport.getTypeName())) {
+                    foundImport = true;
                     String prefixWhitespace = anImport.getPrefix().getWhitespace();
                     Matcher newlineMatcher = Pattern.compile("\\R").matcher(comment.trim());
                     String newCommentText = comment.trim()

--- a/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
@@ -37,11 +37,48 @@ class AddCommentToImportTest implements RewriteTest {
           """
             package foo;
             public class Bar extends Foo {}
+            """,
+          """
+            package foo.bar;
+            public class Baz {
+                public static void someStaticMethod() {}
+            }
             """
         ));
     }
 
     @DocumentExample
+    @Test
+    void wildcardAndStaticImportsRecognized() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(SHORT_COMMENT, "foo.bar.Baz")),
+          //language=java
+          java(
+            """
+              package blah;
+              // Will not match direct package
+              import foo.*;
+              import foo.bar.*;
+              import foo.bar.Baz;
+              import static foo.bar.Baz.someStaticMethod;
+              class Other {}
+              """,
+            """
+              package blah;
+              // Will not match direct package
+              import foo.*;
+              /* Short comment to add */
+              import foo.bar.*;
+              /* Short comment to add */
+              import foo.bar.Baz;
+              /* Short comment to add */
+              import static foo.bar.Baz.someStaticMethod;
+              class Other {}
+              """
+          )
+        );
+    }
+
     @Test
     void addSingleLineComment() {
         rewriteRun(

--- a/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class AddCommentToImportTest implements RewriteTest {
+    private static final String SHORT_COMMENT = "Short comment to add";
+    private static final String LONG_COMMENT = "This is a very long comment to add.\nThe comment uses multiple lines.";
+    private static final String HEAVY_WRAP_COMMENT = "\nLine 1\nLine 2\nLine 3\n";
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().dependsOn(
+          """
+            package foo;
+            public class Foo {}
+            """,
+          """
+            package foo;
+            public class Bar extends Foo {}
+            """
+        ));
+    }
+
+    @DocumentExample
+    @Test
+    void addSingleLineComment() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(SHORT_COMMENT, "foo..*")),
+          //language=java
+          java(
+            """
+              package blah;
+              // Existing Comment 1
+              import foo.Foo;
+              /* Existing Comment 2 */
+              import foo.Bar;
+              class Other {}
+              """,
+            """
+              package blah;
+              // Existing Comment 1
+              /* Short comment to add */
+              import foo.Foo;
+              /* Existing Comment 2 */
+              /* Short comment to add */
+              import foo.Bar;
+              class Other {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void addLongComment() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(LONG_COMMENT, "foo..*")),
+          //language=java
+          java(
+            """
+              package blah;
+              // Existing Comment 1
+              import foo.Foo;
+              /* Existing Comment 2 */
+              import foo.Bar;
+              class Other {}
+              """,
+            """
+              package blah;
+              // Existing Comment 1
+              /*
+               * This is a very long comment to add.
+               * The comment uses multiple lines.
+               */
+              import foo.Foo;
+              /* Existing Comment 2 */
+              /*
+               * This is a very long comment to add.
+               * The comment uses multiple lines.
+               */
+              import foo.Bar;
+              class Other {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void addMultilineComment() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(HEAVY_WRAP_COMMENT, "foo..*")),
+          //language=java
+          java(
+            """
+              package blah;
+              // Existing Comment 1
+              import foo.Foo;
+              /* Existing Comment 2 */
+              import foo.Bar;
+              class Other {}
+              """,
+            """
+              package blah;
+              // Existing Comment 1
+              /*
+               * Line 1
+               * Line 2
+               * Line 3
+               */
+              import foo.Foo;
+              /* Existing Comment 2 */
+              /*
+               * Line 1
+               * Line 2
+               * Line 3
+               */
+              import foo.Bar;
+              class Other {}
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotAddCommentIfAlreadyPresent() {
+        rewriteRun(
+          spec -> spec.recipe(new AddCommentToImport(SHORT_COMMENT, "foo..*")),
+          //language=java
+          java(
+            """
+              package blah;
+              // Short comment to add
+              import foo.Foo;
+              /* Short comment to add */
+              import foo.Bar;
+              class Other {}
+              """
+          )
+        );
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/AddCommentToImportTest.java
@@ -61,7 +61,7 @@ class AddCommentToImportTest implements RewriteTest {
               import foo.bar.*;
               import foo.bar.Baz;
               import static foo.bar.Baz.someStaticMethod;
-              class Other {}
+              class OtherOne {}
               """,
             """
               package blah;
@@ -69,11 +69,53 @@ class AddCommentToImportTest implements RewriteTest {
               import foo.*;
               /* Short comment to add */
               import foo.bar.*;
+              import foo.bar.Baz;
+              import static foo.bar.Baz.someStaticMethod;
+              class OtherOne {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package blah;
+              // Will not match direct package
+              import foo.*;
+              import foo.bar.Baz;
+              import foo.bar.*;
+              import static foo.bar.Baz.someStaticMethod;
+              class OtherTwo {}
+              """,
+            """
+              package blah;
+              // Will not match direct package
+              import foo.*;
               /* Short comment to add */
               import foo.bar.Baz;
+              import foo.bar.*;
+              import static foo.bar.Baz.someStaticMethod;
+              class OtherTwo {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package blah;
+              // Will not match direct package
+              import foo.*;
+              import static foo.bar.Baz.someStaticMethod;
+              import foo.bar.*;
+              import foo.bar.Baz;
+              class OtherThree {}
+              """,
+            """
+              package blah;
+              // Will not match direct package
+              import foo.*;
               /* Short comment to add */
               import static foo.bar.Baz.someStaticMethod;
-              class Other {}
+              import foo.bar.*;
+              import foo.bar.Baz;
+              class OtherThree {}
               """
           )
         );
@@ -87,21 +129,36 @@ class AddCommentToImportTest implements RewriteTest {
           java(
             """
               package blah;
-              // Existing Comment 1
+              // Existing Comment
               import foo.Foo;
-              /* Existing Comment 2 */
               import foo.Bar;
-              class Other {}
+              class OtherOne {}
               """,
             """
               package blah;
-              // Existing Comment 1
+              // Existing Comment
               /* Short comment to add */
               import foo.Foo;
-              /* Existing Comment 2 */
-              /* Short comment to add */
               import foo.Bar;
-              class Other {}
+              class OtherOne {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package blah;
+              /* Existing Comment */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
+              """,
+            """
+              package blah;
+              /* Existing Comment */
+              /* Short comment to add */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
               """
           )
         );
@@ -115,27 +172,42 @@ class AddCommentToImportTest implements RewriteTest {
           java(
             """
               package blah;
-              // Existing Comment 1
+              // Existing Comment
               import foo.Foo;
-              /* Existing Comment 2 */
               import foo.Bar;
-              class Other {}
+              class OtherOne {}
               """,
             """
               package blah;
-              // Existing Comment 1
+              // Existing Comment
               /*
                * This is a very long comment to add.
                * The comment uses multiple lines.
                */
               import foo.Foo;
-              /* Existing Comment 2 */
+              import foo.Bar;
+              class OtherOne {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package blah;
+              /* Existing Comment */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
+              """,
+            """
+              package blah;
+              /* Existing Comment */
               /*
                * This is a very long comment to add.
                * The comment uses multiple lines.
                */
+              import foo.Foo;
               import foo.Bar;
-              class Other {}
+              class OtherTwo {}
               """
           )
         );
@@ -149,29 +221,44 @@ class AddCommentToImportTest implements RewriteTest {
           java(
             """
               package blah;
-              // Existing Comment 1
+              // Existing Comment
               import foo.Foo;
-              /* Existing Comment 2 */
               import foo.Bar;
-              class Other {}
+              class OtherOne {}
               """,
             """
               package blah;
-              // Existing Comment 1
+              // Existing Comment
               /*
                * Line 1
                * Line 2
                * Line 3
                */
               import foo.Foo;
-              /* Existing Comment 2 */
+              import foo.Bar;
+              class OtherOne {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package blah;
+              /* Existing Comment */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
+              """,
+            """
+              package blah;
+              /* Existing Comment */
               /*
                * Line 1
                * Line 2
                * Line 3
                */
+              import foo.Foo;
               import foo.Bar;
-              class Other {}
+              class OtherTwo {}
               """
           )
         );
@@ -187,9 +274,18 @@ class AddCommentToImportTest implements RewriteTest {
               package blah;
               // Short comment to add
               import foo.Foo;
-              /* Short comment to add */
               import foo.Bar;
-              class Other {}
+              class OtherOne {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package blah;
+              /* Short comment to add */
+              import foo.Foo;
+              import foo.Bar;
+              class OtherTwo {}
               """
           )
         );


### PR DESCRIPTION
## What's changed?
Added recipe to allow you to add a comment to an import or multiple imports depending on the pattern provided.

## What's your motivation?
There are some scenarios where we're not going to be able to provide an adequate migration for the usage of a class (like `HttpParams` for example, because it can be populated by any number of things and has been replaced with multiple different classes depending on the usage context). In these cases, we might want to add a comment to imports of the class with some helpful links on how they might be manually replaced instead.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
