### PR TITLE
Make the parser settable on KotlinTemplate

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
@@ -70,19 +70,10 @@ public class GroovyTemplate extends JavaTemplate {
     @SuppressWarnings("unused")
     public static class Builder extends JavaTemplate.Builder {
 
-        private final String code;
-        private final Set<String> imports = new HashSet<>();
-
         private GroovyParser.Builder parser = GroovyParser.builder();
-
-        private Consumer<String> onAfterVariableSubstitution = s -> {
-        };
-        private Consumer<String> onBeforeParseTemplate = s -> {
-        };
 
         Builder(String code) {
             super(code);
-            this.code = code;
         }
 
         @Override
@@ -99,30 +90,8 @@ public class GroovyTemplate extends JavaTemplate {
             return this;
         }
 
-        private void validateImport(String typeName) {
-            if (StringUtils.isBlank(typeName)) {
-                throw new IllegalArgumentException("Imports must not be blank");
-            } else if (typeName.startsWith("import ")) {
-                throw new IllegalArgumentException("Imports are expressed as fully-qualified names and should not include an \"import \" prefix");
-            } else if (typeName.endsWith(";") || typeName.endsWith("\n")) {
-                throw new IllegalArgumentException("Imports are expressed as fully-qualified names and should not include a suffixed terminator");
-            }
-        }
-
         Builder parser(GroovyParser.Builder parser) {
             this.parser = parser;
-            return this;
-        }
-
-        @Override
-        public Builder doAfterVariableSubstitution(Consumer<String> afterVariableSubstitution) {
-            this.onAfterVariableSubstitution = afterVariableSubstitution;
-            return this;
-        }
-
-        @Override
-        public Builder doBeforeParseTemplate(Consumer<String> beforeParseTemplate) {
-            this.onBeforeParseTemplate = beforeParseTemplate;
             return this;
         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
@@ -18,13 +18,11 @@ package org.openrewrite.groovy;
 import org.openrewrite.Cursor;
 import org.openrewrite.groovy.internal.template.GroovySubstitutions;
 import org.openrewrite.groovy.internal.template.GroovyTemplateParser;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.internal.template.Substitutions;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaCoordinates;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyTemplate.java
@@ -88,7 +88,7 @@ public class GroovyTemplate extends JavaTemplate {
             return this;
         }
 
-        Builder parser(GroovyParser.Builder parser) {
+        public Builder parser(GroovyParser.Builder parser) {
             this.parser = parser;
             return this;
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -177,8 +177,8 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
     @SuppressWarnings("unused")
     public static class Builder {
 
-        private final String code;
-        private final Set<String> imports = new HashSet<>();
+        protected final String code;
+        protected final Set<String> imports = new HashSet<>();
         private final Set<String> genericTypes = new HashSet<>();
 
         private boolean contextSensitive;
@@ -186,9 +186,9 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
 
         private JavaParser.Builder<?, ?> parser = org.openrewrite.java.JavaParser.fromJavaVersion();
 
-        private Consumer<String> onAfterVariableSubstitution = s -> {
+        protected Consumer<String> onAfterVariableSubstitution = s -> {
         };
-        private Consumer<String> onBeforeParseTemplate = s -> {
+        protected Consumer<String> onBeforeParseTemplate = s -> {
         };
 
         protected Builder(String code) {
@@ -254,7 +254,7 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
             return this;
         }
 
-        private void validateImport(String typeName) {
+        protected void validateImport(String typeName) {
             if (StringUtils.isBlank(typeName)) {
                 throw new IllegalArgumentException("Imports must not be blank");
             } else if (typeName.startsWith("import ") || typeName.startsWith("static ")) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTemplate.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTemplate.java
@@ -29,19 +29,24 @@ import java.util.function.Consumer;
 import static java.util.Collections.emptySet;
 
 public class KotlinTemplate extends JavaTemplate {
-    private KotlinTemplate(boolean contextSensitive, KotlinParser.Builder parser, String code, Set<String> imports, Consumer<String> onAfterVariableSubstitution, Consumer<String> onBeforeParseTemplate) {
+    private KotlinTemplate(boolean contextSensitive,
+                           KotlinParser.Builder parser,
+                           String code,
+                           Set<String> imports,
+                           Consumer<String> onAfterVariableSubstitution,
+                           Consumer<String> onBeforeParseTemplate) {
         super(
-                code,
-                emptySet(),
+            code,
+            emptySet(),
+            onAfterVariableSubstitution,
+            new KotlinTemplateParser(
+                contextSensitive,
+                augmentClasspath(parser),
                 onAfterVariableSubstitution,
-                new KotlinTemplateParser(
-                        contextSensitive,
-                        augmentClasspath(parser),
-                        onAfterVariableSubstitution,
-                        onBeforeParseTemplate,
-                        imports
-                )
-        );
+                onBeforeParseTemplate,
+                imports
+            )
+             );
     }
 
     private static KotlinParser.Builder augmentClasspath(KotlinParser.Builder parserBuilder) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTemplate.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTemplate.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin;
 
 import org.openrewrite.Cursor;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.internal.template.Substitutions;
 import org.openrewrite.java.tree.J;
@@ -24,7 +23,6 @@ import org.openrewrite.java.tree.JavaCoordinates;
 import org.openrewrite.kotlin.internal.template.KotlinSubstitutions;
 import org.openrewrite.kotlin.internal.template.KotlinTemplateParser;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -70,19 +68,10 @@ public class KotlinTemplate extends JavaTemplate {
     @SuppressWarnings("unused")
     public static class Builder extends JavaTemplate.Builder {
 
-        private final String code;
-        private final Set<String> imports = new HashSet<>();
-
         private KotlinParser.Builder parser = KotlinParser.builder();
-
-        private Consumer<String> onAfterVariableSubstitution = s -> {
-        };
-        private Consumer<String> onBeforeParseTemplate = s -> {
-        };
 
         Builder(String code) {
             super(code);
-            this.code = code;
         }
 
         @Override
@@ -99,37 +88,19 @@ public class KotlinTemplate extends JavaTemplate {
             return this;
         }
 
-        private void validateImport(String typeName) {
-            if (StringUtils.isBlank(typeName)) {
-                throw new IllegalArgumentException("Imports must not be blank");
-            } else if (typeName.startsWith("import ")) {
-                throw new IllegalArgumentException("Imports are expressed as fully-qualified names and should not include an \"import \" prefix");
-            } else if (typeName.endsWith(";") || typeName.endsWith("\n")) {
-                throw new IllegalArgumentException("Imports are expressed as fully-qualified names and should not include a suffixed terminator");
-            }
+        @Override
+        public JavaTemplate.Builder staticImports(String... fullyQualifiedMemberTypeNames) {
+            return imports(fullyQualifiedMemberTypeNames);
         }
 
-        Builder parser(KotlinParser.Builder parser) {
+        public Builder parser(KotlinParser.Builder parser) {
             this.parser = parser;
             return this;
         }
 
         @Override
-        public Builder doAfterVariableSubstitution(Consumer<String> afterVariableSubstitution) {
-            this.onAfterVariableSubstitution = afterVariableSubstitution;
-            return this;
-        }
-
-        @Override
-        public Builder doBeforeParseTemplate(Consumer<String> beforeParseTemplate) {
-            this.onBeforeParseTemplate = beforeParseTemplate;
-            return this;
-        }
-
-        @Override
         public KotlinTemplate build() {
-            return new KotlinTemplate(false, parser.clone(), code, imports,
-                    onAfterVariableSubstitution, onBeforeParseTemplate);
+            return new KotlinTemplate(false, parser.clone(), code, imports, onAfterVariableSubstitution, onBeforeParseTemplate);
         }
     }
 }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTemplate.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinTemplate.java
@@ -36,17 +36,17 @@ public class KotlinTemplate extends JavaTemplate {
                            Consumer<String> onAfterVariableSubstitution,
                            Consumer<String> onBeforeParseTemplate) {
         super(
-            code,
-            emptySet(),
-            onAfterVariableSubstitution,
-            new KotlinTemplateParser(
-                contextSensitive,
-                augmentClasspath(parser),
+                code,
+                emptySet(),
                 onAfterVariableSubstitution,
-                onBeforeParseTemplate,
-                imports
-            )
-             );
+                new KotlinTemplateParser(
+                        contextSensitive,
+                        augmentClasspath(parser),
+                        onAfterVariableSubstitution,
+                        onBeforeParseTemplate,
+                        imports
+                )
+        );
     }
 
     private static KotlinParser.Builder augmentClasspath(KotlinParser.Builder parserBuilder) {

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -38,8 +38,8 @@ class KotlinTemplateTest implements RewriteTest {
               @Override
               public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                   return KotlinTemplate.builder("println(\"foo\")")
-                                       .build()
-                                       .apply(getCursor(), multiVariable.getCoordinates().replace());
+                    .build()
+                    .apply(getCursor(), multiVariable.getCoordinates().replace());
               }
           })),
           kotlin(
@@ -57,7 +57,7 @@ class KotlinTemplateTest implements RewriteTest {
                   }
               }
               """
-                ));
+          ));
     }
 
     @Test
@@ -72,11 +72,10 @@ class KotlinTemplateTest implements RewriteTest {
                   maybeAddImport(ObjectMapper.class.getName(), false);
                   var path = Paths.get(ObjectMapper.class.getProtectionDomain().getCodeSource().getLocation().getPath());
                   return KotlinTemplate.builder("val mapper = ObjectMapper()")
-                                       .parser(KotlinParser.builder()
-                                                           .classpath(List.of(path)))
-                                       .imports(ObjectMapper.class.getName())
-                                       .build()
-                                       .apply(getCursor(), multiVariable.getCoordinates().replace());
+                    .parser(KotlinParser.builder().classpath(List.of(path)))
+                    .imports(ObjectMapper.class.getName())
+                    .build()
+                    .apply(getCursor(), multiVariable.getCoordinates().replace());
               }
           })),
           kotlin(
@@ -96,6 +95,6 @@ class KotlinTemplateTest implements RewriteTest {
                   }
               }
               """
-                ));
+          ));
     }
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -62,7 +62,6 @@ class KotlinTemplateTest implements RewriteTest {
 
     @Test
     void parserClasspath() {
-        var mapper = new ObjectMapper();
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {
               @Override

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -73,7 +73,7 @@ class KotlinTemplateTest implements RewriteTest {
                   var path = Paths.get(ObjectMapper.class.getProtectionDomain().getCodeSource().getLocation().getPath());
                   return KotlinTemplate.builder("val mapper = ObjectMapper()")
                                        .parser(KotlinParser.builder()
-                                                                  .classpath(List.of(path)))
+                                                           .classpath(List.of(path)))
                                        .imports(ObjectMapper.class.getName())
                                        .build()
                                        .apply(getCursor(), multiVariable.getCoordinates().replace());


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This makes `KotlinTemplate#parser()` public so the parser can be set externally.  Does some, admittedly tangential, clean up to reduce duplication between `KotlinTemplate` and `JavaTemplate`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
This fixes 
- #5889 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
